### PR TITLE
fix: add encode_for_signing to Transaction, fix Ledger sign_transaction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /target
 /Cargo.lock
+.vscode
+.idea
+.env

--- a/crates/signer-ledger/Cargo.toml
+++ b/crates/signer-ledger/Cargo.toml
@@ -27,8 +27,10 @@ alloy-sol-types = { workspace = true, optional = true }
 
 [dev-dependencies]
 alloy-consensus.workspace = true
+alloy-rlp.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 serial_test.workspace = true
+tracing-subscriber.workspace = true
 
 [features]
 eip712 = ["alloy-signer/eip712", "dep:alloy-sol-types"]

--- a/crates/signer/src/lib.rs
+++ b/crates/signer/src/lib.rs
@@ -19,7 +19,7 @@ mod error;
 pub use error::{Error, Result, UnsupportedSignerOperation};
 
 mod signer;
-pub use signer::{SignableTx, Signer, SignerSync, TransactionExt};
+pub use signer::{SignableTx, Signer, SignerSync, Transaction, TransactionExt};
 
 mod wallet;
 #[cfg(feature = "mnemonic")]

--- a/crates/signer/src/signer.rs
+++ b/crates/signer/src/signer.rs
@@ -1,11 +1,12 @@
 use crate::Result;
-use alloy_network::Transaction;
 use alloy_primitives::{eip191_hash_message, Address, ChainId, Signature, B256};
 use async_trait::async_trait;
 use auto_impl::auto_impl;
 
 #[cfg(feature = "eip712")]
 use alloy_sol_types::{Eip712Domain, SolStruct};
+
+pub use alloy_network::Transaction;
 
 /// A signable transaction.
 pub type SignableTx = dyn Transaction<Signature = Signature>;
@@ -15,13 +16,6 @@ pub type SignableTx = dyn Transaction<Signature = Signature>;
 /// This trait is implemented for all types that implement [`Transaction`] with [`Signature`] as the
 /// signature associated type.
 pub trait TransactionExt: Transaction<Signature = Signature> {
-    /// Encode the transaction.
-    fn rlp_encode(&self) -> Vec<u8> {
-        let mut out = Vec::new();
-        self.encode(&mut out);
-        out
-    }
-
     /// Set `chain_id` if it is not already set. Checks that the provided `chain_id` matches the
     /// existing `chain_id` if it is already set.
     fn set_chain_id_checked(&mut self, chain_id: ChainId) -> Result<()> {


### PR DESCRIPTION
Added tests for all tx types, discovered a few bugs. signing a legaxy tx still doesn't work for me:

```
failures:
    signer::tests::test_sign_tx_legacy

test result: FAILED. 5 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 19.72s
```

Edit: it looks like it's that exact encoded call that fails, still not sure why.