### PR TITLE
chore: clean up kzg and features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ ethereum_ssz_derive = "0.5"
 ethereum_ssz = "0.5"
 
 # crypto
+c-kzg = { version = "1.0", default-features = false }
 elliptic-curve = { version = "0.13", default-features = false }
 k256 = { version = "0.13", default-features = false, features = ["ecdsa"] }
 sha2 = { version = "0.10", default-features = false }

--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -15,9 +15,12 @@ exclude.workspace = true
 alloy-primitives = { workspace = true, features = ["rlp"] }
 alloy-rlp.workspace = true
 alloy-eips.workspace = true
-thiserror = { workspace = true, optional = true }
-c-kzg = { workspace = true, features = ["serde"], optional = true }
+
 sha2 = "0.10"
+
+# kzg
+thiserror = { workspace = true, optional = true }
+c-kzg = { workspace = true, features = ["std", "serde"], optional = true }
 
 # arbitrary
 arbitrary = { workspace = true, features = ["derive"], optional = true }

--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -16,8 +16,8 @@ alloy-primitives = { workspace = true, features = ["rlp"] }
 alloy-rlp.workspace = true
 alloy-eips.workspace = true
 thiserror = { workspace = true, optional = true }
-c-kzg = { version = "1.0", features = ["serde"], optional = true }
-sha2 = { version = "0.10" }
+c-kzg = { workspace = true, features = ["serde"], optional = true }
+sha2 = "0.10"
 
 # arbitrary
 arbitrary = { workspace = true, features = ["derive"], optional = true }

--- a/crates/consensus/src/transaction/eip4844.rs
+++ b/crates/consensus/src/transaction/eip4844.rs
@@ -16,14 +16,15 @@ use std::mem;
 
 #[cfg(not(feature = "kzg"))]
 use alloy_eips::eip4844::{Blob, Bytes48};
+
 #[cfg(feature = "kzg")]
 use c_kzg::{Blob, Bytes48, KzgCommitment, KzgProof, KzgSettings};
 #[cfg(feature = "kzg")]
 use std::ops::Deref;
 
-#[cfg(feature = "kzg")]
 /// An error that can occur when validating a [TxEip4844Variant].
 #[derive(Debug, thiserror::Error)]
