### PR TITLE
chore(`genesis`): do not make genesis fill out its fields by default

### DIFF
--- a/crates/genesis/src/lib.rs
+++ b/crates/genesis/src/lib.rs
@@ -257,7 +257,7 @@ impl GenesisAccount {
 /// struct](https://github.com/ethereum/go-ethereum/blob/64dccf7aa411c5c7cd36090c3d9b9892945ae813/params/config.go#L349)
 /// for the source of each field.
 #[derive(Clone, Debug, Deserialize, Serialize, Default, PartialEq, Eq)]
-#[serde(default, rename_all = "camelCase")]
+#[serde(rename_all = "camelCase")]
 pub struct ChainConfig {
     /// The network's chain ID.
     #[serde(default = "mainnet_id")]

--- a/crates/genesis/src/lib.rs
+++ b/crates/genesis/src/lib.rs
@@ -28,7 +28,7 @@ use std::collections::HashMap;
 
 /// The genesis block specification.
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase")]
 pub struct Genesis {
     /// The fork configuration for this network.
     #[serde(default)]

--- a/crates/genesis/src/lib.rs
+++ b/crates/genesis/src/lib.rs
@@ -34,22 +34,25 @@ pub struct Genesis {
     #[serde(default)]
     pub config: ChainConfig,
     /// The genesis header nonce.
-    #[serde(with = "u64_hex_or_decimal")]
+    #[serde(default, with = "u64_hex_or_decimal")]
     pub nonce: u64,
     /// The genesis header timestamp.
-    #[serde(with = "u64_hex_or_decimal")]
+    #[serde(default, with = "u64_hex_or_decimal")]
     pub timestamp: u64,
     /// The genesis header extra data.
+    #[serde(default)]
     pub extra_data: Bytes,
     /// The genesis header gas limit.
-    #[serde(with = "u64_hex_or_decimal")]
+    #[serde(default, with = "u64_hex_or_decimal")]
     pub gas_limit: u64,
     /// The genesis header difficulty.
     #[serde(deserialize_with = "deserialize_json_u256")]
     pub difficulty: U256,
     /// The genesis header mix hash.
+    #[serde(default)]
     pub mix_hash: B256,
     /// The genesis header coinbase address.
+    #[serde(default)]
     pub coinbase: Address,
     /// The initial state of accounts in the genesis block.
     pub alloc: HashMap<Address, GenesisAccount>,
@@ -60,13 +63,13 @@ pub struct Genesis {
     // should NOT be set in a real genesis file, but are included here for compatibility with
     // consensus tests, which have genesis files with these fields populated.
     /// The genesis header base fee
-    #[serde(skip_serializing_if = "Option::is_none", with = "u64_hex_or_decimal_opt")]
+    #[serde(skip_serializing_if = "Option::is_none", with = "u64_hex_or_decimal_opt", default)]
     pub base_fee_per_gas: Option<u64>,
     /// The genesis header excess blob gas
-    #[serde(skip_serializing_if = "Option::is_none", with = "u64_hex_or_decimal_opt")]
+    #[serde(skip_serializing_if = "Option::is_none", with = "u64_hex_or_decimal_opt", default)]
     pub excess_blob_gas: Option<u64>,
     /// The genesis header blob gas used
-    #[serde(skip_serializing_if = "Option::is_none", with = "u64_hex_or_decimal_opt")]
+    #[serde(skip_serializing_if = "Option::is_none", with = "u64_hex_or_decimal_opt", default)]
     pub blob_gas_used: Option<u64>,
 }
 
@@ -257,7 +260,7 @@ impl GenesisAccount {
 /// struct](https://github.com/ethereum/go-ethereum/blob/64dccf7aa411c5c7cd36090c3d9b9892945ae813/params/config.go#L349)
 /// for the source of each field.
 #[derive(Clone, Debug, Deserialize, Serialize, Default, PartialEq, Eq)]
-#[serde(rename_all = "camelCase")]
+#[serde(default, rename_all = "camelCase")]
 pub struct ChainConfig {
     /// The network's chain ID.
     #[serde(default = "mainnet_id")]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

#120 ported over the genesis utilities from ethers, but also made it `#[serde(default)]`. I don't think this is desirable as this can lead to footguns—the provider of the genesis file must ensure it's filled out correctly.

## Solution

Revert to the way we used to mark the fields as default.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
