### PR TITLE
 refactor: rename "blob_gas_price" to "blob_base_fee"

### DIFF
--- a/crates/rpc-types/src/eth/transaction/receipt.rs
+++ b/crates/rpc-types/src/eth/transaction/receipt.rs
@@ -27,9 +27,9 @@ pub struct TransactionReceipt {
     /// This is None for non eip-4844 transactions
     #[serde(skip_serializing_if = "Option::is_none")]
     pub blob_gas_used: Option<U128>,
-    /// The price paid by the eip-4844 transaction per blob gas.
+    /// The base fee used by the eip-4844 transaction per blob gas.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub blob_gas_price: Option<U128>,
+    pub blob_base_fee: Option<U128>,
     /// Address of the sender
     pub from: Address,
     /// Address of the receiver. None when its a contract creation transaction.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
According to https://github.com/paradigmxyz/reth/issues/6330, `blob_gas_price` should renamed to `blob_base_fee`. 


<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
A minor update.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