+#[cfg(feature = "kzg")]
 pub enum BlobTransactionValidationError {
     /// Proof validation failed.
     #[error("invalid KZG proof")]
@@ -83,10 +84,10 @@ impl From<(TxEip4844, BlobTransactionSidecar)> for TxEip4844Variant {
 }
 
 impl TxEip4844Variant {
-    #[cfg(feature = "kzg")]
     /// Verifies that the transaction's blob data, commitments, and proofs are all valid.
     ///
     /// See also [TxEip4844::validate_blob]
+    #[cfg(feature = "kzg")]
     pub fn validate(
         &self,
         proof_settings: &KzgSettings,
@@ -731,10 +732,10 @@ impl TxEip4844WithSidecar {
         Self { tx, sidecar }
     }
 
-    #[cfg(feature = "kzg")]
     /// Verifies that the transaction's blob data, commitments, and proofs are all valid.
     ///
     /// See also [TxEip4844::validate_blob]
+    #[cfg(feature = "kzg")]
     pub fn validate_blob(
         &self,
         proof_settings: &KzgSettings,
@@ -1048,10 +1049,12 @@ pub(crate) fn kzg_to_versioned_hash(commitment: &[u8]) -> B256 {
 mod tests {
     use super::{BlobTransactionSidecar, TxEip4844, TxEip4844WithSidecar};
     use crate::{SignableTransaction, TxEnvelope};
-    #[cfg(not(feature = "kzg"))]
-    use alloy_eips::eip4844::{Blob, Bytes48};
     use alloy_primitives::{Signature, U256};
     use alloy_rlp::{Decodable, Encodable};
+
+    #[cfg(not(feature = "kzg"))]
+    use alloy_eips::eip4844::{Blob, Bytes48};
+
     #[cfg(feature = "kzg")]
     use c_kzg::{Blob, Bytes48};
 

--- a/crates/eips/Cargo.toml
+++ b/crates/eips/Cargo.toml
@@ -21,7 +21,8 @@ serde = { workspace = true, default-features = false, optional = true }
 
 # kzg
 derive_more = { workspace = true, optional = true }
-c-kzg = { workspace = true, features = ["std"], optional = true }
+c-kzg = { workspace = true, optional = true }
+once_cell = { workspace = true, features = ["race", "alloc"], optional = true }
 
 # ssz
 ethereum_ssz_derive = { workspace = true, optional = true }
@@ -41,9 +42,9 @@ serde_json.workspace = true
 
 [features]
 default = ["std"]
-std = ["alloy-primitives/std", "alloy-rlp/std", "serde?/std"]
+std = ["alloy-primitives/std", "alloy-rlp/std", "serde?/std", "c-kzg?/std", "once_cell?/std"]
 serde = ["dep:serde", "alloy-primitives/serde", "c-kzg?/serde"]
-kzg = ["std", "dep:derive_more", "dep:c-kzg"]
+kzg = ["dep:derive_more", "dep:c-kzg", "dep:once_cell"]
 ssz = ["std", "dep:ethereum_ssz", "dep:ethereum_ssz_derive", "alloy-primitives/ssz"]
 arbitrary = [
     "std",

--- a/crates/eips/Cargo.toml
+++ b/crates/eips/Cargo.toml
@@ -21,8 +21,7 @@ serde = { workspace = true, default-features = false, optional = true }
 
 # kzg
 derive_more = { workspace = true, optional = true }
-c-kzg = { version = "1.0", features = ["serde"], optional = true }
-once_cell = { workspace = true, optional = true }
+c-kzg = { workspace = true, features = ["std"], optional = true }
 
 # ssz
 ethereum_ssz_derive = { workspace = true, optional = true }
@@ -43,7 +42,9 @@ serde_json.workspace = true
 [features]
 default = ["std"]
 std = ["alloy-primitives/std", "alloy-rlp/std", "serde?/std"]
-serde = ["dep:serde", "alloy-primitives/serde"]
+serde = ["dep:serde", "alloy-primitives/serde", "c-kzg?/serde"]
+kzg = ["std", "dep:derive_more", "dep:c-kzg"]
+ssz = ["std", "dep:ethereum_ssz", "dep:ethereum_ssz_derive", "alloy-primitives/ssz"]
 arbitrary = [
     "std",
     "dep:arbitrary",
@@ -51,5 +52,3 @@ arbitrary = [
     "dep:proptest",
     "alloy-primitives/arbitrary",
 ]
-kzg = ["std", "dep:derive_more", "dep:c-kzg", "dep:once_cell", "once_cell/std"]
-ssz = ["dep:ethereum_ssz", "dep:ethereum_ssz_derive", "alloy-primitives/ssz", "std"]

--- a/crates/eips/src/eip4844/env_settings.rs
+++ b/crates/eips/src/eip4844/env_settings.rs
@@ -1,23 +1,21 @@
 use crate::eip4844::trusted_setup_points::{G1_POINTS, G2_POINTS};
 use c_kzg::KzgSettings;
-use once_cell::sync::Lazy;
 use std::{
     hash::{Hash, Hasher},
-    sync::Arc,
+    sync::{Arc, OnceLock},
 };
 
-/// KZG Settings that allow us to specify a custom trusted setup.
-/// or use hardcoded default settings.
+/// KZG settings.
 #[derive(Debug, Clone, Default, Eq)]
 pub enum EnvKzgSettings {
-    /// Default mainnet trusted setup
+    /// Default mainnet trusted setup.
     #[default]
     Default,
     /// Custom trusted setup.
     Custom(Arc<KzgSettings>),
 }
 
-// Implement PartialEq and Hash manually because `c_kzg::KzgSettings` does not implement them
+// Implement PartialEq and Hash manually because `c_kzg::KzgSettings` does not implement them.
 impl PartialEq for EnvKzgSettings {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
@@ -39,40 +37,20 @@ impl Hash for EnvKzgSettings {
 }
 
 impl EnvKzgSettings {
-    /// Return set KZG settings.
+    /// Returns the KZG settings.
     ///
-    /// In will initialize the default settings if it is not already loaded.
+    /// This will initialize the default settings if it is not already loaded.
+    #[inline]
     pub fn get(&self) -> &KzgSettings {
         match self {
             Self::Default => {
-                let load = || {
-                    KzgSettings::load_trusted_setup(G1_POINTS.as_ref(), G2_POINTS.as_ref())
+                static DEFAULT: OnceLock<KzgSettings> = OnceLock::new();
+                DEFAULT.get_or_init(|| {
+                    KzgSettings::load_trusted_setup(&G1_POINTS.0, &G2_POINTS.0)
                         .expect("failed to load default trusted setup")
-                };
-                #[cfg(feature = "std")]
-                {
-                    use once_cell as _;
-                    use std::sync::OnceLock;
-
-                    static DEFAULT: OnceLock<KzgSettings> = OnceLock::new();
-                    DEFAULT.get_or_init(load)
-                }
-                #[cfg(not(feature = "std"))]
-                {
-                    use once_cell::race::OnceBox;
-                    static DEFAULT: OnceBox<KzgSettings> = OnceBox::new();
-                    DEFAULT.get_or_init(|| alloc::boxed::Box::new(load))
-                }
+                })
             }
             Self::Custom(settings) => settings,
         }
     }
 }
-
-/// KZG trusted setup
-pub static MAINNET_KZG_TRUSTED_SETUP: Lazy<Arc<KzgSettings>> = Lazy::new(|| {
-    Arc::new(
-        KzgSettings::load_trusted_setup(&G1_POINTS.0, &G2_POINTS.0)
-            .expect("failed to load trusted setup"),
-    )
-});

--- a/crates/eips/src/eip4844/trusted_setup_points.rs
+++ b/crates/eips/src/eip4844/trusted_setup_points.rs
@@ -3,7 +3,7 @@ use core::fmt;
 use derive_more::{AsMut, AsRef, Deref, DerefMut};
 
 #[allow(unused_imports)]
-use std::boxed::Box;
+use alloc::boxed::Box;
 
 pub use c_kzg::{BYTES_PER_G1_POINT, BYTES_PER_G2_POINT};
 

--- a/crates/eips/src/lib.rs
+++ b/crates/eips/src/lib.rs
@@ -16,7 +16,8 @@
 #![cfg_attr(feature = "arbitrary", cfg(feature = "std"))]
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#[cfg(not(feature = "std"))]
+#[allow(unused_imports)]
+#[macro_use]
 extern crate alloc;
 
 pub mod eip1559;


### PR DESCRIPTION
The current implementation uses an Arc so it can never be no-std, and the `MAINNET` static is unnecessary as `EnvKzgSettings::Default.get` should be used instead.

cc @developeruche we should switch out `MAINNET` static usage in Reth to the enum