### PR TITLE
fix: early return for `JsonStorageKey` to `String`

### DIFF
--- a/crates/rpc-types/src/serde_helpers/storage.rs
+++ b/crates/rpc-types/src/serde_helpers/storage.rs
@@ -105,3 +105,14 @@ where
         None => Ok(None),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_storage_key() {
+        let key = JsonStorageKey::default();
+        assert_eq!(String::from(key), String::from("0x0"));
+    }
+}

--- a/crates/rpc-types/src/serde_helpers/storage.rs
+++ b/crates/rpc-types/src/serde_helpers/storage.rs
@@ -43,8 +43,13 @@ impl From<JsonStorageKey> for String {
         // `eth_getProof` implementation in geth simply mirrors the input
         //
         // see the use of `hexKey` in the `eth_getProof` response:
-        // <https://github.com/ethereum/go-ethereum/blob/00a73fbcce3250b87fc4160f3deddc44390848f4/internal/ethapi/api.go#L658-L690>
+        // <https://github.com/ethereum/go-ethereum/blob/b87b9b45331f87fb1da379c5f17a81ebc3738c6e/internal/ethapi/api.go#L689-L763>
         let bytes = uint.to_be_bytes_trimmed_vec();
+        // Early return if the input is empty. This case is added to satisfy the hive tests.
+        // <https://github.com/ethereum/go-ethereum/blob/b87b9b45331f87fb1da379c5f17a81ebc3738c6e/internal/ethapi/api.go#L727-L729>
+        if bytes.is_empty() {
+            return "0x0".to_string();
+        }
         let mut hex = String::with_capacity(2 + bytes.len() * 2);
         hex.push_str("0x");
         for byte in bytes {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
Solves the serialization issue for the `JsonStorageKey` type which serializes the 0 key to `0x`. As per the hive tests, it should serialize to `0x0` (https://github.com/ethereum/execution-apis/blob/main/tests/eth_getProof/get-account-proof-with-storage.io).
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Add an early return on the conversion of the storage key to a String, in order to manually return `0x0`. This is similar to the implementation found in `geth` (https://github.com/ethereum/go-ethereum/blob/b87b9b45331f87fb1da379c5f17a81ebc3738c6e/internal/ethapi/api.go#L727-L729).
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [x] Breaking changes
