### PR TITLE
feat(json-rpc): use `Cow` instead of `&'static str` for method names

### DIFF
--- a/crates/json-rpc/README.md
+++ b/crates/json-rpc/README.md
@@ -29,8 +29,6 @@ Requests are sent via transports (see [alloy-transports]). This results in 1 of
 
 ### Limitations
 
-- This library models the method name as a `&'static str`, and is therefore
-  unsuitable for use with RPC servers with dynamic method names.
 - This library does not support borrowing response data from the deserializer.
   This is intended to simplify client implementations, but makes the library
   poorly suited for use in a high-performance server.

--- a/crates/json-rpc/src/request.rs
+++ b/crates/json-rpc/src/request.rs
@@ -195,7 +195,7 @@ impl SerializedRequest {
     }
 
     /// Returns the request method.
-    pub const fn method(&self) -> &Cow<'static, str> {
+    pub fn method(&self) -> &str {
         &self.meta.method
     }
 

--- a/crates/pubsub/src/managers/in_flight.rs
+++ b/crates/pubsub/src/managers/in_flight.rs
@@ -41,7 +41,7 @@ impl InFlight {
     }
 
     /// Check if the request is a subscription.
-    pub(crate) const fn is_subscription(&self) -> bool {
+    pub(crate) fn is_subscription(&self) -> bool {
         self.request.is_subscription()
     }
 

--- a/crates/rpc-client/src/batch.rs
+++ b/crates/rpc-client/src/batch.rs
@@ -114,7 +114,6 @@ impl<'a, Conn> BatchRequest<'a, Conn>
 where
     Conn: Transport + Clone,
 {
-    #[must_use = "Waiters do nothing unless polled. A Waiter will never resolve unless the batch is sent!"]
     /// Add a call to the batch.
     ///
     /// ### Errors
@@ -122,7 +121,7 @@ where
     /// If the request cannot be serialized, this will return an error.
     pub fn add_call<Params: RpcParam, Resp: RpcReturn>(
         &mut self,
-        method: &'static str,
+        method: impl Into<Cow<'static, str>>,
         params: &Params,
     ) -> TransportResult<Waiter<Resp>> {
         let request = self.transport.make_request(method, Cow::Borrowed(params));

--- a/crates/rpc-client/src/client.rs
+++ b/crates/rpc-client/src/client.rs
@@ -3,6 +3,7 @@ use alloy_json_rpc::{Id, Request, RpcParam, RpcReturn};
 use alloy_transport::{BoxTransport, Transport, TransportConnect, TransportError};
 use alloy_transport_http::Http;
 use std::{
+    borrow::Cow,
     ops::Deref,
     sync::{
         atomic::{AtomicU64, Ordering},
@@ -91,7 +92,7 @@ impl<T: Transport> RpcClient<T> {
     /// See [`PollerBuilder`] for examples and more details.
     pub fn prepare_static_poller<Params, Resp>(
         &self,
-        method: &'static str,
+        method: impl Into<Cow<'static, str>>,
         params: Params,
     ) -> PollerBuilder<T, Params, Resp>
     where
@@ -198,7 +199,7 @@ impl<T> RpcClientInner<T> {
     #[inline]
     pub fn make_request<Params: RpcParam>(
         &self,
-        method: &'static str,
+        method: impl Into<Cow<'static, str>>,
         params: Params,
     ) -> Request<Params> {
         Request::new(method, self.next_id(), params)
@@ -248,7 +249,7 @@ impl<T: Transport + Clone> RpcClientInner<T> {
     #[doc(alias = "prepare")]
     pub fn request<Params: RpcParam, Resp: RpcReturn>(
         &self,
-        method: &'static str,
+        method: impl Into<Cow<'static, str>>,
         params: Params,
     ) -> RpcCall<T, Params, Resp> {
         let request = self.make_request(method, params);


### PR DESCRIPTION
This allows dynamic method names in the type representation.