### PR TITLE
chore: bump core

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,10 +108,10 @@ tempfile = "3.10"
 
 # TODO: Remove eventually.
 [patch.crates-io]
-alloy-sol-macro = { git = "https://github.com/alloy-rs/core", rev = "907d61a45a9135e979310990744080eef5f03fe5" }
-alloy-primitives = { git = "https://github.com/alloy-rs/core", rev = "907d61a45a9135e979310990744080eef5f03fe5" }
-alloy-sol-types = { git = "https://github.com/alloy-rs/core", rev = "907d61a45a9135e979310990744080eef5f03fe5" }
-alloy-json-abi = { git = "https://github.com/alloy-rs/core", rev = "907d61a45a9135e979310990744080eef5f03fe5" }
-alloy-dyn-abi = { git = "https://github.com/alloy-rs/core", rev = "907d61a45a9135e979310990744080eef5f03fe5" }
-syn-solidity = { git = "https://github.com/alloy-rs/core", rev = "907d61a45a9135e979310990744080eef5f03fe5" }
-alloy-core = { git = "https://github.com/alloy-rs/core", rev = "907d61a45a9135e979310990744080eef5f03fe5" }
+alloy-sol-macro = { git = "https://github.com/alloy-rs/core", rev = "1bac7678797fcd1bee2f2580825724b4165b12c1" }
+alloy-primitives = { git = "https://github.com/alloy-rs/core", rev = "1bac7678797fcd1bee2f2580825724b4165b12c1" }
+alloy-sol-types = { git = "https://github.com/alloy-rs/core", rev = "1bac7678797fcd1bee2f2580825724b4165b12c1" }
+alloy-json-abi = { git = "https://github.com/alloy-rs/core", rev = "1bac7678797fcd1bee2f2580825724b4165b12c1" }
+alloy-dyn-abi = { git = "https://github.com/alloy-rs/core", rev = "1bac7678797fcd1bee2f2580825724b4165b12c1" }
+syn-solidity = { git = "https://github.com/alloy-rs/core", rev = "1bac7678797fcd1bee2f2580825724b4165b12c1" }
+alloy-core = { git = "https://github.com/alloy-rs/core", rev = "1bac7678797fcd1bee2f2580825724b4165b12c1" }

--- a/crates/signer-aws/Cargo.toml
+++ b/crates/signer-aws/Cargo.toml
@@ -20,7 +20,7 @@ alloy-signer.workspace = true
 async-trait.workspace = true
 aws-sdk-kms = { version = "1", default-features = false }
 k256.workspace = true
-spki.workspace = true
+spki = { workspace = true, features = ["std"]}
 thiserror.workspace = true
 tracing.workspace = true
 


### PR DESCRIPTION
## Motivation

~~@DaniPopes CI fails with this error: https://github.com/alloy-rs/alloy/actions/runs/8392690542/job/22985932109?pr=361~~

~~Looks like the cause is disabled `std` feature of `spki` in #367~~

enabled it for signer-aws, didn't know exact no_std subset

## Solution


## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
