### PR TITLE
feat: subscription type

### DIFF
--- a/crates/json-rpc/src/request.rs
+++ b/crates/json-rpc/src/request.rs
@@ -167,6 +167,7 @@ impl SerializedRequest {
     }
 
     /// Consume the serialized request, returning the underlying [`RawValue`].
+    #[allow(clippy::missing_const_for_fn)] // erroneous lint
     pub fn into_serialized(self) -> Box<RawValue> {
         self.request
     }

--- a/crates/pubsub/Cargo.toml
+++ b/crates/pubsub/Cargo.toml
@@ -18,6 +18,7 @@ alloy-transport.workspace = true
 
 bimap.workspace = true
 futures.workspace = true
+serde.workspace = true
 serde_json.workspace = true
 tokio = { workspace = true, features = ["macros", "sync"] }
 tower.workspace = true

--- a/crates/pubsub/src/frontend.rs
+++ b/crates/pubsub/src/frontend.rs
@@ -1,14 +1,13 @@
-use crate::{ix::PubSubInstruction, managers::InFlight};
+use crate::{ix::PubSubInstruction, managers::InFlight, RawSubscription};
 use alloy_json_rpc::{RequestPacket, Response, ResponsePacket, SerializedRequest};
 use alloy_primitives::U256;
 use alloy_transport::{TransportError, TransportErrorKind, TransportFut};
 use futures::{future::try_join_all, FutureExt, TryFutureExt};
-use serde_json::value::RawValue;
 use std::{
     future::Future,
     task::{Context, Poll},
 };
-use tokio::sync::{broadcast, mpsc, oneshot};
+use tokio::sync::{mpsc, oneshot};
 
 /// A `PubSubFrontend` is [`Transport`] composed of a channel to a running
 /// PubSub service.
