### PR TITLE
fix: dont skip gas used ratio if empty

### DIFF
--- a/crates/rpc-types/src/eth/fee.rs
+++ b/crates/rpc-types/src/eth/fee.rs
@@ -37,8 +37,8 @@ pub struct FeeHistory {
     /// # Note
     ///
     /// The `Option` is only for compatability with Erigon and Geth.
-    //#[serde(skip_serializing_if = "Vec::is_empty")]
-    #[serde(default)]
+    /// Empty list is skipped only for compatability with Erigon and Geth.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub base_fee_per_gas: Vec<U256>,
     /// An array of block gas used ratios. These are calculated as the ratio
     /// of `gasUsed` and `gasLimit`.
@@ -46,12 +46,11 @@ pub struct FeeHistory {
     /// # Note
     ///
     /// The `Option` is only for compatability with Erigon and Geth.
-    #[serde(default)]
     pub gas_used_ratio: Vec<f64>,
     /// Lowest number block of the returned range.
     pub oldest_block: U256,
     /// An (optional) array of effective priority fee per gas data points from a single
     /// block. All zeroes are returned if the block is empty.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reward: Option<Vec<Vec<U256>>>,
 }


### PR DESCRIPTION
Ethers expects `base_fee_per_gas` always, but it can be omitted:

https://github.com/ethereum/go-ethereum/blob/0004c6b229b787281760b14fb9460ffd9c2496f1/internal/ethapi/api.go#L86

To make Anvil tests pass I opened up this temporary workaround.

We do however seem to have a bug wrt `gas_used_ratio`, it should always be in the response:

https://github.com/ethereum/go-ethereum/blob/0004c6b229b787281760b14fb9460ffd9c2496f1/internal/ethapi/api.go#L88

This PR brings the types in line with the patch in https://github.com/paradigmxyz/reth/pull/5512

Edit: Workaround removed as this was patched in ethers https://github.com/gakonst/ethers-rs/pull/2683