### PR TITLE
feat(node-bindings): add methods for returning instance urls

### DIFF
--- a/crates/node-bindings/Cargo.toml
+++ b/crates/node-bindings/Cargo.toml
@@ -19,6 +19,7 @@ serde_json.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
+url.workspace = true
 
 [dev-dependencies]
 rand.workspace = true

--- a/crates/node-bindings/src/anvil.rs
+++ b/crates/node-bindings/src/anvil.rs
@@ -11,6 +11,7 @@ use std::{
     time::{Duration, Instant},
 };
 use thiserror::Error;
+use url::Url;
 
 /// How long we will wait for anvil to indicate that it is ready.
 const ANVIL_STARTUP_TIMEOUT_MILLIS: u64 = 10_000;
@@ -67,6 +68,16 @@ impl AnvilInstance {
     /// Returns the Websocket endpoint of this instance
     pub fn ws_endpoint(&self) -> String {
         format!("ws://localhost:{}", self.port)
+    }
+
+    /// Returns the HTTP endpoint url of this instance
+    pub fn endpoint_url(&self) -> Url {
+        Url::parse(&self.endpoint()).unwrap()
+    }
+
+    /// Returns the Websocket endpoint url of this instance
+    pub fn ws_endpoint_url(&self) -> Url {
+        Url::parse(&self.ws_endpoint()).unwrap()
     }
 }
 

--- a/crates/node-bindings/src/geth.rs
+++ b/crates/node-bindings/src/geth.rs
@@ -691,7 +691,6 @@ mod tests {
     fn run_with_tempdir(f: impl Fn(&Path)) {
         let temp_dir = tempfile::tempdir().unwrap();
         let temp_dir_path = temp_dir.path();
-        println!("temp dir: {:?}", temp_dir_path);
         f(temp_dir_path);
         #[cfg(not(windows))]
         temp_dir.close().unwrap();

--- a/crates/node-bindings/src/geth.rs
+++ b/crates/node-bindings/src/geth.rs
@@ -15,6 +15,7 @@ use std::{
 };
 use tempfile::tempdir;
 use thiserror::Error;
+use url::Url;
 
 /// How long we will wait for geth to indicate that it is ready.
 const GETH_STARTUP_TIMEOUT: Duration = Duration::from_secs(10);
@@ -74,6 +75,16 @@ impl GethInstance {
     /// Returns the Websocket endpoint of this instance
     pub fn ws_endpoint(&self) -> String {
         format!("ws://localhost:{}", self.port)
+    }
+
+    /// Returns the HTTP endpoint url of this instance
+    pub fn endpoint_url(&self) -> Url {
+        Url::parse(&self.endpoint()).unwrap()
+    }
+
+    /// Returns the Websocket endpoint url of this instance
+    pub fn ws_endpoint_url(&self) -> Url {
+        Url::parse(&self.ws_endpoint()).unwrap()
     }
 
     /// Returns the path to this instances' IPC socket
@@ -680,6 +691,7 @@ mod tests {
     fn run_with_tempdir(f: impl Fn(&Path)) {
         let temp_dir = tempfile::tempdir().unwrap();
         let temp_dir_path = temp_dir.path();
+        println!("temp dir: {:?}", temp_dir_path);
         f(temp_dir_path);
         #[cfg(not(windows))]
         temp_dir.close().unwrap();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

The existing methods such as `endpoint()` and `ws_endpoint()` would return the URLs as a `String`. One would have to parse the String as a URL and then pass it to the provider. 

## Solution

Adds two methods `endpoint_url()` and `ws_endpoint_url()`  which return the `HTTP` and `WS` urls respectively for both `anvil` and `geth` instances.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
