### PR TITLE
fix(`consensus`): ensure into_signed forces correct format for eip1559/2930 txs

### DIFF
--- a/crates/consensus/src/transaction/eip1559.rs
+++ b/crates/consensus/src/transaction/eip1559.rs
@@ -231,7 +231,6 @@ impl Decodable for TxEip1559 {
 
 impl Transaction for TxEip1559 {
     type Signature = Signature;
-    // type Receipt = ReceiptWithBloom;
 
     fn into_signed(self, signature: Signature) -> Signed<Self> {
         let mut buf = vec![];
@@ -239,7 +238,10 @@ impl Transaction for TxEip1559 {
         self.encode_signed(&signature, &mut buf);
         let hash = keccak256(&buf);
 
-        Signed::new_unchecked(self, signature, hash)
+        // Drop any v chain id value to ensure the signature format is correct at the time of
+        // combination for an EIP-1559 transaction. V should indicate the y-parity of the
+        // signature.
+        Signed::new_unchecked(self, signature.with_parity_bool(), hash)
     }
 
     fn encode_signed(&self, signature: &Signature, out: &mut dyn BufMut) {

--- a/crates/consensus/src/transaction/eip2930.rs
+++ b/crates/consensus/src/transaction/eip2930.rs
@@ -200,7 +200,10 @@ impl Transaction for TxEip2930 {
         self.encode_signed(&signature, &mut buf);
         let hash = keccak256(&buf);
 
-        Signed::new_unchecked(self, signature, hash)
+        // Drop any v chain id value to ensure the signature format is correct at the time of
+        // combination for an EIP-2930 transaction. V should indicate the y-parity of the
+        // signature.
+        Signed::new_unchecked(self, signature.with_parity_bool(), hash)
     }
 
     fn encode_signed(&self, signature: &Signature, out: &mut dyn BufMut) {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Closes #144. 

## Solution

This ensures that, at the time of combining the signature with the tx, the correct format is applied for 2930/1559 txs, removing any eip-155 application.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
