### PR TITLE
feat(layers): FillTxLayer

### DIFF
--- a/crates/provider/src/builder.rs
+++ b/crates/provider/src/builder.rs
@@ -7,9 +7,9 @@ use std::marker::PhantomData;
 /// A layering abstraction in the vein of [`tower::Layer`]
 ///
 /// [`tower::Layer`]: https://docs.rs/tower/latest/tower/trait.Layer.html
-pub trait ProviderLayer<P: Provider<N, T>, N: Network, T: Transport + Clone> {
+pub trait ProviderLayer<P: Provider<N, T> + Clone, N: Network, T: Transport + Clone> {
     /// The provider constructed by this layer.
-    type Provider: Provider<N, T>;
+    type Provider: Provider<N, T> + Clone;
 
     /// Wrap the given provider in the layer's provider.
     fn layer(&self, inner: P) -> Self::Provider;
@@ -23,7 +23,7 @@ impl<P, N, T> ProviderLayer<P, N, T> for Identity
 where
     T: Transport + Clone,
     N: Network,
-    P: Provider<N, T>,
+    P: Provider<N, T> + Clone,
 {
     type Provider = P;
 
@@ -50,7 +50,7 @@ impl<P, N, T, Inner, Outer> ProviderLayer<P, N, T> for Stack<Inner, Outer>
 where
     T: Transport + Clone,
     N: Network,
-    P: Provider<N, T>,
+    P: Provider<N, T> + Clone,
     Inner: ProviderLayer<P, N, T>,
     Outer: ProviderLayer<Inner::Provider, N, T>,
 {
@@ -128,7 +128,7 @@ impl<L, N> ProviderBuilder<L, N> {
     pub fn provider<P, T>(self, provider: P) -> L::Provider
     where
         L: ProviderLayer<P, N, T>,
-        P: Provider<N, T>,
+        P: Provider<N, T> + Clone,
         T: Transport + Clone,
         N: Network,
     {

--- a/crates/provider/src/layers/fill_tx.rs
+++ b/crates/provider/src/layers/fill_tx.rs
@@ -76,14 +76,11 @@ where
             async { self.gas_estimation_provider.handle_legacy_tx(tx).await }.right_future()
         };
 
-        match futures::try_join!(chain_id_fut, nonce_fut, gas_estimation_fut) {
-            Ok((chain_id, nonce, _)) => {
-                tx.set_chain_id(chain_id);
-                tx.set_nonce(nonce);
-                Ok(())
-            }
-            Err(e) => Err(e),
-        }
+        let (chain_id, nonce, _) = futures::try_join!(chain_id_fut, nonce_fut, gas_estimation_fut)?;
+
+        tx.set_chain_id(chain_id);
+        tx.set_nonce(nonce);
+        Ok(())
     }
 }
 

--- a/crates/provider/src/layers/fill_tx.rs
+++ b/crates/provider/src/layers/fill_tx.rs
@@ -1,0 +1,213 @@
+use crate::{
+    layers::{GasEstimatorProvider, ManagedNonceProvider},
+    PendingTransactionBuilder, Provider, ProviderLayer, RootProvider,
+};
+use alloy_network::{Network, TransactionBuilder};
+use alloy_transport::{Transport, TransportError, TransportErrorKind, TransportResult};
+use async_trait::async_trait;
+use futures::FutureExt;
+use std::marker::PhantomData;
+
+/// A layer that fills in missing transaction fields.
+#[derive(Debug, Clone, Copy)]
+pub struct FillTxLayer;
+
+impl<P, N, T> ProviderLayer<P, N, T> for FillTxLayer
+where
+    P: Provider<N, T> + Clone,
+    N: Network,
+    T: Transport + Clone,
+{
+    type Provider = FillTxProvider<N, T, P>;
+
+    fn layer(&self, inner: P) -> Self::Provider {
+        let nonce_provider = ManagedNonceProvider::new(inner.clone());
+        let gas_estimation_provider = GasEstimatorProvider::new(inner.clone());
+        FillTxProvider { inner, nonce_provider, gas_estimation_provider, _phantom: PhantomData }
+    }
+}
+
+/// A provider that fills in missing transaction fields.
+#[derive(Debug, Clone)]
+pub struct FillTxProvider<N, T, P>
+where
+    N: Network,
+    T: Transport + Clone,
+    P: Provider<N, T> + Clone,
+{
+    inner: P,
+    nonce_provider: ManagedNonceProvider<N, T, P>,
+    gas_estimation_provider: GasEstimatorProvider<N, T, P>,
+    _phantom: PhantomData<(N, T)>,
+}
+
+impl<N, T, P> FillTxProvider<N, T, P>
+where
+    N: Network,
+    T: Transport + Clone,
+    P: Provider<N, T> + Clone,
+{
+    /// Fills in missing transaction fields.
+    pub async fn fill_tx(&self, tx: &mut N::TransactionRequest) -> TransportResult<()> {
+        let chain_id_fut = if let Some(chain_id) = tx.chain_id() {
+            async move { Ok(chain_id) }.left_future()
+        } else {
+            async move { self.inner.get_chain_id().await.map(|ci| ci.to::<u64>()) }.right_future()
+        };
+
+        // Check if `from` is set
+        if tx.nonce().is_none() && tx.from().is_none() {
+            return Err(TransportError::Transport(TransportErrorKind::Custom(
+                "`from` field must be set in transaction request to populate the `nonce` field"
+                    .into(),
+            )));
+        }
+
+        let nonce_fut = if let Some(nonce) = tx.nonce() {
+            async move { Ok(nonce) }.left_future()
+        } else {
+            let from = tx.from().unwrap();
+            async move { self.nonce_provider.get_next_nonce(from).await }.right_future()
+        };
+
+        let gas_estimation_fut = if tx.gas_price().is_none() {
+            async { self.gas_estimation_provider.handle_eip1559_tx(tx).await }.left_future()
+        } else {
+            async { self.gas_estimation_provider.handle_legacy_tx(tx).await }.right_future()
+        };
+
+        match futures::try_join!(chain_id_fut, nonce_fut, gas_estimation_fut) {
+            Ok((chain_id, nonce, _)) => {
+                tx.set_chain_id(chain_id);
+                tx.set_nonce(nonce);
+                Ok(())
+            }
+            Err(e) => Err(e),
+        }
+    }
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+impl<N, T, P> Provider<N, T> for FillTxProvider<N, T, P>
+where
+    N: Network,
+    T: Transport + Clone,
+    P: Provider<N, T> + Clone,
+{
+    #[inline]
+    fn root(&self) -> &RootProvider<N, T> {
+        self.inner.root()
+    }
+
+    async fn send_transaction(
+        &self,
+        mut tx: N::TransactionRequest,
+    ) -> TransportResult<PendingTransactionBuilder<'_, N, T>> {
+        self.fill_tx(&mut tx).await?;
+        self.inner.send_transaction(tx).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ProviderBuilder;
+    use alloy_network::EthereumSigner;
+    use alloy_node_bindings::Anvil;
+    use alloy_primitives::{address, U256};
+    use alloy_rpc_client::RpcClient;
+    use alloy_rpc_types::TransactionRequest;
+    use alloy_transport_http::Http;
+    use reqwest::Client;
+
+    #[tokio::test]
+    async fn test_1559_tx_no_nonce_no_chain_id() {
+        let anvil = Anvil::new().spawn();
+        let url = anvil.endpoint_url();
+
+        let http = Http::<Client>::new(url);
+
+        let wallet = alloy_signer_wallet::Wallet::from(anvil.keys()[0].clone());
+
+        let provider = ProviderBuilder::new()
+            .layer(FillTxLayer)
+            .signer(EthereumSigner::from(wallet))
+            .provider(RootProvider::new(RpcClient::new(http, true)));
+
+        let tx = TransactionRequest {
+            from: Some(anvil.addresses()[0]),
+            value: Some(U256::from(100)),
+            to: address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045").into(),
+            ..Default::default()
+        };
+
+        let tx = provider.send_transaction(tx).await.unwrap();
+
+        let tx = provider.get_transaction_by_hash(tx.tx_hash().to_owned()).await.unwrap();
+
+        assert_eq!(tx.max_fee_per_gas, Some(U256::from(0x77359400)));
+        assert_eq!(tx.max_priority_fee_per_gas, Some(U256::from(0x0)));
+        assert_eq!(tx.gas, U256::from(21000));
+        assert_eq!(tx.nonce, 0);
+        assert_eq!(tx.chain_id, Some(31337));
+    }
+
+    #[tokio::test]
+    async fn test_legacy_tx_no_nonce_chain_id() {
+        let anvil = Anvil::new().spawn();
+        let url = anvil.endpoint_url();
+
+        let http = Http::<Client>::new(url);
+
+        let wallet = alloy_signer_wallet::Wallet::from(anvil.keys()[0].clone());
+
+        let provider = ProviderBuilder::new()
+            .layer(FillTxLayer)
+            .signer(EthereumSigner::from(wallet))
+            .provider(RootProvider::new(RpcClient::new(http, true)));
+
+        let gas_price = provider.get_gas_price().await.unwrap();
+        let tx = TransactionRequest {
+            from: Some(anvil.addresses()[0]),
+            value: Some(U256::from(100)),
+            to: address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045").into(),
+            chain_id: Some(31337),
+            gas_price: Some(gas_price),
+            ..Default::default()
+        };
+
+        let tx = provider.send_transaction(tx).await.unwrap();
+
+        let tx = provider.get_transaction_by_hash(tx.tx_hash().to_owned()).await.unwrap();
+
+        assert_eq!(tx.gas_price, Some(gas_price));
+        assert_eq!(tx.gas, U256::from(21000));
+        assert_eq!(tx.nonce, 0);
+        assert_eq!(tx.chain_id, Some(31337));
+    }
+
+    #[tokio::test]
+    #[should_panic]
+    async fn test_no_from() {
+        let anvil = Anvil::new().spawn();
+        let url = anvil.endpoint_url();
+
+        let http = Http::<Client>::new(url);
+
+        let wallet = alloy_signer_wallet::Wallet::from(anvil.keys()[0].clone());
+
+        let provider = ProviderBuilder::new()
+            .layer(FillTxLayer)
+            .signer(EthereumSigner::from(wallet))
+            .provider(RootProvider::new(RpcClient::new(http, true)));
+
+        let tx = TransactionRequest {
+            value: Some(U256::from(100)),
+            to: address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045").into(),
+            ..Default::default()
+        };
+
+        let _ = provider.send_transaction(tx).await.unwrap();
+    }
+}

--- a/crates/provider/src/layers/mod.rs
+++ b/crates/provider/src/layers/mod.rs
@@ -10,3 +10,6 @@ pub use nonce::{ManagedNonceLayer, ManagedNonceProvider};
 
 mod gas;
 pub use gas::{GasEstimatorLayer, GasEstimatorProvider};
+
+mod fill_tx;
+pub use fill_tx::{FillTxLayer, FillTxProvider};

--- a/crates/provider/src/layers/signer.rs
+++ b/crates/provider/src/layers/signer.rs
@@ -38,7 +38,7 @@ impl<S> SignerLayer<S> {
 
 impl<P, N, T, S> ProviderLayer<P, N, T> for SignerLayer<S>
 where
-    P: Provider<N, T>,
+    P: Provider<N, T> + Clone,
     N: Network,
     T: Transport + Clone,
     S: NetworkSigner<N> + Clone,
@@ -59,12 +59,12 @@ where
 /// You cannot construct this provider directly. Use [`ProviderBuilder`] with a [`SignerLayer`].
 ///
 /// [`ProviderBuilder`]: crate::ProviderBuilder
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct SignerProvider<N, T, P, S>
 where
     N: Network,
     T: Transport + Clone,
-    P: Provider<N, T>,
+    P: Provider<N, T> + Clone,
 {
     inner: P,
     signer: S,
@@ -77,7 +77,7 @@ impl<N, T, P, S> Provider<N, T> for SignerProvider<N, T, P, S>
 where
     N: Network,
     T: Transport + Clone,
-    P: Provider<N, T>,
+    P: Provider<N, T> + Clone,
     S: NetworkSigner<N>,
 {
     #[inline]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Unify the `ManagedNonceProvider` and `GasEstimatorProvider` to concurrently populate missing tx fields.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Implement a `FillTxLayer` that concurrently calls the following methods:
- `get_next_nonce` from `ManagedNonceProvider` to populate the `nonce` field.
- `handle_eip1559_tx` and `handle_legacy_tx` from `GasEstimatorProvider` to populate gas related fields.
- `get_chain_id` from provider directly to populate the `chain_id` field.

In order to achieve this, the following changes were made:

1. Introduced the `Clone` trait bound on the `Provider<N, T>` for `ProviderBuilder` enable the cloning of the underlying provider and initializing of the `ManageNonceProvider` and `GasEstimatorProvider` directly in `FillTxLayer`

2. Added `pub(crate) fn new` method to both `ManageNonceProvider` and `GasEstimatorProvider` to instantiate them directly from the `FillTxLayer`

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
