### PR TITLE
fix: correctly treat `confirmation` for `watch_pending_transaction`

### DIFF
--- a/crates/provider/src/heart.rs
+++ b/crates/provider/src/heart.rs
@@ -384,7 +384,7 @@ impl<S: Stream<Item = Block> + Unpin + 'static> Heartbeat<S> {
 impl<S> Heartbeat<S> {
     /// Check if any transactions have enough confirmations to notify.
     fn check_confirmations(&mut self, current_height: &U256) {
-        let to_keep = self.waiting_confs.split_off(current_height);
+        let to_keep = self.waiting_confs.split_off(&(current_height + U256::from(1)));
         let to_notify = std::mem::replace(&mut self.waiting_confs, to_keep);
         for watcher in to_notify.into_values().flatten() {
             watcher.notify();

--- a/crates/provider/src/heart.rs
+++ b/crates/provider/src/heart.rs
@@ -438,14 +438,14 @@ impl<S> Heartbeat<S> {
         for watcher in to_check {
             // If `confirmations` is 0 we can notify the watcher immediately.
             let confirmations = watcher.config.required_confirmations;
-            if confirmations == 0 {
+            if confirmations <= 1 {
                 watcher.notify();
                 continue;
             }
             // Otherwise add it to the waiting list.
             debug!(tx=%watcher.config.tx_hash, %block_height, confirmations, "adding to waiting list");
             self.waiting_confs
-                .entry(*block_height + U256::from(confirmations))
+                .entry(*block_height + U256::from(confirmations) + U256::from(1))
                 .or_default()
                 .push(watcher);
         }

--- a/crates/provider/src/heart.rs
+++ b/crates/provider/src/heart.rs
@@ -436,7 +436,7 @@ impl<S> Heartbeat<S> {
         let to_check =
             block.transactions.hashes().filter_map(|tx_hash| self.unconfirmed.remove(tx_hash));
         for watcher in to_check {
-            // If `confirmations` is 0 we can notify the watcher immediately.
+            // If `confirmations` is not more than 1 we can notify the watcher immediately.
             let confirmations = watcher.config.required_confirmations;
             if confirmations <= 1 {
                 watcher.notify();

--- a/crates/provider/src/heart.rs
+++ b/crates/provider/src/heart.rs
@@ -209,7 +209,7 @@ pub struct PendingTransactionConfig {
 impl PendingTransactionConfig {
     /// Create a new watch for a transaction.
     pub const fn new(tx_hash: B256) -> Self {
-        Self { tx_hash, required_confirmations: 0, timeout: None }
+        Self { tx_hash, required_confirmations: 1, timeout: None }
     }
 
     /// Returns the transaction hash.
@@ -445,7 +445,7 @@ impl<S> Heartbeat<S> {
             // Otherwise add it to the waiting list.
             debug!(tx=%watcher.config.tx_hash, %block_height, confirmations, "adding to waiting list");
             self.waiting_confs
-                .entry(*block_height + U256::from(confirmations) + U256::from(1))
+                .entry(*block_height + U256::from(confirmations) - U256::from(1))
                 .or_default()
                 .push(watcher);
         }


### PR DESCRIPTION
## Motivation

Current logic was not treating `confirmations` in the expected way (tx being included = 1 confirmation)
Also `split_off` splits off keys including the one at which split is being performed, thus we actually notified `TxWatcher` about txses one block later

Two open questions:
1. Currently if tx is sent, included into block and one more block is mined (basically tx included into block X and latest block is X+1), then call to `watch_pending_transaction` will indefinitely wait for a block with targeted tx. Is this expected? Feels like a footgun, especially considering that we don't have a default timeout
2. It feels like `watch_pending_transaction` users specifying `confirmations > 1` would also be interested in ensuring that no reorg has happened and that tx is actually on-chain, should we add a parameter for that?
