### PR TITLE
bug: correct `is_create` condition

### DIFF
--- a/crates/rpc-trace-types/src/parity.rs
+++ b/crates/rpc-trace-types/src/parity.rs
@@ -180,7 +180,7 @@ impl Action {
 
     /// Returns true if this is a create action
     pub const fn is_create(&self) -> bool {
-        matches!(self, Action::Call(_))
+        matches!(self, Action::Create(_))
     }
 
     /// Returns true if this is a selfdestruct action


### PR DESCRIPTION
I think this part was copied over from reth so I'm not sure if this is a bug we've had or not, but `is_create` for Parity traces currently check if the `Action` is a call, not a create.