### PR TITLE
feat(`consensus`): TypedTransaction

### DIFF
--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -24,6 +24,8 @@ mod receipt;
 pub use receipt::{Receipt, ReceiptEnvelope, ReceiptWithBloom};
 
 mod transaction;
-pub use transaction::{TxEip1559, TxEip2930, TxEnvelope, TxLegacy, TxType};
+pub use transaction::{
+    TxEip1559, TxEip2930, TxEnvelope, TxLegacy, TxType, TypedTransactionRequest,
+};
 
 pub use alloy_network::TxKind;

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -24,8 +24,6 @@ mod receipt;
 pub use receipt::{Receipt, ReceiptEnvelope, ReceiptWithBloom};
 
 mod transaction;
-pub use transaction::{
-    TxEip1559, TxEip2930, TxEnvelope, TxLegacy, TxType, TypedTransactionRequest,
-};
+pub use transaction::{TxEip1559, TxEip2930, TxEnvelope, TxLegacy, TxType, TypedTransaction};
 
 pub use alloy_network::TxKind;

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -25,6 +25,8 @@ pub use receipt::{Receipt, ReceiptEnvelope, ReceiptWithBloom};
 
 mod transaction;
 
-pub use transaction::{TxEip1559, TxEip2930, TxEip4844, TxEnvelope, TxLegacy, TxType, TypedTransaction};
+pub use transaction::{
+    TxEip1559, TxEip2930, TxEip4844, TxEnvelope, TxLegacy, TxType, TypedTransaction,
+};
 
 pub use alloy_network::TxKind;

--- a/crates/consensus/src/transaction/eip4844.rs
+++ b/crates/consensus/src/transaction/eip4844.rs
@@ -239,6 +239,18 @@ impl TxEip4844 {
     }
 }
 
