### PR TITLE
fix(`rpc-types`): set Uncle as default for BlockTransactions

### DIFF
--- a/crates/rpc-types/src/eth/block.rs
+++ b/crates/rpc-types/src/eth/block.rs
@@ -27,8 +27,10 @@ pub struct Block {
     pub uncles: Vec<B256>,
     /// Block Transactions. In the case of an uncle block, this field is not included in RPC
     /// responses, and when deserialized, it will be set to [BlockTransactions::Uncle].
-    #[serde(skip_serializing_if = "BlockTransactions::is_uncle")]
-    #[serde(default = "BlockTransactions::uncle")]
+    #[serde(
+        skip_serializing_if = "BlockTransactions::is_uncle",
+        default = "BlockTransactions::uncle"
+    )]
     pub transactions: BlockTransactions,
     /// Integer the size of this block in bytes.
     pub size: Option<U256>,

--- a/crates/rpc-types/src/eth/block.rs
+++ b/crates/rpc-types/src/eth/block.rs
@@ -112,7 +112,7 @@ pub struct Header {
 
 /// Block Transactions depending on the boolean attribute of `eth_getBlockBy*`,
 /// or if used by `eth_getUncle*`
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum BlockTransactions {
     /// Only hashes
@@ -120,6 +120,7 @@ pub enum BlockTransactions {
     /// Full transactions
     Full(Vec<Transaction>),
     /// Special case for uncle response.
+    #[default]
     Uncle,
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

When fetching uncle blocks, these blocks never contain a `transactions` field. This means that normal serialization into a `Block` can fail as `BlockTransactions` doesn't have a default and therefore will just not be added to the `Block` struct at all, causing a serde failure.

## Solution

In the case the field is missing, simply include the field as default with an `BlockTransactions::Uncle` instance.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
