### PR TITLE
refactor: dedupe `CallRequest`/`TransactionRequest`

### DIFF
--- a/crates/contract/src/call.rs
+++ b/crates/contract/src/call.rs
@@ -285,7 +285,8 @@ impl<P: TempProvider, D: CallDecoder> CallBuilder<P, D> {
     /// If the internal transaction is an EIP-1559 one, then it sets both
     /// `max_fee_per_gas` and `max_priority_fee_per_gas` to the same value
     pub fn gas_price(mut self, gas_price: U256) -> Self {
-        self.request = self.request.gas_price(gas_price);
+        self.request = self.request.max_fee_per_gas(gas_price);
+        self.request = self.request.max_priority_fee_per_gas(gas_price);
         self
     }
 

--- a/crates/contract/src/call.rs
+++ b/crates/contract/src/call.rs
@@ -3,7 +3,11 @@ use alloy_dyn_abi::{DynSolValue, FunctionExt, JsonAbiExt};
 use alloy_json_abi::Function;
 use alloy_primitives::{Address, Bytes, U256, U64};
 use alloy_providers::provider::TempProvider;
-use alloy_rpc_types::{state::StateOverride, BlockId, CallInput, CallRequest, TransactionReceipt};
+use alloy_rpc_types::{
+    request::{TransactionInput, TransactionRequest},
+    state::StateOverride,
+    BlockId, TransactionReceipt,
+};
 use alloy_sol_types::SolCall;
 use std::{
     future::{Future, IntoFuture},
@@ -189,7 +193,7 @@ impl CallDecoder for () {
 pub struct CallBuilder<P, D> {
     // TODO: this will not work with `send_transaction` and does not differentiate between EIP-1559
     // and legacy tx
-    request: CallRequest,
+    request: TransactionRequest,
     block: Option<BlockId>,
     state: Option<StateOverride>,
     provider: P,
@@ -249,7 +253,8 @@ impl<P: TempProvider> RawCallBuilder<P> {
 
 impl<P: TempProvider, D: CallDecoder> CallBuilder<P, D> {
     fn new_inner(provider: P, input: Bytes, decoder: D) -> Self {
-        let request = CallRequest { input: CallInput::new(input), ..Default::default() };
+        let request =
+            TransactionRequest { input: TransactionInput::new(input), ..Default::default() };
         Self { request, decoder, provider, block: None, state: None }
     }
 

--- a/crates/contract/src/call.rs
+++ b/crates/contract/src/call.rs
@@ -277,7 +277,7 @@ impl<P: TempProvider, D: CallDecoder> CallBuilder<P, D> {
 
     /// Sets the `gas` field in the transaction to the provided value
     pub fn gas(mut self, gas: U256) -> Self {
-        self.request = self.request.gas(gas);
+        self.request = self.request.gas_limit(gas);
         self
     }
 

--- a/crates/rpc-trace-types/src/tracerequest.rs
+++ b/crates/rpc-trace-types/src/tracerequest.rs
@@ -1,7 +1,7 @@
 //! Builder style functions for `trace_call`
 
 use crate::parity::TraceType;
-use alloy_rpc_types::{state::StateOverride, BlockId, BlockOverrides, CallRequest};
+use alloy_rpc_types::{request::TransactionRequest, state::StateOverride, BlockId, BlockOverrides};
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 
@@ -9,7 +9,7 @@ use std::collections::HashSet;
 #[derive(Debug, Serialize, Deserialize, Default)]
 pub struct TraceCallRequest {
     /// call request object
-    pub call: CallRequest,
+    pub call: TransactionRequest,
     /// trace types
     pub trace_types: HashSet<TraceType>,
     /// Optional: blockId
@@ -21,8 +21,8 @@ pub struct TraceCallRequest {
 }
 
 impl TraceCallRequest {
-    /// Returns a new [`TraceCallRequest`] given a [`CallRequest`] and [`HashSet<TraceType>`]
-    pub fn new(call: CallRequest) -> Self {
+    /// Returns a new [`TraceCallRequest`] given a [`TransactionRequest`] and [`HashSet<TraceType>`]
+    pub fn new(call: TransactionRequest) -> Self {
         Self {
             call,
             trace_types: HashSet::new(),

--- a/crates/rpc-types/src/eth/call.rs
+++ b/crates/rpc-types/src/eth/call.rs
@@ -1,5 +1,5 @@
-use crate::{AccessList, BlockId, BlockOverrides};
-use alloy_primitives::{Address, Bytes, B256, U256, U64, U8};
+use crate::{request::TransactionRequest, BlockId, BlockOverrides};
+use alloy_primitives::Bytes;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 /// Bundle of transactions
@@ -7,7 +7,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 #[serde(default, rename_all = "camelCase")]
 pub struct Bundle {
     /// All transactions to execute
-    pub transactions: Vec<CallRequest>,
+    pub transactions: Vec<TransactionRequest>,
     /// Block overrides to apply
     pub block_override: Option<BlockOverrides>,
 }
@@ -97,201 +97,6 @@ impl<'de> Deserialize<'de> for TransactionIndex {
     }
 }
 
-/// Call request for `eth_call` and adjacent methods.
-#[derive(Debug, Clone, Default, Eq, PartialEq, Serialize, Deserialize, Hash)]
-#[serde(default, rename_all = "camelCase")]
-pub struct CallRequest {
-    /// From
-    pub from: Option<Address>,
-    /// To
-    pub to: Option<Address>,
-    /// Gas Price
-    pub gas_price: Option<U256>,
-    /// EIP-1559 Max base fee the caller is willing to pay
-    pub max_fee_per_gas: Option<U256>,
-    /// EIP-1559 Priority fee the caller is paying to the block author
-    pub max_priority_fee_per_gas: Option<U256>,
-    /// Gas
-    pub gas: Option<U256>,
-    /// Value
-    pub value: Option<U256>,
-    /// Transaction input data
-    #[serde(default, flatten)]
-    pub input: CallInput,
-    /// Nonce
-    pub nonce: Option<U64>,
-    /// chain id
-    pub chain_id: Option<U64>,
-    /// AccessList
-    pub access_list: Option<AccessList>,
-    /// Max Fee per Blob gas for EIP-4844 transactions
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub max_fee_per_blob_gas: Option<U256>,
-    /// Blob Versioned Hashes for EIP-4844 transactions
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub blob_versioned_hashes: Option<Vec<B256>>,
-    /// EIP-2718 type
-    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
-    pub transaction_type: Option<U8>,
-}
-
-impl CallRequest {
-    /// Returns the configured fee cap, if any.
-    ///
-    /// The returns `gas_price` (legacy) if set or `max_fee_per_gas` (EIP1559)
-    #[inline]
-    pub fn fee_cap(&self) -> Option<U256> {
-        self.gas_price.or(self.max_fee_per_gas)
-    }
-
-    /// Returns true if the request has a `blobVersionedHashes` field but it is empty.
-    #[inline]
-    pub fn has_empty_blob_hashes(&self) -> bool {
-        self.blob_versioned_hashes.as_ref().map(|blobs| blobs.is_empty()).unwrap_or(false)
-    }
-
-    /// Sets the `from` field in the call to the provided address
-    #[inline]
-    pub const fn from(mut self, from: Address) -> Self {
-        self.from = Some(from);
-        self
-    }
-
-    /// Sets the `to` field in the call to the provided address
-    #[inline]
-    pub const fn to(mut self, to: Option<Address>) -> Self {
-        self.to = to;
-        self
-    }
-
-    /// Sets the `gas` field in the transaction to the provided value
-    pub const fn gas(mut self, gas: U256) -> Self {
-        self.gas = Some(gas);
-        self
-    }
-
-    /// Sets the `gas_price` field in the transaction to the provided value
-    /// If the internal transaction is an EIP-1559 one, then it sets both
-    /// `max_fee_per_gas` and `max_priority_fee_per_gas` to the same value
-    pub const fn gas_price(mut self, gas_price: U256) -> Self {
-        // todo: Add legacy support
-        self.max_fee_per_gas = Some(gas_price);
-        self.max_fee_per_gas = Some(gas_price);
-        self
-    }
-
-    /// Sets the `value` field in the transaction to the provided value
-    pub const fn value(mut self, value: U256) -> Self {
-        self.value = Some(value);
-        self
-    }
-
-    /// Sets the `nonce` field in the transaction to the provided value
-    pub const fn nonce(mut self, nonce: U64) -> Self {
-        self.nonce = Some(nonce);
-        self
-    }
-
-    /// Calculates the address that will be created by the transaction, if any.
-    ///
-    /// Returns `None` if the transaction is not a contract creation (the `to` field is set), or if
-    /// the `from` or `nonce` fields are not set.
-    pub fn calculate_create_address(&self) -> Option<Address> {
-        if self.to.is_some() {
-            return None;
-        }
-        let from = self.from.as_ref()?;
-        let nonce = self.nonce?;
-        Some(from.create(nonce.to()))
-    }
-}
-
-/// Helper type that supports both `data` and `input` fields that map to transaction input data.
-///
-/// This is done for compatibility reasons where older implementations used `data` instead of the
-/// newer, recommended `input` field.
-///
-/// If both fields are set, it is expected that they contain the same value, otherwise an error is
-/// returned.
-#[derive(Debug, Clone, Default, Eq, PartialEq, Serialize, Deserialize, Hash)]
-pub struct CallInput {
-    /// Transaction data
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub input: Option<Bytes>,
-    /// Transaction data
-    ///
-    /// This is the same as `input` but is used for backwards compatibility: <https://github.com/ethereum/go-ethereum/issues/15628>
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub data: Option<Bytes>,
-}
-
-impl CallInput {
-    /// Creates a new instance with the given input data.
-    pub const fn new(data: Bytes) -> Self {
-        Self::maybe_input(Some(data))
-    }
-
-    /// Creates a new instance with the given input data.
-    pub const fn maybe_input(input: Option<Bytes>) -> Self {
-        Self { input, data: None }
-    }
-
-    /// Consumes the type and returns the optional input data.
-    #[inline]
-    pub fn into_input(self) -> Option<Bytes> {
-        self.input.or(self.data)
-    }
-
-    /// Consumes the type and returns the optional input data.
-    ///
-    /// Returns an error if both `data` and `input` fields are set and not equal.
-    #[inline]
-    pub fn try_into_unique_input(self) -> Result<Option<Bytes>, CallInputError> {
-        self.check_unique_input().map(|()| self.into_input())
-    }
-
-    /// Returns the optional input data.
-    #[inline]
-    pub fn input(&self) -> Option<&Bytes> {
-        self.input.as_ref().or(self.data.as_ref())
-    }
-
-    /// Returns the optional input data.
-    ///
-    /// Returns an error if both `data` and `input` fields are set and not equal.
-    #[inline]
-    pub fn unique_input(&self) -> Result<Option<&Bytes>, CallInputError> {
-        self.check_unique_input().map(|()| self.input())
-    }
-
-    fn check_unique_input(&self) -> Result<(), CallInputError> {
-        if let (Some(input), Some(data)) = (&self.input, &self.data) {
-            if input != data {
-                return Err(CallInputError::default());
-            }
-        }
-        Ok(())
-    }
-}
-
-impl From<Bytes> for CallInput {
-    fn from(input: Bytes) -> Self {
-        Self { input: Some(input), data: None }
-    }
-}
-
-impl From<Option<Bytes>> for CallInput {
-    fn from(input: Option<Bytes>) -> Self {
-        Self { input, data: None }
-    }
-}
-
-/// Error thrown when both `data` and `input` fields are set and not equal.
-#[derive(Debug, Default, thiserror::Error)]
-#[error("both \"data\" and \"input\" are set and not equal. Please use \"input\" to pass transaction call data")]
-#[non_exhaustive]
-pub struct CallInputError;
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -309,30 +114,5 @@ mod tests {
         let s = "-2";
         let res = serde_json::from_str::<TransactionIndex>(s);
         assert!(res.is_err());
-    }
-
-    #[test]
-    fn serde_call_request() {
-        let s = r#"{"accessList":[],"data":"0x0902f1ac","to":"0xa478c2975ab1ea89e8196811f51a7b7ade33eb11","type":"0x02"}"#;
-        let _req = serde_json::from_str::<CallRequest>(s).unwrap();
-    }
-
-    #[test]
-    fn serde_unique_call_input() {
-        let s = r#"{"accessList":[],"data":"0x0902f1ac", "input":"0x0902f1ac","to":"0xa478c2975ab1ea89e8196811f51a7b7ade33eb11","type":"0x02"}"#;
-        let req = serde_json::from_str::<CallRequest>(s).unwrap();
-        assert!(req.input.try_into_unique_input().unwrap().is_some());
-
-        let s = r#"{"accessList":[],"data":"0x0902f1ac","to":"0xa478c2975ab1ea89e8196811f51a7b7ade33eb11","type":"0x02"}"#;
-        let req = serde_json::from_str::<CallRequest>(s).unwrap();
-        assert!(req.input.try_into_unique_input().unwrap().is_some());
-
-        let s = r#"{"accessList":[],"input":"0x0902f1ac","to":"0xa478c2975ab1ea89e8196811f51a7b7ade33eb11","type":"0x02"}"#;
-        let req = serde_json::from_str::<CallRequest>(s).unwrap();
-        assert!(req.input.try_into_unique_input().unwrap().is_some());
-
-        let s = r#"{"accessList":[],"data":"0x0902f1ac", "input":"0x0902f1","to":"0xa478c2975ab1ea89e8196811f51a7b7ade33eb11","type":"0x02"}"#;
-        let req = serde_json::from_str::<CallRequest>(s).unwrap();
-        assert!(req.input.try_into_unique_input().is_err());
     }
 }

--- a/crates/rpc-types/src/eth/mod.rs
+++ b/crates/rpc-types/src/eth/mod.rs
@@ -20,7 +20,7 @@ mod work;
 
 pub use account::*;
 pub use block::*;
-pub use call::{Bundle, CallInput, CallInputError, CallRequest, EthCallResponse, StateContext};
+pub use call::{Bundle, EthCallResponse, StateContext};
 pub use fee::{FeeHistory, TxGasAndReward};
 pub use filter::*;
 pub use index::Index;

--- a/crates/rpc-types/src/eth/transaction/blob.rs
+++ b/crates/rpc-types/src/eth/transaction/blob.rs
@@ -4,7 +4,7 @@ use crate::kzg::{Blob, Bytes48};
 use serde::{Deserialize, Serialize};
 
 /// This represents a set of blobs, and its corresponding commitments and proofs.
-#[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
 #[repr(C)]
 pub struct BlobTransactionSidecar {
     /// The blob data.

--- a/crates/rpc-types/src/eth/transaction/request.rs
+++ b/crates/rpc-types/src/eth/transaction/request.rs
@@ -3,48 +3,48 @@ use crate::{eth::transaction::AccessList, other::OtherFields, BlobTransactionSid
 use alloy_primitives::{Address, Bytes, B256, U128, U256, U64, U8};
 use serde::{Deserialize, Serialize};
 
-/// Represents _all_ transaction requests to/from RPC
+/// Represents _all_ transaction requests to/from RPC.
 #[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 #[serde(rename_all = "camelCase")]
 pub struct TransactionRequest {
-    /// from address
+    /// The address of the transaction author.
     pub from: Option<Address>,
-    /// to address
+    /// The destination address of the transaction.
     pub to: Option<Address>,
-    /// legacy, gas Price
+    /// The legacy gas price.
     #[serde(default)]
     pub gas_price: Option<U128>,
-    /// max base fee per gas sender is willing to pay
+    /// The max base fee per gas the sender is willing to pay.
     #[serde(default)]
     pub max_fee_per_gas: Option<U128>,
-    /// miner tip
+    /// The max priority fee per gas the sender is willing to pay, also called the miner tip.
     #[serde(default)]
     pub max_priority_fee_per_gas: Option<U128>,
-    /// Max Fee per Blob gas for EIP-4844 transactions
+    /// The max fee per blob gas for EIP-4844 blob transactions.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_fee_per_blob_gas: Option<U256>,
-    /// gas
+    /// The gas limit for the transaction.
     pub gas: Option<U256>,
-    /// value of th tx in wei
+    /// The value transferred in the transaction, in wei.
     pub value: Option<U256>,
-    /// Any additional data sent
+    /// Transaction data.
     #[serde(default, flatten)]
     pub input: TransactionInput,
-    /// Transaction nonce
+    /// The nonce of the transaction.
     pub nonce: Option<U64>,
-    /// chain id
+    /// The chain ID for the transaction.
     pub chain_id: Option<U64>,
-    /// warm storage access pre-payment
+    /// An EIP-2930 access list, which lowers cost for accessing accounts and storages in the list. See [EIP-2930](https://eips.ethereum.org/EIPS/eip-2930) for more information.
     #[serde(default)]
     pub access_list: Option<AccessList>,
-    /// EIP-2718 type
+    /// The EIP-2718 transaction type. See [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718) for more information.
     #[serde(rename = "type")]
     pub transaction_type: Option<U8>,
-    /// Blob Versioned Hashes for EIP-4844 transactions
+    /// Blob versioned hashes for EIP-4844 transactions.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub blob_versioned_hashes: Option<Vec<B256>>,
-    /// sidecar for EIP-4844 transactions
+    /// Blob sidecar for EIP-4844 transactions.
     pub sidecar: Option<BlobTransactionSidecar>,
     /// Support for arbitrary additional fields.
     #[serde(flatten)]

--- a/crates/rpc-types/src/eth/transaction/request.rs
+++ b/crates/rpc-types/src/eth/transaction/request.rs
@@ -103,8 +103,8 @@ impl TransactionRequest {
     }
 
     /// Sets the gas limit for the transaction.
-    pub fn gas_limit(mut self, gas_limit: u64) -> Self {
-        self.gas = Some(U256::from(gas_limit));
+    pub fn gas_limit(mut self, gas_limit: U256) -> Self {
+        self.gas = Some(gas_limit);
         self
     }
 

--- a/crates/rpc-types/src/eth/transaction/request.rs
+++ b/crates/rpc-types/src/eth/transaction/request.rs
@@ -127,8 +127,8 @@ impl TransactionRequest {
 
     /// Sets the recipient address for the transaction.
     #[inline]
-    pub const fn to(mut self, to: Address) -> Self {
-        self.to = Some(to);
+    pub const fn to(mut self, to: Option<Address>) -> Self {
+        self.to = to;
         self
     }
 

--- a/crates/rpc-types/src/eth/transaction/request.rs
+++ b/crates/rpc-types/src/eth/transaction/request.rs
@@ -109,8 +109,8 @@ impl TransactionRequest {
     }
 
     /// Sets the nonce for the transaction.
-    pub fn nonce(mut self, nonce: u64) -> Self {
-        self.nonce = Some(U64::from(nonce));
+    pub fn nonce(mut self, nonce: U64) -> Self {
+        self.nonce = Some(nonce);
         self
     }
 

--- a/crates/rpc-types/src/eth/transaction/request.rs
+++ b/crates/rpc-types/src/eth/transaction/request.rs
@@ -103,25 +103,25 @@ impl TransactionRequest {
     }
 
     /// Sets the gas limit for the transaction.
-    pub fn gas_limit(mut self, gas_limit: U256) -> Self {
+    pub const fn gas_limit(mut self, gas_limit: U256) -> Self {
         self.gas = Some(gas_limit);
         self
     }
 
     /// Sets the nonce for the transaction.
-    pub fn nonce(mut self, nonce: U64) -> Self {
+    pub const fn nonce(mut self, nonce: U64) -> Self {
         self.nonce = Some(nonce);
         self
     }
 
     /// Sets the maximum fee per gas for the transaction.
-    pub fn max_fee_per_gas(mut self, max_fee_per_gas: U256) -> Self {
+    pub const fn max_fee_per_gas(mut self, max_fee_per_gas: U256) -> Self {
         self.max_fee_per_gas = Some(max_fee_per_gas);
         self
     }
 
     /// Sets the maximum priority fee per gas for the transaction.
-    pub fn max_priority_fee_per_gas(mut self, max_priority_fee_per_gas: U256) -> Self {
+    pub const fn max_priority_fee_per_gas(mut self, max_priority_fee_per_gas: U256) -> Self {
         self.max_priority_fee_per_gas = Some(max_priority_fee_per_gas);
         self
     }
@@ -134,7 +134,7 @@ impl TransactionRequest {
     }
 
     /// Sets the value (amount) for the transaction.
-    pub fn value(mut self, value: U256) -> Self {
+    pub const fn value(mut self, value: U256) -> Self {
         self.value = Some(value);
         self
     }

--- a/crates/rpc-types/src/eth/transaction/request.rs
+++ b/crates/rpc-types/src/eth/transaction/request.rs
@@ -1,9 +1,9 @@
 //! Alloy basic Transaction Request type.
-use crate::{eth::transaction::AccessList, other::OtherFields, BlobTransactionSidecar};
-use alloy_primitives::{Address, Bytes, U128, U256, U64, U8};
+use crate::{eth::transaction::AccessList, other::OtherFields};
+use alloy_primitives::{Address, Bytes, B256, U128, U256, U64, U8};
 use serde::{Deserialize, Serialize};
 
-/// Represents _all_ transaction requests received from RPC
+/// Represents _all_ transaction requests to/from RPC
 #[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 #[serde(rename_all = "camelCase")]
@@ -21,13 +21,16 @@ pub struct TransactionRequest {
     /// miner tip
     #[serde(default)]
     pub max_priority_fee_per_gas: Option<U128>,
+    /// Max Fee per Blob gas for EIP-4844 transactions
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_fee_per_blob_gas: Option<U256>,
     /// gas
     pub gas: Option<U256>,
     /// value of th tx in wei
     pub value: Option<U256>,
     /// Any additional data sent
-    #[serde(alias = "input")]
-    pub data: Option<Bytes>,
+    #[serde(default, flatten)]
+    pub input: TransactionInput,
     /// Transaction nonce
     pub nonce: Option<U64>,
     /// warm storage access pre-payment
@@ -36,8 +39,11 @@ pub struct TransactionRequest {
     /// EIP-2718 type
     #[serde(rename = "type")]
     pub transaction_type: Option<U8>,
-    /// sidecar for EIP-4844 transactions
-    pub sidecar: Option<BlobTransactionSidecar>,
+    /// Blob Versioned Hashes for EIP-4844 transactions
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub blob_versioned_hashes: Option<Vec<B256>>,
+    /// chain id
+    pub chain_id: Option<U64>,
     /// Support for arbitrary additional fields.
     #[serde(flatten)]
     pub other: OtherFields,
@@ -46,6 +52,27 @@ pub struct TransactionRequest {
 // == impl TransactionRequest ==
 
 impl TransactionRequest {
+    /// Returns the configured fee cap, if any.
+    ///
+    /// The returns `gas_price` (legacy) if set or `max_fee_per_gas` (EIP1559)
+    #[inline]
+    pub fn fee_cap(&self) -> Option<U128> {
+        self.gas_price.or(self.max_fee_per_gas)
+    }
+
+    /// Returns true if the request has a `blobVersionedHashes` field but it is empty.
+    #[inline]
+    pub fn has_empty_blob_hashes(&self) -> bool {
+        self.blob_versioned_hashes.as_ref().map(|blobs| blobs.is_empty()).unwrap_or(false)
+    }
+
+    /// Sets the `from` field in the call to the provided address
+    #[inline]
+    pub const fn from(mut self, from: Address) -> Self {
+        self.from = Some(from);
+        self
+    }
+
     /// Sets the gas limit for the transaction.
     pub fn gas_limit(mut self, gas_limit: u64) -> Self {
         self.gas = Some(U256::from(gas_limit));
@@ -71,12 +98,13 @@ impl TransactionRequest {
     }
 
     /// Sets the recipient address for the transaction.
+    #[inline]
     pub const fn to(mut self, to: Address) -> Self {
         self.to = Some(to);
         self
     }
-    /// Sets the value (amount) for the transaction.
 
+    /// Sets the value (amount) for the transaction.
     pub fn value(mut self, value: u128) -> Self {
         self.value = Some(U256::from(value));
         self
@@ -89,8 +117,8 @@ impl TransactionRequest {
     }
 
     /// Sets the input data for the transaction.
-    pub fn input(mut self, input: Bytes) -> Self {
-        self.data = Some(input);
+    pub fn input(mut self, input: TransactionInput) -> Self {
+        self.input = input;
         self
     }
 
@@ -98,5 +126,134 @@ impl TransactionRequest {
     pub fn transaction_type(mut self, transaction_type: u8) -> Self {
         self.transaction_type = Some(U8::from(transaction_type));
         self
+    }
+
+    /// Calculates the address that will be created by the transaction, if any.
+    ///
+    /// Returns `None` if the transaction is not a contract creation (the `to` field is set), or if
+    /// the `from` or `nonce` fields are not set.
+    pub fn calculate_create_address(&self) -> Option<Address> {
+        if self.to.is_some() {
+            return None;
+        }
+        let from = self.from.as_ref()?;
+        let nonce = self.nonce?;
+        Some(from.create(nonce.to()))
+    }
+}
+
+/// Helper type that supports both `data` and `input` fields that map to transaction input data.
+///
+/// This is done for compatibility reasons where older implementations used `data` instead of the
+/// newer, recommended `input` field.
+///
+/// If both fields are set, it is expected that they contain the same value, otherwise an error is
+/// returned.
+#[derive(Debug, Clone, Default, Eq, PartialEq, Serialize, Deserialize, Hash)]
+pub struct TransactionInput {
+    /// Transaction data
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub input: Option<Bytes>,
+    /// Transaction data
+    ///
+    /// This is the same as `input` but is used for backwards compatibility: <https://github.com/ethereum/go-ethereum/issues/15628>
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<Bytes>,
+}
+
+impl TransactionInput {
+    /// Creates a new instance with the given input data.
+    pub const fn new(data: Bytes) -> Self {
+        Self::maybe_input(Some(data))
+    }
+
+    /// Creates a new instance with the given input data.
+    pub const fn maybe_input(input: Option<Bytes>) -> Self {
+        Self { input, data: None }
+    }
+
+    /// Consumes the type and returns the optional input data.
+    #[inline]
+    pub fn into_input(self) -> Option<Bytes> {
+        self.input.or(self.data)
+    }
+
+    /// Consumes the type and returns the optional input data.
+    ///
+    /// Returns an error if both `data` and `input` fields are set and not equal.
+    #[inline]
+    pub fn try_into_unique_input(self) -> Result<Option<Bytes>, TransactionInputError> {
+        self.check_unique_input().map(|()| self.into_input())
+    }
+
+    /// Returns the optional input data.
+    #[inline]
+    pub fn input(&self) -> Option<&Bytes> {
+        self.input.as_ref().or(self.data.as_ref())
+    }
+
+    /// Returns the optional input data.
+    ///
+    /// Returns an error if both `data` and `input` fields are set and not equal.
+    #[inline]
+    pub fn unique_input(&self) -> Result<Option<&Bytes>, TransactionInputError> {
+        self.check_unique_input().map(|()| self.input())
+    }
+
+    fn check_unique_input(&self) -> Result<(), TransactionInputError> {
+        if let (Some(input), Some(data)) = (&self.input, &self.data) {
+            if input != data {
+                return Err(TransactionInputError::default());
+            }
+        }
+        Ok(())
+    }
+}
+
+impl From<Bytes> for TransactionInput {
+    fn from(input: Bytes) -> Self {
+        Self { input: Some(input), data: None }
+    }
+}
+
+impl From<Option<Bytes>> for TransactionInput {
+    fn from(input: Option<Bytes>) -> Self {
+        Self { input, data: None }
+    }
+}
+
+/// Error thrown when both `data` and `input` fields are set and not equal.
+#[derive(Debug, Default, thiserror::Error)]
+#[error("both \"data\" and \"input\" are set and not equal. Please use \"input\" to pass transaction call data")]
+#[non_exhaustive]
+pub struct TransactionInputError;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serde_tx_request() {
+        let s = r#"{"accessList":[],"data":"0x0902f1ac","to":"0xa478c2975ab1ea89e8196811f51a7b7ade33eb11","type":"0x02"}"#;
+        let _req = serde_json::from_str::<TransactionRequest>(s).unwrap();
+    }
+
+    #[test]
+    fn serde_unique_call_input() {
+        let s = r#"{"accessList":[],"data":"0x0902f1ac", "input":"0x0902f1ac","to":"0xa478c2975ab1ea89e8196811f51a7b7ade33eb11","type":"0x02"}"#;
+        let req = serde_json::from_str::<TransactionRequest>(s).unwrap();
+        assert!(req.input.try_into_unique_input().unwrap().is_some());
+
+        let s = r#"{"accessList":[],"data":"0x0902f1ac","to":"0xa478c2975ab1ea89e8196811f51a7b7ade33eb11","type":"0x02"}"#;
+        let req = serde_json::from_str::<TransactionRequest>(s).unwrap();
+        assert!(req.input.try_into_unique_input().unwrap().is_some());
+
+        let s = r#"{"accessList":[],"input":"0x0902f1ac","to":"0xa478c2975ab1ea89e8196811f51a7b7ade33eb11","type":"0x02"}"#;
+        let req = serde_json::from_str::<TransactionRequest>(s).unwrap();
+        assert!(req.input.try_into_unique_input().unwrap().is_some());
+
+        let s = r#"{"accessList":[],"data":"0x0902f1ac", "input":"0x0902f1","to":"0xa478c2975ab1ea89e8196811f51a7b7ade33eb11","type":"0x02"}"#;
+        let req = serde_json::from_str::<TransactionRequest>(s).unwrap();
+        assert!(req.input.try_into_unique_input().is_err());
     }
 }

--- a/crates/rpc-types/src/eth/transaction/request.rs
+++ b/crates/rpc-types/src/eth/transaction/request.rs
@@ -14,13 +14,13 @@ pub struct TransactionRequest {
     pub to: Option<Address>,
     /// The legacy gas price.
     #[serde(default)]
-    pub gas_price: Option<U128>,
+    pub gas_price: Option<U256>,
     /// The max base fee per gas the sender is willing to pay.
     #[serde(default)]
-    pub max_fee_per_gas: Option<U128>,
+    pub max_fee_per_gas: Option<U256>,
     /// The max priority fee per gas the sender is willing to pay, also called the miner tip.
     #[serde(default)]
-    pub max_priority_fee_per_gas: Option<U128>,
+    pub max_priority_fee_per_gas: Option<U256>,
     /// The max fee per blob gas for EIP-4844 blob transactions.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_fee_per_blob_gas: Option<U256>,
@@ -58,7 +58,7 @@ impl TransactionRequest {
     ///
     /// The returns `gas_price` (legacy) if set or `max_fee_per_gas` (EIP1559)
     #[inline]
-    pub fn fee_cap(&self) -> Option<U128> {
+    pub fn fee_cap(&self) -> Option<U256> {
         self.gas_price.or(self.max_fee_per_gas)
     }
 
@@ -88,14 +88,14 @@ impl TransactionRequest {
     }
 
     /// Sets the maximum fee per gas for the transaction.
-    pub fn max_fee_per_gas(mut self, max_fee_per_gas: u128) -> Self {
-        self.max_fee_per_gas = Some(U128::from(max_fee_per_gas));
+    pub fn max_fee_per_gas(mut self, max_fee_per_gas: U256) -> Self {
+        self.max_fee_per_gas = Some(max_fee_per_gas);
         self
     }
 
     /// Sets the maximum priority fee per gas for the transaction.
-    pub fn max_priority_fee_per_gas(mut self, max_priority_fee_per_gas: u128) -> Self {
-        self.max_priority_fee_per_gas = Some(U128::from(max_priority_fee_per_gas));
+    pub fn max_priority_fee_per_gas(mut self, max_priority_fee_per_gas: U256) -> Self {
+        self.max_priority_fee_per_gas = Some(max_priority_fee_per_gas);
         self
     }
 
@@ -107,8 +107,8 @@ impl TransactionRequest {
     }
 
     /// Sets the value (amount) for the transaction.
-    pub fn value(mut self, value: u128) -> Self {
-        self.value = Some(U256::from(value));
+    pub fn value(mut self, value: U256) -> Self {
+        self.value = Some(value);
         self
     }
 

--- a/crates/rpc-types/src/eth/transaction/request.rs
+++ b/crates/rpc-types/src/eth/transaction/request.rs
@@ -1,5 +1,5 @@
 //! Alloy basic Transaction Request type.
-use crate::{eth::transaction::AccessList, other::OtherFields};
+use crate::{eth::transaction::AccessList, other::OtherFields, BlobTransactionSidecar};
 use alloy_primitives::{Address, Bytes, B256, U128, U256, U64, U8};
 use serde::{Deserialize, Serialize};
 
@@ -33,6 +33,8 @@ pub struct TransactionRequest {
     pub input: TransactionInput,
     /// Transaction nonce
     pub nonce: Option<U64>,
+    /// chain id
+    pub chain_id: Option<U64>,
     /// warm storage access pre-payment
     #[serde(default)]
     pub access_list: Option<AccessList>,
@@ -42,8 +44,8 @@ pub struct TransactionRequest {
     /// Blob Versioned Hashes for EIP-4844 transactions
     #[serde(skip_serializing_if = "Option::is_none")]
     pub blob_versioned_hashes: Option<Vec<B256>>,
-    /// chain id
-    pub chain_id: Option<U64>,
+    /// sidecar for EIP-4844 transactions
+    pub sidecar: Option<BlobTransactionSidecar>,
     /// Support for arbitrary additional fields.
     #[serde(flatten)]
     pub other: OtherFields,

--- a/crates/rpc-types/src/eth/transaction/request.rs
+++ b/crates/rpc-types/src/eth/transaction/request.rs
@@ -1,4 +1,6 @@
 //! Alloy basic Transaction Request type.
+use std::hash::Hash;
+
 use crate::{eth::transaction::AccessList, other::OtherFields, BlobTransactionSidecar};
 use alloy_primitives::{Address, Bytes, B256, U256, U64, U8};
 use serde::{Deserialize, Serialize};
@@ -49,6 +51,30 @@ pub struct TransactionRequest {
     /// Support for arbitrary additional fields.
     #[serde(flatten)]
     pub other: OtherFields,
+}
+
+impl Hash for TransactionRequest {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.from.hash(state);
+        self.to.hash(state);
+        self.gas_price.hash(state);
+        self.max_fee_per_gas.hash(state);
+        self.max_priority_fee_per_gas.hash(state);
+        self.max_fee_per_blob_gas.hash(state);
+        self.gas.hash(state);
+        self.value.hash(state);
+        self.input.hash(state);
+        self.nonce.hash(state);
+        self.chain_id.hash(state);
+        self.access_list.hash(state);
+        self.transaction_type.hash(state);
+        self.blob_versioned_hashes.hash(state);
+        self.sidecar.hash(state);
+        for (k, v) in self.other.iter() {
+            k.hash(state);
+            v.to_string().hash(state);
+        }
+    }
 }
 
 // == impl TransactionRequest ==

--- a/crates/rpc-types/src/eth/transaction/request.rs
+++ b/crates/rpc-types/src/eth/transaction/request.rs
@@ -47,6 +47,7 @@ pub struct TransactionRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub blob_versioned_hashes: Option<Vec<B256>>,
     /// Blob sidecar for EIP-4844 transactions.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub sidecar: Option<BlobTransactionSidecar>,
     /// Support for arbitrary additional fields.
     #[serde(flatten)]

--- a/crates/rpc-types/src/eth/transaction/request.rs
+++ b/crates/rpc-types/src/eth/transaction/request.rs
@@ -1,6 +1,6 @@
 //! Alloy basic Transaction Request type.
 use crate::{eth::transaction::AccessList, other::OtherFields, BlobTransactionSidecar};
-use alloy_primitives::{Address, Bytes, B256, U128, U256, U64, U8};
+use alloy_primitives::{Address, Bytes, B256, U256, U64, U8};
 use serde::{Deserialize, Serialize};
 
 /// Represents _all_ transaction requests to/from RPC.


### PR DESCRIPTION
## Motivation

`CallRequest` and `TransactionRequest` are basically the same type, with very few differences:

- `TransactionRequest` was missing an optional chain ID
- `TransactionRequest` was missing `max_fee_per_blob_gas`
- `CallRequest` and `TransactionRequest` had different blob fields

Since they also serve the same purpose, this PR dedupes them, to make sure there is only one tx request type, which is important for the network abstraction.

## Solution

Dedupe them, porting over fields missing from either.

I removed the blob transaction sidecar, but only because I didn't really know if it is actually a part of the spec. As far as I could tell, only `blob_versioned_hashes` and the gas field is. I asked @mattsse for direction in case he knew, but ultimately we didn't land on anything.

This is a breaking change for obvious reasons, and it not simply a "import new type" migration path, as I also ported over `CallInput` for `TransactionRequest`

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
