### PR TITLE
fix: correctly process chainId field

### DIFF
--- a/crates/rpc-types/src/eth/transaction/mod.rs
+++ b/crates/rpc-types/src/eth/transaction/mod.rs
@@ -71,6 +71,7 @@ pub struct Transaction {
     /// The chain id of the transaction, if any.
     #[serde(default)]
     #[serde(with = "alloy_serde::u64_hex_opt")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub chain_id: Option<u64>,
     /// Contains the blob hashes for eip-4844 transactions.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]

--- a/crates/rpc-types/src/eth/transaction/mod.rs
+++ b/crates/rpc-types/src/eth/transaction/mod.rs
@@ -69,9 +69,7 @@ pub struct Transaction {
     #[serde(flatten, skip_serializing_if = "Option::is_none")]
     pub signature: Option<Signature>,
     /// The chain id of the transaction, if any.
-    #[serde(default)]
-    #[serde(with = "alloy_serde::u64_hex_opt")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::u64_hex_opt")]
     pub chain_id: Option<u64>,
     /// Contains the blob hashes for eip-4844 transactions.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]

--- a/crates/rpc-types/src/eth/transaction/mod.rs
+++ b/crates/rpc-types/src/eth/transaction/mod.rs
@@ -69,6 +69,7 @@ pub struct Transaction {
     #[serde(flatten, skip_serializing_if = "Option::is_none")]
     pub signature: Option<Signature>,
     /// The chain id of the transaction, if any.
+    #[serde(default)]
     #[serde(with = "alloy_serde::u64_hex_opt")]
     pub chain_id: Option<u64>,
     /// Contains the blob hashes for eip-4844 transactions.
@@ -311,6 +312,26 @@ mod tests {
         assert_eq!(
             serialized,
             r#"{"hash":"0x0000000000000000000000000000000000000000000000000000000000000001","nonce":"0x2","blockHash":"0x0000000000000000000000000000000000000000000000000000000000000003","blockNumber":"0x4","transactionIndex":"0x5","from":"0x0000000000000000000000000000000000000006","to":"0x0000000000000000000000000000000000000007","value":"0x8","gasPrice":"0x9","gas":"0xa","maxFeePerGas":"0x15","maxPriorityFeePerGas":"0x16","input":"0x0b0c0d","r":"0xe","s":"0xe","v":"0xe","yParity":"0x1","chainId":"0x11","type":"0x14"}"#
+        );
+        let deserialized: Transaction = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(transaction, deserialized);
+    }
+
+    #[test]
+    fn serde_minimal_transaction() {
+        let transaction = Transaction {
+            hash: B256::with_last_byte(1),
+            nonce: 2,
+            from: Address::with_last_byte(6),
+            value: U256::from(8),
+            gas: U256::from(10),
+            input: Bytes::from(vec![11, 12, 13]),
+            ..Default::default()
+        };
+        let serialized = serde_json::to_string(&transaction).unwrap();
+        assert_eq!(
+            serialized,
+            r#"{"hash":"0x0000000000000000000000000000000000000000000000000000000000000001","nonce":"0x2","blockHash":null,"blockNumber":null,"transactionIndex":null,"from":"0x0000000000000000000000000000000000000006","to":null,"value":"0x8","gas":"0xa","input":"0x0b0c0d"}"#
         );
         let deserialized: Transaction = serde_json::from_str(&serialized).unwrap();
         assert_eq!(transaction, deserialized);


### PR DESCRIPTION
## Motivation

WIthout `serde(default)` legacy transactions without chainId field can't be deserialized right now

## Solution


## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
