### PR TITLE
fix(providers): some methods have invalid formats for parameters

### DIFF
--- a/crates/providers/src/provider.rs
+++ b/crates/providers/src/provider.rs
@@ -338,8 +338,8 @@ impl<T: Transport + Clone + Send + Sync> TempProvider for Provider<T> {
         &self,
         block: BlockNumberOrTag,
     ) -> TransportResult<Vec<TransactionReceipt>>
-where {
-        self.inner.prepare("eth_getBlockReceipts", block).await
+        where {
+        self.inner.prepare("eth_getBlockReceipts", (block, )).await
     }
 
     /// Gets an uncle block through the tag [BlockId] and index [U64].
@@ -698,6 +698,15 @@ mod providers_test {
             .await
             .unwrap();
         assert_eq!(fee_history.oldest_block, U256::ZERO);
+    }
+
+    #[tokio::test]
+    #[ignore] // Anvil has yet to implement the `eth_getBlockReceipts` method.
+    async fn gets_block_receipts() {
+        let anvil = Anvil::new().spawn();
+        let provider = Provider::try_from(&anvil.endpoint()).unwrap();
+        let receipts = provider.get_block_receipts(BlockNumberOrTag::Latest).await.unwrap();
+        assert_eq!(receipts.len(), 0);
     }
 
     #[tokio::test]

--- a/crates/providers/src/provider.rs
+++ b/crates/providers/src/provider.rs
@@ -337,9 +337,8 @@ impl<T: Transport + Clone + Send + Sync> TempProvider for Provider<T> {
     async fn get_block_receipts(
         &self,
         block: BlockNumberOrTag,
-    ) -> TransportResult<Vec<TransactionReceipt>>
-        where {
-        self.inner.prepare("eth_getBlockReceipts", (block, )).await
+    ) -> TransportResult<Vec<TransactionReceipt>> {
+        self.inner.prepare("eth_getBlockReceipts", (block,)).await
     }
 
     /// Gets an uncle block through the tag [BlockId] and index [U64].
@@ -375,7 +374,7 @@ impl<T: Transport + Clone + Send + Sync> TempProvider for Provider<T> {
 
     /// Sends an already-signed transaction.
     async fn send_raw_transaction(&self, tx: Bytes) -> TransportResult<TxHash> {
-        self.inner.prepare("eth_sendRawTransaction", (tx, )).await
+        self.inner.prepare("eth_sendRawTransaction", (tx,)).await
     }
 
     /// Estimates the EIP1559 `maxFeePerGas` and `maxPriorityFeePerGas` fields.
@@ -469,7 +468,7 @@ impl<T: Transport + Clone + Send + Sync> TempProvider for Provider<T> {
         &self,
         block: BlockNumberOrTag,
     ) -> TransportResult<Vec<LocalizedTransactionTrace>> {
-        self.inner.prepare("trace_block", (block, )).await
+        self.inner.prepare("trace_block", (block,)).await
     }
 
     /// Sends a raw request with the methods and params specified to the internal connection,
@@ -727,6 +726,9 @@ mod providers_test {
                 bytes!("f865808477359400825208940000000000000000000000000000000000000000018082f4f5a00505e227c1c636c76fac55795db1a40a4d24840d81b40d2fe0cc85767f6bd202a01e91b437099a8a90234ac5af3cb7ca4fb1432e133f75f9a91678eaf5f487c74b")
             )
             .await.unwrap();
-        assert_eq!(tx_hash.to_string(), "0x9dae5cf33694a02e8a7d5de3fe31e9d05ca0ba6e9180efac4ab20a06c9e598a3");
+        assert_eq!(
+            tx_hash.to_string(),
+            "0x9dae5cf33694a02e8a7d5de3fe31e9d05ca0ba6e9180efac4ab20a06c9e598a3"
+        );
     }
 }

--- a/crates/providers/src/provider.rs
+++ b/crates/providers/src/provider.rs
@@ -469,7 +469,7 @@ where {
         &self,
         block: BlockNumberOrTag,
     ) -> TransportResult<Vec<LocalizedTransactionTrace>> {
-        self.inner.prepare("trace_block", block).await
+        self.inner.prepare("trace_block", (block, )).await
     }
 
     /// Sends a raw request with the methods and params specified to the internal connection,
@@ -698,5 +698,13 @@ mod providers_test {
             .await
             .unwrap();
         assert_eq!(fee_history.oldest_block, U256::ZERO);
+    }
+
+    #[tokio::test]
+    async fn gets_block_traces() {
+        let anvil = Anvil::new().spawn();
+        let provider = Provider::try_from(&anvil.endpoint()).unwrap();
+        let traces = provider.trace_block(BlockNumberOrTag::Latest).await.unwrap();
+        assert_eq!(traces.len(), 0);
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

The formats of parameters in the `eth_sendRawTransaction`, `trace_block`, and `eth_getBlockReceipts` methods are invalid.

```diff
- self.inner.prepare("trace_block", block).await
+ self.inner.prepare("trace_block", (block, )).await
```

```diff
{
  "method": "trace_block",
- "params": "latest",
+ "params": [
+   "latest"
+ ],
  "id": 0,
  "jsonrpc": "2.0"
}
```

### Example

```rust
use alloy_providers::provider::{Provider, TempProvider};
use alloy_rpc_types::BlockNumberOrTag;
use anyhow::Result;

#[tokio::main]
async fn main() -> Result<()> {
    let provider = Provider::try_from("https://rpc.ankr.com/eth/")?;
    let traces = provider.trace_block(BlockNumberOrTag::Latest).await?;

    for trace in traces {
        println!("{:?}", trace)
    }

    Ok(())
}
```

### Output

```plaintext
Error: Server returned an error response: ErrorPayload code -32600, message: "invalid request", contains payload: false
```

I'm currently working on implementing the `eth_getBlockReceipts` method for **Anvil**, but this issue is hindering my progress.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Corrected the wrong parameters format and added unit tests.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
