### PR TITLE
feat: update priority fee estimator

### DIFF
--- a/crates/provider/src/provider.rs
+++ b/crates/provider/src/provider.rs
@@ -787,11 +787,11 @@ pub trait Provider<N: Network, T: Transport + Clone = BoxTransport>: Send + Sync
 
         // use the provided fee estimator function, or fallback to the default implementation.
         let (max_fee_per_gas, max_priority_fee_per_gas) = if let Some(es) = estimator {
-            es(base_fee_per_gas, fee_history.reward.unwrap_or_default())
+            es(base_fee_per_gas, &fee_history.reward.unwrap_or_default())
         } else {
             utils::eip1559_default_estimator(
                 base_fee_per_gas,
-                fee_history.reward.unwrap_or_default(),
+                &fee_history.reward.unwrap_or_default(),
             )
         };
 

--- a/crates/provider/src/utils.rs
+++ b/crates/provider/src/utils.rs
@@ -3,7 +3,7 @@
 use alloy_primitives::U256;
 
 /// The number of blocks from the past for which the fee rewards are fetched for fee estimation.
-pub const EIP1559_FEE_ESTIMATION_PAST_BLOCKS: u64 = 5;
+pub const EIP1559_FEE_ESTIMATION_PAST_BLOCKS: u64 = 10;
 /// Multiplier for the current base fee to estimate max base fee for the next block.
 pub const EIP1559_BASE_FEE_MULTIPLIER: f64 = 2.0;
 /// The default percentile of gas premiums that are fetched for fee estimation.

--- a/crates/provider/src/utils.rs
+++ b/crates/provider/src/utils.rs
@@ -20,8 +20,15 @@ fn estimate_priority_fee(rewards: &[Vec<U256>]) -> U256 {
     }
 
     rewards.sort();
+
     // Return the median.
-    *rewards[rewards.len() / 2]
+    let n = rewards.len();
+    
+    if n % 2 == 0 {
+        (*rewards[n / 2 - 1] + *rewards[n / 2]) / U256::from(2)
+    } else {
+        *rewards[(n + 1) / 2]
+    }
 }
 
 /// The default EIP-1559 fee estimator which is based on the work by [MetaMask](https://github.com/MetaMask/core/blob/main/packages/gas-fee-controller/src/fetchGasEstimatesViaEthFeeHistory/calculateGasFeeEstimatesForPriorityLevels.ts#L56)

--- a/crates/provider/src/utils.rs
+++ b/crates/provider/src/utils.rs
@@ -1,6 +1,6 @@
 //! Provider-related utilities.
 
-use alloy_primitives::{I256, U256};
+use alloy_primitives::U256;
 
 /// The number of blocks from the past for which the fee rewards are fetched for fee estimation.
 pub const EIP1559_FEE_ESTIMATION_PAST_BLOCKS: u64 = 5;
@@ -8,9 +8,6 @@ pub const EIP1559_FEE_ESTIMATION_PAST_BLOCKS: u64 = 5;
 pub const EIP1559_BASE_FEE_MULTIPLIER: f64 = 2.0;
 /// The default percentile of gas premiums that are fetched for fee estimation.
 pub const EIP1559_FEE_ESTIMATION_REWARD_PERCENTILE: f64 = 20.0;
-/// The threshold max change/difference (in %) at which we will ignore the fee history values
-/// under it.
-pub const EIP1559_FEE_ESTIMATION_THRESHOLD_MAX_CHANGE: i64 = 200;
 
 /// An estimator function for EIP1559 fees.
 pub type EstimatorFunction = fn(U256, Vec<Vec<U256>>) -> (U256, U256);
