### PR TITLE
fix(providers): receipts of unmined blocks should be null

### DIFF
--- a/crates/providers/src/provider.rs
+++ b/crates/providers/src/provider.rs
@@ -124,7 +124,7 @@ pub trait TempProvider: Send + Sync {
     async fn get_block_receipts(
         &self,
         block: BlockNumberOrTag,
-    ) -> TransportResult<Vec<TransactionReceipt>>;
+    ) -> TransportResult<Option<Vec<TransactionReceipt>>>;
 
     /// Gets an uncle block through the tag [BlockId] and index [U64].
     async fn get_uncle(&self, tag: BlockId, idx: U64) -> TransportResult<Option<Block>>;
@@ -337,7 +337,7 @@ impl<T: Transport + Clone + Send + Sync> TempProvider for Provider<T> {
     async fn get_block_receipts(
         &self,
         block: BlockNumberOrTag,
-    ) -> TransportResult<Vec<TransactionReceipt>> {
+    ) -> TransportResult<Option<Vec<TransactionReceipt>>> {
         self.inner.prepare("eth_getBlockReceipts", (block,)).await
     }
 
@@ -705,7 +705,7 @@ mod providers_test {
         let anvil = Anvil::new().spawn();
         let provider = Provider::try_from(&anvil.endpoint()).unwrap();
         let receipts = provider.get_block_receipts(BlockNumberOrTag::Latest).await.unwrap();
-        assert_eq!(receipts.len(), 0);
+        assert!(receipts.is_some());
     }
 
     #[tokio::test]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

The provider cannot distinguish between non-existent blocks and blocks without transactions when using the `eth_getBlockReceipts` method.

### RPC responses

- The block exists, but there are no transactions.

```json
{
  "jsonrpc": "2.0",
  "id": 0,
  "result": []
}
```

 - The block does not exist.

```json
{
  "jsonrpc": "2.0",
  "id": 0,
  "result": null
}
```

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Use `Option` to distinguish between `[]` and `null`.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [x] Breaking changes
