### PR TITLE
fix: remove app-layer usage of transport error

### DIFF
--- a/crates/json-rpc/src/error.rs
+++ b/crates/json-rpc/src/error.rs
@@ -8,6 +8,10 @@ pub enum RpcError<E, ErrResp = Box<RawValue>> {
     #[error("server returned an error response: {0}")]
     ErrorResp(ErrorPayload<ErrResp>),
 
+    /// Server returned a null response when a non-null response was expected.
+    #[error("server returned a null response when a non-null response was expected")]
+    NullResp,
+
     /// JSON serialization error.
     #[error("serialization error: {0}")]
     SerError(
@@ -92,6 +96,11 @@ impl<E, ErrResp> RpcError<E, ErrResp> {
     /// Check if the error is an error response.
     pub const fn is_error_resp(&self) -> bool {
         matches!(self, Self::ErrorResp(_))
+    }
+
+    /// Check if the error is a null response.
+    pub const fn is_null_resp(&self) -> bool {
+        matches!(self, Self::NullResp)
     }
 
     /// Fallible conversion to an error response.

--- a/crates/json-rpc/src/error.rs
+++ b/crates/json-rpc/src/error.rs
@@ -12,6 +12,10 @@ pub enum RpcError<E, ErrResp = Box<RawValue>> {
     #[error("server returned a null response when a non-null response was expected")]
     NullResp,
 
+    /// Rpc server returned an unsupported feature.
+    #[error("unsupported feature: {0}")]
+    UnsupportedFeature(&'static str),
+
     /// JSON serialization error.
     #[error("serialization error: {0}")]
     SerError(

--- a/crates/provider/src/heart.rs
+++ b/crates/provider/src/heart.rs
@@ -1,6 +1,7 @@
 //! Block heartbeat and pending transaction watcher.
 
 use crate::{Provider, RootProvider};
+use alloy_json_rpc::RpcError;
 use alloy_network::Network;
 use alloy_primitives::{B256, U256};
 use alloy_rpc_types::Block;
@@ -182,7 +183,8 @@ impl<'a, N: Network, T: Transport + Clone> PendingTransactionBuilder<'a, N, T> {
         let pending_tx = self.provider.watch_pending_transaction(self.config).await?;
         let hash = pending_tx.await?;
         let receipt = self.provider.get_transaction_receipt(hash).await?;
-        receipt.ok_or_else(TransportErrorKind::missing_receipt)
+
+        receipt.ok_or(RpcError::NullResp)
     }
 }
 

--- a/crates/provider/src/layers/gas.rs
+++ b/crates/provider/src/layers/gas.rs
@@ -123,7 +123,7 @@ where
                 tx.set_max_priority_fee_per_gas(eip1559_fees.max_priority_fee_per_gas);
                 Ok(())
             }
-            Err(RpcError::NullResp) => self.handle_legacy_tx(tx).await,
+            Err(RpcError::UnsupportedFeature("eip1559")) => self.handle_legacy_tx(tx).await,
             Err(e) => Err(e),
         }
     }

--- a/crates/provider/src/provider.rs
+++ b/crates/provider/src/provider.rs
@@ -771,8 +771,11 @@ pub trait Provider<N: Network, T: Transport + Clone = BoxTransport>: Send + Sync
             )
         )?;
 