+impl Encodable for TxEip4844 {
+    fn encode(&self, out: &mut dyn BufMut) {
+        Header { list: true, payload_length: self.fields_len() }.encode(out);
+        self.encode_fields(out);
+    }
+
+    fn length(&self) -> usize {
+        let payload_length = self.fields_len();
+        length_of_length(payload_length) + payload_length
+    }
+}
+
 impl Transaction for TxEip4844 {
     type Signature = Signature;
 

--- a/crates/consensus/src/transaction/mod.rs
+++ b/crates/consensus/src/transaction/mod.rs
@@ -10,5 +10,5 @@ pub use legacy::TxLegacy;
 mod envelope;
 pub use envelope::{TxEnvelope, TxType};
 
-mod request;
-pub use request::TypedTransactionRequest;
+mod typed;
+pub use typed::TypedTransaction;

--- a/crates/consensus/src/transaction/mod.rs
+++ b/crates/consensus/src/transaction/mod.rs
@@ -9,3 +9,6 @@ pub use legacy::TxLegacy;
 
 mod envelope;
 pub use envelope::{TxEnvelope, TxType};
+
+mod request;
+pub use request::TypedTransactionRequest;

--- a/crates/consensus/src/transaction/request.rs
+++ b/crates/consensus/src/transaction/request.rs
@@ -40,7 +40,7 @@ impl From<TxEip1559> for TypedTransactionRequest {
 
 impl TypedTransactionRequest {
     /// Return the [`TxType`] of the inner txn.
-    pub fn tx_type(&self) -> TxType {
+    pub const fn tx_type(&self) -> TxType {
         match self {
             Self::Legacy(_) => TxType::Legacy,
             Self::Eip2930(_) => TxType::Eip2930,

--- a/crates/consensus/src/transaction/request.rs
+++ b/crates/consensus/src/transaction/request.rs
@@ -1,0 +1,256 @@
+use alloy_network::Transaction;
+use alloy_primitives::Signature;
+use alloy_rlp::Encodable;
+
+use crate::{TxEip1559, TxEip2930, TxEnvelope, TxLegacy, TxType};
+
+/// The TypedTransactionRequest enum represents all Ethereum transaction request types.
+///
+/// Its variants correspond to specific allowed transactions:
+/// 1. Legacy (pre-EIP2718) [`TxLegacy`]
+/// 2. EIP2930 (state access lists) [`TxEip2930`]
+/// 3. EIP1559 [`TxEip1559`]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum TypedTransactionRequest {
+    /// Legacy transaction
+    Legacy(TxLegacy),
+    /// EIP-2930 transaction
+    Eip2930(TxEip2930),
+    /// EIP-1559 transaction
+    Eip1559(TxEip1559),
+}
+
+impl From<TxLegacy> for TypedTransactionRequest {
+    fn from(tx: TxLegacy) -> Self {
+        Self::Legacy(tx)
+    }
+}
+
+impl From<TxEip2930> for TypedTransactionRequest {
+    fn from(tx: TxEip2930) -> Self {
+        Self::Eip2930(tx)
+    }
+}
+
+impl From<TxEip1559> for TypedTransactionRequest {
+    fn from(tx: TxEip1559) -> Self {
+        Self::Eip1559(tx)
+    }
+}
+
+impl TypedTransactionRequest {
+    /// Return the [`TxType`] of the inner txn.
+    pub fn tx_type(&self) -> TxType {
+        match self {
+            Self::Legacy(_) => TxType::Legacy,
+            Self::Eip2930(_) => TxType::Eip2930,
+            Self::Eip1559(_) => TxType::Eip1559,
+        }
+    }
+
+    /// Consumes the type and returns the EIP-2718 enveloped transaction with the given signature.
+    pub fn to_enveloped(self, sig: Signature) -> TxEnvelope {
+        match self {
+            Self::Legacy(tx) => crate::TxEnvelope::Legacy(tx.into_signed(sig)),
+            Self::Eip2930(tx) => crate::TxEnvelope::Eip2930(tx.into_signed(sig)),
+            Self::Eip1559(tx) => crate::TxEnvelope::Eip1559(tx.into_signed(sig)),
+        }
+    }
+
+    /// Sets the chain ID for the transaction.
+    pub fn set_chain_id(&mut self, chain_id: alloy_primitives::ChainId) {
+        match self {
+            Self::Legacy(tx) => tx.set_chain_id(chain_id),
+            Self::Eip2930(tx) => tx.set_chain_id(chain_id),
+            Self::Eip1559(tx) => tx.set_chain_id(chain_id),
+        }
+    }
+}
+
+impl Encodable for TypedTransactionRequest {
+    fn encode(&self, out: &mut dyn alloy_rlp::BufMut) {
+        match self {
+            Self::Legacy(tx) => tx.encode(out),
+            Self::Eip2930(tx) => tx.encode(out),
+            Self::Eip1559(tx) => tx.encode(out),
+        }
+    }
+}
+
+impl Transaction for TypedTransactionRequest {
+    type Signature = Signature;
+
+    fn encode_for_signing(&self, out: &mut dyn alloy_rlp::BufMut) {
+        match self {
+            Self::Legacy(tx) => tx.encode_for_signing(out),
+            Self::Eip2930(tx) => tx.encode_for_signing(out),
+            Self::Eip1559(tx) => tx.encode_for_signing(out),
+        }
+    }
+
+    fn chain_id(&self) -> Option<alloy_primitives::ChainId> {
+        match self {
+            Self::Legacy(tx) => tx.chain_id(),
+            Self::Eip2930(tx) => tx.chain_id(),
+            Self::Eip1559(tx) => tx.chain_id(),
+        }
+    }
+
+    fn decode_signed(_buf: &mut &[u8]) -> alloy_rlp::Result<alloy_network::Signed<Self>>
+    where
+        Self: Sized,
+    {
+        unimplemented!();
+    }
+
+    fn encode_signed(&self, signature: &Signature, out: &mut dyn alloy_rlp::BufMut) {
+        match self {
+            Self::Legacy(tx) => tx.encode_signed(signature, out),
+            Self::Eip2930(tx) => tx.encode_signed(signature, out),
+            Self::Eip1559(tx) => tx.encode_signed(signature, out),
+        }
+    }
+
+    fn encoded_for_signing(&self) -> Vec<u8> {
+        match self {
+            Self::Legacy(tx) => tx.encoded_for_signing(),
+            Self::Eip2930(tx) => tx.encoded_for_signing(),
+            Self::Eip1559(tx) => tx.encoded_for_signing(),
+        }
+    }
+
+    fn gas_limit(&self) -> u64 {
+        match self {
+            Self::Legacy(tx) => tx.gas_limit(),
+            Self::Eip2930(tx) => tx.gas_limit(),
+            Self::Eip1559(tx) => tx.gas_limit(),
+        }
+    }
+
+    fn gas_price(&self) -> Option<alloy_primitives::U256> {
+        match self {
+            Self::Legacy(tx) => tx.gas_price(),
+            Self::Eip2930(tx) => tx.gas_price(),
+            Self::Eip1559(tx) => tx.gas_price(),
+        }
+    }
+
+    fn input(&self) -> &[u8] {
+        match self {
+            Self::Legacy(tx) => tx.input(),
+            Self::Eip2930(tx) => tx.input(),
+            Self::Eip1559(tx) => tx.input(),
+        }
+    }
+
+    fn input_mut(&mut self) -> &mut alloy_primitives::Bytes {
+        match self {
+            Self::Legacy(tx) => tx.input_mut(),
+            Self::Eip2930(tx) => tx.input_mut(),
+            Self::Eip1559(tx) => tx.input_mut(),
+        }
+    }
+
+    fn into_signed(self, _signature: Signature) -> alloy_network::Signed<Self, Self::Signature>
+    where
+        Self: Sized,
+    {
+        unimplemented!();
+    }
+
+    fn nonce(&self) -> u64 {
+        match self {
+            Self::Legacy(tx) => tx.nonce(),
+            Self::Eip2930(tx) => tx.nonce(),
+            Self::Eip1559(tx) => tx.nonce(),
+        }
+    }
+
+    fn payload_len_for_signature(&self) -> usize {
+        match self {
+            Self::Legacy(tx) => tx.payload_len_for_signature(),
+            Self::Eip2930(tx) => tx.payload_len_for_signature(),
+            Self::Eip1559(tx) => tx.payload_len_for_signature(),
+        }
+    }
+
+    fn set_chain_id(&mut self, chain_id: alloy_primitives::ChainId) {
+        match self {
+            Self::Legacy(tx) => tx.set_chain_id(chain_id),
+            Self::Eip2930(tx) => tx.set_chain_id(chain_id),
+            Self::Eip1559(tx) => tx.set_chain_id(chain_id),
+        }
+    }
+
+    fn set_gas_limit(&mut self, limit: u64) {
+        match self {
+            Self::Legacy(tx) => tx.set_gas_limit(limit),
+            Self::Eip2930(tx) => tx.set_gas_limit(limit),
+            Self::Eip1559(tx) => tx.set_gas_limit(limit),
+        }
+    }
+
+    fn set_gas_price(&mut self, price: alloy_primitives::U256) {
+        match self {
+            Self::Legacy(tx) => tx.set_gas_price(price),
+            Self::Eip2930(tx) => tx.set_gas_price(price),
+            Self::Eip1559(tx) => tx.set_gas_price(price),
+        }
+    }
+
+    fn set_input(&mut self, data: alloy_primitives::Bytes) {
+        match self {
+            Self::Legacy(tx) => tx.set_input(data),
+            Self::Eip2930(tx) => tx.set_input(data),
+            Self::Eip1559(tx) => tx.set_input(data),
+        }
+    }
+
+    fn set_nonce(&mut self, nonce: u64) {
+        match self {
+            Self::Legacy(tx) => tx.set_nonce(nonce),
+            Self::Eip2930(tx) => tx.set_nonce(nonce),
+            Self::Eip1559(tx) => tx.set_nonce(nonce),
+        }
+    }
+
+    fn set_to(&mut self, to: alloy_network::TxKind) {
+        match self {
+            Self::Legacy(tx) => tx.set_to(to),
+            Self::Eip2930(tx) => tx.set_to(to),
+            Self::Eip1559(tx) => tx.set_to(to),
+        }
+    }
+
+    fn set_value(&mut self, value: alloy_primitives::U256) {
+        match self {
+            Self::Legacy(tx) => tx.set_value(value),
+            Self::Eip2930(tx) => tx.set_value(value),
+            Self::Eip1559(tx) => tx.set_value(value),
+        }
+    }
+
+    fn signature_hash(&self) -> alloy_primitives::B256 {
+        match self {
+            Self::Legacy(tx) => tx.signature_hash(),
+            Self::Eip2930(tx) => tx.signature_hash(),
+            Self::Eip1559(tx) => tx.signature_hash(),
+        }
+    }
+
+    fn to(&self) -> alloy_network::TxKind {
+        match self {
+            Self::Legacy(tx) => tx.to(),
+            Self::Eip2930(tx) => tx.to(),
+            Self::Eip1559(tx) => tx.to(),
+        }
+    }
+
+    fn value(&self) -> alloy_primitives::U256 {
+        match self {
+            Self::Legacy(tx) => tx.value(),
+            Self::Eip2930(tx) => tx.value(),
+            Self::Eip1559(tx) => tx.value(),
+        }
+    }
+}

--- a/crates/consensus/src/transaction/typed.rs
+++ b/crates/consensus/src/transaction/typed.rs
@@ -4,14 +4,14 @@ use alloy_rlp::Encodable;
 
 use crate::{TxEip1559, TxEip2930, TxEnvelope, TxLegacy, TxType};
 
-/// The TypedTransactionRequest enum represents all Ethereum transaction request types.
+/// The TypedTransaction enum represents all Ethereum transaction request types.
 ///
 /// Its variants correspond to specific allowed transactions:
 /// 1. Legacy (pre-EIP2718) [`TxLegacy`]
 /// 2. EIP2930 (state access lists) [`TxEip2930`]
 /// 3. EIP1559 [`TxEip1559`]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum TypedTransactionRequest {
+pub enum TypedTransaction {
     /// Legacy transaction
     Legacy(TxLegacy),
     /// EIP-2930 transaction
@@ -20,25 +20,25 @@ pub enum TypedTransactionRequest {
     Eip1559(TxEip1559),
 }
 
-impl From<TxLegacy> for TypedTransactionRequest {
+impl From<TxLegacy> for TypedTransaction {
     fn from(tx: TxLegacy) -> Self {
         Self::Legacy(tx)
     }
 }
 
-impl From<TxEip2930> for TypedTransactionRequest {
+impl From<TxEip2930> for TypedTransaction {
     fn from(tx: TxEip2930) -> Self {
         Self::Eip2930(tx)
     }
 }
 
-impl From<TxEip1559> for TypedTransactionRequest {
+impl From<TxEip1559> for TypedTransaction {
     fn from(tx: TxEip1559) -> Self {
         Self::Eip1559(tx)
     }
 }
 
-impl TypedTransactionRequest {
+impl TypedTransaction {
     /// Return the [`TxType`] of the inner txn.
     pub const fn tx_type(&self) -> TxType {
         match self {
@@ -67,7 +67,7 @@ impl TypedTransactionRequest {
     }
 }
 
-impl Encodable for TypedTransactionRequest {
+impl Encodable for TypedTransaction {
     fn encode(&self, out: &mut dyn alloy_rlp::BufMut) {
         match self {
             Self::Legacy(tx) => tx.encode(out),
@@ -77,7 +77,7 @@ impl Encodable for TypedTransactionRequest {
     }
 }
 
-impl Transaction for TypedTransactionRequest {
+impl Transaction for TypedTransaction {
     type Signature = Signature;
 
     fn encode_for_signing(&self, out: &mut dyn alloy_rlp::BufMut) {

--- a/crates/consensus/src/transaction/typed.rs
+++ b/crates/consensus/src/transaction/typed.rs
@@ -2,7 +2,7 @@ use alloy_network::Transaction;
 use alloy_primitives::Signature;
 use alloy_rlp::Encodable;
 
-use crate::{TxEip1559, TxEip2930, TxEnvelope, TxLegacy, TxType};
+use crate::{TxEip1559, TxEip2930, TxEip4844, TxEnvelope, TxLegacy, TxType};
 
 /// The TypedTransaction enum represents all Ethereum transaction request types.
 ///
@@ -10,6 +10,7 @@ use crate::{TxEip1559, TxEip2930, TxEnvelope, TxLegacy, TxType};
 /// 1. Legacy (pre-EIP2718) [`TxLegacy`]
 /// 2. EIP2930 (state access lists) [`TxEip2930`]
 /// 3. EIP1559 [`TxEip1559`]
+/// 4. EIP4844 [`TxEip4844`]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum TypedTransaction {
     /// Legacy transaction
@@ -18,6 +19,8 @@ pub enum TypedTransaction {
     Eip2930(TxEip2930),
     /// EIP-1559 transaction
     Eip1559(TxEip1559),
+    /// EIP-4844 transaction
+    Eip4844(TxEip4844),
 }
 
 impl From<TxLegacy> for TypedTransaction {
@@ -38,6 +41,12 @@ impl From<TxEip1559> for TypedTransaction {
     }
 }
 
+impl From<TxEip4844> for TypedTransaction {
+    fn from(tx: TxEip4844) -> Self {
+        Self::Eip4844(tx)
+    }
+}
+
 impl TypedTransaction {
     /// Return the [`TxType`] of the inner txn.
     pub const fn tx_type(&self) -> TxType {
@@ -45,6 +54,31 @@ impl TypedTransaction {
             Self::Legacy(_) => TxType::Legacy,
             Self::Eip2930(_) => TxType::Eip2930,
             Self::Eip1559(_) => TxType::Eip1559,
+            Self::Eip4844(_) => TxType::Eip4844,
+        }
+    }
+
+    /// Return the inner legacy transaction if it exists.
+    pub const fn legacy(&self) -> Option<&TxLegacy> {
+        match self {
+            Self::Legacy(tx) => Some(tx),
+            _ => None,
+        }
+    }
+
+    /// Return the inner EIP-2930 transaction if it exists.
+    pub const fn eip2930(&self) -> Option<&TxEip2930> {
+        match self {
+            Self::Eip2930(tx) => Some(tx),
+            _ => None,
+        }
+    }
+
+    /// Return the inner EIP-1559 transaction if it exists.
+    pub const fn eip1559(&self) -> Option<&TxEip1559> {
+        match self {
+            Self::Eip1559(tx) => Some(tx),
+            _ => None,
         }
     }
 
@@ -54,6 +88,7 @@ impl TypedTransaction {
             Self::Legacy(tx) => crate::TxEnvelope::Legacy(tx.into_signed(sig)),
             Self::Eip2930(tx) => crate::TxEnvelope::Eip2930(tx.into_signed(sig)),
             Self::Eip1559(tx) => crate::TxEnvelope::Eip1559(tx.into_signed(sig)),
+            Self::Eip4844(tx) => crate::TxEnvelope::Eip4844(tx.into_signed(sig)),
         }
     }
 
@@ -63,6 +98,7 @@ impl TypedTransaction {
             Self::Legacy(tx) => tx.set_chain_id(chain_id),
             Self::Eip2930(tx) => tx.set_chain_id(chain_id),
             Self::Eip1559(tx) => tx.set_chain_id(chain_id),
+            Self::Eip4844(tx) => tx.set_chain_id(chain_id),
         }
     }
 }
@@ -73,6 +109,7 @@ impl Encodable for TypedTransaction {
             Self::Legacy(tx) => tx.encode(out),
             Self::Eip2930(tx) => tx.encode(out),
             Self::Eip1559(tx) => tx.encode(out),
+            Self::Eip4844(tx) => tx.encode(out),
         }
     }
 }
@@ -85,6 +122,7 @@ impl Transaction for TypedTransaction {
             Self::Legacy(tx) => tx.encode_for_signing(out),
             Self::Eip2930(tx) => tx.encode_for_signing(out),
             Self::Eip1559(tx) => tx.encode_for_signing(out),
+            Self::Eip4844(tx) => tx.encode_for_signing(out),
         }
     }
 
@@ -93,6 +131,7 @@ impl Transaction for TypedTransaction {
             Self::Legacy(tx) => tx.chain_id(),
             Self::Eip2930(tx) => tx.chain_id(),
             Self::Eip1559(tx) => tx.chain_id(),
+            Self::Eip4844(tx) => tx.chain_id(),
         }
     }
 
@@ -108,6 +147,7 @@ impl Transaction for TypedTransaction {
             Self::Legacy(tx) => tx.encode_signed(signature, out),
             Self::Eip2930(tx) => tx.encode_signed(signature, out),
             Self::Eip1559(tx) => tx.encode_signed(signature, out),
+            Self::Eip4844(tx) => tx.encode_signed(signature, out),
         }
     }
 
@@ -116,6 +156,7 @@ impl Transaction for TypedTransaction {
             Self::Legacy(tx) => tx.encoded_for_signing(),
             Self::Eip2930(tx) => tx.encoded_for_signing(),
             Self::Eip1559(tx) => tx.encoded_for_signing(),
+            Self::Eip4844(tx) => tx.encoded_for_signing(),
         }
     }
 
@@ -124,6 +165,7 @@ impl Transaction for TypedTransaction {
             Self::Legacy(tx) => tx.gas_limit(),
             Self::Eip2930(tx) => tx.gas_limit(),
             Self::Eip1559(tx) => tx.gas_limit(),
+            Self::Eip4844(tx) => tx.gas_limit(),
         }
     }
 
@@ -132,6 +174,7 @@ impl Transaction for TypedTransaction {
             Self::Legacy(tx) => tx.gas_price(),
             Self::Eip2930(tx) => tx.gas_price(),
             Self::Eip1559(tx) => tx.gas_price(),
+            Self::Eip4844(tx) => tx.gas_price(),
         }
     }
 
@@ -140,6 +183,7 @@ impl Transaction for TypedTransaction {
             Self::Legacy(tx) => tx.input(),
             Self::Eip2930(tx) => tx.input(),
             Self::Eip1559(tx) => tx.input(),
+            Self::Eip4844(tx) => tx.input(),
         }
     }
 
@@ -148,6 +192,7 @@ impl Transaction for TypedTransaction {
             Self::Legacy(tx) => tx.input_mut(),
             Self::Eip2930(tx) => tx.input_mut(),
             Self::Eip1559(tx) => tx.input_mut(),
+            Self::Eip4844(tx) => tx.input_mut(),
         }
     }
 
@@ -163,6 +208,7 @@ impl Transaction for TypedTransaction {
             Self::Legacy(tx) => tx.nonce(),
             Self::Eip2930(tx) => tx.nonce(),
             Self::Eip1559(tx) => tx.nonce(),
+            Self::Eip4844(tx) => tx.nonce(),
         }
     }
 
@@ -171,6 +217,7 @@ impl Transaction for TypedTransaction {
             Self::Legacy(tx) => tx.payload_len_for_signature(),
             Self::Eip2930(tx) => tx.payload_len_for_signature(),
             Self::Eip1559(tx) => tx.payload_len_for_signature(),
+            Self::Eip4844(tx) => tx.payload_len_for_signature(),
         }
     }
 
@@ -179,6 +226,7 @@ impl Transaction for TypedTransaction {
             Self::Legacy(tx) => tx.set_chain_id(chain_id),
             Self::Eip2930(tx) => tx.set_chain_id(chain_id),
             Self::Eip1559(tx) => tx.set_chain_id(chain_id),
+            Self::Eip4844(tx) => tx.set_chain_id(chain_id),
         }
     }
 
@@ -187,6 +235,7 @@ impl Transaction for TypedTransaction {
             Self::Legacy(tx) => tx.set_gas_limit(limit),
             Self::Eip2930(tx) => tx.set_gas_limit(limit),
             Self::Eip1559(tx) => tx.set_gas_limit(limit),
+            Self::Eip4844(tx) => tx.set_gas_limit(limit),
         }
     }
 
@@ -195,6 +244,7 @@ impl Transaction for TypedTransaction {
             Self::Legacy(tx) => tx.set_gas_price(price),
             Self::Eip2930(tx) => tx.set_gas_price(price),
             Self::Eip1559(tx) => tx.set_gas_price(price),
+            Self::Eip4844(tx) => tx.set_gas_price(price),
         }
     }
 
@@ -203,6 +253,7 @@ impl Transaction for TypedTransaction {
             Self::Legacy(tx) => tx.set_input(data),
             Self::Eip2930(tx) => tx.set_input(data),
             Self::Eip1559(tx) => tx.set_input(data),
+            Self::Eip4844(tx) => tx.set_input(data),
         }
     }
 