@@ -20,55 +17,16 @@ fn estimate_priority_fee(rewards: Vec<Vec<U256>>) -> U256 {
     if rewards.is_empty() {
         return U256::ZERO;
     }
-    if rewards.len() == 1 {
-        return rewards[0];
-    }
-    // Sort the rewards as we will eventually take the median.
+
     rewards.sort();
-
-    // A copy of the same vector is created for convenience to calculate percentage change
-    // between subsequent fee values.
-    let mut rewards_copy = rewards.clone();
-    rewards_copy.rotate_left(1);
-
-    let mut percentage_change: Vec<I256> = rewards
-        .iter()
-        .zip(rewards_copy.iter())
-        .map(|(a, b)| {
-            let a = I256::try_from(*a).expect("priority fee overflow");
-            let b = I256::try_from(*b).expect("priority fee overflow");
-            ((b - a) * I256::try_from(100).expect("Unexpected overflow")) / a
-        })
-        .collect();
-    percentage_change.pop();
-
-    // Fetch the max of the percentage change, and that element's index.
-    let max_change = percentage_change.iter().max().unwrap();
-    let max_change_index = percentage_change.iter().position(|&c| c == *max_change).unwrap();
-
-    // If we encountered a big change in fees at a certain position, then consider only
-    // the values >= it.
-    let values = if *max_change
-        >= I256::from_raw(U256::from(EIP1559_FEE_ESTIMATION_THRESHOLD_MAX_CHANGE))
-        && (max_change_index >= (rewards.len() / 2))
-    {
-        rewards[max_change_index..].to_vec()
-    } else {
-        rewards
-    };
-
     // Return the median.
-    values[values.len() / 2]
+    rewards[rewards.len() / 2]
 }
 
-/// The default EIP-1559 fee estimator which is based on the work by [MyCrypto](https://github.com/MyCryptoHQ/MyCrypto/blob/master/src/services/ApiService/Gas/eip1559.ts)
+/// The default EIP-1559 fee estimator which is based on the work by [MetaMask](https://github.com/MetaMask/core/blob/main/packages/gas-fee-controller/src/fetchGasEstimatesViaEthFeeHistory/calculateGasFeeEstimatesForPriorityLevels.ts#L56)
+/// (constants for "medium" priority level are used)
 pub fn eip1559_default_estimator(base_fee_per_gas: U256, rewards: Vec<Vec<U256>>) -> (U256, U256) {
     let max_priority_fee_per_gas = estimate_priority_fee(rewards);
     let potential_max_fee = base_fee_per_gas * U256::from(EIP1559_BASE_FEE_MULTIPLIER);
-    let max_fee_per_gas = if max_priority_fee_per_gas > potential_max_fee {
-        max_priority_fee_per_gas + potential_max_fee
-    } else {
-        potential_max_fee
-    };
-    (max_fee_per_gas, max_priority_fee_per_gas)
+    (potential_max_fee, max_priority_fee_per_gas)
 }

--- a/crates/provider/src/utils.rs
+++ b/crates/provider/src/utils.rs
@@ -23,11 +23,11 @@ fn estimate_priority_fee(rewards: &[Vec<U256>]) -> U256 {
 
     // Return the median.
     let n = rewards.len();
-    
+
     if n % 2 == 0 {
         (*rewards[n / 2 - 1] + *rewards[n / 2]) / U256::from(2)
     } else {
-        *rewards[(n + 1) / 2]
+        *rewards[n / 2]
     }
 }
 

--- a/crates/provider/src/utils.rs
+++ b/crates/provider/src/utils.rs
@@ -38,3 +38,49 @@ pub fn eip1559_default_estimator(base_fee_per_gas: U256, rewards: &[Vec<U256>]) 
     let potential_max_fee = base_fee_per_gas * U256::from(EIP1559_BASE_FEE_MULTIPLIER);
     (potential_max_fee, max_priority_fee_per_gas)
 }
+
+#[cfg(test)]
+mod tests {
+    use std::vec;
+
+    use super::*;
+
+    #[test]
+    fn test_estimate_priority_fee() {
+        let rewards = vec![
+            vec![U256::from(10_000_000_000_u64)],
+            vec![U256::from(200_000_000_000_u64)],
+            vec![U256::from(3_000_000_000_u64)],
+        ];
+        assert_eq!(super::estimate_priority_fee(&rewards), U256::from(10_000_000_000_u64));
+
+        let rewards = vec![
+            vec![U256::from(400_000_000_000_u64)],
+            vec![U256::from(2_000_000_000_u64)],
+            vec![U256::from(5_000_000_000_u64)],
+            vec![U256::from(3_000_000_000_u64)],
+        ];
+
+        assert_eq!(super::estimate_priority_fee(&rewards), U256::from(4_000_000_000_u64));
+
+        let rewards = vec![vec![U256::from(0)], vec![U256::from(0)], vec![U256::from(0)]];
+
+        assert_eq!(super::estimate_priority_fee(&rewards), U256::from(0));
+
+        assert_eq!(super::estimate_priority_fee(&vec![]), U256::from(0));
+    }
+
+    #[test]
+    fn test_eip1559_default_estimator() {
+        let base_fee_per_gas = U256::from(1_000_000_000_u64);
+        let rewards = vec![
+            vec![U256::from(200_000_000_000_u64)],
+            vec![U256::from(200_000_000_000_u64)],
+            vec![U256::from(300_000_000_000_u64)],
+        ];
+        assert_eq!(
+            super::eip1559_default_estimator(base_fee_per_gas, &rewards),
+            (U256::from(2_000_000_000_u64), U256::from(200_000_000_000_u64))
+        );
+    }
+}