-        let base_fee_per_gas =
-            bf.ok_or(RpcError::NullResp)?.header.base_fee_per_gas.ok_or(RpcError::NullResp)?;
+        let base_fee_per_gas = bf
+            .ok_or(RpcError::NullResp)?
+            .header
+            .base_fee_per_gas
+            .ok_or(RpcError::UnsupportedFeature("eip1559"))?;
 
         Ok(estimator.unwrap_or(utils::eip1559_default_estimator)(
             base_fee_per_gas,

--- a/crates/provider/src/provider.rs
+++ b/crates/provider/src/provider.rs
@@ -6,7 +6,7 @@ use crate::{
     utils::{self, Eip1559Estimation, EstimatorFunction},
     PendingTransactionBuilder,
 };
-use alloy_json_rpc::{RpcParam, RpcReturn};
+use alloy_json_rpc::{RpcError, RpcParam, RpcReturn};
 use alloy_network::{Network, TransactionBuilder};
 use alloy_primitives::{
     hex, Address, BlockHash, BlockNumber, Bytes, StorageKey, StorageValue, TxHash, B256, U256, U64,
@@ -762,41 +762,23 @@ pub trait Provider<N: Network, T: Transport + Clone = BoxTransport>: Send + Sync
         &self,
         estimator: Option<EstimatorFunction>,
     ) -> TransportResult<Eip1559Estimation> {
-        let base_fee_per_gas = match self.get_block_by_number(BlockNumberOrTag::Latest, false).await
-        {
-            Ok(Some(block)) => match block.header.base_fee_per_gas {
-                Some(base_fee_per_gas) => base_fee_per_gas,
-                None => return Err(TransportErrorKind::custom_str("EIP-1559 not activated")),
-            },
-
-            Ok(None) => return Err(TransportErrorKind::custom_str("Latest block not found")),
-
-            Err(err) => return Err(err),
-        };
-
-        let fee_history = match self
-            .get_fee_history(
+        let (bf, fh) = futures::join!(
+            self.get_block_by_number(BlockNumberOrTag::Latest, false),
+            self.get_fee_history(
                 U256::from(utils::EIP1559_FEE_ESTIMATION_PAST_BLOCKS),
                 BlockNumberOrTag::Latest,
                 &[utils::EIP1559_FEE_ESTIMATION_REWARD_PERCENTILE],
             )
-            .await
-        {
-            Ok(fee_history) => fee_history,
-            Err(err) => return Err(err),
-        };
+        );
 
-        // use the provided fee estimator function, or fallback to the default implementation.
-        let (max_fee_per_gas, max_priority_fee_per_gas) = if let Some(es) = estimator {
-            es(base_fee_per_gas, &fee_history.reward.unwrap_or_default())
-        } else {
-            utils::eip1559_default_estimator(
-                base_fee_per_gas,
-                &fee_history.reward.unwrap_or_default(),
-            )
-        };
+        let base_fee_per_gas =
+            bf?.ok_or(RpcError::NullResp)?.header.base_fee_per_gas.ok_or(RpcError::NullResp)?;
+        let fee_history = fh?;
 
-        Ok(Eip1559Estimation { max_fee_per_gas, max_priority_fee_per_gas })
+        Ok(estimator.unwrap_or(utils::eip1559_default_estimator)(
+            base_fee_per_gas,
+            &fee_history.reward.unwrap_or_default(),
+        ))
     }
 
     /// Get the account and storage values of the specified account including the merkle proofs.

--- a/crates/transport/src/error.rs
+++ b/crates/transport/src/error.rs
@@ -31,10 +31,6 @@ pub enum TransportErrorKind {
     #[error("subscriptions are not available on this provider")]
     PubsubUnavailable,
 
-    /// Transaction confirmed but `get_transaction_receipt` returned `None`.
-    #[error("transaction confirmed but receipt returned was null")]
-    MissingReceipt,
-
     /// Custom error.
     #[error("{0}")]
     Custom(#[source] Box<dyn StdError + Send + Sync + 'static>),
@@ -70,10 +66,5 @@ impl TransportErrorKind {
     /// Instantiate a new `TransportError::PubsubUnavailable`.
     pub const fn pubsub_unavailable() -> TransportError {
         RpcError::Transport(Self::PubsubUnavailable)
-    }
-
-    /// Instantiate a new `TransportError::MissingReceipt`.
-    pub const fn missing_receipt() -> TransportError {
-        RpcError::Transport(Self::MissingReceipt)
     }
 }


### PR DESCRIPTION
## Motivation

TransportError should capture `Transport`-layer errors, not application or RPC semantics errors. RPC semantics errors should be captured by `RpcError` (note that `TransportErrorKind` instantiates an `RpcError<TransportError>`, not a `TransportError`). Application errors should be captured by either RpcError (e.g. when the application expects a non-null response) or by an ErrResp

## Solution

- Remove usages of `TransportErrorKing::custom_str`
- Remove `MissingReceipt` variant from TransportError
- Add `NullResp` variant to `RpcError`

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [x] Breaking changes