@@ -211,6 +262,7 @@ impl Transaction for TypedTransaction {
             Self::Legacy(tx) => tx.set_nonce(nonce),
             Self::Eip2930(tx) => tx.set_nonce(nonce),
             Self::Eip1559(tx) => tx.set_nonce(nonce),
+            Self::Eip4844(tx) => tx.set_nonce(nonce),
         }
     }
 
@@ -219,6 +271,7 @@ impl Transaction for TypedTransaction {
             Self::Legacy(tx) => tx.set_to(to),
             Self::Eip2930(tx) => tx.set_to(to),
             Self::Eip1559(tx) => tx.set_to(to),
+            Self::Eip4844(tx) => tx.set_to(to),
         }
     }
 
@@ -227,6 +280,7 @@ impl Transaction for TypedTransaction {
             Self::Legacy(tx) => tx.set_value(value),
             Self::Eip2930(tx) => tx.set_value(value),
             Self::Eip1559(tx) => tx.set_value(value),
+            Self::Eip4844(tx) => tx.set_value(value),
         }
     }
 
@@ -235,6 +289,7 @@ impl Transaction for TypedTransaction {
             Self::Legacy(tx) => tx.signature_hash(),
             Self::Eip2930(tx) => tx.signature_hash(),
             Self::Eip1559(tx) => tx.signature_hash(),
+            Self::Eip4844(tx) => tx.signature_hash(),
         }
     }
 
