### PR TITLE
Fix: change nonce from `U64` to `u64` 

### DIFF
--- a/crates/contract/src/call.rs
+++ b/crates/contract/src/call.rs
@@ -2,7 +2,7 @@ use crate::{Error, Result};
 use alloy_dyn_abi::{DynSolValue, FunctionExt, JsonAbiExt};
 use alloy_json_abi::Function;
 use alloy_network::{Network, ReceiptResponse, TransactionBuilder};
-use alloy_primitives::{Address, Bytes, U256, U64};
+use alloy_primitives::{Address, Bytes, U256};
 use alloy_provider::{PendingTransactionBuilder, Provider};
 use alloy_rpc_types::{state::StateOverride, BlockId};
 use alloy_sol_types::SolCall;
@@ -306,7 +306,7 @@ impl<N: Network, T: Transport + Clone, P: Provider<N, T>, D: CallDecoder> CallBu
     }
 
     /// Sets the `nonce` field in the transaction to the provided value
-    pub fn nonce(mut self, nonce: U64) -> Self {
+    pub fn nonce(mut self, nonce: u64) -> Self {
         self.request.set_nonce(nonce);
         self
     }

--- a/crates/genesis/src/lib.rs
+++ b/crates/genesis/src/lib.rs
@@ -20,7 +20,7 @@
 use alloy_primitives::{Address, Bytes, B256, U256};
 use alloy_serde::{
     json_u256::{deserialize_json_ttd_opt, deserialize_json_u256},
-    num::{u64_hex_or_decimal, u64_hex_or_decimal_opt},
+    num::{u64_hex, u64_hex_opt, u64_hex_or_decimal, u64_hex_or_decimal_opt},
     storage::deserialize_storage_map,
 };
 use serde::{Deserialize, Serialize};
@@ -34,7 +34,7 @@ pub struct Genesis {
     #[serde(default)]
     pub config: ChainConfig,
     /// The genesis header nonce.
-    #[serde(with = "u64_hex_or_decimal")]
+    #[serde(with = "u64_hex")]
     pub nonce: u64,
     /// The genesis header timestamp.
     #[serde(with = "u64_hex_or_decimal")]
@@ -212,7 +212,7 @@ impl Genesis {
 #[serde(deny_unknown_fields)]
 pub struct GenesisAccount {
     /// The nonce of the account at genesis.
-    #[serde(skip_serializing_if = "Option::is_none", with = "u64_hex_or_decimal_opt", default)]
+    #[serde(skip_serializing_if = "Option::is_none", with = "u64_hex_opt", default)]
     pub nonce: Option<u64>,
     /// The balance of the account at genesis.
     #[serde(deserialize_with = "deserialize_json_u256")]

--- a/crates/genesis/src/lib.rs
+++ b/crates/genesis/src/lib.rs
@@ -20,7 +20,7 @@
 use alloy_primitives::{Address, Bytes, B256, U256};
 use alloy_serde::{
     json_u256::{deserialize_json_ttd_opt, deserialize_json_u256},
-    num::{u64_hex, u64_hex_opt, u64_hex_or_decimal, u64_hex_or_decimal_opt},
+    num::{u64_hex_or_decimal, u64_hex_or_decimal_opt},
     storage::deserialize_storage_map,
 };
 use serde::{Deserialize, Serialize};
@@ -34,7 +34,7 @@ pub struct Genesis {
     #[serde(default)]
     pub config: ChainConfig,
     /// The genesis header nonce.
-    #[serde(with = "u64_hex")]
+    #[serde(with = "u64_hex_or_decimal")]
     pub nonce: u64,
     /// The genesis header timestamp.
     #[serde(with = "u64_hex_or_decimal")]
@@ -212,7 +212,7 @@ impl Genesis {
 #[serde(deny_unknown_fields)]
 pub struct GenesisAccount {
     /// The nonce of the account at genesis.
-    #[serde(skip_serializing_if = "Option::is_none", with = "u64_hex_opt", default)]
+    #[serde(skip_serializing_if = "Option::is_none", with = "u64_hex_or_decimal_opt", default)]
     pub nonce: Option<u64>,
     /// The balance of the account at genesis.
     #[serde(deserialize_with = "deserialize_json_u256")]

--- a/crates/network/src/ethereum/builder.rs
+++ b/crates/network/src/ethereum/builder.rs
@@ -2,7 +2,7 @@ use crate::{
     BuilderResult, Ethereum, Network, NetworkSigner, TransactionBuilder, TransactionBuilderError,
 };
 use alloy_consensus::{TxEip1559, TxEip2930, TxEip4844, TxEip4844Variant, TxLegacy};
-use alloy_primitives::{Address, TxKind, U256, U64};
+use alloy_primitives::{Address, TxKind, U256};
 use alloy_rpc_types::request::TransactionRequest;
 
 impl TransactionBuilder<Ethereum> for alloy_rpc_types::TransactionRequest {
@@ -14,11 +14,11 @@ impl TransactionBuilder<Ethereum> for alloy_rpc_types::TransactionRequest {
         self.chain_id = Some(chain_id);
     }
 
-    fn nonce(&self) -> Option<U64> {
+    fn nonce(&self) -> Option<u64> {
         self.nonce
     }
 
-    fn set_nonce(&mut self, nonce: U64) {
+    fn set_nonce(&mut self, nonce: u64) {
         self.nonce = Some(nonce);
     }
 
@@ -135,7 +135,7 @@ impl TransactionBuilder<Ethereum> for alloy_rpc_types::TransactionRequest {
 fn build_legacy(request: TransactionRequest) -> Result<TxLegacy, TransactionBuilderError> {
     Ok(TxLegacy {
         chain_id: request.chain_id,
-        nonce: request.nonce.ok_or_else(|| TransactionBuilderError::MissingKey("nonce"))?.to(),
+        nonce: request.nonce.ok_or_else(|| TransactionBuilderError::MissingKey("nonce"))?,
         gas_price: request
             .gas_price
             .ok_or_else(|| TransactionBuilderError::MissingKey("gas_price"))?
@@ -154,7 +154,7 @@ fn build_legacy(request: TransactionRequest) -> Result<TxLegacy, TransactionBuil
 fn build_1559(request: TransactionRequest) -> Result<TxEip1559, TransactionBuilderError> {
     Ok(TxEip1559 {
         chain_id: request.chain_id.unwrap_or(1),
-        nonce: request.nonce.ok_or_else(|| TransactionBuilderError::MissingKey("nonce"))?.to(),
+        nonce: request.nonce.ok_or_else(|| TransactionBuilderError::MissingKey("nonce"))?,
         max_priority_fee_per_gas: request
             .max_priority_fee_per_gas
             .ok_or_else(|| TransactionBuilderError::MissingKey("max_priority_fee_per_gas"))?
@@ -178,7 +178,7 @@ fn build_1559(request: TransactionRequest) -> Result<TxEip1559, TransactionBuild
 fn build_2930(request: TransactionRequest) -> Result<TxEip2930, TransactionBuilderError> {
     Ok(TxEip2930 {
         chain_id: request.chain_id.unwrap_or(1),
-        nonce: request.nonce.ok_or_else(|| TransactionBuilderError::MissingKey("nonce"))?.to(),
+        nonce: request.nonce.ok_or_else(|| TransactionBuilderError::MissingKey("nonce"))?,
         gas_price: request
             .gas_price
             .ok_or_else(|| TransactionBuilderError::MissingKey("gas_price"))?
@@ -198,7 +198,7 @@ fn build_2930(request: TransactionRequest) -> Result<TxEip2930, TransactionBuild
 fn build_4844(request: TransactionRequest) -> Result<TxEip4844, TransactionBuilderError> {
     Ok(TxEip4844 {
         chain_id: request.chain_id.unwrap_or(1),
-        nonce: request.nonce.ok_or_else(|| TransactionBuilderError::MissingKey("nonce"))?.to(),
+        nonce: request.nonce.ok_or_else(|| TransactionBuilderError::MissingKey("nonce"))?,
         gas_limit: request
             .gas
             .ok_or_else(|| TransactionBuilderError::MissingKey("gas_limit"))?

--- a/crates/network/src/transaction/builder.rs
+++ b/crates/network/src/transaction/builder.rs
@@ -1,6 +1,6 @@
 use super::signer::NetworkSigner;
 use crate::Network;
-use alloy_primitives::{Address, Bytes, ChainId, TxKind, U256, U64};
+use alloy_primitives::{Address, Bytes, ChainId, TxKind, U256};
 use futures_utils_wasm::impl_future;
 
 /// Error type for transaction builders.
@@ -58,13 +58,13 @@ pub trait TransactionBuilder<N: Network>: Default + Sized + Send + Sync + 'stati
     }
 
     /// Get the nonce for the transaction.
-    fn nonce(&self) -> Option<U64>;
+    fn nonce(&self) -> Option<u64>;
 
     /// Set the nonce for the transaction.
-    fn set_nonce(&mut self, nonce: U64);
+    fn set_nonce(&mut self, nonce: u64);
 
     /// Builder-pattern method for setting the nonce.
-    fn with_nonce(mut self, nonce: U64) -> Self {
+    fn with_nonce(mut self, nonce: u64) -> Self {
         self.set_nonce(nonce);
         self
     }
@@ -115,7 +115,7 @@ pub trait TransactionBuilder<N: Network>: Default + Sized + Send + Sync + 'stati
         }
         let from = self.from()?;
         let nonce = self.nonce()?;
-        Some(from.create(nonce.to()))
+        Some(from.create(nonce))
     }
 
     /// Get the value for the transaction.

--- a/crates/provider/src/layers/nonce.rs
+++ b/crates/provider/src/layers/nonce.rs
@@ -136,7 +136,7 @@ mod tests {
     use crate::ProviderBuilder;
     use alloy_network::EthereumSigner;
     use alloy_node_bindings::Anvil;
-    use alloy_primitives::{address, U256, U64};
+    use alloy_primitives::{address, U256};
     use alloy_rpc_client::RpcClient;
     use alloy_rpc_types::TransactionRequest;
     use alloy_transport_http::Http;
@@ -193,11 +193,11 @@ mod tests {
         let pending = provider.send_transaction(tx.clone()).await.unwrap();
         let tx_hash = pending.watch().await.unwrap();
         let mined_tx = provider.get_transaction_by_hash(tx_hash).await.expect("tx didn't finalize");
-        assert_eq!(mined_tx.nonce, U64::from(0));
+        assert_eq!(mined_tx.nonce, 0);
 
         let pending = provider.send_transaction(tx).await.unwrap();
         let tx_hash = pending.watch().await.unwrap();
         let mined_tx = provider.get_transaction_by_hash(tx_hash).await.expect("tx didn't finalize");
-        assert_eq!(mined_tx.nonce, U64::from(1));
+        assert_eq!(mined_tx.nonce, 1);
     }
 }

--- a/crates/provider/src/layers/nonce.rs
+++ b/crates/provider/src/layers/nonce.rs
@@ -1,6 +1,6 @@
 use crate::{PendingTransactionBuilder, Provider, ProviderLayer, RootProvider};
 use alloy_network::{Network, TransactionBuilder};
-use alloy_primitives::{Address, U64};
+use alloy_primitives::Address;
 use alloy_transport::{Transport, TransportResult};
 use async_trait::async_trait;
 use dashmap::DashMap;
@@ -82,7 +82,7 @@ where
     T: Transport + Clone,
     P: Provider<N, T>,
 {
-    async fn get_next_nonce(&self, from: Address) -> TransportResult<U64> {
+    async fn get_next_nonce(&self, from: Address) -> TransportResult<u64> {
         // locks dashmap internally for a short duration to clone the `Arc`
         let mutex = Arc::clone(self.nonces.entry(from).or_default().value());
 
@@ -91,13 +91,13 @@ where
         match *nonce {
             Some(ref mut nonce) => {
                 *nonce += 1;
-                Ok(U64::from(*nonce))
+                Ok(*nonce)
             }
             None => {
                 // initialize the nonce if we haven't seen this account before
                 let initial_nonce = self.inner.get_transaction_count(from, None).await?;
                 *nonce = Some(initial_nonce.to());
-                Ok(initial_nonce)
+                Ok(initial_nonce.to())
             }
         }
     }

--- a/crates/provider/src/layers/nonce.rs
+++ b/crates/provider/src/layers/nonce.rs
@@ -136,7 +136,7 @@ mod tests {
     use crate::ProviderBuilder;
     use alloy_network::EthereumSigner;
     use alloy_node_bindings::Anvil;
-    use alloy_primitives::{address, U256};
+    use alloy_primitives::{address, U256, U64};
     use alloy_rpc_client::RpcClient;
     use alloy_rpc_types::TransactionRequest;
     use alloy_transport_http::Http;

--- a/crates/provider/src/layers/signer.rs
+++ b/crates/provider/src/layers/signer.rs
@@ -120,7 +120,7 @@ mod tests {
             .provider(RootProvider::new(RpcClient::new(http, true)));
 
         let tx = TransactionRequest {
-            nonce: Some(U64::from(0)),
+            nonce: Some(0),
             value: Some(U256::from(100)),
             to: address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045").into(),
             gas_price: Some(U256::from(20e9)),

--- a/crates/provider/src/layers/signer.rs
+++ b/crates/provider/src/layers/signer.rs
@@ -101,7 +101,7 @@ mod tests {
     use crate::{Provider, ProviderBuilder, RootProvider};
     use alloy_network::EthereumSigner;
     use alloy_node_bindings::Anvil;
-    use alloy_primitives::{address, b256, U256, U64};
+    use alloy_primitives::{address, b256, U256};
     use alloy_rpc_client::RpcClient;
     use alloy_rpc_types::TransactionRequest;
     use alloy_transport_http::Http;

--- a/crates/rpc-types/src/eth/transaction/mod.rs
+++ b/crates/rpc-types/src/eth/transaction/mod.rs
@@ -3,6 +3,7 @@
 use crate::eth::other::OtherFields;
 pub use access_list::{AccessList, AccessListItem, AccessListWithGasUsed};
 use alloy_primitives::{Address, Bytes, B256, U128, U256, U64};
+use alloy_serde::num::u64_hex_or_decimal;
 pub use blob::BlobTransactionSidecar;
 pub use common::TransactionInfo;
 pub use optimism::OptimismTransactionReceiptFields;
@@ -28,7 +29,8 @@ pub struct Transaction {
     /// Hash
     pub hash: B256,
     /// Nonce
-    pub nonce: U64,
+    #[serde(with = "u64_hex_or_decimal")]
+    pub nonce: u64,
     /// Block hash
     pub block_hash: Option<B256>,
     /// Block number
@@ -94,7 +96,7 @@ mod tests {
     fn serde_transaction() {
         let transaction = Transaction {
             hash: B256::with_last_byte(1),
-            nonce: U64::from(2),
+            nonce: 2,
             block_hash: Some(B256::with_last_byte(3)),
             block_number: Some(U256::from(4)),
             transaction_index: Some(U256::from(5)),
@@ -132,7 +134,7 @@ mod tests {
     fn serde_transaction_with_parity_bit() {
         let transaction = Transaction {
             hash: B256::with_last_byte(1),
-            nonce: U64::from(2),
+            nonce: 2,
             block_hash: Some(B256::with_last_byte(3)),
             block_number: Some(U256::from(4)),
             transaction_index: Some(U256::from(5)),

--- a/crates/rpc-types/src/eth/transaction/mod.rs
+++ b/crates/rpc-types/src/eth/transaction/mod.rs
@@ -3,7 +3,6 @@
 use crate::eth::other::OtherFields;
 pub use access_list::{AccessList, AccessListItem, AccessListWithGasUsed};
 use alloy_primitives::{Address, Bytes, B256, U128, U256, U64};
-use alloy_serde::num::u64_hex_or_decimal;
 pub use blob::BlobTransactionSidecar;
 pub use common::TransactionInfo;
 pub use optimism::OptimismTransactionReceiptFields;
@@ -29,7 +28,7 @@ pub struct Transaction {
     /// Hash
     pub hash: B256,
     /// Nonce
-    #[serde(with = "u64_hex_or_decimal")]
+    #[serde(with = "alloy_serde::num::u64_hex")]
     pub nonce: u64,
     /// Block hash
     pub block_hash: Option<B256>,

--- a/crates/rpc-types/src/eth/transaction/request.rs
+++ b/crates/rpc-types/src/eth/transaction/request.rs
@@ -34,7 +34,7 @@ pub struct TransactionRequest {
     #[serde(default, flatten)]
     pub input: TransactionInput,
     /// The nonce of the transaction.
-    #[serde(with = "u64_hex_or_decimal_opt")]
+    #[serde(default, with = "u64_hex_or_decimal_opt")]
     pub nonce: Option<u64>,
     /// The chain ID for the transaction.
     pub chain_id: Option<ChainId>,

--- a/crates/rpc-types/src/eth/transaction/request.rs
+++ b/crates/rpc-types/src/eth/transaction/request.rs
@@ -2,6 +2,7 @@
 
 use crate::{eth::transaction::AccessList, other::OtherFields, BlobTransactionSidecar};
 use alloy_primitives::{Address, Bytes, ChainId, B256, U256, U8};
+use alloy_serde::num::u64_hex_or_decimal_opt;
 use serde::{Deserialize, Serialize};
 use std::hash::Hash;
 
@@ -33,7 +34,7 @@ pub struct TransactionRequest {
     #[serde(default, flatten)]
     pub input: TransactionInput,
     /// The nonce of the transaction.
-    #[serde(with = "alloy_serde::u64_hex_or_decimal_opt")]
+    #[serde(with = "u64_hex_or_decimal_opt")]
     pub nonce: Option<u64>,
     /// The chain ID for the transaction.
     pub chain_id: Option<ChainId>,

--- a/crates/rpc-types/src/eth/transaction/request.rs
+++ b/crates/rpc-types/src/eth/transaction/request.rs
@@ -1,7 +1,7 @@
 //! Alloy basic Transaction Request type.
 
 use crate::{eth::transaction::AccessList, other::OtherFields, BlobTransactionSidecar};
-use alloy_primitives::{Address, Bytes, ChainId, B256, U256, U64, U8};
+use alloy_primitives::{Address, Bytes, ChainId, B256, U256, U8};
 use serde::{Deserialize, Serialize};
 use std::hash::Hash;
 
@@ -33,7 +33,8 @@ pub struct TransactionRequest {
     #[serde(default, flatten)]
     pub input: TransactionInput,
     /// The nonce of the transaction.
-    pub nonce: Option<U64>,
+    #[serde(with = "alloy_serde::u64_hex_or_decimal_opt")]
+    pub nonce: Option<u64>,
     /// The chain ID for the transaction.
     pub chain_id: Option<ChainId>,
     /// An EIP-2930 access list, which lowers cost for accessing accounts and storages in the list. See [EIP-2930](https://eips.ethereum.org/EIPS/eip-2930) for more information.
@@ -108,7 +109,7 @@ impl TransactionRequest {
     }
 
     /// Sets the nonce for the transaction.
-    pub const fn nonce(mut self, nonce: U64) -> Self {
+    pub const fn nonce(mut self, nonce: u64) -> Self {
         self.nonce = Some(nonce);
         self
     }

--- a/crates/rpc-types/src/eth/transaction/request.rs
+++ b/crates/rpc-types/src/eth/transaction/request.rs
@@ -2,7 +2,6 @@
 
 use crate::{eth::transaction::AccessList, other::OtherFields, BlobTransactionSidecar};
 use alloy_primitives::{Address, Bytes, ChainId, B256, U256, U8};
-use alloy_serde::num::u64_hex_or_decimal_opt;
 use serde::{Deserialize, Serialize};
 use std::hash::Hash;
 
@@ -34,7 +33,7 @@ pub struct TransactionRequest {
     #[serde(default, flatten)]
     pub input: TransactionInput,
     /// The nonce of the transaction.
-    #[serde(default, with = "u64_hex_or_decimal_opt")]
+    #[serde(default, with = "alloy_serde::num::u64_hex_opt")]
     pub nonce: Option<u64>,
     /// The chain ID for the transaction.
     pub chain_id: Option<ChainId>,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Closes #335 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Uses Serde's `with =` attribute and the existing `u64_hex` / `u64_hex_opt` to make sure RPC structs stay compliant.

~~Opening this PR as a draft first to get initial feedback.~~ ~~If implementation is correct I can add the other fields (`chain_id`, `transaction_type`, u128 native fields?)~~ (largely implemented in #338)

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
