### PR TITLE
feat: serde for consensus tx types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,10 +112,10 @@ tempfile = "3.10"
 
 # TODO: Remove eventually.
 [patch.crates-io]
-alloy-sol-macro = { git = "https://github.com/klkvr/core", rev = "0473659" }
-alloy-primitives = { git = "https://github.com/klkvr/core", rev = "0473659" }
-alloy-sol-types = { git = "https://github.com/klkvr/core", rev = "0473659" }
-alloy-json-abi = { git = "https://github.com/klkvr/core", rev = "0473659" }
-alloy-dyn-abi = { git = "https://github.com/klkvr/core", rev = "0473659" }
-syn-solidity = { git = "https://github.com/klkvr/core", rev = "0473659" }
-alloy-core = { git = "https://github.com/klkvr/core", rev = "0473659" }
+alloy-sol-macro = { git = "https://github.com/klkvr/core", rev = "1bac767" }
+alloy-primitives = { git = "https://github.com/klkvr/core", rev = "1bac767" }
+alloy-sol-types = { git = "https://github.com/klkvr/core", rev = "1bac767" }
+alloy-json-abi = { git = "https://github.com/klkvr/core", rev = "1bac767" }
+alloy-dyn-abi = { git = "https://github.com/klkvr/core", rev = "1bac767" }
+syn-solidity = { git = "https://github.com/klkvr/core", rev = "1bac767" }
+alloy-core = { git = "https://github.com/klkvr/core", rev = "1bac767" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,10 +112,10 @@ tempfile = "3.10"
 
 # TODO: Remove eventually.
 [patch.crates-io]
-alloy-sol-macro = { git = "https://github.com/klkvr/core", rev = "1bac767" }
-alloy-primitives = { git = "https://github.com/klkvr/core", rev = "1bac767" }
-alloy-sol-types = { git = "https://github.com/klkvr/core", rev = "1bac767" }
-alloy-json-abi = { git = "https://github.com/klkvr/core", rev = "1bac767" }
-alloy-dyn-abi = { git = "https://github.com/klkvr/core", rev = "1bac767" }
-syn-solidity = { git = "https://github.com/klkvr/core", rev = "1bac767" }
-alloy-core = { git = "https://github.com/klkvr/core", rev = "1bac767" }
+alloy-sol-macro = { git = "https://github.com/alloy-rs/core", rev = "1bac767" }
+alloy-primitives = { git = "https://github.com/alloy-rs/core", rev = "1bac767" }
+alloy-sol-types = { git = "https://github.com/alloy-rs/core", rev = "1bac767" }
+alloy-json-abi = { git = "https://github.com/alloy-rs/core", rev = "1bac767" }
+alloy-dyn-abi = { git = "https://github.com/alloy-rs/core", rev = "1bac767" }
+syn-solidity = { git = "https://github.com/alloy-rs/core", rev = "1bac767" }
+alloy-core = { git = "https://github.com/alloy-rs/core", rev = "1bac767" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,10 +112,10 @@ tempfile = "3.10"
 
 # TODO: Remove eventually.
 [patch.crates-io]
-alloy-sol-macro = { git = "https://github.com/alloy-rs/core", rev = "1bac767" }
-alloy-primitives = { git = "https://github.com/alloy-rs/core", rev = "1bac767" }
-alloy-sol-types = { git = "https://github.com/alloy-rs/core", rev = "1bac767" }
-alloy-json-abi = { git = "https://github.com/alloy-rs/core", rev = "1bac767" }
-alloy-dyn-abi = { git = "https://github.com/alloy-rs/core", rev = "1bac767" }
-syn-solidity = { git = "https://github.com/alloy-rs/core", rev = "1bac767" }
-alloy-core = { git = "https://github.com/alloy-rs/core", rev = "1bac767" }
+alloy-sol-macro = { git = "https://github.com/alloy-rs/core", rev = "ff33969" }
+alloy-primitives = { git = "https://github.com/alloy-rs/core", rev = "ff33969" }
+alloy-sol-types = { git = "https://github.com/alloy-rs/core", rev = "ff33969" }
+alloy-json-abi = { git = "https://github.com/alloy-rs/core", rev = "ff33969" }
+alloy-dyn-abi = { git = "https://github.com/alloy-rs/core", rev = "ff33969" }
+syn-solidity = { git = "https://github.com/alloy-rs/core", rev = "ff33969" }
+alloy-core = { git = "https://github.com/alloy-rs/core", rev = "ff33969" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,10 +112,10 @@ tempfile = "3.10"
 
 # TODO: Remove eventually.
 [patch.crates-io]
-alloy-sol-macro = { git = "https://github.com/alloy-rs/core", rev = "1bac7678797fcd1bee2f2580825724b4165b12c1" }
-alloy-primitives = { git = "https://github.com/alloy-rs/core", rev = "1bac7678797fcd1bee2f2580825724b4165b12c1" }
-alloy-sol-types = { git = "https://github.com/alloy-rs/core", rev = "1bac7678797fcd1bee2f2580825724b4165b12c1" }
-alloy-json-abi = { git = "https://github.com/alloy-rs/core", rev = "1bac7678797fcd1bee2f2580825724b4165b12c1" }
-alloy-dyn-abi = { git = "https://github.com/alloy-rs/core", rev = "1bac7678797fcd1bee2f2580825724b4165b12c1" }
-syn-solidity = { git = "https://github.com/alloy-rs/core", rev = "1bac7678797fcd1bee2f2580825724b4165b12c1" }
-alloy-core = { git = "https://github.com/alloy-rs/core", rev = "1bac7678797fcd1bee2f2580825724b4165b12c1" }
+alloy-sol-macro = { git = "https://github.com/klkvr/core", rev = "0473659" }
+alloy-primitives = { git = "https://github.com/klkvr/core", rev = "0473659" }
+alloy-sol-types = { git = "https://github.com/klkvr/core", rev = "0473659" }
+alloy-json-abi = { git = "https://github.com/klkvr/core", rev = "0473659" }
+alloy-dyn-abi = { git = "https://github.com/klkvr/core", rev = "0473659" }
+syn-solidity = { git = "https://github.com/klkvr/core", rev = "0473659" }
+alloy-core = { git = "https://github.com/klkvr/core", rev = "0473659" }

--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -15,10 +15,11 @@ exclude.workspace = true
 alloy-primitives = { workspace = true, features = ["rlp"] }
 alloy-rlp.workspace = true
 alloy-eips.workspace = true
+alloy-serde = { workspace = true, optional = true }
+
 thiserror = { workspace = true, optional = true }
 c-kzg = { version = "1.0", features = ["serde"], optional = true }
 sha2 = { version = "0.10", optional = true }
-alloy-serde = { workspace = true, optional = true }
 
 # arbitrary
 arbitrary = { workspace = true, features = ["derive"], optional = true }

--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -17,18 +17,24 @@ alloy-rlp.workspace = true
 alloy-eips.workspace = true
 thiserror = { workspace = true, optional = true }
 c-kzg = { version = "1.0", features = ["serde"], optional = true }
-sha2 = { version = "0.10" }
+sha2 = { version = "0.10", optional = true }
+alloy-serde = { workspace = true, optional = true }
 
 # arbitrary
 arbitrary = { workspace = true, features = ["derive"], optional = true }
+
+# serde
+serde = { workspace = true, features = ["derive"], optional = true }
 
 [dev-dependencies]
 alloy-signer.workspace = true
 arbitrary = { workspace = true, features = ["derive"] }
 k256.workspace = true
 tokio = { workspace = true, features = ["macros"] }
+serde_json.workspace = true
 
 [features]
 k256 = ["alloy-primitives/k256"]
 kzg = ["dep:c-kzg", "dep:thiserror"]
 arbitrary = ["dep:arbitrary", "alloy-eips/arbitrary"]
+serde = ["dep:serde", "alloy-primitives/serde", "dep:alloy-serde"]

--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -37,4 +37,4 @@ serde_json.workspace = true
 k256 = ["alloy-primitives/k256"]
 kzg = ["dep:c-kzg", "dep:thiserror"]
 arbitrary = ["dep:arbitrary", "alloy-eips/arbitrary"]
-serde = ["dep:serde", "alloy-primitives/serde", "dep:alloy-serde"]
+serde = ["dep:serde", "alloy-primitives/serde", "dep:alloy-serde", "alloy-eips/serde"]

--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -19,7 +19,7 @@ alloy-serde = { workspace = true, optional = true }
 
 thiserror = { workspace = true, optional = true }
 c-kzg = { version = "1.0", features = ["serde"], optional = true }
-sha2 = { version = "0.10", optional = true }
+sha2 = { version = "0.10" }
 
 # arbitrary
 arbitrary = { workspace = true, features = ["derive"], optional = true }

--- a/crates/consensus/src/signed.rs
+++ b/crates/consensus/src/signed.rs
@@ -3,8 +3,11 @@ use alloy_primitives::{Signature, B256};
 
 /// A transaction with a signature and hash seal.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Signed<T, Sig = Signature> {
+    #[cfg_attr(feature = "serde", serde(flatten))]
     tx: T,
+    #[cfg_attr(feature = "serde", serde(flatten))]
     signature: Sig,
     hash: B256,
 }

--- a/crates/consensus/src/transaction/eip1559.rs
+++ b/crates/consensus/src/transaction/eip1559.rs
@@ -46,7 +46,7 @@ pub struct TxEip1559 {
     pub max_priority_fee_per_gas: u128,
     /// The 160-bit address of the message call’s recipient or, for a contract creation
     /// transaction, ∅, used here to denote the only member of B0 ; formally Tt.
-    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "TxKind::is_create"))]
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "TxKind::is_create"))]
     pub to: TxKind,
     /// A scalar value equal to the number of Wei to
     /// be transferred to the message call’s recipient or,

