### PR TITLE
fix(transaction-request): Support HEX `TransactionRequest.chain_id`

### DIFF
--- a/crates/rpc-types/src/eth/transaction/request.rs
+++ b/crates/rpc-types/src/eth/transaction/request.rs
@@ -36,6 +36,7 @@ pub struct TransactionRequest {
     #[serde(default, with = "alloy_serde::num::u64_hex_opt")]
     pub nonce: Option<u64>,
     /// The chain ID for the transaction.
+    #[serde(default, with = "alloy_serde::num::u64_hex_opt")]
     pub chain_id: Option<ChainId>,
     /// An EIP-2930 access list, which lowers cost for accessing accounts and storages in the list. See [EIP-2930](https://eips.ethereum.org/EIPS/eip-2930) for more information.
     #[serde(default)]
@@ -290,5 +291,18 @@ mod tests {
             req.other.get_deserialized::<B256>("sourceHash").unwrap().unwrap(),
             b256!("bf7e331f7f7c1dd2e05159666b3bf8bc7a8a3a9eb1d518969eab529dd9b88c1a")
         );
+    }
+
+    #[test]
+    fn serde_tx_chain_id_field() {
+        let chain_id: u64 = 12345678;
+
+        let chain_id_as_num = format!(r#"{{"chainId": {} }}"#, chain_id);
+        let req1 = serde_json::from_str::<TransactionRequest>(&chain_id_as_num).unwrap();
+        assert_eq!(req1.chain_id.unwrap(), chain_id);
+
+        let chain_id_as_hex = format!(r#"{{"chainId": "0x{:x}" }}"#, chain_id);
+        let req2 = serde_json::from_str::<TransactionRequest>(&chain_id_as_hex).unwrap();
+        assert_eq!(req2.chain_id.unwrap(), chain_id);
     }
 }


### PR DESCRIPTION
Support HEX TransactionRequest.chain_id` as per Ethereum JSON-RPC specification. 

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

While switching between node clients (GETH and RETH) there was an inconsistency in the `TransactionRequest.chain_id` implementation. 

To support the behavior, specified in Ethereum JSON-RPC specification the `chain_id` serialization was extended to support
**hex** input. 

Specs: https://ethereum.github.io/execution-apis/api-documentation/
<img width="1240" alt="image" src="https://github.com/alloy-rs/alloy/assets/9192608/d0fa10b7-2122-4297-a7bb-d9e82ad46da8">


<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Reuse custom serializer, already implemented for `nonce` field to support **hex** input for `chain_id` field.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
