### PR TITLE
feat: re-export EnvKzgSettings

### DIFF
--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -30,5 +30,5 @@ tokio = { workspace = true, features = ["macros"] }
 
 [features]
 k256 = ["alloy-primitives/k256"]
-kzg = ["dep:c-kzg", "dep:thiserror"]
+kzg = ["dep:c-kzg", "dep:thiserror", "alloy-eips/kzg"]
 arbitrary = ["dep:arbitrary", "alloy-eips/arbitrary"]

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -33,6 +33,9 @@ pub use transaction::{
 #[cfg(feature = "kzg")]
 pub use transaction::BlobTransactionValidationError;
 
+#[cfg(feature = "kzg")]
+pub use alloy_eips::eip4844::env_settings::EnvKzgSettings;
+
 mod sealed;
 pub use sealed::{Sealable, Sealed};
 

--- a/crates/consensus/src/transaction/eip4844/builder.rs
+++ b/crates/consensus/src/transaction/eip4844/builder.rs
@@ -343,9 +343,8 @@ impl<T: SidecarCoder> SidecarBuilder<T> {
     #[cfg(feature = "kzg")]
     pub fn build_with_settings(
         self,
-        settings: &crate::EnvKzgSettings,
+        settings: &c_kzg::KzgSettings,
     ) -> Result<crate::BlobTransactionSidecar, c_kzg::Error> {
-        let settings = settings.get();
         let mut commitments = Vec::with_capacity(self.inner.blobs.len());
         let mut proofs = Vec::with_capacity(self.inner.blobs.len());
         for blob in self.inner.blobs.iter() {
@@ -362,7 +361,7 @@ impl<T: SidecarCoder> SidecarBuilder<T> {
     /// settings.
     #[cfg(feature = "kzg")]
     pub fn build(self) -> Result<crate::BlobTransactionSidecar, c_kzg::Error> {
-        self.build_with_settings(&crate::EnvKzgSettings::Default)
+        self.build_with_settings(crate::EnvKzgSettings::Default.get())
     }
 
     /// Take the blobs from the builder, without committing them to a KZG proof.


### PR DESCRIPTION

## Motivation

Quality of life improvement post #349 

## Solution

- re-export `EnvKzgSettings` from alloy-consensus to allow easy use with `SidecarBuilder`
- refactor `SidecarBuilder::build` to use default settings
- add `SidecarBuilder::build_with_settings`

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [x] Breaking changes
