### PR TITLE
feat(`rpc-types`): add support for other fields in call/txrequest

### DIFF
--- a/crates/rpc-types/src/eth/transaction/request.rs
+++ b/crates/rpc-types/src/eth/transaction/request.rs
@@ -1,6 +1,6 @@
 //! Alloy basic Transaction Request type.
-use crate::eth::transaction::AccessList;
-use alloy_primitives::{Address, Bytes, U128, U256, U64, U8};
+use crate::{eth::transaction::AccessList, other::OtherFields};
+use alloy_primitives::{Address, Bytes, B256, U128, U256, U64, U8};
 use serde::{Deserialize, Serialize};
 
 /// Represents _all_ transaction requests received from RPC
@@ -36,6 +36,30 @@ pub struct TransactionRequest {
     /// EIP-2718 type
     #[serde(rename = "type")]
     pub transaction_type: Option<U8>,
+    /// Support for arbitrary additional fields.
+    #[serde(flatten)]
+    pub other: OtherFields,
+}
+
+/// Optimism specific transaction fields
+#[derive(Debug, Copy, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OptimismTransactionFields {
+    /// Hash that uniquely identifies the source of the deposit.
+    #[serde(rename = "sourceHash", skip_serializing_if = "Option::is_none")]
+    pub source_hash: Option<B256>,
+    /// The ETH value to mint on L2
+    #[serde(rename = "mint", skip_serializing_if = "Option::is_none")]
+    pub mint: Option<U128>,
+    /// Field indicating whether the transaction is a system transaction, and therefore
+    /// exempt from the L2 gas limit.
+    #[serde(rename = "isSystemTx", skip_serializing_if = "Option::is_none")]
+    pub is_system_tx: Option<bool>,
+}
+
+impl From<OptimismTransactionFields> for OtherFields {
+    fn from(value: OptimismTransactionFields) -> Self {
+        serde_json::to_value(value).unwrap().try_into().unwrap()
+    }
 }
 
 // == impl TransactionRequest ==


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

unblocks further alloy migration on anvil (foundry), as we need extra fields on rpc tx requests.

## Solution

Add them

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
