### PR TITLE
Convert non-200 http responses into errors

### DIFF
--- a/crates/transport-http/src/hyper.rs
+++ b/crates/transport-http/src/hyper.rs
@@ -30,6 +30,8 @@ where
 
             let resp = this.client.request(req).await.map_err(TransportErrorKind::custom)?;
 
+            let status = resp.status();
+
             // unpack data from the response body. We do this regardless of
             // the status code, as we want to return the error in the body if
             // there is one.
@@ -37,11 +39,10 @@ where
                 .await
                 .map_err(TransportErrorKind::custom)?;
 
-            if resp.status() != hyper::StatusCode::OK {
+            if status != hyper::StatusCode::OK {
                 return Err(TransportErrorKind::custom_str(&format!(
                     "HTTP error: {} with body: {:?}",
-                    resp.status(),
-                    body
+                    status, body
                 )));
             }
 

--- a/crates/transport-http/src/hyper.rs
+++ b/crates/transport-http/src/hyper.rs
@@ -30,7 +30,7 @@ where
 
             let resp = this.client.request(req).await.map_err(TransportErrorKind::custom)?;
 
-            // unpack json from the response body. We do this regardless of
+            // unpack data from the response body. We do this regardless of
             // the status code, as we want to return the error in the body if
             // there is one.
             let body = hyper::body::to_bytes(resp.into_body())

--- a/crates/transport-http/src/hyper.rs
+++ b/crates/transport-http/src/hyper.rs
@@ -41,8 +41,9 @@ where
 
             if status != hyper::StatusCode::OK {
                 return Err(TransportErrorKind::custom_str(&format!(
-                    "HTTP error: {} with body: {:?}",
-                    status, body
+                    r#"HTTP error: {} with body: "{}""#,
+                    status,
+                    String::from_utf8_lossy(body.as_ref())
                 )));
             }
 

--- a/crates/transport-http/src/reqwest.rs
+++ b/crates/transport-http/src/reqwest.rs
@@ -1,6 +1,7 @@
 use crate::Http;
 use alloy_json_rpc::{RequestPacket, ResponsePacket};
 use alloy_transport::{TransportError, TransportErrorKind, TransportFut};
+use reqwest::Response;
 use std::task;
 use tower::Service;
 
@@ -15,7 +16,9 @@ impl Http<reqwest::Client> {
                 .json(&req)
                 .send()
                 .await
+                .and_then(Response::error_for_status)
                 .map_err(TransportErrorKind::custom)?;
+
             let body = resp.bytes().await.map_err(TransportErrorKind::custom)?;
 
             serde_json::from_slice(&body)


### PR DESCRIPTION
Currently non-200 responses proceed to JSON deser. This causes them to be treated as `TransportError::custom` variants.

Closes #253 

## Motivation

Prevent server errors from being treated as JSON

## Solution

Capture the errors

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
