### PR TITLE
docs: do not accept grammar prs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,6 +120,11 @@ commit signing. This option allows us to make small changes to your PR to bring
 it in line with these standards. It helps us get your PR in faster, and with
 less work from you.
 
+### Contributions Related to Spelling and Grammar
+
+At this time, we will not be accepting contributions that only fix spelling or grammatical errors in documentation, code or
+elsewhere.
+
 ### Cargo Commands
 
 This section lists some commonly needed commands.

--- a/crates/rpc-types/src/eth/filter.rs
+++ b/crates/rpc-types/src/eth/filter.rs
@@ -816,7 +816,7 @@ impl FilteredParams {
         self.filter.as_ref().map(|f| f.address.matches(address)).unwrap_or(true)
     }
 
-    /// Returns `true` if the log matches the the given topics
+    /// Returns `true` if the log matches the given topics
     pub fn filter_topics(&self, log_topics: &[B256]) -> bool {
         let topics = match self.filter.as_ref() {
             None => return true,

--- a/crates/transport/src/error.rs
+++ b/crates/transport/src/error.rs
@@ -28,7 +28,7 @@ pub enum TransportErrorKind {
     BackendGone,
 
     /// Pubsub service is not available for the current provider.
-    #[error("subscriptions are not avalaible on this provider")]
+    #[error("subscriptions are not available on this provider")]
     PubsubUnavailable,
 
     /// Transaction confirmed but `get_transaction_receipt` returned `None`.


### PR DESCRIPTION
## Motivation

A common RPGF farming strategy is to open PRs to fix grammar/typos with a bot

## Solution

Don't allow it

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
