### PR TITLE
fix: name lifetime in reference to self in TransportConnect

### DIFF
--- a/crates/transport/src/connect.rs
+++ b/crates/transport/src/connect.rs
@@ -20,7 +20,7 @@ pub trait TransportConnect: Sized + Send + Sync + 'static {
     fn is_local(&self) -> bool;
 
     /// Connect to the transport, returning a `Transport` instance.
-    fn get_transport<'a: 'b, 'b>(&self) -> Pbf<'b, Self::Transport, TransportError>;
+    fn get_transport<'a: 'b, 'b>(&'a self) -> Pbf<'b, Self::Transport, TransportError>;
 }
 
 /// Connection details for a transport that can be boxed.


### PR DESCRIPTION
Inbound from telegram @robinsdan :)

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
