### PR TITLE
refactor: remove `async_trait` in tx builder

### DIFF
--- a/crates/network/src/ethereum/builder.rs
+++ b/crates/network/src/ethereum/builder.rs
@@ -4,10 +4,7 @@ use crate::{
 use alloy_consensus::{TxEip1559, TxEip2930, TxEip4844, TxEip4844Variant, TxLegacy};
 use alloy_primitives::{Address, TxKind, U256, U64};
 use alloy_rpc_types::request::TransactionRequest;
-use async_trait::async_trait;
 
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl TransactionBuilder<Ethereum> for alloy_rpc_types::TransactionRequest {
     fn chain_id(&self) -> Option<alloy_primitives::ChainId> {
         self.chain_id


### PR DESCRIPTION
## Motivation

Closes #268

## Solution

We can't use `async fn` because we need the `Send` bound for `NetworkSigner`

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
