### PR TITLE
fix: make `TransactionReceipt::transaction_hash` field mandatory

### DIFF
--- a/crates/provider/src/layers/signer.rs
+++ b/crates/provider/src/layers/signer.rs
@@ -144,7 +144,7 @@ mod tests {
 
         let receipt =
             provider.get_transaction_receipt(local_hash2).await.unwrap().expect("no receipt");
-        let receipt_hash = receipt.transaction_hash.expect("no receipt hash");
+        let receipt_hash = receipt.transaction_hash;
         assert_eq!(receipt_hash, node_hash);
     }
 }

--- a/crates/provider/src/provider.rs
+++ b/crates/provider/src/provider.rs
@@ -1088,8 +1088,7 @@ mod tests {
             .get_receipt()
             .await
             .expect("failed to await pending tx")
-            .transaction_hash
-            .unwrap();
+            .transaction_hash;
         assert_eq!(hash1, hash2);
     }
 
@@ -1286,7 +1285,7 @@ mod tests {
         assert!(receipt.is_some());
         let receipt = receipt.unwrap();
         assert_eq!(
-            receipt.transaction_hash.unwrap(),
+            receipt.transaction_hash,
             b256!("5c03fab9114ceb98994b43892ade87ddfd9ae7e8f293935c3bd29d435dc9fd95")
         );
     }

--- a/crates/provider/src/provider.rs
+++ b/crates/provider/src/provider.rs
@@ -1084,11 +1084,8 @@ mod tests {
 
         let builder = provider.send_transaction(tx).await.expect("failed to send tx");
         let hash1 = *builder.tx_hash();
-        let hash2 = builder
-            .get_receipt()
-            .await
-            .expect("failed to await pending tx")
-            .transaction_hash;
+        let hash2 =
+            builder.get_receipt().await.expect("failed to await pending tx").transaction_hash;
         assert_eq!(hash1, hash2);
     }
 

--- a/crates/rpc-types/src/eth/transaction/receipt.rs
+++ b/crates/rpc-types/src/eth/transaction/receipt.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 #[serde(rename_all = "camelCase")]
 pub struct TransactionReceipt {
     /// Transaction Hash.
-    pub transaction_hash: Option<B256>,
+    pub transaction_hash: B256,
     /// Index within the block.
     pub transaction_index: U64,
     /// Hash of the block this transaction was included within.


### PR DESCRIPTION
## Motivation

Option initially came from Reth, but it should be mandatory

Ref https://github.com/ethereum/go-ethereum/blob/ba2dd9385c2a51134e520083dc732787a813b107/core/types/receipt.go#L62-L62

## Solution

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
