### PR TITLE
fix: enable reqwest default-tls feature in transport-http

### DIFF
--- a/crates/transport-http/Cargo.toml
+++ b/crates/transport-http/Cargo.toml
@@ -25,6 +25,9 @@ reqwest = { workspace = true, features = ["serde_json", "json"], optional = true
 hyper = { workspace = true, features = ["full"], optional = true }
 
 [features]
-default = ["reqwest"]
-reqwest = ["dep:reqwest", "dep:alloy-json-rpc", "dep:serde_json", "dep:tower", "reqwest/default-tls"]
+default = ["reqwest", "reqwest-default-tls"]
+reqwest = ["dep:reqwest", "dep:alloy-json-rpc", "dep:serde_json", "dep:tower"]
 hyper = ["dep:hyper", "dep:alloy-json-rpc", "dep:serde_json", "dep:tower"]
+reqwest-default-tls = ["reqwest?/default-tls"]
+reqwest-native-tls = ["reqwest?/native-tls"]
+reqwest-rustls-tls = ["reqwest?/rustls-tls"]

--- a/crates/transport-http/Cargo.toml
+++ b/crates/transport-http/Cargo.toml
@@ -26,5 +26,5 @@ hyper = { workspace = true, features = ["full"], optional = true }
 
 [features]
 default = ["reqwest"]
-reqwest = ["dep:reqwest", "dep:alloy-json-rpc", "dep:serde_json", "dep:tower"]
+reqwest = ["dep:reqwest", "dep:alloy-json-rpc", "dep:serde_json", "dep:tower", "reqwest/default-tls"]
 hyper = ["dep:hyper", "dep:alloy-json-rpc", "dep:serde_json", "dep:tower"]


### PR DESCRIPTION
## Motivation
Reqwest has `default-tls` as a default feature (https://docs.rs/reqwest/latest/reqwest/#optional-features), however alloy crates import dependencies with `default-features = false`.

The `alloy` metadata crate has `default-tls` as its default feature, which in turn enables this feature in reqwest, so connections using tls via https work fine when using the `alloy` crate.

However, `alloy-providers`, `alloy-rpc-client`, and `alloy-transport-http` also depend on reqwest, but provide no option to enable `default-tls`. So if these crates are used directly (instead of eg `alloy::alloy_providers`) then it will panic when trying to connect to a https url.

## Solution

The simplest fix was to add this to the reqwest feature (default) in the `alloy-transport-http` cargo toml.
Both `alloy-providers` and `alloy-rpc-client` also enable `alloy-transport-http/reqwest` by default, so this enables the reqwest feature for those crates as well.

To confirm the fix:
https://github.com/alloy-rs/alloy/blob/86027c9bb984f3a12a30ffd2a3c5f2f06595f1d6/crates/rpc-client/tests/it/http.rs#L5-L15

1) Uncomment `#[tokio::test]`
2) Run `HTTP_PROVIDER_URL=https://rpc.ankr.com/eth cargo test --package alloy-rpc-client -- http::it_makes_a_request --exact`

Test passes successfully vs the previous panic in the linked issue.

Fixes https://github.com/alloy-rs/alloy/issues/247

## PR Checklist

- [] Added Tests
- [] Added Documentation
- [] Breaking changes
