### PR TITLE
feat(`transport-http`): make `request` public

### DIFF
--- a/crates/transport-http/src/reqwest.rs
+++ b/crates/transport-http/src/reqwest.rs
@@ -6,7 +6,7 @@ use tower::Service;
 
 impl Http<reqwest::Client> {
     /// Make a request.
-    fn request(&self, req: RequestPacket) -> TransportFut<'static> {
+    pub fn request(&self, req: RequestPacket) -> TransportFut<'static> {
         let this = self.clone();
         Box::pin(async move {
             let resp = this


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

When making a transport that wraps http/ws/ipc it's handy to get access to the low-level "send" functions. They're available in both ws & ipc but not in http.

## Solution

Make `Http<reqwest::Client>::request` public.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