--- a/crates/consensus/src/transaction/eip1559.rs
+++ b/crates/consensus/src/transaction/eip1559.rs
@@ -6,16 +6,21 @@ use std::mem;
 
 /// A transaction with a priority fee ([EIP-1559](https://eips.ethereum.org/EIPS/eip-1559)).
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct TxEip1559 {
     /// EIP-155: Simple replay attack protection
-    pub chain_id: u64,
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::u64_hex_or_decimal"))]
+    pub chain_id: ChainId,
     /// A scalar value equal to the number of transactions sent by the sender; formally Tn.
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::u64_hex_or_decimal"))]
     pub nonce: u64,
     /// A scalar value equal to the maximum
     /// amount of gas that should be used in executing
     /// this transaction. This is paid up-front, before any
     /// computation is done and may not be increased
     /// later; formally Tg.
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::u64_hex_or_decimal"))]
     pub gas_limit: u64,
     /// A scalar value equal to the maximum
     /// amount of gas that should be used in executing
@@ -28,6 +33,7 @@ pub struct TxEip1559 {
     /// 340282366920938463463374607431768211455
     ///
     /// This is also known as `GasFeeCap`
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::u128_hex_or_decimal"))]
     pub max_fee_per_gas: u128,
     /// Max Priority fee that transaction is paying
     ///
@@ -36,9 +42,11 @@ pub struct TxEip1559 {
     /// 340282366920938463463374607431768211455
     ///
     /// This is also known as `GasTipCap`
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::u128_hex_or_decimal"))]
     pub max_priority_fee_per_gas: u128,
     /// The 160-bit address of the message call’s recipient or, for a contract creation
     /// transaction, ∅, used here to denote the only member of B0 ; formally Tt.
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "TxKind::is_create"))]
     pub to: TxKind,
     /// A scalar value equal to the number of Wei to
     /// be transferred to the message call’s recipient or,

