### PR TITLE
docs: update incorrect comment

### DIFF
--- a/crates/rpc-types/src/eth/transaction/receipt.rs
+++ b/crates/rpc-types/src/eth/transaction/receipt.rs
@@ -48,7 +48,9 @@ pub struct TransactionReceipt {
     /// Status: either 1 (success) or 0 (failure). Only present after activation of EIP-658
     #[serde(skip_serializing_if = "Option::is_none", rename = "status")]
     pub status_code: Option<U64>,
-    /// EIP-2718 Transaction type, Some(1) for AccessList transaction, None for Legacy
+    /// EIP-2718 Transaction type.
+    ///
+    /// For legacy transactions this returns `0`. For EIP-2718 transactions this returns the type.
     #[serde(rename = "type")]
     pub transaction_type: U8,
     /// Arbitrary extra fields.


### PR DESCRIPTION
closes #327

this simply returns 0x0 for legacy, see also geth:

https://github.com/ethereum/go-ethereum/blob/ba2dd9385c2a51134e520083dc732787a813b107/internal/ethapi/api.go#L1701-L1701

https://github.com/ethereum/go-ethereum/blob/ba2dd9385c2a51134e520083dc732787a813b107/core/types/tx_legacy.go#L95-L95