### PR TITLE
perf: use raw http response bytes

### DIFF
--- a/crates/transport-http/src/reqwest.rs
+++ b/crates/transport-http/src/reqwest.rs
@@ -16,9 +16,10 @@ impl Http<reqwest::Client> {
                 .send()
                 .await
                 .map_err(TransportErrorKind::custom)?;
-            let json = resp.text().await.map_err(TransportErrorKind::custom)?;
+            let body = resp.bytes().await.map_err(TransportErrorKind::custom)?;
 
-            serde_json::from_str(&json).map_err(|err| TransportError::deser_err(err, &json))
+            serde_json::from_slice(&body)
+                .map_err(|err| TransportError::deser_err(err, String::from_utf8_lossy(&body)))
         })
     }
 }


### PR DESCRIPTION
reqwest::Response::text decodes the body with the "utf-8" charset 

we can ignore this step and instead decode from the raw response directly.

this is also how `Response::json` is implemented