### PR TITLE
making get_transaction_count accept a block

### DIFF
--- a/crates/providers/src/lib.rs
+++ b/crates/providers/src/lib.rs
@@ -19,6 +19,7 @@
 use alloy_network::{Network, Transaction};
 use alloy_primitives::Address;
 use alloy_rpc_client::RpcClient;
+use alloy_rpc_types::BlockId;
 use alloy_transport::{BoxTransport, Transport, TransportResult};
 use std::{borrow::Cow, marker::PhantomData};
 
@@ -97,13 +98,12 @@ pub trait Provider<N: Network, T: Transport = BoxTransport>: Send + Sync {
 
     /// Get the transaction count for an address. Used for finding the
     /// appropriate nonce.
-    ///
-    /// TODO: block number/hash/tag
     async fn get_transaction_count(
         &self,
         address: Address,
+        tag: Option<BlockId>,
     ) -> TransportResult<alloy_primitives::U256> {
-        self.inner().get_transaction_count(address).await
+        self.inner().get_transaction_count(address, tag).await
     }
 
     /// Send a transaction to the network.
@@ -144,10 +144,11 @@ impl<N: Network, T: Transport + Clone> Provider<N, T> for NetworkRpcClient<N, T>
     async fn get_transaction_count(
         &self,
         address: Address,
+        tag: Option<BlockId>,
     ) -> TransportResult<alloy_primitives::U256> {
         self.prepare(
             "eth_getTransactionCount",
-            Cow::<(Address, String)>::Owned((address, "latest".to_string())),
+            Cow::<(Address, BlockId)>::Owned((address, tag.unwrap_or_default())),
         )
         .await
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

We are implementing a revm Database with alloy and need to get the account's nonce at a specific block height.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

I'm adding the block parameter. I couldn't find a justification in the docs/issues to understand if there was another idea for its implementation.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [x] Breaking changes
