### PR TITLE
fix: use u64 for block numbers

### DIFF
--- a/crates/providers/src/provider.rs
+++ b/crates/providers/src/provider.rs
@@ -51,7 +51,7 @@ pub trait TempProvider: Send + Sync {
         Self: Sync;
 
     /// Gets the last block number available.
-    async fn get_block_number(&self) -> TransportResult<U64>
+    async fn get_block_number(&self) -> TransportResult<u64>
     where
         Self: Sync;
 
@@ -289,7 +289,7 @@ impl<T: Transport + Clone + Send + Sync> TempProvider for Provider<T> {
     }
 
     /// Gets the last block number available.
-    async fn get_block_number(&self) -> TransportResult<U64>
+    async fn get_block_number(&self) -> TransportResult<u64>
     where
         Self: Sync,
     {
@@ -718,7 +718,7 @@ mod providers_test {
         let anvil = Anvil::new().spawn();
         let provider = Provider::try_from(&anvil.endpoint()).unwrap();
         let num = provider.get_block_number().await.unwrap();
-        assert_eq!(U64::ZERO, num)
+        assert_eq!(0, num)
     }
 
     #[tokio::test]

--- a/crates/rpc-types/src/eth/block.rs
+++ b/crates/rpc-types/src/eth/block.rs
@@ -247,12 +247,12 @@ pub enum BlockNumberOrTag {
     /// Pending block (not yet part of the blockchain)
     Pending,
     /// Block by number from canon chain
-    Number(U64),
+    Number(u64),
 }
 
 impl BlockNumberOrTag {
     /// Returns the numeric block number if explicitly set
-    pub const fn as_number(&self) -> Option<U64> {
+    pub const fn as_number(&self) -> Option<u64> {
         match *self {
             BlockNumberOrTag::Number(num) => Some(num),
             _ => None,
@@ -292,13 +292,13 @@ impl BlockNumberOrTag {
 
 impl From<u64> for BlockNumberOrTag {
     fn from(num: u64) -> Self {
-        BlockNumberOrTag::Number(U64::from(num))
+        BlockNumberOrTag::Number(num)
     }
 }
 
 impl From<U64> for BlockNumberOrTag {
     fn from(num: U64) -> Self {
-        BlockNumberOrTag::Number(num)
+        num.to::<u64>().into()
     }
 }
 
@@ -308,9 +308,7 @@ impl Serialize for BlockNumberOrTag {
         S: Serializer,
     {
         match *self {
-            BlockNumberOrTag::Number(ref x) => {
-                serializer.serialize_str(&format!("0x{:x}", x.to::<u64>()))
-            },
+            BlockNumberOrTag::Number(ref x) => serializer.serialize_str(&format!("0x{x:x}")),
             BlockNumberOrTag::Latest => serializer.serialize_str("latest"),
             BlockNumberOrTag::Finalized => serializer.serialize_str("finalized"),
             BlockNumberOrTag::Safe => serializer.serialize_str("safe"),
@@ -342,7 +340,7 @@ impl FromStr for BlockNumberOrTag {
             "pending" => Self::Pending,
             _number => {
                 if let Some(hex_val) = s.strip_prefix("0x") {
-                    let number = U64::from_str_radix(hex_val, 16);
+                    let number = u64::from_str_radix(hex_val, 16);
                     BlockNumberOrTag::Number(number?)
                 } else {
                     return Err(HexStringMissingPrefixError::default().into());
@@ -420,13 +418,13 @@ impl BlockId {
 
 impl From<u64> for BlockId {
     fn from(num: u64) -> Self {
-        BlockNumberOrTag::Number(U64::from(num)).into()
+        BlockNumberOrTag::Number(num).into()
     }
 }
 
 impl From<U64> for BlockId {
     fn from(num: U64) -> Self {
-        BlockNumberOrTag::Number(num).into()
+        BlockNumberOrTag::Number(num.to()).into()
     }
 }
 

--- a/crates/rpc-types/src/eth/filter.rs
+++ b/crates/rpc-types/src/eth/filter.rs
@@ -455,12 +455,12 @@ impl Filter {
     }
 
     /// Returns the numeric value of the `toBlock` field
-    pub fn get_to_block(&self) -> Option<U64> {
+    pub fn get_to_block(&self) -> Option<u64> {
         self.block_option.get_to_block().and_then(|b| b.as_number())
     }
 
     /// Returns the numeric value of the `fromBlock` field
-    pub fn get_from_block(&self) -> Option<U64> {
+    pub fn get_from_block(&self) -> Option<u64> {
         self.block_option.get_from_block().and_then(|b| b.as_number())
     }
 
@@ -759,7 +759,7 @@ impl FilteredParams {
     }
 
     /// Returns true if the filter matches the given block number
-    pub fn filter_block_range(&self, block_number: U64) -> bool {
+    pub fn filter_block_range(&self, block_number: u64) -> bool {
         if self.filter.is_none() {
             return true;
         }


### PR DESCRIPTION
## Motivation

It's easier to work with `u64` instead of `U64`. A miscommunication led us to switch to `U64` in #22 

## Solution

Use `u64`

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