--- a/crates/provider/src/utils.rs
+++ b/crates/provider/src/utils.rs
@@ -41,9 +41,8 @@ pub fn eip1559_default_estimator(base_fee_per_gas: U256, rewards: &[Vec<U256>]) 
 
 #[cfg(test)]
 mod tests {
-    use std::vec;
-
     use super::*;
+    use std::vec;
 
     #[test]
     fn test_estimate_priority_fee() {
@@ -67,7 +66,7 @@ mod tests {
 
         assert_eq!(super::estimate_priority_fee(&rewards), U256::from(0));
 
-        assert_eq!(super::estimate_priority_fee(&vec![]), U256::from(0));
+        assert_eq!(super::estimate_priority_fee(&[]), U256::from(0));
     }
 
     #[test]

--- a/crates/provider/src/utils.rs
+++ b/crates/provider/src/utils.rs
@@ -10,22 +10,23 @@ pub const EIP1559_BASE_FEE_MULTIPLIER: f64 = 2.0;
 pub const EIP1559_FEE_ESTIMATION_REWARD_PERCENTILE: f64 = 20.0;
 
 /// An estimator function for EIP1559 fees.
-pub type EstimatorFunction = fn(U256, Vec<Vec<U256>>) -> (U256, U256);
+pub type EstimatorFunction = fn(U256, &[Vec<U256>]) -> (U256, U256);
 
-fn estimate_priority_fee(rewards: Vec<Vec<U256>>) -> U256 {
-    let mut rewards: Vec<U256> = rewards.iter().map(|r| r[0]).filter(|r| *r > U256::ZERO).collect();
+fn estimate_priority_fee(rewards: &[Vec<U256>]) -> U256 {
+    let mut rewards =
+        rewards.iter().filter_map(|r| r.first().filter(|r| **r > U256::ZERO)).collect::<Vec<_>>();
     if rewards.is_empty() {
         return U256::ZERO;
     }
 
     rewards.sort();
     // Return the median.
-    rewards[rewards.len() / 2]
+    *rewards[rewards.len() / 2]
 }
 
 /// The default EIP-1559 fee estimator which is based on the work by [MetaMask](https://github.com/MetaMask/core/blob/main/packages/gas-fee-controller/src/fetchGasEstimatesViaEthFeeHistory/calculateGasFeeEstimatesForPriorityLevels.ts#L56)
 /// (constants for "medium" priority level are used)
-pub fn eip1559_default_estimator(base_fee_per_gas: U256, rewards: Vec<Vec<U256>>) -> (U256, U256) {
+pub fn eip1559_default_estimator(base_fee_per_gas: U256, rewards: &[Vec<U256>]) -> (U256, U256) {
     let max_priority_fee_per_gas = estimate_priority_fee(rewards);
     let potential_max_fee = base_fee_per_gas * U256::from(EIP1559_BASE_FEE_MULTIPLIER);
     (potential_max_fee, max_priority_fee_per_gas)


### PR DESCRIPTION
## Motivation

Current estimator version is not flexible and will always return 3 gwei priority fee if base fee is less than 100 gwei which is not correct for L2s (and often pretty high even for Mainnet).

## Solution

New impl was inspired by Metamask estimator and introduces following changes:
1. We no more use `EIP1559_FEE_ESTIMATION_THRESHOLD_MAX_CHANGE` because it could've resulted in overestimated gas prices. Let's consider `rewards` with following contents: `[100, 1, 1, 1, 1]`, in this case we'd filter out all 1's because of spike caused by a single 100 price, and the resulted priority fee estimate will be 100 gwei which is incorrect. Using median should be enough for a fair estimate filtering out potential anomalies.
2. We now simply multiply base fee by 2 to calculate max base fee instead of using `base_fee_surged` oriented on mainnet.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
