### PR TITLE
suppport legacy implementation in CallBuilder

### DIFF
--- a/crates/contract/src/call.rs
+++ b/crates/contract/src/call.rs
@@ -271,8 +271,9 @@ impl<P: TempProvider, D: CallDecoder> CallBuilder<P, D> {
     }
 
     /// Uses a Legacy transaction instead of an EIP-1559 one to execute the call
-    pub fn legacy(self) -> Self {
-        todo!()
+    pub fn to(mut self, to: Option<Address>) -> Self {
+        self.request = self.request.to(to);
+        self
     }
 
     /// Sets the `gas` field in the transaction to the provided value

--- a/crates/contract/src/call.rs
+++ b/crates/contract/src/call.rs
@@ -271,8 +271,9 @@ impl<P: TempProvider, D: CallDecoder> CallBuilder<P, D> {
     }
 
     /// Uses a Legacy transaction instead of an EIP-1559 one to execute the call
-    pub fn to(mut self, to: Option<Address>) -> Self {
-        self.request = self.request.to(to);
+    pub fn legacy(mut self) -> Self {
+        self.request = self.request.max_fee_per_gas(U256::ZERO);
+        self.request = self.request.max_priority_fee_per_gas(U256::ZERO);
         self
     }
 


### PR DESCRIPTION
implemented the `legacy` method in `CallBuilder` to allow switching from EIP-1559 tx to legacy tx 