### PR TITLE
fix: Modify the transport crate name in documents and fix the link

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ feature-parity in Alloy. No action is currently needed from devs.
 This repository contains the following crates:
 
 - [`alloy-json-rpc`] - Core data types for JSON-RPC 2.0 clients.
-- [`alloy-transports`] - Transport implementations for JSON-RPC 2.0 clients.
+- [`alloy-transport`] - Transport implementations for JSON-RPC 2.0 clients.
 - [`alloy-networks`] - Network abstraction for RPC types. Allows capturing
   different RPC param and response types on a per-network basis.
 - [`alloy-providers`] - A client trait for interacting with Ethereum-like RPC
@@ -27,7 +27,7 @@ This repository contains the following crates:
   different RPC types on a per-network basis.
 
 [`alloy-json-rpc`]: ./crates/json-rpc
-[`alloy-transports`]: ./crates/transports
+[`alloy-transport`]: ./crates/transport
 [`alloy-networks`]: ./crates/networks
 [`alloy-providers`]: ./crates/providers
 

--- a/crates/transport/README.md
+++ b/crates/transport/README.md
@@ -1,4 +1,4 @@
-# alloy-transports
+# alloy-transport
 
 <!-- TODO: More links and real doctests -->
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

The original crate name was "alloy-transport," but in several places in the documentation, it was written as "alloy-transports." 
Also, it was causing broken links.


<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