--- a/crates/consensus/src/transaction/eip2930.rs
+++ b/crates/consensus/src/transaction/eip2930.rs
@@ -6,10 +6,14 @@ use std::mem;
 
 /// Transaction with an [`AccessList`] ([EIP-2930](https://eips.ethereum.org/EIPS/eip-2930)).
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct TxEip2930 {
     /// Added as EIP-pub 155: Simple replay attack protection
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::u64_hex_or_decimal"))]
     pub chain_id: ChainId,
     /// A scalar value equal to the number of transactions sent by the sender; formally Tn.
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::u64_hex_or_decimal"))]
     pub nonce: u64,
     /// A scalar value equal to the number of
     /// Wei to be paid per unit of gas for all computation
@@ -18,12 +22,14 @@ pub struct TxEip2930 {
     /// As ethereum circulation is around 120mil eth as of 2022 that is around
     /// 120000000000000000000000000 wei we are safe to use u128 as its max number is:
     /// 340282366920938463463374607431768211455
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::u128_hex_or_decimal"))]
     pub gas_price: u128,
     /// A scalar value equal to the maximum
     /// amount of gas that should be used in executing
     /// this transaction. This is paid up-front, before any
     /// computation is done and may not be increased
     /// later; formally Tg.
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::u64_hex_or_decimal"))]
     pub gas_limit: u64,
     /// The 160-bit address of the message call’s recipient or, for a contract creation
     /// transaction, ∅, used here to denote the only member of B0 ; formally Tt.

--- a/crates/consensus/src/transaction/eip2930.rs
+++ b/crates/consensus/src/transaction/eip2930.rs
@@ -33,6 +33,7 @@ pub struct TxEip2930 {
     pub gas_limit: u64,
     /// The 160-bit address of the message call’s recipient or, for a contract creation
     /// transaction, ∅, used here to denote the only member of B0 ; formally Tt.
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "TxKind::is_create"))]
     pub to: TxKind,
     /// A scalar value equal to the number of Wei to
     /// be transferred to the message call’s recipient or,