@@ -29,8 +28,7 @@ impl PubSubFrontend {
     pub fn get_subscription(
         &self,
         id: U256,
-    ) -> impl Future<Output = Result<broadcast::Receiver<Box<RawValue>>, TransportError>> + Send + 'static
-    {
+    ) -> impl Future<Output = Result<RawSubscription, TransportError>> + Send + 'static {
         let backend_tx = self.tx.clone();
         async move {
             let (tx, rx) = oneshot::channel();

--- a/crates/pubsub/src/ix.rs
+++ b/crates/pubsub/src/ix.rs
@@ -1,15 +1,15 @@
-use crate::managers::InFlight;
+use crate::{managers::InFlight, RawSubscription};
+
 use alloy_primitives::U256;
-use serde_json::value::RawValue;
 use std::fmt;
-use tokio::sync::{broadcast, oneshot};
+use tokio::sync::oneshot;
 
 /// Instructions for the pubsub service.
 pub(crate) enum PubSubInstruction {
     /// Send a request.
     Request(InFlight),
     /// Get the subscription ID for a local ID.
-    GetSub(U256, oneshot::Sender<broadcast::Receiver<Box<RawValue>>>),
+    GetSub(U256, oneshot::Sender<RawSubscription>),
     /// Unsubscribe from a subscription.
     Unsubscribe(U256),
 }

--- a/crates/pubsub/src/lib.rs
+++ b/crates/pubsub/src/lib.rs
@@ -32,3 +32,6 @@ pub use handle::{ConnectionHandle, ConnectionInterface};
 mod managers;
 
 mod service;
+
+mod sub;
+pub use sub::{RawSubscription, Subscription, SubscriptionItem};

--- a/crates/pubsub/src/service.rs
+++ b/crates/pubsub/src/service.rs
@@ -2,7 +2,7 @@ use crate::{
     handle::ConnectionHandle,
     ix::PubSubInstruction,
     managers::{InFlight, RequestManager, SubscriptionManager},
-    PubSubConnect, PubSubFrontend,
+    PubSubConnect, PubSubFrontend, RawSubscription,
 };
 
 use alloy_json_rpc::{Id, PubSubItem, Request, RequestMeta, Response, ResponsePayload};
@@ -12,7 +12,7 @@ use alloy_transport::{
     TransportError, TransportErrorKind, TransportResult,
 };
 use serde_json::value::RawValue;
-use tokio::sync::{broadcast, mpsc, oneshot};
+use tokio::sync::{mpsc, oneshot};
 
 #[derive(Debug)]
 /// The service contains the backend handle, a subscription manager, and the
@@ -128,11 +128,11 @@ where
     fn service_get_sub(
         &mut self,
         local_id: U256,
-        tx: oneshot::Sender<broadcast::Receiver<Box<RawValue>>>,
+        tx: oneshot::Sender<RawSubscription>,
     ) -> TransportResult<()> {
         let local_id = local_id.into();
 
-        if let Some(rx) = self.subs.get_rx(local_id) {
+        if let Some(rx) = self.subs.get_subscription(local_id) {
             let _ = tx.send(rx);
         }
 

--- a/crates/pubsub/src/sub.rs
+++ b/crates/pubsub/src/sub.rs
@@ -143,8 +143,8 @@ impl<T> Subscription<T> {
         self.inner.len()
     }
 
-    /// Wrapper for [`resubscribe`]. Create a new [`SubInner`], starting from
-    /// the current tail element.
+    /// Wrapper for [`resubscribe`]. Create a new [`RawSubscription`], starting
+    /// from the current tail element.
     ///
     /// [`resubscribe`]: broadcast::Receiver::resubscribe
     pub fn resubscribe_inner(&self) -> RawSubscription {
@@ -197,6 +197,8 @@ impl<T: DeserializeOwned> Subscription<T> {
 
     /// Wrapper for [`blocking_recv`]. Block the current thread until a message
     /// of the expected type is available.
+    ///
+    /// [`blocking_recv`]: broadcast::Receiver::blocking_recv
     pub fn blocking_recv(&mut self) -> Result<T, broadcast::error::RecvError> {
         loop {
             match self.blocking_recv_any()? {
@@ -208,6 +210,8 @@ impl<T: DeserializeOwned> Subscription<T> {
 
     /// Wrapper for [`recv`]. Await an item of the expected type from the
     /// channel.
+    ///
+    /// [`recv`]: broadcast::Receiver::recv
     pub async fn recv(&mut self) -> Result<T, broadcast::error::RecvError> {
         loop {
             match self.recv_any().await? {
@@ -219,6 +223,8 @@ impl<T: DeserializeOwned> Subscription<T> {
 
     /// Wrapper for [`try_recv`]. Attempt to receive a message of the expected
     /// type from the channel without awaiting.
+    ///
+    /// [`try_recv`]: broadcast::Receiver::try_recv
     pub fn try_recv(&mut self) -> Result<T, broadcast::error::TryRecvError> {
         loop {
             match self.try_recv_any()? {

--- a/crates/pubsub/src/sub.rs
+++ b/crates/pubsub/src/sub.rs
@@ -118,6 +118,12 @@ impl<T> Subscription<T> {
         self.inner.local_id()
     }
 
+    /// Convert the subscription into its inner [`RawSubscription`].
+    #[allow(clippy::missing_const_for_fn)] // erroneous lint
+    pub fn into_raw(self) -> RawSubscription {
+        self.inner
+    }
+
     /// Get a reference to the inner subscription.
     pub const fn inner(&self) -> &RawSubscription {
         &self.inner

--- a/crates/pubsub/src/sub.rs
+++ b/crates/pubsub/src/sub.rs
@@ -1,0 +1,187 @@
+use alloy_primitives::B256;
+use serde::de::DeserializeOwned;
+use serde_json::value::RawValue;
+use tokio::sync::broadcast;
+
+/// A Subscription is a feed of notifications from the server, identified by a
+/// local ID.
+///
+/// This type is mostly a wrapper around [`broadcast::Receiver`], and exposes
+/// the same methods.
+#[derive(Debug)]
+pub struct RawSubscription {
+    /// The channel via which notifications are received.
+    pub(crate) rx: broadcast::Receiver<Box<RawValue>>,
+    /// The local ID of the subscription.
+    pub(crate) local_id: B256,
+}
+
+impl RawSubscription {
+    /// Get the local ID of the subscription.
+    pub const fn local_id(&self) -> B256 {
+        self.local_id
+    }
+
+    /// Wrapper for [`blocking_recv`]. Block the current thread until a message
+    /// is available.
+    ///
+    /// [`blocking_recv`]: broadcast::Receiver::blocking_recv
+    pub fn blocking_recv(&mut self) -> Result<Box<RawValue>, broadcast::error::RecvError> {
+        self.rx.blocking_recv()
+    }
+
+    /// Returns `true` if the broadcast channel is empty (i.e. there are
+    /// currently no notifications to receive).
+    pub fn is_empty(&self) -> bool {
+        self.rx.is_empty()
+    }
+
+    /// Returns the number of messages in the broadcast channel that this
+    /// receiver has yet to receive.
+    pub fn len(&self) -> usize {
+        self.rx.len()
+    }
+
+    /// Wrapper for [`recv`]. Await an item from the channel.
+    ///
+    /// [`recv`]: broadcast::Receiver::recv
+    pub async fn recv(&mut self) -> Result<Box<RawValue>, broadcast::error::RecvError> {
+        self.rx.recv().await
+    }
+
+    /// Wrapper for [`resubscribe`]. Create a new Subscription, starting from
+    /// the current tail element.
+    ///
+    /// [`resubscribe`]: broadcast::Receiver::resubscribe
+    pub fn resubscribe(&self) -> Self {
+        Self { rx: self.rx.resubscribe(), local_id: self.local_id }
+    }
+
+    /// Wrapper for [`same_channel`]. Returns `true` if the two subscriptions
+    /// share the same broadcast channel.
+    ///
+    /// [`same_channel`]: broadcast::Receiver::same_channel
+    pub fn same_channel(&self, other: &Self) -> bool {
+        self.rx.same_channel(&other.rx)
+    }
+
+    /// Wrapper for [`try_recv`]. Attempt to receive a message from the channel
+    /// without awaiting.
+    ///
+    /// [`try_recv`]: broadcast::Receiver::try_recv
+    pub fn try_recv(&mut self) -> Result<Box<RawValue>, broadcast::error::TryRecvError> {
+        self.rx.try_recv()
+    }
+}
+
+#[derive(Debug)]
+/// An item in a typed [`Subscription`]. This is either the expected type, or
+/// some serialized value of another type.
+pub enum SubscriptionItem<T> {
+    /// The expected item.
+    Item(T),
+    /// Some other value.
+    Other(Box<RawValue>),
+}
+
+impl<T: DeserializeOwned> From<Box<RawValue>> for SubscriptionItem<T> {
+    fn from(value: Box<RawValue>) -> Self {
+        if let Ok(item) = serde_json::from_str(value.get()) {
+            SubscriptionItem::Item(item)
+        } else {
+            SubscriptionItem::Other(value)
+        }
+    }
+}
+
+/// A Subscription is a feed of notifications from the server of a specific
+/// type `T`, identified by a local ID.
+#[derive(Debug)]
+pub struct Subscription<T> {
+    pub(crate) inner: RawSubscription,
+    _pd: std::marker::PhantomData<T>,
+}
+
+impl<T> From<RawSubscription> for Subscription<T> {
+    fn from(inner: RawSubscription) -> Self {
+        Self { inner, _pd: std::marker::PhantomData }
+    }
+}
+
+impl<T> Subscription<T> {
+    /// Get the local ID of the subscription.
+    pub fn local_id(&self) -> B256 {
+        self.inner.local_id()
+    }
+
+    /// Get a reference to the inner subscription.
+    pub fn inner(&self) -> &RawSubscription {
+        &self.inner
+    }
+
+    /// Get a mutable reference to the inner subscription.
+    pub fn inner_mut(&mut self) -> &mut RawSubscription {
+        &mut self.inner
+    }
+
+    /// Returns `true` if the broadcast channel is empty (i.e. there are
+    /// currently no notifications to receive).
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    /// Returns the number of messages in the broadcast channel that this
+    /// receiver has yet to receive.
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    /// Wrapper for [`resubscribe`]. Create a new [`SubInner`], starting from
+    /// the current tail element.
+    ///
+    /// [`resubscribe`]: broadcast::Receiver::resubscribe
+    pub fn resubscribe_inner(&self) -> RawSubscription {
+        self.inner.resubscribe()
+    }
+
+    /// Wrapper for [`resubscribe`]. Create a new `Subscription`, starting from
+    /// the current tail element.
+    ///
+    /// [`resubscribe`]: broadcast::Receiver::resubscribe
+    pub fn resubscribe(&self) -> Self {
+        self.inner.resubscribe().into()
+    }
+
+    /// Wrapper for [`same_channel`]. Returns `true` if the two subscriptions
+    /// share the same broadcast channel.
+    ///
+    /// [`same_channel`]: broadcast::Receiver::same_channel
+    pub fn same_channel<U>(&self, other: &Subscription<U>) -> bool {
+        self.inner.same_channel(&other.inner)
+    }
+}
+
+impl<T: DeserializeOwned> Subscription<T> {
+    /// Wrapper for [`blocking_recv`]. Block the current thread until a message
+    /// is available.
+    ///
+    /// [`blocking_recv`]: broadcast::Receiver::blocking_recv
+    pub fn blocking_recv(&mut self) -> Result<SubscriptionItem<T>, broadcast::error::RecvError> {
+        self.inner.blocking_recv().map(Into::into)
+    }
+
+    /// Wrapper for [`recv`]. Await an item from the channel.
+    ///
+    /// [`recv`]: broadcast::Receiver::recv
+    pub async fn recv(&mut self) -> Result<Box<RawValue>, broadcast::error::RecvError> {
+        self.inner.recv().await.map(Into::into)
+    }
+
+    /// Wrapper for [`try_recv`]. Attempt to receive a message from the channel
+    /// without awaiting.
+    ///
+    /// [`try_recv`]: broadcast::Receiver::try_recv
+    pub fn try_recv(&mut self) -> Result<SubscriptionItem<T>, broadcast::error::TryRecvError> {
+        self.inner.try_recv().map(Into::into)
+    }
+}

--- a/crates/pubsub/src/sub.rs
+++ b/crates/pubsub/src/sub.rs
@@ -114,12 +114,12 @@ impl<T> From<RawSubscription> for Subscription<T> {
 
 impl<T> Subscription<T> {
     /// Get the local ID of the subscription.
-    pub fn local_id(&self) -> B256 {
+    pub const fn local_id(&self) -> B256 {
         self.inner.local_id()
     }
 
     /// Get a reference to the inner subscription.
-    pub fn inner(&self) -> &RawSubscription {
+    pub const fn inner(&self) -> &RawSubscription {
         &self.inner
     }
 

--- a/crates/rpc-client/Cargo.toml
+++ b/crates/rpc-client/Cargo.toml
@@ -47,6 +47,6 @@ tracing-subscriber = { version = "0.3.17", features = ["std", "env-filter"] }
 default = ["reqwest"]
 reqwest = ["dep:url", "dep:reqwest", "alloy-transport-http/reqwest"]
 hyper = ["dep:url", "dep:hyper", "alloy-transport-http/hyper"]
-pubsub = ["dep:tokio", "dep:alloy-pubsub", "dep:alloy-primitives"]
+pubsub = ["dep:alloy-pubsub", "dep:alloy-primitives"]
 ws = ["pubsub", "dep:alloy-transport-ws"]
 ipc = ["pubsub", "dep:alloy-transport-ipc"]

--- a/crates/rpc-client/Cargo.toml
+++ b/crates/rpc-client/Cargo.toml
@@ -27,7 +27,6 @@ alloy-pubsub = { workspace = true, optional = true }
 alloy-transport-ws = { workspace = true, optional = true }
 hyper = { workspace = true, optional = true }
 reqwest = { workspace = true, optional = true }
-tokio = { workspace = true, optional = true }
 url = { workspace = true, optional = true }
 serde.workspace = true
 

--- a/crates/rpc-client/Cargo.toml
+++ b/crates/rpc-client/Cargo.toml
@@ -28,7 +28,8 @@ alloy-transport-ws = { workspace = true, optional = true }
 hyper = { workspace = true, optional = true }
 reqwest = { workspace = true, optional = true }
 url = { workspace = true, optional = true }
-serde.workspace = true
+
+serde =  { workspace = true, optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 alloy-transport-ipc = { workspace = true, optional = true }
@@ -47,6 +48,6 @@ tracing-subscriber = { version = "0.3.17", features = ["std", "env-filter"] }
 default = ["reqwest"]
 reqwest = ["dep:url", "dep:reqwest", "alloy-transport-http/reqwest"]
 hyper = ["dep:url", "dep:hyper", "alloy-transport-http/hyper"]
-pubsub = ["dep:alloy-pubsub", "dep:alloy-primitives"]
+pubsub = ["dep:alloy-pubsub", "dep:alloy-primitives", "dep:serde"]
 ws = ["pubsub", "dep:alloy-transport-ws"]
 ipc = ["pubsub", "dep:alloy-transport-ipc"]

--- a/crates/rpc-client/Cargo.toml
+++ b/crates/rpc-client/Cargo.toml
@@ -29,6 +29,7 @@ hyper = { workspace = true, optional = true }
 reqwest = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }
 url = { workspace = true, optional = true }
+serde.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 alloy-transport-ipc = { workspace = true, optional = true }

--- a/crates/rpc-client/Cargo.toml
+++ b/crates/rpc-client/Cargo.toml
@@ -40,6 +40,8 @@ alloy-node-bindings.workspace = true
 alloy-transport-ipc = { workspace = true, features = ["mock"] }
 alloy-transport-ws.workspace = true
 
+tokio.workspace = true
+
 tempfile = "3"
 test-log = { version = "0.2.13", default-features = false, features = ["trace"] }
 tracing-subscriber = { version = "0.3.17", features = ["std", "env-filter"] }

--- a/crates/rpc-client/src/client.rs
+++ b/crates/rpc-client/src/client.rs
@@ -131,12 +131,20 @@ where
 #[cfg(feature = "pubsub")]
 mod pubsub_impl {
     use super::*;
-    use alloy_pubsub::{PubSubConnect, PubSubFrontend, Subscription};
+    use alloy_pubsub::{PubSubConnect, PubSubFrontend, RawSubscription, Subscription};
 
     impl RpcClient<PubSubFrontend> {
-        /// Get a [`broadcast::Receiver`] for the given subscription ID.
-        pub async fn get_watcher(&self, id: alloy_primitives::U256) -> Subscription {
+        /// Get a [`RawSubscription`] for the given subscription ID.
+        pub async fn get_raw_subscription(&self, id: alloy_primitives::U256) -> RawSubscription {
             self.transport.get_subscription(id).await.unwrap()
+        }
+
+        /// Get a [`Subscription`] for the given subscription ID.
+        pub async fn get_subscription<T: serde::de::DeserializeOwned>(
+            &self,
+            id: alloy_primitives::U256,
+        ) -> Subscription<T> {
+            Subscription::from(self.get_raw_subscription(id).await)
         }
 
         /// Connect to a transport via a [`PubSubConnect`] implementor.

--- a/crates/rpc-client/src/client.rs
+++ b/crates/rpc-client/src/client.rs
@@ -131,15 +131,11 @@ where
 #[cfg(feature = "pubsub")]
 mod pubsub_impl {
     use super::*;
-    use alloy_pubsub::{PubSubConnect, PubSubFrontend};
-    use tokio::sync::broadcast;
+    use alloy_pubsub::{PubSubConnect, PubSubFrontend, Subscription};
 
     impl RpcClient<PubSubFrontend> {
         /// Get a [`broadcast::Receiver`] for the given subscription ID.
-        pub async fn get_watcher(
-            &self,
-            id: alloy_primitives::U256,
-        ) -> broadcast::Receiver<Box<serde_json::value::RawValue>> {
+        pub async fn get_watcher(&self, id: alloy_primitives::U256) -> Subscription {
             self.transport.get_subscription(id).await.unwrap()
         }
 


### PR DESCRIPTION
Adds the following types:
- `RawSubscription`
- `SubscriptionItem<T>`
- `Subscription<T>`

## Motivation

Lay groundwork for RAII subscriptions and subscription configuration.

## Solution

Add `Subscription` type around the raw `tokio::broadcast::Receiver`

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [x] Breaking changes
