### PR TITLE
fix: deserialize block num as U64

### DIFF
--- a/crates/providers/src/provider.rs
+++ b/crates/providers/src/provider.rs
@@ -289,11 +289,12 @@ impl<T: Transport + Clone + Send + Sync> TempProvider for Provider<T> {
     }
 
     /// Gets the last block number available.
+    /// Gets the last block number available.
     async fn get_block_number(&self) -> TransportResult<u64>
-    where
-        Self: Sync,
+        where
+            Self: Sync,
     {
-        self.inner.prepare("eth_blockNumber", Cow::<()>::Owned(())).await
+        self.inner.prepare("eth_blockNumber", Cow::<()>::Owned(())).await.map(|num: U64| num.to::<u64>())
     }
 
     /// Gets the balance of the account at the specified tag, which defaults to latest.


### PR DESCRIPTION

We need to be able to deser things like `0x1` to `u64` but Rust does not do this by default, so we deser it as `U64` intermittently and cast it to `u64` 
