### PR TITLE
fix(`consensus`): populate chain id when decoding signed legacy txs

### DIFF
--- a/crates/consensus/src/transaction/legacy.rs
+++ b/crates/consensus/src/transaction/legacy.rs
@@ -232,10 +232,9 @@ impl Transaction for TxLegacy {
 
         let v = signature.v();
 
-        match v {
-            Parity::Eip155(_) => tx.chain_id = v.chain_id(),
-            _ => {}
-        };
+        if let Parity::Eip155(_) = v {
+            tx.chain_id = v.chain_id();
+        }
 
         Ok(tx.into_signed(signature))
     }

--- a/crates/consensus/src/transaction/legacy.rs
+++ b/crates/consensus/src/transaction/legacy.rs
@@ -226,7 +226,16 @@ impl Transaction for TxLegacy {
         if !header.list {
             return Err(alloy_rlp::Error::UnexpectedString);
         }
-        let tx = Self::decode_fields(buf)?;
+        let mut tx = Self::decode_fields(buf)?;
+
+        // If the buffer is not empty, it should be an eip-155 encoded chain_id.
+        if !buf.is_empty() {
+            let mut chain_buf = *buf;
+            let chain_id = ChainId::decode(&mut chain_buf)?;
+            // EIP-155: v = {0, 1} + CHAIN_ID * 2 + 35
+            tx.chain_id = ((chain_id - 35) >> 1).into();
+        }
+
         let signature = Signature::decode_rlp_vrs(buf)?;
 
         Ok(tx.into_signed(signature))
@@ -335,5 +344,27 @@ mod tests {
 
         assert_eq!(*signed_tx.hash(), hash, "Expected same hash");
         assert_eq!(signed_tx.recover_signer().unwrap(), signer, "Recovering signer should pass.");
+    }
+
+    #[test]
+    #[cfg(feature = "k256")]
+    fn decode_legacy_and_recover_signer() {
+        use crate::TxLegacy;
+        use alloy_network::Signed;
+        use alloy_primitives::address;
+        use alloy_rlp::Decodable;
+
+        let raw_tx = "f9015482078b8505d21dba0083022ef1947a250d5630b4cf539739df2c5dacb4c659f2488d880c46549a521b13d8b8e47ff36ab50000000000000000000000000000000000000000000066ab5a608bd00a23f2fe000000000000000000000000000000000000000000000000000000000000008000000000000000000000000048c04ed5691981c42154c6167398f95e8f38a7ff00000000000000000000000000000000000000000000000000000000632ceac70000000000000000000000000000000000000000000000000000000000000002000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc20000000000000000000000006c6ee5e31d828de241282b9606c8e98ea48526e225a0c9077369501641a92ef7399ff81c21639ed4fd8fc69cb793cfa1dbfab342e10aa0615facb2f1bcf3274a354cfe384a38d0cc008a11c2dd23a69111bc6930ba27a8";
+
+        let tx = <Signed<TxLegacy> as Decodable>::decode(
+            &mut alloy_primitives::hex::decode(raw_tx).unwrap().as_slice(),
+        )
+        .unwrap();
+
+        let recovered = tx.recover_signer().unwrap();
+        let expected = address!("a12e1462d0ceD572f396F58B6E2D03894cD7C8a4");
+
+        assert_eq!(tx.chain_id, Some(1), "Expected same chain id");
+        assert_eq!(expected, recovered, "Expected same signer");
     }
 }

--- a/crates/consensus/src/transaction/legacy.rs
+++ b/crates/consensus/src/transaction/legacy.rs
@@ -1,6 +1,6 @@
 use crate::TxKind;
 use alloy_network::{Signed, Transaction};
-use alloy_primitives::{keccak256, Bytes, ChainId, Parity, Signature, B256, U256};
+use alloy_primitives::{keccak256, Bytes, ChainId, Signature, B256, U256};
 use alloy_rlp::{length_of_length, BufMut, Decodable, Encodable, Header, Result};
 use std::mem;
 

--- a/crates/consensus/src/transaction/legacy.rs
+++ b/crates/consensus/src/transaction/legacy.rs
@@ -228,12 +228,13 @@ impl Transaction for TxLegacy {
         }
         let mut tx = Self::decode_fields(buf)?;
 
-        // If the buffer is not empty, it should be an eip-155 encoded chain_id.
         if !buf.is_empty() {
             let mut chain_buf = *buf;
-            let chain_id = ChainId::decode(&mut chain_buf)?;
-            // EIP-155: v = {0, 1} + CHAIN_ID * 2 + 35
-            tx.chain_id = ((chain_id - 35) >> 1).into();
+            let v = ChainId::decode(&mut chain_buf)?;
+            if v >= 35 {
+                // EIP-155: v = {0, 1} + CHAIN_ID * 2 + 35
+                tx.chain_id = ((v - 35) >> 1).into();
+            }
         }
 
         let signature = Signature::decode_rlp_vrs(buf)?;

--- a/crates/consensus/src/transaction/legacy.rs
+++ b/crates/consensus/src/transaction/legacy.rs
@@ -344,6 +344,7 @@ mod tests {
 
     #[test]
     #[cfg(feature = "k256")]
+    // Test vector from https://github.com/alloy-rs/alloy/issues/125
     fn decode_legacy_and_recover_signer() {
         use crate::TxLegacy;
         use alloy_network::Signed;

--- a/crates/consensus/src/transaction/legacy.rs
+++ b/crates/consensus/src/transaction/legacy.rs
@@ -232,9 +232,7 @@ impl Transaction for TxLegacy {
 
         let v = signature.v();
 
-        if let Parity::Eip155(_) = v {
-            tx.chain_id = v.chain_id();
-        }
+        tx.chain_id = v.chain_id();
 
         Ok(tx.into_signed(signature))
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

The chain id was not being populated when decoding a signed legacy tx, leading to decoding issues.

Closes #125

## Solution

Populate the chain id param when decoding.

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