--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -481,7 +481,7 @@ mod tests {
             max_fee_per_gas: 50_000_000_000,
             max_priority_fee_per_gas: 1_000_000_000_000,
             gas_limit: 1_000_000,
-            to: TxKind::Create,
+            to: Address::random(),
             value: U256::from(10e18),
             input: Bytes::new(),
             access_list: AccessList(vec![AccessListItem {
@@ -500,7 +500,7 @@ mod tests {
                 max_fee_per_gas: 50_000_000_000,
                 max_priority_fee_per_gas: 1_000_000_000_000,
                 gas_limit: 1_000_000,
-                to: TxKind::Create,
+                to: Address::random(),
                 value: U256::from(10e18),
                 input: Bytes::new(),
                 access_list: AccessList(vec![AccessListItem {

--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -473,6 +473,8 @@ mod tests {
     #[test]
     #[cfg(feature = "serde")]
     fn test_serde_roundtrip_eip4844() {
+        use crate::BlobTransactionSidecar;
+
         let tx = TxEip4844Variant::TxEip4844(TxEip4844 {
             chain_id: 1,
             nonce: 100,
@@ -488,6 +490,27 @@ mod tests {
             }]),
             blob_versioned_hashes: vec![B256::random()],
             max_fee_per_blob_gas: 0,
+        });
+        test_serde_roundtrip(tx);
+
+        let tx = TxEip4844Variant::TxEip4844WithSidecar(TxEip4844WithSidecar {
+            tx: TxEip4844 {
+                chain_id: 1,
+                nonce: 100,
+                max_fee_per_gas: 50_000_000_000,
+                max_priority_fee_per_gas: 1_000_000_000_000,
+                gas_limit: 1_000_000,
+                to: TxKind::Create,
+                value: U256::from(10e18),
+                input: Bytes::new(),
+                access_list: AccessList(vec![AccessListItem {
+                    address: Address::random(),
+                    storage_keys: vec![B256::random()],
+                }]),
+                blob_versioned_hashes: vec![B256::random()],
+                max_fee_per_blob_gas: 0,
+            },
+            sidecar: BlobTransactionSidecar { ..Default::default() },
         });
         test_serde_roundtrip(tx);
     }

--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -61,12 +61,17 @@ impl TryFrom<u8> for TxType {
 ///
 /// [EIP-2718]: https://eips.ethereum.org/EIPS/eip-2718
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type"))]
 pub enum TxEnvelope {
     /// An untagged [`TxLegacy`].
+    #[serde(rename = "0x00", alias = "0x0")]
     Legacy(Signed<TxLegacy>),
     /// A [`TxEip2930`] tagged with type 1.
+    #[serde(rename = "0x01", alias = "0x1")]
     Eip2930(Signed<TxEip2930>),
     /// A [`TxEip1559`] tagged with type 2.
+    #[serde(rename = "0x02", alias = "0x2")]
     Eip1559(Signed<TxEip1559>),
     /// A TxEip4844 tagged with type 3.
     /// An EIP-4844 transaction has two network representations:
@@ -75,6 +80,7 @@ pub enum TxEnvelope {
     ///
     /// 2 - The transaction with a sidecar, which is the form used to
     /// send transactions to the network.
+    #[serde(rename = "0x03", alias = "0x3")]
     Eip4844(Signed<TxEip4844Variant>),
 }
 
@@ -397,5 +403,92 @@ mod tests {
         let encoded = tx.encoded_2718();
         assert_eq!(encoded, hex_data);
         assert_eq!(tx.encode_2718_len(), hex_data.len());
+    }
+
+    #[cfg(feature = "serde")]
+    fn test_serde_roundtrip<T: SignableTransaction<Signature>>(tx: T)
+    where
+        Signed<T>: Into<TxEnvelope>,
+    {
+        let signature = Signature::test_signature();
+        let tx_envelope: TxEnvelope = tx.into_signed(signature).into();
+
+        let serialized = serde_json::to_string(&tx_envelope).unwrap();
+        let deserialized: TxEnvelope = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(tx_envelope, deserialized);
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn test_serde_roundtrip_legacy() {
+        let tx = TxLegacy {
+            chain_id: Some(1),
+            nonce: 100,
+            gas_price: 3_000_000_000,
+            gas_limit: 50_000,
+            to: TxKind::Call(Address::default()),
+            value: U256::from(10e18),
+            input: Bytes::new(),
+        };
+        test_serde_roundtrip(tx);
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn test_serde_roundtrip_eip1559() {
+        let tx = TxEip1559 {
+            chain_id: 1,
+            nonce: 100,
+            max_fee_per_gas: 50_000_000_000,
+            max_priority_fee_per_gas: 1_000_000_000_000,
+            gas_limit: 1_000_000,
+            to: TxKind::Create,
+            value: U256::from(10e18),
+            input: Bytes::new(),
+            access_list: AccessList(vec![AccessListItem {
+                address: Address::random(),
+                storage_keys: vec![B256::random()],
+            }]),
+        };
+        test_serde_roundtrip(tx);
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn test_serde_roundtrip_eip2930() {
+        let tx = TxEip2930 {
+            chain_id: u64::MAX,
+            nonce: u64::MAX,
+            gas_price: u128::MAX,
+            gas_limit: u64::MAX,
+            to: TxKind::Call(Address::random()),
+            value: U256::MAX,
+            input: Bytes::new(),
+            access_list: Default::default(),
+        };
+        test_serde_roundtrip(tx);
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn test_serde_roundtrip_eip4844() {
+        let tx = TxEip4844Variant::TxEip4844(TxEip4844 {
+            chain_id: 1,
+            nonce: 100,
+            max_fee_per_gas: 50_000_000_000,
+            max_priority_fee_per_gas: 1_000_000_000_000,
+            gas_limit: 1_000_000,
+            to: TxKind::Create,
+            value: U256::from(10e18),
+            input: Bytes::new(),
+            access_list: AccessList(vec![AccessListItem {
+                address: Address::random(),
+                storage_keys: vec![B256::random()],
+            }]),
+            blob_versioned_hashes: vec![B256::random()],
+            max_fee_per_blob_gas: 0,
+        });
+        test_serde_roundtrip(tx);
     }
 }

--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -65,13 +65,13 @@ impl TryFrom<u8> for TxType {
 #[cfg_attr(feature = "serde", serde(tag = "type"))]
 pub enum TxEnvelope {
     /// An untagged [`TxLegacy`].
-    #[serde(rename = "0x00", alias = "0x0")]
+    #[cfg_attr(feature = "serde", serde(rename = "0x00", alias = "0x0"))]
     Legacy(Signed<TxLegacy>),
     /// A [`TxEip2930`] tagged with type 1.
-    #[serde(rename = "0x01", alias = "0x1")]
+    #[cfg_attr(feature = "serde", serde(rename = "0x01", alias = "0x1"))]
     Eip2930(Signed<TxEip2930>),
     /// A [`TxEip1559`] tagged with type 2.
-    #[serde(rename = "0x02", alias = "0x2")]
+    #[cfg_attr(feature = "serde", serde(rename = "0x02", alias = "0x2"))]
     Eip1559(Signed<TxEip1559>),
     /// A TxEip4844 tagged with type 3.
     /// An EIP-4844 transaction has two network representations:
@@ -80,7 +80,7 @@ pub enum TxEnvelope {
     ///
     /// 2 - The transaction with a sidecar, which is the form used to
     /// send transactions to the network.
-    #[serde(rename = "0x03", alias = "0x3")]
+    #[cfg_attr(feature = "serde", serde(rename = "0x03", alias = "0x3"))]
     Eip4844(Signed<TxEip4844Variant>),
 }
 

--- a/crates/consensus/src/transaction/legacy.rs
+++ b/crates/consensus/src/transaction/legacy.rs
@@ -32,6 +32,7 @@ pub struct TxLegacy {
     pub gas_limit: u64,
     /// The 160-bit address of the message call’s recipient or, for a contract creation
     /// transaction, ∅, used here to denote the only member of B0 ; formally Tt.
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "TxKind::is_create"))]
     pub to: TxKind,
     /// A scalar value equal to the number of Wei to
     /// be transferred to the message call’s recipient or,

--- a/crates/consensus/src/transaction/legacy.rs
+++ b/crates/consensus/src/transaction/legacy.rs
@@ -5,10 +5,14 @@ use std::mem;
 
 /// Legacy transaction.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct TxLegacy {
     /// Added as EIP-155: Simple replay attack protection
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::u64_hex_or_decimal_opt"))]
     pub chain_id: Option<ChainId>,
     /// A scalar value equal to the number of transactions sent by the sender; formally Tn.
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::u64_hex_or_decimal"))]
     pub nonce: u64,
     /// A scalar value equal to the number of
     /// Wei to be paid per unit of gas for all computation
@@ -17,12 +21,14 @@ pub struct TxLegacy {
     /// As ethereum circulation is around 120mil eth as of 2022 that is around
     /// 120000000000000000000000000 wei we are safe to use u128 as its max number is:
     /// 340282366920938463463374607431768211455
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::u128_hex_or_decimal"))]
     pub gas_price: u128,
     /// A scalar value equal to the maximum
     /// amount of gas that should be used in executing
     /// this transaction. This is paid up-front, before any
     /// computation is done and may not be increased
     /// later; formally Tg.
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::u64_hex_or_decimal"))]
     pub gas_limit: u64,
     /// The 160-bit address of the message call’s recipient or, for a contract creation
     /// transaction, ∅, used here to denote the only member of B0 ; formally Tt.

--- a/crates/consensus/src/transaction/legacy.rs
+++ b/crates/consensus/src/transaction/legacy.rs
@@ -9,7 +9,13 @@ use std::mem;
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct TxLegacy {
     /// Added as EIP-155: Simple replay attack protection
-    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::u64_hex_or_decimal_opt", skip_serializing_if = "Option::is_none"))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(
+            with = "alloy_serde::u64_hex_or_decimal_opt",
+            skip_serializing_if = "Option::is_none"
+        )
+    )]
     pub chain_id: Option<ChainId>,
     /// A scalar value equal to the number of transactions sent by the sender; formally Tn.
     #[cfg_attr(feature = "serde", serde(with = "alloy_serde::u64_hex_or_decimal"))]

--- a/crates/consensus/src/transaction/legacy.rs
+++ b/crates/consensus/src/transaction/legacy.rs
@@ -9,7 +9,7 @@ use std::mem;
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct TxLegacy {
     /// Added as EIP-155: Simple replay attack protection
-    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::u64_hex_or_decimal_opt"))]
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::u64_hex_or_decimal_opt", skip_serializing_if = "Option::is_none"))]
     pub chain_id: Option<ChainId>,
     /// A scalar value equal to the number of transactions sent by the sender; formally Tn.
     #[cfg_attr(feature = "serde", serde(with = "alloy_serde::u64_hex_or_decimal"))]

--- a/crates/consensus/src/transaction/legacy.rs
+++ b/crates/consensus/src/transaction/legacy.rs
@@ -13,7 +13,8 @@ pub struct TxLegacy {
         feature = "serde",
         serde(
             with = "alloy_serde::u64_hex_or_decimal_opt",
-            skip_serializing_if = "Option::is_none"
+            skip_serializing_if = "Option::is_none",
+            default
         )
     )]
     pub chain_id: Option<ChainId>,

--- a/crates/consensus/src/transaction/legacy.rs
+++ b/crates/consensus/src/transaction/legacy.rs
@@ -12,9 +12,9 @@ pub struct TxLegacy {
     #[cfg_attr(
         feature = "serde",
         serde(
+            default,
             with = "alloy_serde::u64_hex_or_decimal_opt",
             skip_serializing_if = "Option::is_none",
-            default
         )
     )]
     pub chain_id: Option<ChainId>,

--- a/crates/consensus/src/transaction/typed.rs
+++ b/crates/consensus/src/transaction/typed.rs
@@ -13,16 +13,16 @@ use alloy_primitives::TxKind;
 #[cfg_attr(feature = "serde", serde(tag = "type"))]
 pub enum TypedTransaction {
     /// Legacy transaction
-    #[serde(rename = "0x00", alias = "0x0")]
+    #[cfg_attr(feature = "serde", serde(rename = "0x00", alias = "0x0"))]
     Legacy(TxLegacy),
     /// EIP-2930 transaction
-    #[serde(rename = "0x01", alias = "0x1")]
+    #[cfg_attr(feature = "serde", serde(rename = "0x01", alias = "0x1"))]
     Eip2930(TxEip2930),
     /// EIP-1559 transaction
-    #[serde(rename = "0x02", alias = "0x2")]
+    #[cfg_attr(feature = "serde", serde(rename = "0x02", alias = "0x2"))]
     Eip1559(TxEip1559),
     /// EIP-4844 transaction
-    #[serde(rename = "0x03", alias = "0x3")]
+    #[cfg_attr(feature = "serde", serde(rename = "0x03", alias = "0x3"))]
     Eip4844(TxEip4844Variant),
 }
 

--- a/crates/consensus/src/transaction/typed.rs
+++ b/crates/consensus/src/transaction/typed.rs
@@ -9,14 +9,20 @@ use alloy_primitives::TxKind;
 /// 3. EIP1559 [`TxEip1559`]
 /// 4. EIP4844 [`TxEip4844Variant`]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type"))]
 pub enum TypedTransaction {
     /// Legacy transaction
+    #[serde(rename = "0x00", alias = "0x0")]
     Legacy(TxLegacy),
     /// EIP-2930 transaction
+    #[serde(rename = "0x01", alias = "0x1")]
     Eip2930(TxEip2930),
     /// EIP-1559 transaction
+    #[serde(rename = "0x02", alias = "0x2")]
     Eip1559(TxEip1559),
     /// EIP-4844 transaction
+    #[serde(rename = "0x03", alias = "0x3")]
     Eip4844(TxEip4844Variant),
 }
 

--- a/crates/eips/src/eip2930.rs
+++ b/crates/eips/src/eip2930.rs
@@ -48,7 +48,6 @@ impl AccessListItem {
     derive(proptest_derive::Arbitrary, arbitrary::Arbitrary)
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct AccessList(
     #[cfg_attr(
         all(any(test, feature = "arbitrary"), feature = "std"),

--- a/crates/serde/src/num.rs
+++ b/crates/serde/src/num.rs
@@ -208,23 +208,13 @@ pub mod u128_hex_or_decimal {
     use alloy_primitives::U128;
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-    #[derive(Deserialize)]
-    #[serde(untagged)]
-    enum NumberOrHexU128 {
-        Hex(U128),
-        Int(u128),
-    }
-
     /// Deserializes an `u64` accepting a hex quantity string with optional 0x prefix or
     /// a number
     pub fn deserialize<'de, D>(deserializer: D) -> Result<u128, D::Error>
     where
         D: Deserializer<'de>,
     {
-        match NumberOrHexU128::deserialize(deserializer)? {
-            NumberOrHexU128::Int(val) => Ok(val),
-            NumberOrHexU128::Hex(val) => Ok(val.to()),
-        }
+        U128::deserialize(deserializer).map(|val| val.to())
     }
 
     /// Serializes u64 as hex string


### PR DESCRIPTION
## Motivation

Adds `Serialize` and `Deserialize` impls for `TypedTransaction`, `TxEnvelope`, etc.

Bumps core

## Solution

I don't really like the way we manage `type` on tagged tx enums, current version is from ethers, perhaps there is a way we can do better here?

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
