### PR TITLE
chore(`rpc-types`): make CallRequest hash

### DIFF
--- a/crates/rpc-types/src/eth/call.rs
+++ b/crates/rpc-types/src/eth/call.rs
@@ -1,5 +1,5 @@
-use crate::{other::OtherFields, AccessList, BlockId, BlockOverrides};
-use alloy_primitives::{Address, Bytes, B256, U128, U256, U64, U8};
+use crate::{AccessList, BlockId, BlockOverrides};
+use alloy_primitives::{Address, Bytes, B256, U256, U64, U8};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 /// Bundle of transactions
@@ -98,7 +98,7 @@ impl<'de> Deserialize<'de> for TransactionIndex {
 }
 
 /// Call request for `eth_call` and adjacent methods.
-#[derive(Debug, Clone, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Eq, PartialEq, Serialize, Deserialize, Hash)]
 #[serde(default, rename_all = "camelCase")]
 pub struct CallRequest {
     /// From
@@ -133,30 +133,6 @@ pub struct CallRequest {
     /// EIP-2718 type
     #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
     pub transaction_type: Option<U8>,
-    /// Support for arbitrary additional fields.
-    #[serde(flatten)]
-    pub other: OtherFields,
-}
-
-/// Optimism specific transaction fields
-#[derive(Debug, Copy, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct OptimismTransactionFields {
-    /// Hash that uniquely identifies the source of the deposit.
-    #[serde(rename = "sourceHash", skip_serializing_if = "Option::is_none")]
-    pub source_hash: Option<B256>,
-    /// The ETH value to mint on L2
-    #[serde(rename = "mint", skip_serializing_if = "Option::is_none")]
-    pub mint: Option<U128>,
-    /// Field indicating whether the transaction is a system transaction, and therefore
-    /// exempt from the L2 gas limit.
-    #[serde(rename = "isSystemTx", skip_serializing_if = "Option::is_none")]
-    pub is_system_tx: Option<bool>,
-}
-
-impl From<OptimismTransactionFields> for OtherFields {
-    fn from(value: OptimismTransactionFields) -> Self {
-        serde_json::to_value(value).unwrap().try_into().unwrap()
-    }
 }
 
 impl CallRequest {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

CallRequest needs to be hash for anvil, and it doesn't actually need the additional fields for now. We can always re-add them later if so.

## Solution

Make it hash, remove other fields.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