@@ -243,6 +298,7 @@ impl Transaction for TypedTransaction {
             Self::Legacy(tx) => tx.to(),
             Self::Eip2930(tx) => tx.to(),
             Self::Eip1559(tx) => tx.to(),
+            Self::Eip4844(tx) => tx.to(),
         }
     }
 
@@ -251,6 +307,7 @@ impl Transaction for TypedTransaction {
             Self::Legacy(tx) => tx.value(),
             Self::Eip2930(tx) => tx.value(),
             Self::Eip1559(tx) => tx.value(),
+            Self::Eip4844(tx) => tx.value(),
         }
     }
 }

--- a/crates/signer/src/wallet/private_key.rs
+++ b/crates/signer/src/wallet/private_key.rs
@@ -169,7 +169,7 @@ impl FromStr for Wallet<SigningKey> {
 mod tests {
     use super::*;
     use crate::{LocalWallet, Result, SignableTx, Signer, SignerSync};
-    use alloy_consensus::{TxEip1559, TxEip2930, TxLegacy, TypedTransactionRequest};
+    use alloy_consensus::{TxEip1559, TxEip2930, TxLegacy, TypedTransaction};
     use alloy_network::Transaction;
     use alloy_primitives::{address, b256, ChainId, Signature, U256};
 
@@ -334,7 +334,7 @@ mod tests {
     #[tokio::test]
     async fn signs_typed_tx_test() {
         async fn sign_typed_tx_test(
-            tx: &mut TypedTransactionRequest,
+            tx: &mut TypedTransaction,
             chain_id: Option<ChainId>,
         ) -> Result<Signature> {
             let mut before = tx.clone();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

There is no proper concrete type which contains all ethereum transaction types implemented (legacy/eip2930/eip1559), which can be used by a `alloy-providers` or `alloy-contract` for remote/local signing and sending txs to the network. We have `TransactionRequest`/`CallRequest`, but it is an RPC type, and does not support encoding / signing.

## Solution

Adds `TypedTransaction` to `alloy-consensus`—an enum which represents the unsigned version of `TxEnvelope`, which can contain any of the ethereum transaction types. 

The rationale behind this type is for it to be the built-in concrete type used in providers to either use for remote account signing (`send_transaction`), or for signing locally and sending through the network (`send_raw_transaction`). 

In the case of `send_raw_transaction`, it is expected for the `TypedTransaction` to be signed, and to then be converted into a `TxEnvelope` through `to_enveloped`, which can then be encoded and sent through the network. Decoding is not implemented, as this type is not meant be used in this manner.

With #178, we should also be able to implement a conversion from `TransactionRequest` -> `TypedTransaction`, which currently exists in ethers with `into_typed_tx`.

The enum implements `Transaction`, meaning it is signable by the alloy signers.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
