### PR TITLE
[WIP] feat(`consensus`): add extra EIP-4844 types needed

### DIFF
--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -16,6 +16,9 @@ alloy-network.workspace = true
 alloy-primitives = { workspace = true, features = ["rlp"] }
 alloy-rlp.workspace = true
 alloy-eips.workspace = true
+thiserror.workspace = true
+c-kzg = { version = "0.4.2", features = ["serde"] }
+sha2 = "0.10.7"
 
 # arbitrary
 arbitrary = { workspace = true, features = ["derive"], optional = true }

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -24,6 +24,9 @@ mod receipt;
 pub use receipt::{Receipt, ReceiptEnvelope, ReceiptWithBloom};
 
 mod transaction;
-pub use transaction::{TxEip1559, TxEip2930, TxEip4844, TxEnvelope, TxLegacy, TxType};
+pub use transaction::{
+    BlobTransaction, BlobTransactionSidecar, TxEip1559, TxEip2930, TxEip4844, TxEnvelope, TxLegacy,
+    TxType,
+};
 
 pub use alloy_network::TxKind;

--- a/crates/consensus/src/transaction/mod.rs
+++ b/crates/consensus/src/transaction/mod.rs
@@ -8,7 +8,7 @@ mod legacy;
 pub use legacy::TxLegacy;
 
 mod eip4844;
-pub use eip4844::TxEip4844;
+pub use eip4844::{BlobTransaction, BlobTransactionSidecar, TxEip4844};
 
 mod envelope;
 pub use envelope::{TxEnvelope, TxType};


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

We still need to add a few `EIP-4844` types to be able to properly send and decode full EIP-4844 txs with a sidecar. Right now we can't do that, and the `TxEip4844` contained in the envelope is incomplete, as it misses the sidecar.

## Solution

Add the needed types. Mostly ported from reth. WIP, needs tests added and proper encoding/decoding fns to be implemented yet.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
