### PR TITLE
feat: derive `Hash` for `TypedTransaction`

### DIFF
--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -16,7 +16,7 @@ alloy-primitives = { workspace = true, features = ["rlp"] }
 alloy-rlp.workspace = true
 alloy-eips.workspace = true
 thiserror = { workspace = true, optional = true }
-c-kzg = { version = "0.4.2", features = ["serde"], optional = true }
+c-kzg = { version = "1.0", features = ["serde"], optional = true }
 sha2 = { version = "0.10", optional = true }
 
 # arbitrary

--- a/crates/consensus/src/transaction/eip4844.rs
+++ b/crates/consensus/src/transaction/eip4844.rs
@@ -49,7 +49,7 @@ pub enum BlobTransactionValidationError {
 /// It can either be a standalone transaction, mainly seen when retrieving historical transactions,
 /// or a transaction with a sidecar, which is used when submitting a transaction to the network and
 /// when receiving and sending transactions during the gossip stage.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum TxEip4844Variant {
     /// A standalone transaction with blob hashes and max blob fee.
     TxEip4844(TxEip4844),
@@ -606,7 +606,7 @@ impl Decodable for TxEip4844 {
 /// This is defined in [EIP-4844](https://eips.ethereum.org/EIPS/eip-4844#networking) as an element
 /// of a `PooledTransactions` response, and is also used as the format for sending raw transactions
 /// through the network (eth_sendRawTransaction/eth_sendTransaction).
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]
 pub struct TxEip4844WithSidecar {
     /// The actual transaction.
     pub tx: TxEip4844,
@@ -694,7 +694,7 @@ impl Transaction for TxEip4844WithSidecar {
 }
 
 /// This represents a set of blobs, and its corresponding commitments and proofs.
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]
 #[repr(C)]
 pub struct BlobTransactionSidecar {
     /// The blob data.

--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -10,7 +10,7 @@ use alloy_rlp::{length_of_length, Decodable, Encodable};
 /// [2930]: https://eips.ethereum.org/EIPS/eip-2930
 /// [4844]: https://eips.ethereum.org/EIPS/eip-4844
 #[repr(u8)]
-#[derive(Debug, Copy, Clone, Eq, PartialEq, PartialOrd, Ord)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, PartialOrd, Ord, Hash)]
 pub enum TxType {
     /// Wrapped legacy transaction type.
     Legacy = 0,

--- a/crates/consensus/src/transaction/typed.rs
+++ b/crates/consensus/src/transaction/typed.rs
@@ -8,7 +8,7 @@ use alloy_primitives::TxKind;
 /// 2. EIP2930 (state access lists) [`TxEip2930`]
 /// 3. EIP1559 [`TxEip1559`]
 /// 4. EIP4844 [`TxEip4844Variant`]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum TypedTransaction {
     /// Legacy transaction
     Legacy(TxLegacy),


### PR DESCRIPTION
## Motivation

This is needed for some caches in Foundry

## Solution

This was previously blocked by KZG types not being `Hash`

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
