### PR TITLE
feat(`rpc-types`): add optimism module and refactor types

### DIFF
--- a/crates/rpc-types/src/eth/transaction/mod.rs
+++ b/crates/rpc-types/src/eth/transaction/mod.rs
@@ -5,13 +5,15 @@ pub use access_list::{AccessList, AccessListItem, AccessListWithGasUsed};
 use alloy_primitives::{Address, Bytes, B256, U128, U256, U64};
 pub use blob::BlobTransactionSidecar;
 pub use common::TransactionInfo;
-pub use receipt::{OptimismTransactionReceiptFields, TransactionReceipt};
+pub use optimism::OptimismTransactionReceiptFields;
+pub use receipt::TransactionReceipt;
 use serde::{Deserialize, Serialize};
 pub use signature::{Parity, Signature};
 
 mod access_list;
 mod common;
 pub mod kzg;
+pub mod optimism;
 mod receipt;
 pub mod request;
 mod signature;
@@ -81,27 +83,6 @@ pub struct Transaction {
     /// This captures fields that are not native to ethereum but included in ethereum adjacent networks, for example fields the [optimism `eth_getTransactionByHash` request](https://docs.alchemy.com/alchemy/apis/optimism/eth-gettransactionbyhash) returns additional fields that this type will capture
     #[serde(flatten)]
     pub other: OtherFields,
-}
-
-/// Optimism specific transaction fields
-#[derive(Debug, Copy, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct OptimismTransactionFields {
-    /// Hash that uniquely identifies the source of the deposit.
-    #[serde(rename = "sourceHash", skip_serializing_if = "Option::is_none")]
-    pub source_hash: Option<B256>,
-    /// The ETH value to mint on L2
-    #[serde(rename = "mint", skip_serializing_if = "Option::is_none")]
-    pub mint: Option<U128>,
-    /// Field indicating whether the transaction is a system transaction, and therefore
-    /// exempt from the L2 gas limit.
-    #[serde(rename = "isSystemTx", skip_serializing_if = "Option::is_none")]
-    pub is_system_tx: Option<bool>,
-}
-
-impl From<OptimismTransactionFields> for OtherFields {
-    fn from(value: OptimismTransactionFields) -> Self {
-        serde_json::to_value(value).unwrap().try_into().unwrap()
-    }
 }
 
 #[cfg(test)]

--- a/crates/rpc-types/src/eth/transaction/optimism.rs
+++ b/crates/rpc-types/src/eth/transaction/optimism.rs
@@ -1,0 +1,53 @@
+//! Misc Optimism-specific types
+use alloy_primitives::{B256, U128, U256, U64};
+use serde::{Deserialize, Serialize};
+
+use crate::other::OtherFields;
+
+/// Optimism specific transaction fields
+#[derive(Debug, Copy, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OptimismTransactionFields {
+    /// Hash that uniquely identifies the source of the deposit.
+    #[serde(rename = "sourceHash", skip_serializing_if = "Option::is_none")]
+    pub source_hash: Option<B256>,
+    /// The ETH value to mint on L2
+    #[serde(rename = "mint", skip_serializing_if = "Option::is_none")]
+    pub mint: Option<U128>,
+    /// Field indicating whether the transaction is a system transaction, and therefore
+    /// exempt from the L2 gas limit.
+    #[serde(rename = "isSystemTx", skip_serializing_if = "Option::is_none")]
+    pub is_system_tx: Option<bool>,
+}
+
+/// Additional fields for Optimism transaction receipts
+#[derive(Clone, Copy, Default, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OptimismTransactionReceiptFields {
+    /// Deposit nonce for deposit transactions post-regolith
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deposit_nonce: Option<U64>,
+    /// L1 fee for the transaction
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub l1_fee: Option<U256>,
+    /// L1 fee scalar for the transaction
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub l1_fee_scalar: Option<U256>,
+    /// L1 gas price for the transaction
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub l1_gas_price: Option<U256>,
+    /// L1 gas used for the transaction
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub l1_gas_used: Option<U256>,
+}
+
+impl From<OptimismTransactionFields> for OtherFields {
+    fn from(value: OptimismTransactionFields) -> Self {
+        serde_json::to_value(value).unwrap().try_into().unwrap()
+    }
+}
+
+impl From<OptimismTransactionReceiptFields> for OtherFields {
+    fn from(value: OptimismTransactionReceiptFields) -> Self {
+        serde_json::to_value(value).unwrap().try_into().unwrap()
+    }
+}

--- a/crates/rpc-types/src/eth/transaction/receipt.rs
+++ b/crates/rpc-types/src/eth/transaction/receipt.rs
@@ -55,30 +55,3 @@ pub struct TransactionReceipt {
     #[serde(flatten)]
     pub other: OtherFields,
 }
-
-/// Additional fields for Optimism transaction receipts
-#[derive(Clone, Copy, Default, Debug, Eq, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct OptimismTransactionReceiptFields {
-    /// Deposit nonce for deposit transactions post-regolith
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub deposit_nonce: Option<U64>,
-    /// L1 fee for the transaction
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub l1_fee: Option<U256>,
-    /// L1 fee scalar for the transaction
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub l1_fee_scalar: Option<U256>,
-    /// L1 gas price for the transaction
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub l1_gas_price: Option<U256>,
-    /// L1 gas used for the transaction
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub l1_gas_used: Option<U256>,
-}
-
-impl From<OptimismTransactionReceiptFields> for OtherFields {
-    fn from(value: OptimismTransactionReceiptFields) -> Self {
-        serde_json::to_value(value).unwrap().try_into().unwrap()
-    }
-}

--- a/crates/rpc-types/src/eth/transaction/request.rs
+++ b/crates/rpc-types/src/eth/transaction/request.rs
@@ -1,6 +1,6 @@
 //! Alloy basic Transaction Request type.
 use crate::{eth::transaction::AccessList, other::OtherFields, BlobTransactionSidecar};
-use alloy_primitives::{Address, Bytes, B256, U128, U256, U64, U8};
+use alloy_primitives::{Address, Bytes, U128, U256, U64, U8};
 use serde::{Deserialize, Serialize};
 
 /// Represents _all_ transaction requests received from RPC
@@ -98,26 +98,5 @@ impl TransactionRequest {
     pub fn transaction_type(mut self, transaction_type: u8) -> Self {
         self.transaction_type = Some(U8::from(transaction_type));
         self
-    }
-}
-
-/// Optimism specific transaction fields
-#[derive(Debug, Copy, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct OptimismTransactionFields {
-    /// Hash that uniquely identifies the source of the deposit.
-    #[serde(rename = "sourceHash", skip_serializing_if = "Option::is_none")]
-    pub source_hash: Option<B256>,
-    /// The ETH value to mint on L2
-    #[serde(rename = "mint", skip_serializing_if = "Option::is_none")]
-    pub mint: Option<U128>,
-    /// Field indicating whether the transaction is a system transaction, and therefore
-    /// exempt from the L2 gas limit.
-    #[serde(rename = "isSystemTx", skip_serializing_if = "Option::is_none")]
-    pub is_system_tx: Option<bool>,
-}
-
-impl From<OptimismTransactionFields> for OtherFields {
-    fn from(value: OptimismTransactionFields) -> Self {
-        serde_json::to_value(value).unwrap().try_into().unwrap()
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

We should have the op types as a separate module. Closes #113

## Solution

Add a separate module for op types and their from impls.

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
