### PR TITLE
ci: bump rust version to 1.76 in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: ["stable", "nightly", "1.75"] # MSRV
+        rust: ["stable", "nightly", "1.76"] # MSRV
         flags: ["--no-default-features", "", "--all-features"]
         exclude:
           # Some features have higher MSRV.
-          - rust: "1.75" # MSRV
+          - rust: "1.76" # MSRV
             flags: "--all-features"
     steps:
       - uses: actions/checkout@v3
@@ -43,13 +43,13 @@ jobs:
           cache-on-failure: true
       # Only run tests on latest stable and above
       - name: Install cargo-nextest
-        if: ${{ matrix.rust != '1.75' }} # MSRV
+        if: ${{ matrix.rust != '1.76' }} # MSRV
         uses: taiki-e/install-action@nextest
       - name: build
-        if: ${{ matrix.rust == '1.75' }} # MSRV
+        if: ${{ matrix.rust == '1.76' }} # MSRV
         run: cargo build --workspace ${{ matrix.flags }}
       - name: test
-        if: ${{ matrix.rust != '1.75' }} # MSRV
+        if: ${{ matrix.rust != '1.76' }} # MSRV
         run: cargo nextest run --workspace ${{ matrix.flags }}
 
   wasm:


### PR DESCRIPTION
## Motivation
Bump rust version to 1.76 to pass the cargo clippy ci problems