### PR TITLE
chore(`rpc-types`): add FromStr impl for BlockId

### DIFF
--- a/crates/rpc-types/src/eth/block.rs
+++ b/crates/rpc-types/src/eth/block.rs
@@ -1211,4 +1211,80 @@ mod tests {
         let serialized = serde_json::to_string(&num).unwrap();
         assert_eq!(serialized, "\"0x1\"");
     }
+
+    #[test]
+    fn can_parse_eip1898_block_ids() {
+        let num = serde_json::json!(
+            { "blockNumber": "0x0" }
+        );
+        let id = serde_json::from_value::<BlockId>(num).unwrap();
+        assert_eq!(id, BlockId::Number(BlockNumberOrTag::Number(0u64.into())));
+
+        let num = serde_json::json!(
+            { "blockNumber": "pending" }
+        );
+        let id = serde_json::from_value::<BlockId>(num).unwrap();
+        assert_eq!(id, BlockId::Number(BlockNumberOrTag::Pending));
+
+        let num = serde_json::json!(
+            { "blockNumber": "latest" }
+        );
+        let id = serde_json::from_value::<BlockId>(num).unwrap();
+        assert_eq!(id, BlockId::Number(BlockNumberOrTag::Latest));
+
+        let num = serde_json::json!(
+            { "blockNumber": "finalized" }
+        );
+        let id = serde_json::from_value::<BlockId>(num).unwrap();
+        assert_eq!(id, BlockId::Number(BlockNumberOrTag::Finalized));
+
+        let num = serde_json::json!(
+            { "blockNumber": "safe" }
+        );
+        let id = serde_json::from_value::<BlockId>(num).unwrap();
+        assert_eq!(id, BlockId::Number(BlockNumberOrTag::Safe));
+
+        let num = serde_json::json!(
+            { "blockNumber": "earliest" }
+        );
+        let id = serde_json::from_value::<BlockId>(num).unwrap();
+        assert_eq!(id, BlockId::Number(BlockNumberOrTag::Earliest));
+
+        let num = serde_json::json!("0x0");
+        let id = serde_json::from_value::<BlockId>(num).unwrap();
+        assert_eq!(id, BlockId::Number(BlockNumberOrTag::Number(0u64.into())));
+
+        let num = serde_json::json!("pending");
+        let id = serde_json::from_value::<BlockId>(num).unwrap();
+        assert_eq!(id, BlockId::Number(BlockNumberOrTag::Pending));
+
+        let num = serde_json::json!("latest");
+        let id = serde_json::from_value::<BlockId>(num).unwrap();
+        assert_eq!(id, BlockId::Number(BlockNumberOrTag::Latest));
+
+        let num = serde_json::json!("finalized");
+        let id = serde_json::from_value::<BlockId>(num).unwrap();
+        assert_eq!(id, BlockId::Number(BlockNumberOrTag::Finalized));
+
+        let num = serde_json::json!("safe");
+        let id = serde_json::from_value::<BlockId>(num).unwrap();
+        assert_eq!(id, BlockId::Number(BlockNumberOrTag::Safe));
+
+        let num = serde_json::json!("earliest");
+        let id = serde_json::from_value::<BlockId>(num).unwrap();
+        assert_eq!(id, BlockId::Number(BlockNumberOrTag::Earliest));
+
+        let num = serde_json::json!(
+            { "blockHash": "0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3" }
+        );
+        let id = serde_json::from_value::<BlockId>(num).unwrap();
+        assert_eq!(
+            id,
+            BlockId::Hash(
+                "0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3"
+                    .parse::<B256>()
+                    .unwrap().into()
+            )
+        );
+    }
 }

--- a/crates/rpc-types/src/eth/block.rs
+++ b/crates/rpc-types/src/eth/block.rs
@@ -1218,7 +1218,7 @@ mod tests {
             { "blockNumber": "0x0" }
         );
         let id = serde_json::from_value::<BlockId>(num).unwrap();
-        assert_eq!(id, BlockId::Number(BlockNumberOrTag::Number(0u64.into())));
+        assert_eq!(id, BlockId::Number(BlockNumberOrTag::Number(0u64)));
 
         let num = serde_json::json!(
             { "blockNumber": "pending" }
@@ -1252,7 +1252,7 @@ mod tests {
 
         let num = serde_json::json!("0x0");
         let id = serde_json::from_value::<BlockId>(num).unwrap();
-        assert_eq!(id, BlockId::Number(BlockNumberOrTag::Number(0u64.into())));
+        assert_eq!(id, BlockId::Number(BlockNumberOrTag::Number(0u64)));
 
         let num = serde_json::json!("pending");
         let id = serde_json::from_value::<BlockId>(num).unwrap();
@@ -1283,7 +1283,8 @@ mod tests {
             BlockId::Hash(
                 "0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3"
                     .parse::<B256>()
-                    .unwrap().into()
+                    .unwrap()
+                    .into()
             )
         );
     }

--- a/crates/rpc-types/src/eth/block.rs
+++ b/crates/rpc-types/src/eth/block.rs
@@ -750,13 +750,20 @@ pub struct ParseBlockIdError {
 impl FromStr for BlockId {
     type Err = ParseBlockIdError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match u64::from_str(s) {
-            Ok(val) => Ok(BlockId::Number(BlockNumberOrTag::Number(val))),
-            Err(parse_int_error) => match B256::from_str(s) {
-                Ok(val) => Ok(BlockId::Hash(val.into())),
-                Err(hex_error) => {
-                    Err(ParseBlockIdError { input: s.to_string(), parse_int_error, hex_error })
-                }
+        match s {
+            "latest" => Ok(BlockId::Number(BlockNumberOrTag::Latest)),
+            "finalized" => Ok(BlockId::Number(BlockNumberOrTag::Finalized)),
+            "safe" => Ok(BlockId::Number(BlockNumberOrTag::Safe)),
+            "earliest" => Ok(BlockId::Number(BlockNumberOrTag::Earliest)),
+            "pending" => Ok(BlockId::Number(BlockNumberOrTag::Pending)),
+            _ => match u64::from_str(s) {
+                Ok(val) => Ok(BlockId::Number(BlockNumberOrTag::Number(val))),
+                Err(parse_int_error) => match B256::from_str(s) {
+                    Ok(val) => Ok(BlockId::Hash(val.into())),
+                    Err(hex_error) => {
+                        Err(ParseBlockIdError { input: s.to_string(), parse_int_error, hex_error })
+                    }
+                },
             },
         }
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

This was missing, and there were no tests for block id.

## Solution

Adds a `FromStr` impl for `BlockId` and some tests.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
