### PR TITLE
Impl TryFrom<alloy_rpc_types::Log> for alloy_primitives::Log

### DIFF
--- a/crates/rpc-types/src/eth/log.rs
+++ b/crates/rpc-types/src/eth/log.rs
@@ -26,6 +26,22 @@ pub struct Log {
     pub removed: bool,
 }
 
+impl TryFrom<Log> for alloy_primitives::Log {
+    type Error = LogError;
+
+    fn try_from(value: Log) -> Result<Self, Self::Error> {
+        alloy_primitives::Log::new(value.topics, value.data).ok_or(LogError::InvalidTopics)
+    }
+}
+
+/// Error that can occur when converting other types to logs
+#[derive(Debug, thiserror::Error)]
+pub enum LogError {
+    /// The topics are invalid
+    #[error("invalid topics")]
+    InvalidTopics,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/rpc-types/src/eth/log.rs
+++ b/crates/rpc-types/src/eth/log.rs
@@ -30,16 +30,16 @@ impl TryFrom<Log> for alloy_primitives::Log {
     type Error = LogError;
 
     fn try_from(value: Log) -> Result<Self, Self::Error> {
-        alloy_primitives::Log::new(value.topics, value.data).ok_or(LogError::InvalidTopics)
+        alloy_primitives::Log::new(value.topics, value.data).ok_or(LogError::TooManyTopics)
     }
 }
 
 /// Error that can occur when converting other types to logs
 #[derive(Debug, thiserror::Error)]
 pub enum LogError {
-    /// The topics are invalid
-    #[error("invalid topics")]
-    InvalidTopics,
+    /// There are too many topics
+    #[error("too many topics")]
+    TooManyTopics,
 }
 
 #[cfg(test)]

--- a/crates/rpc-types/src/eth/mod.rs
+++ b/crates/rpc-types/src/eth/mod.rs
@@ -20,7 +20,7 @@ pub use block::*;
 pub use call::{Bundle, CallInput, CallInputError, CallRequest, EthCallResponse, StateContext};
 pub use fee::{FeeHistory, TxGasAndReward};
 pub use filter::*;
-pub use log::Log;
+pub use log::*;
 pub use raw_log::{logs_bloom, Log as RawLog};
 pub use syncing::*;
 pub use transaction::*;


### PR DESCRIPTION
Came across the following use case:

- Retrieve logs with `Provider::get_logs()` that returns a `Vec` of `alloy_rpc_types::Log`
- Then decode logs using `SolEvent::decode_log_object()` that accept a `alloy_primitives::Log`

So I needed to convert `alloy_rpc_types::Log` to `alloy_primitives::Log`, hence this PR.