### PR TITLE
avoid unnecessary serialize for RequestPacket.

### DIFF
--- a/crates/json-rpc/src/packet.rs
+++ b/crates/json-rpc/src/packet.rs
@@ -1,7 +1,6 @@
 use crate::{Id, Response, SerializedRequest};
 use serde::{
     de::{self, Deserializer, MapAccess, SeqAccess, Visitor},
-    ser::SerializeSeq,
     Deserialize, Serialize,
 };
 use serde_json::value::RawValue;
@@ -35,14 +34,8 @@ impl Serialize for RequestPacket {
         S: serde::Serializer,
     {
         match self {
-            RequestPacket::Single(single) => single.serialized().serialize(serializer),
-            RequestPacket::Batch(batch) => {
-                let mut seq = serializer.serialize_seq(Some(batch.len()))?;
-                for req in batch {
-                    seq.serialize_element(req.serialized())?;
-                }
-                seq.end()
-            }
+            RequestPacket::Single(single) => single.serialize(serializer),
+            RequestPacket::Batch(batch) => batch.serialize(serializer),
         }
     }
 }
@@ -54,8 +47,13 @@ impl RequestPacket {
     }
 
     /// Serialize the packet as a boxed [`RawValue`].
-    pub fn serialize(&self) -> serde_json::Result<Box<RawValue>> {
-        serde_json::to_string(self).and_then(RawValue::from_string)
+    pub fn serialize(self) -> serde_json::Result<Box<RawValue>> {
+        match self {
+            RequestPacket::Single(single) => Ok(single.take_request()),
+            RequestPacket::Batch(batch) => {
+                serde_json::to_string(&batch).and_then(RawValue::from_string)
+            }
+        }
     }
 
     /// Get the request IDs of all subscription requests in the packet.

--- a/crates/json-rpc/src/request.rs
+++ b/crates/json-rpc/src/request.rs
@@ -206,3 +206,12 @@ impl SerializedRequest {
         }
     }
 }
+
+impl Serialize for SerializedRequest {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.request.serialize(serializer)
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Current implementation will serialize the request twice: `Reqeust<Params>` -> `SerializedRequest` -> `hyper/reqwest request's json body`.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Replace `RequestPacket::serialize(&self)` with  `RequestPacket::serialize(self)`, we can avoid the second serialize for hyper client.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
