### PR TITLE
fix: serialize block num w/o leading zeros

### DIFF
--- a/crates/rpc-types/src/eth/block.rs
+++ b/crates/rpc-types/src/eth/block.rs
@@ -308,7 +308,9 @@ impl Serialize for BlockNumberOrTag {
         S: Serializer,
     {
         match *self {
-            BlockNumberOrTag::Number(ref x) => serializer.serialize_str(&format!("0x{x:x}")),
+            BlockNumberOrTag::Number(ref x) => {
+                serializer.serialize_str(&format!("0x{:x}", x.to::<u64>()))
+            },
             BlockNumberOrTag::Latest => serializer.serialize_str("latest"),
             BlockNumberOrTag::Finalized => serializer.serialize_str("finalized"),
             BlockNumberOrTag::Safe => serializer.serialize_str("safe"),


### PR DESCRIPTION
## Motivation

RPC nodes expect no leading zeros on block numbers, but `U64` serializes with leading 0s.

## Solution

Convert the `U64` to `u64` to discard the leading zeros.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
