### PR TITLE
fix: force clippy to stable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
-      - run: cargo clippy --workspace --all-targets --all-features
+      - run: cargo +stable clippy --workspace --all-targets --all-features
         env:
           RUSTFLAGS: -Dwarnings
 


### PR DESCRIPTION
# Motivation

Prevent future random CI breakage

# Solution

Set clippy to stable in CI

there may be a better way to achieve this, but this way is straightforward

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
