### PR TITLE
feature: embed primitives Log in rpc Log and consensus Receipt in rpc Receipt

### DIFF
--- a/crates/consensus/src/receipt/envelope.rs
+++ b/crates/consensus/src/receipt/envelope.rs
@@ -1,5 +1,6 @@
 use crate::{Receipt, ReceiptWithBloom, TxType};
 use alloy_eips::eip2718::{Decodable2718, Encodable2718};
+use alloy_primitives::Log;
 use alloy_rlp::{length_of_length, BufMut, Decodable, Encodable};
 
 /// Receipt envelope, as defined in [EIP-2718].
@@ -15,28 +16,28 @@ use alloy_rlp::{length_of_length, BufMut, Decodable, Encodable};
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(tag = "type"))]
-pub enum ReceiptEnvelope {
+pub enum ReceiptEnvelope<T = Log> {
     /// Receipt envelope with no type flag.
     #[cfg_attr(feature = "serde", serde(rename = "0x00", alias = "0x0"))]
-    Legacy(ReceiptWithBloom),
+    Legacy(ReceiptWithBloom<T>),
     /// Receipt envelope with type flag 1, containing a [EIP-2930] receipt.
     ///
     /// [EIP-2930]: https://eips.ethereum.org/EIPS/eip-2930
     #[cfg_attr(feature = "serde", serde(rename = "0x01", alias = "0x1"))]
-    Eip2930(ReceiptWithBloom),
+    Eip2930(ReceiptWithBloom<T>),
     /// Receipt envelope with type flag 2, containing a [EIP-1559] receipt.
     ///
     /// [EIP-1559]: https://eips.ethereum.org/EIPS/eip-1559
     #[cfg_attr(feature = "serde", serde(rename = "0x02", alias = "0x2"))]
-    Eip1559(ReceiptWithBloom),
+    Eip1559(ReceiptWithBloom<T>),
     /// Receipt envelope with type flag 2, containing a [EIP-4844] receipt.
     ///
     /// [EIP-4844]: https://eips.ethereum.org/EIPS/eip-4844
     #[cfg_attr(feature = "serde", serde(rename = "0x03", alias = "0x3"))]
-    Eip4844(ReceiptWithBloom),
+    Eip4844(ReceiptWithBloom<T>),
 }
 
-impl ReceiptEnvelope {
+impl<T> ReceiptEnvelope<T> {
     /// Return the [`TxType`] of the inner receipt.
     pub const fn tx_type(&self) -> TxType {
         match self {
@@ -49,7 +50,7 @@ impl ReceiptEnvelope {
 
     /// Return the inner receipt with bloom. Currently this is infallible,
     /// however, future receipt types may be added.
-    pub const fn as_receipt_with_bloom(&self) -> Option<&ReceiptWithBloom> {
+    pub const fn as_receipt_with_bloom(&self) -> Option<&ReceiptWithBloom<T>> {
         match self {
             Self::Legacy(t) | Self::Eip2930(t) | Self::Eip1559(t) | Self::Eip4844(t) => Some(t),
         }
@@ -57,14 +58,16 @@ impl ReceiptEnvelope {
 
     /// Return the inner receipt. Currently this is infallible, however, future
     /// receipt types may be added.
-    pub const fn as_receipt(&self) -> Option<&Receipt> {
+    pub const fn as_receipt(&self) -> Option<&Receipt<T>> {
         match self {
             Self::Legacy(t) | Self::Eip2930(t) | Self::Eip1559(t) | Self::Eip4844(t) => {
                 Some(&t.receipt)
             }
         }
     }
+}
 
+impl ReceiptEnvelope {
     /// Get the length of the inner receipt in the 2718 encoding.
     pub fn inner_length(&self) -> usize {
         self.as_receipt_with_bloom().unwrap().length()

--- a/crates/consensus/src/receipt/envelope.rs
+++ b/crates/consensus/src/receipt/envelope.rs
@@ -18,22 +18,22 @@ use alloy_rlp::{length_of_length, BufMut, Decodable, Encodable};
 #[cfg_attr(feature = "serde", serde(tag = "type"))]
 pub enum ReceiptEnvelope<T = Log> {
     /// Receipt envelope with no type flag.
-    #[cfg_attr(feature = "serde", serde(rename = "0x00", alias = "0x0"))]
+    #[cfg_attr(feature = "serde", serde(rename = "0x0", alias = "0x00"))]
     Legacy(ReceiptWithBloom<T>),
     /// Receipt envelope with type flag 1, containing a [EIP-2930] receipt.
     ///
     /// [EIP-2930]: https://eips.ethereum.org/EIPS/eip-2930
-    #[cfg_attr(feature = "serde", serde(rename = "0x01", alias = "0x1"))]
+    #[cfg_attr(feature = "serde", serde(rename = "0x1", alias = "0x01"))]
     Eip2930(ReceiptWithBloom<T>),
     /// Receipt envelope with type flag 2, containing a [EIP-1559] receipt.
     ///
     /// [EIP-1559]: https://eips.ethereum.org/EIPS/eip-1559
-    #[cfg_attr(feature = "serde", serde(rename = "0x02", alias = "0x2"))]
+    #[cfg_attr(feature = "serde", serde(rename = "0x2", alias = "0x02"))]
     Eip1559(ReceiptWithBloom<T>),
     /// Receipt envelope with type flag 2, containing a [EIP-4844] receipt.
     ///
     /// [EIP-4844]: https://eips.ethereum.org/EIPS/eip-4844
-    #[cfg_attr(feature = "serde", serde(rename = "0x03", alias = "0x3"))]
+    #[cfg_attr(feature = "serde", serde(rename = "0x3", alias = "0x03"))]
     Eip4844(ReceiptWithBloom<T>),
 }
 

--- a/crates/consensus/src/receipt/envelope.rs
+++ b/crates/consensus/src/receipt/envelope.rs
@@ -13,20 +13,26 @@ use alloy_rlp::{length_of_length, BufMut, Decodable, Encodable};
 ///
 /// [EIP-2718]: https://eips.ethereum.org/EIPS/eip-2718
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type"))]
 pub enum ReceiptEnvelope {
     /// Receipt envelope with no type flag.
+    #[cfg_attr(feature = "serde", serde(rename = "0x00", alias = "0x0"))]
     Legacy(ReceiptWithBloom),
     /// Receipt envelope with type flag 1, containing a [EIP-2930] receipt.
     ///
     /// [EIP-2930]: https://eips.ethereum.org/EIPS/eip-2930
+    #[cfg_attr(feature = "serde", serde(rename = "0x01", alias = "0x1"))]
     Eip2930(ReceiptWithBloom),
     /// Receipt envelope with type flag 2, containing a [EIP-1559] receipt.
     ///
     /// [EIP-1559]: https://eips.ethereum.org/EIPS/eip-1559
+    #[cfg_attr(feature = "serde", serde(rename = "0x02", alias = "0x2"))]
     Eip1559(ReceiptWithBloom),
     /// Receipt envelope with type flag 2, containing a [EIP-4844] receipt.
     ///
     /// [EIP-4844]: https://eips.ethereum.org/EIPS/eip-4844
+    #[cfg_attr(feature = "serde", serde(rename = "0x03", alias = "0x3"))]
     Eip4844(ReceiptWithBloom),
 }
 

--- a/crates/consensus/src/receipt/mod.rs
+++ b/crates/consensus/src/receipt/mod.rs
@@ -55,9 +55,9 @@ mod tests {
                             bytes!("0100ff"),
                         ),
                     }],
-                    success: false,
+                    status: false,
                 },
-                bloom: [0; 256].into(),
+                logs_bloom: [0; 256].into(),
             });
 
         receipt.network_encode(&mut data);
@@ -87,9 +87,9 @@ mod tests {
                             bytes!("0100ff"),
                         ),
                     }],
-                    success: false,
+                    status: false,
                 },
-                bloom: [0; 256].into(),
+                logs_bloom: [0; 256].into(),
             };
 
         let receipt = ReceiptWithBloom::decode(&mut &data[..]).unwrap();
@@ -100,7 +100,7 @@ mod tests {
     fn gigantic_receipt() {
         let receipt = Receipt {
             cumulative_gas_used: 16747627,
-            success: true,
+            status: true,
             logs: vec![
                 Log {
                     address: address!("4bf56695415f725e43c3e04354b604bcfb6dfb6e"),

--- a/crates/consensus/src/receipt/receipts.rs
+++ b/crates/consensus/src/receipt/receipts.rs
@@ -5,13 +5,15 @@ use alloy_rlp::{length_of_length, BufMut, Decodable, Encodable};
 /// Receipt containing result of transaction execution.
 #[derive(Clone, Debug, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct Receipt {
     /// If transaction is executed successfully.
     ///
     /// This is the `statusCode`
     #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity_bool"))]
-    pub success: bool,
+    pub status: bool,
     /// Gas used
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::u64_hex_or_decimal"))]
     pub cumulative_gas_used: u64,
     /// Log send from contracts.
     pub logs: Vec<Log>,
@@ -33,7 +35,7 @@ impl Receipt {
 
 impl TxReceipt for Receipt {
     fn success(&self) -> bool {
-        self.success
+        self.status
     }
 
     fn bloom(&self) -> Bloom {
@@ -56,24 +58,27 @@ impl TxReceipt for Receipt {
 ///
 /// [`Sealed`]: crate::sealed::Sealed
 #[derive(Clone, Debug, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct ReceiptWithBloom {
+    #[cfg_attr(feature = "serde", serde(flatten))]
     /// The receipt.
     pub receipt: Receipt,
     /// The bloom filter.
-    pub bloom: Bloom,
+    pub logs_bloom: Bloom,
 }
 
 impl TxReceipt for ReceiptWithBloom {
     fn success(&self) -> bool {
-        self.receipt.success
+        self.receipt.status
     }
 
     fn bloom(&self) -> Bloom {
-        self.bloom
+        self.logs_bloom
     }
 
     fn bloom_cheap(&self) -> Option<Bloom> {
-        Some(self.bloom)
+        Some(self.logs_bloom)
     }
 
     fn cumulative_gas_used(&self) -> u64 {
@@ -88,14 +93,14 @@ impl TxReceipt for ReceiptWithBloom {
 impl From<Receipt> for ReceiptWithBloom {
     fn from(receipt: Receipt) -> Self {
         let bloom = receipt.bloom_slow();
-        ReceiptWithBloom { receipt, bloom }
+        ReceiptWithBloom { receipt, logs_bloom: bloom }
     }
 }
 
 impl ReceiptWithBloom {
     /// Create new [ReceiptWithBloom]
     pub const fn new(receipt: Receipt, bloom: Bloom) -> Self {
-        Self { receipt, bloom }
+        Self { receipt, logs_bloom: bloom }
     }
 
     /// Consume the structure, returning only the receipt
@@ -107,13 +112,13 @@ impl ReceiptWithBloom {
     /// Consume the structure, returning the receipt and the bloom filter
     #[allow(clippy::missing_const_for_fn)] // false positive
     pub fn into_components(self) -> (Receipt, Bloom) {
-        (self.receipt, self.bloom)
+        (self.receipt, self.logs_bloom)
     }
 
     fn payload_len(&self) -> usize {
-        self.receipt.success.length()
+        self.receipt.status.length()
             + self.receipt.cumulative_gas_used.length()
-            + self.bloom.length()
+            + self.logs_bloom.length()
             + self.receipt.logs.length()
     }
 
@@ -125,9 +130,9 @@ impl ReceiptWithBloom {
     /// Encodes the receipt data.
     fn encode_fields(&self, out: &mut dyn BufMut) {
         self.receipt_rlp_header().encode(out);
-        self.receipt.success.encode(out);
+        self.receipt.status.encode(out);
         self.receipt.cumulative_gas_used.encode(out);
-        self.bloom.encode(out);
+        self.logs_bloom.encode(out);
         self.receipt.logs.encode(out);
     }
 
@@ -145,9 +150,9 @@ impl ReceiptWithBloom {
         let bloom = Decodable::decode(b)?;
         let logs = Decodable::decode(b)?;
 
-        let receipt = Receipt { success, cumulative_gas_used, logs };
+        let receipt = Receipt { status: success, cumulative_gas_used, logs };
 
-        let this = Self { receipt, bloom };
+        let this = Self { receipt, logs_bloom: bloom };
         let consumed = started_len - b.len();
         if consumed != rlp_head.payload_length {
             return Err(alloy_rlp::Error::ListLengthMismatch {
@@ -166,9 +171,9 @@ impl alloy_rlp::Encodable for ReceiptWithBloom {
     }
 
     fn length(&self) -> usize {
-        let payload_length = self.receipt.success.length()
+        let payload_length = self.receipt.status.length()
             + self.receipt.cumulative_gas_used.length()
-            + self.bloom.length()
+            + self.logs_bloom.length()
             + self.receipt.logs.length();
         payload_length + length_of_length(payload_length)
     }
@@ -186,6 +191,6 @@ impl<'a> arbitrary::Arbitrary<'a> for Receipt {
         let success = bool::arbitrary(u)?;
         let cumulative_gas_used = u64::arbitrary(u)?;
         let logs = u.arbitrary_iter()?.take(4).collect::<Result<Vec<_>, _>>()?;
-        Ok(Self { success, cumulative_gas_used, logs })
+        Ok(Self { status: success, cumulative_gas_used, logs })
     }
 }

--- a/crates/consensus/src/receipt/receipts.rs
+++ b/crates/consensus/src/receipt/receipts.rs
@@ -4,25 +4,17 @@ use alloy_rlp::{length_of_length, BufMut, Decodable, Encodable};
 
 /// Receipt containing result of transaction execution.
 #[derive(Clone, Debug, PartialEq, Eq, Default)]
-#[cfg_attr(feautre = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Receipt {
     /// If transaction is executed successfully.
     ///
     /// This is the `statusCode`
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity_bool"))]
     pub success: bool,
     /// Gas used
     pub cumulative_gas_used: u64,
     /// Log send from contracts.
     pub logs: Vec<Log>,
-}
-
-#[cfg(feature = "serde")]
-fn deser_quantity_bool<'a, D>(deserializer: D) -> Result<bool, D::Error>
-where
-    D: serde::Deserializer<'a>,
-{
-    let value = alloy_primitives::aliases::U1::deserialize(deserializer)?;
-    Ok(!value.is_zero())
 }
 
 impl Receipt {

--- a/crates/consensus/src/receipt/receipts.rs
+++ b/crates/consensus/src/receipt/receipts.rs
@@ -13,7 +13,7 @@ pub struct Receipt {
     #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity_bool"))]
     pub status: bool,
     /// Gas used
-    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::u64_hex_or_decimal"))]
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::u64_hex"))]
     pub cumulative_gas_used: u64,
     /// Log send from contracts.
     pub logs: Vec<Log>,

--- a/crates/consensus/src/receipt/receipts.rs
+++ b/crates/consensus/src/receipt/receipts.rs
@@ -6,7 +6,7 @@ use alloy_rlp::{length_of_length, BufMut, Decodable, Encodable};
 #[derive(Clone, Debug, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
-pub struct Receipt {
+pub struct Receipt<T = Log> {
     /// If transaction is executed successfully.
     ///
     /// This is the `statusCode`
@@ -16,7 +16,7 @@ pub struct Receipt {
     #[cfg_attr(feature = "serde", serde(with = "alloy_serde::u64_hex"))]
     pub cumulative_gas_used: u64,
     /// Log send from contracts.
-    pub logs: Vec<Log>,
+    pub logs: Vec<T>,
 }
 
 impl Receipt {
@@ -60,10 +60,10 @@ impl TxReceipt for Receipt {
 #[derive(Clone, Debug, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
-pub struct ReceiptWithBloom {
+pub struct ReceiptWithBloom<T = Log> {
     #[cfg_attr(feature = "serde", serde(flatten))]
     /// The receipt.
-    pub receipt: Receipt,
+    pub receipt: Receipt<T>,
     /// The bloom filter.
     pub logs_bloom: Bloom,
 }

--- a/crates/consensus/src/receipt/receipts.rs
+++ b/crates/consensus/src/receipt/receipts.rs
@@ -4,6 +4,7 @@ use alloy_rlp::{length_of_length, BufMut, Decodable, Encodable};
 
 /// Receipt containing result of transaction execution.
 #[derive(Clone, Debug, PartialEq, Eq, Default)]
+#[cfg_attr(feautre = "serde", derive(Serialize, Deserialize))]
 pub struct Receipt {
     /// If transaction is executed successfully.
     ///
@@ -13,6 +14,15 @@ pub struct Receipt {
     pub cumulative_gas_used: u64,
     /// Log send from contracts.
     pub logs: Vec<Log>,
+}
+
+#[cfg(feature = "serde")]
+fn deser_quantity_bool<'a, D>(deserializer: D) -> Result<bool, D::Error>
+where
+    D: serde::Deserializer<'a>,
+{
+    let value = alloy_primitives::aliases::U1::deserialize(deserializer)?;
+    Ok(!value.is_zero())
 }
 
 impl Receipt {

--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -65,13 +65,13 @@ impl TryFrom<u8> for TxType {
 #[cfg_attr(feature = "serde", serde(tag = "type"))]
 pub enum TxEnvelope {
     /// An untagged [`TxLegacy`].
-    #[cfg_attr(feature = "serde", serde(rename = "0x00", alias = "0x0"))]
+    #[cfg_attr(feature = "serde", serde(rename = "0x0", alias = "0x00"))]
     Legacy(Signed<TxLegacy>),
     /// A [`TxEip2930`] tagged with type 1.
-    #[cfg_attr(feature = "serde", serde(rename = "0x01", alias = "0x1"))]
+    #[cfg_attr(feature = "serde", serde(rename = "0x1", alias = "0x01"))]
     Eip2930(Signed<TxEip2930>),
     /// A [`TxEip1559`] tagged with type 2.
-    #[cfg_attr(feature = "serde", serde(rename = "0x02", alias = "0x2"))]
+    #[cfg_attr(feature = "serde", serde(rename = "0x2", alias = "0x02"))]
     Eip1559(Signed<TxEip1559>),
     /// A TxEip4844 tagged with type 3.
     /// An EIP-4844 transaction has two network representations:
@@ -80,7 +80,7 @@ pub enum TxEnvelope {
     ///
     /// 2 - The transaction with a sidecar, which is the form used to
     /// send transactions to the network.
-    #[cfg_attr(feature = "serde", serde(rename = "0x03", alias = "0x3"))]
+    #[cfg_attr(feature = "serde", serde(rename = "0x3", alias = "0x03"))]
     Eip4844(Signed<TxEip4844Variant>),
 }
 

--- a/crates/contract/src/event.rs
+++ b/crates/contract/src/event.rs
@@ -244,7 +244,7 @@ mod tests {
         let (stream_event, stream_log) = stream.next().await.unwrap().unwrap();
         assert_eq!(stream_event, expected_event);
         assert_eq!(stream_log.inner.address, *contract.address());
-        assert_eq!(stream_log.block_number, Some(U256::from(2)));
+        assert_eq!(stream_log.block_number, Some(2));
 
         // This is not going to return `None`
         // assert!(stream.next().await.is_none());

--- a/crates/contract/src/event.rs
+++ b/crates/contract/src/event.rs
@@ -214,10 +214,10 @@ mod tests {
     async fn event_filters() {
         init_tracing();
 
-        #[cfg(feature = "pubsub")]
+        #[cfg(feature = "ws")]
         let (provider, anvil) = spawn_anvil();
 
-        #[cfg(not(feature = "pubsub"))]
+        #[cfg(not(feature = "ws"))]
         let (provider, _anvil) = spawn_anvil();
 
         let contract = MyContract::deploy(&provider).await.unwrap();
@@ -254,11 +254,12 @@ mod tests {
         assert_eq!(all[0].0, expected_event);
         assert_eq!(all[0].1, stream_log);
 
-        #[cfg(feature = "pubsub")]
+        #[cfg(feature = "ws")]
         {
-            let ws = alloy_rpc_client::WsConnect::new(anvil.ws_endpoint());
-            let client = RpcClient::connect_pubsub(ws).await.unwrap();
-            let provider = RootProvider::<Ethereum, _>::new(client);
+            let provider = alloy_provider::ProviderBuilder::default()
+                .on_ws(anvil.ws_endpoint())
+                .await
+                .unwrap();
 
             let contract = MyContract::new(*contract.address(), provider);
             let event = contract.MyEvent_filter();

--- a/crates/provider/src/layers/gas.rs
+++ b/crates/provider/src/layers/gas.rs
@@ -250,11 +250,8 @@ mod tests {
 
         let tx = tx.get_receipt().await.unwrap();
 
-        let set_gas_price = U128::from(0x3b9aca00);
-        let set_gas_limit = U256::from(0x5208);
-
-        assert_eq!(tx.effective_gas_price, set_gas_price);
-        assert_eq!(tx.gas_used, Some(set_gas_limit));
+        assert_eq!(tx.effective_gas_price, 0x3b9aca00);
+        assert_eq!(tx.gas_used, Some(0x5208));
     }
 
     #[tokio::test]
@@ -284,9 +281,7 @@ mod tests {
 
         let tx = tx.get_receipt().await.unwrap();
 
-        let set_gas_limit = U256::from(0x5208);
-
-        assert_eq!(tx.gas_used, Some(set_gas_limit));
+        assert_eq!(tx.gas_used, Some(0x5208));
     }
 
     #[tokio::test]
@@ -315,8 +310,6 @@ mod tests {
 
         let tx = tx.get_receipt().await.unwrap();
 
-        let set_gas_price = U128::from(0x6fc23ac0);
-
-        assert_eq!(tx.effective_gas_price, set_gas_price);
+        assert_eq!(tx.effective_gas_price, 0x6fc23ac0);
     }
 }

--- a/crates/provider/src/layers/gas.rs
+++ b/crates/provider/src/layers/gas.rs
@@ -217,7 +217,7 @@ mod tests {
     use crate::ProviderBuilder;
     use alloy_network::EthereumSigner;
     use alloy_node_bindings::Anvil;
-    use alloy_primitives::{address, U128};
+    use alloy_primitives::address;
     use alloy_rpc_client::RpcClient;
     use alloy_rpc_types::TransactionRequest;
     use alloy_transport_http::Http;

--- a/crates/rpc-types/Cargo.toml
+++ b/crates/rpc-types/Cargo.toml
@@ -34,6 +34,7 @@ proptest-derive = { version = "0.4", optional = true }
 
 # jsonrpsee
 jsonrpsee-types = { version = "0.20", optional = true }
+alloy-sol-types.workspace = true
 
 [features]
 arbitrary = ["dep:arbitrary", "dep:proptest-derive", "dep:proptest", "alloy-primitives/arbitrary"]

--- a/crates/rpc-types/src/eth/log.rs
+++ b/crates/rpc-types/src/eth/log.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::{LogData, B256, U256};
+use alloy_primitives::{LogData, B256};
 use serde::{Deserialize, Serialize};
 
 /// Ethereum Log emitted by a transaction
@@ -12,13 +12,16 @@ pub struct Log<T = LogData> {
     /// Hash of the block the transaction that emitted this log was mined in
     pub block_hash: Option<B256>,
     /// Number of the block the transaction that emitted this log was mined in
-    pub block_number: Option<U256>,
+    #[serde(with = "alloy_serde::u64_hex_opt")]
+    pub block_number: Option<u64>,
     /// Transaction Hash
     pub transaction_hash: Option<B256>,
     /// Index of the Transaction in the block
-    pub transaction_index: Option<U256>,
+    #[serde(with = "alloy_serde::u64_hex_opt")]
+    pub transaction_index: Option<u64>,
     /// Log Index in Block
-    pub log_index: Option<U256>,
+    #[serde(with = "alloy_serde::u64_hex_opt")]
+    pub log_index: Option<u64>,
     /// Geth Compatibility Field: whether this log was removed
     #[serde(default)]
     pub removed: bool,
@@ -26,8 +29,8 @@ pub struct Log<T = LogData> {
 
 impl<T> Log<T> {
     /// Getter for the address field. Shortcut for `log.inner.address`.
-    pub const fn address(&self) -> &alloy_primitives::Address {
-        &self.inner.address
+    pub const fn address(&self) -> alloy_primitives::Address {
+        self.inner.address
     }
 
     /// Getter for the data field. Shortcut for `log.inner.data`.
@@ -126,10 +129,10 @@ mod tests {
                 ),
             },
             block_hash: Some(B256::with_last_byte(0x69)),
-            block_number: Some(U256::from(0x69)),
+            block_number: Some(0x69),
             transaction_hash: Some(B256::with_last_byte(0x69)),
-            transaction_index: Some(U256::from(0x69)),
-            log_index: Some(U256::from(0x69)),
+            transaction_index: Some(0x69),
+            log_index: Some(0x69),
             removed: false,
         };
         let serialized = serde_json::to_string(&log).unwrap();

--- a/crates/rpc-types/src/eth/log.rs
+++ b/crates/rpc-types/src/eth/log.rs
@@ -26,12 +26,12 @@ pub struct Log<T = LogData> {
 
 impl<T> Log<T> {
     /// Getter for the address field. Shortcut for `log.inner.address`.
-    pub fn address(&self) -> &alloy_primitives::Address {
+    pub const fn address(&self) -> &alloy_primitives::Address {
         &self.inner.address
     }
 
     /// Getter for the data field. Shortcut for `log.inner.data`.
-    pub fn data(&self) -> &T {
+    pub const fn data(&self) -> &T {
         &self.inner.data
     }
 }
@@ -39,7 +39,7 @@ impl<T> Log<T> {
 impl Log<LogData> {
     /// Getter for the topics field. Shortcut for `log.inner.topics()`.
     pub fn topics(&self) -> &[B256] {
-        &self.inner.topics()
+        self.inner.topics()
     }
 
     /// Get the topic list, mutably. This gives access to the internal

--- a/crates/rpc-types/src/eth/transaction/receipt.rs
+++ b/crates/rpc-types/src/eth/transaction/receipt.rs
@@ -1,3 +1,4 @@
+use crate::Log;
 use alloy_consensus::{ReceiptEnvelope, TxType};
 use alloy_primitives::{Address, B256, U64, U8};
 use serde::{Deserialize, Serialize};
@@ -8,7 +9,7 @@ use serde::{Deserialize, Serialize};
 pub struct TransactionReceipt {
     /// The receipt envelope, which contains the consensus receipt data..
     #[serde(flatten)]
-    pub inner: ReceiptEnvelope,
+    pub inner: ReceiptEnvelope<Log>,
 
     /// Transaction Hash.
     pub transaction_hash: B256,
@@ -58,8 +59,8 @@ pub struct TransactionReceipt {
     pub transaction_type: U8,
 }
 
-impl AsRef<ReceiptEnvelope> for TransactionReceipt {
-    fn as_ref(&self) -> &ReceiptEnvelope {
+impl AsRef<ReceiptEnvelope<Log>> for TransactionReceipt {
+    fn as_ref(&self) -> &ReceiptEnvelope<Log> {
         &self.inner
     }
 }
@@ -96,7 +97,7 @@ impl TransactionReceipt {
 mod test {
 
     use alloy_consensus::{Receipt, ReceiptEnvelope, ReceiptWithBloom};
-    use alloy_primitives::{b256, bloom, Bloom};
+    use alloy_primitives::{address, b256, bloom, Bloom};
 
     use super::*;
 
@@ -120,5 +121,17 @@ mod test {
                 logs_bloom: EXPECTED_BLOOM
             })
         ));
+
+        let log = receipt.inner.as_receipt().unwrap().logs.first().unwrap();
+        assert_eq!(log.address(), address!("dac17f958d2ee523a2206206994597c13d831ec7"));
+        assert_eq!(log.log_index, Some(0x118));
+        assert_eq!(
+            log.topics(),
+            vec![
+                b256!("8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925"),
+                b256!("0000000000000000000000009a53bfba35269414f3b2d20b52ca01b15932c7b2"),
+                b256!("00000000000000000000000039e5dbb9d2fead31234d7c647d6ce77d85826f76")
+            ],
+        )
     }
 }

--- a/crates/rpc-types/src/eth/transaction/receipt.rs
+++ b/crates/rpc-types/src/eth/transaction/receipt.rs
@@ -1,6 +1,6 @@
 use crate::Log;
 use alloy_consensus::{ReceiptEnvelope, TxType};
-use alloy_primitives::{Address, B256, U64};
+use alloy_primitives::{Address, B256};
 use serde::{Deserialize, Serialize};
 
 /// Transaction receipt

--- a/crates/rpc-types/src/eth/transaction/receipt.rs
+++ b/crates/rpc-types/src/eth/transaction/receipt.rs
@@ -1,45 +1,48 @@
-use crate::Log;
-use alloy_primitives::{Address, Bloom, B256, U128, U256, U64, U8};
+use alloy_consensus::ReceiptEnvelope;
+use alloy_primitives::{Address, B256, U64, U8};
 use serde::{Deserialize, Serialize};
 
 /// Transaction receipt
-#[derive(Clone, Default, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TransactionReceipt {
+    /// The receipt envelope, which contains the consensus receipt data..
+    #[serde(flatten)]
+    pub inner: ReceiptEnvelope,
+
     /// Transaction Hash.
     pub transaction_hash: B256,
     /// Index within the block.
-    pub transaction_index: U64,
+    #[serde(with = "alloy_serde::u64_hex_or_decimal")]
+    pub transaction_index: u64,
     /// Hash of the block this transaction was included within.
     pub block_hash: Option<B256>,
     /// Number of the block this transaction was included within.
-    pub block_number: Option<U256>,
-    // /// Cumulative gas used within the block after this was executed.
-    // pub cumulative_gas_used: U256,
+
+    #[serde(with = "alloy_serde::u64_hex_opt")]
+    pub block_number: Option<u64>,
     /// Gas used by this transaction alone.
-    pub gas_used: Option<U256>,
+    #[serde(with = "alloy_serde::u64_hex_opt")]
+    pub gas_used: Option<u64>,
     /// The price paid post-execution by the transaction (i.e. base fee + priority fee). Both
     /// fields in 1559-style transactions are maximums (max fee + max priority fee), the amount
     /// that's actually paid by users can only be determined post-execution
-    pub effective_gas_price: U128,
+    #[serde(with = "alloy_serde::u64_hex_or_decimal")]
+    pub effective_gas_price: u64,
     /// Blob gas used by the eip-4844 transaction
     ///
     /// This is None for non eip-4844 transactions
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub blob_gas_used: Option<U128>,
+    #[serde(skip_serializing_if = "Option::is_none", with = "alloy_serde::u64_hex_opt", default)]
+    pub blob_gas_used: Option<u64>,
     /// The price paid by the eip-4844 transaction per blob gas.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub blob_gas_price: Option<U128>,
+    #[serde(skip_serializing_if = "Option::is_none", with = "alloy_serde::u64_hex_opt", default)]
+    pub blob_gas_price: Option<u64>,
     /// Address of the sender
     pub from: Address,
     /// Address of the receiver. None when its a contract creation transaction.
     pub to: Option<Address>,
     /// Contract address created, or None if not a deployment.
     pub contract_address: Option<Address>,
-    /// Logs emitted by this transaction.
-    pub logs: Vec<Log>,
-    /// Logs bloom
-    pub logs_bloom: Bloom,
     /// The post-transaction stateroot (pre Byzantium)
     ///
     /// EIP98 makes this optional field, if it's missing then skip serializing it
@@ -53,6 +56,12 @@ pub struct TransactionReceipt {
     /// For legacy transactions this returns `0`. For EIP-2718 transactions this returns the type.
     #[serde(rename = "type")]
     pub transaction_type: U8,
+}
+
+impl AsRef<ReceiptEnvelope> for TransactionReceipt {
+    fn as_ref(&self) -> &ReceiptEnvelope {
+        &self.inner
+    }
 }
 
 impl TransactionReceipt {

--- a/crates/rpc-types/src/eth/transaction/receipt.rs
+++ b/crates/rpc-types/src/eth/transaction/receipt.rs
@@ -76,7 +76,7 @@ impl TransactionReceipt {
     }
 
     /// Returns the transaction type.
-    pub fn transaction_type(&self) -> TxType {
+    pub const fn transaction_type(&self) -> TxType {
         self.inner.tx_type()
     }
 

--- a/crates/rpc-types/src/eth/transaction/receipt.rs
+++ b/crates/rpc-types/src/eth/transaction/receipt.rs
@@ -67,7 +67,7 @@ impl AsRef<ReceiptEnvelope<Log>> for TransactionReceipt {
 
 impl TransactionReceipt {
     /// Returns the status of the transaction.
-    pub fn status(&self) -> bool {
+    pub const fn status(&self) -> bool {
         match &self.inner {
             ReceiptEnvelope::Eip1559(receipt)
             | ReceiptEnvelope::Eip2930(receipt)

--- a/crates/rpc-types/src/eth/transaction/receipt.rs
+++ b/crates/rpc-types/src/eth/transaction/receipt.rs
@@ -1,4 +1,4 @@
-use alloy_consensus::ReceiptEnvelope;
+use alloy_consensus::{ReceiptEnvelope, TxType};
 use alloy_primitives::{Address, B256, U64, U8};
 use serde::{Deserialize, Serialize};
 
@@ -13,7 +13,7 @@ pub struct TransactionReceipt {
     /// Transaction Hash.
     pub transaction_hash: B256,
     /// Index within the block.
-    #[serde(with = "alloy_serde::u64_hex_or_decimal")]
+    #[serde(with = "alloy_serde::u64_hex")]
     pub transaction_index: u64,
     /// Hash of the block this transaction was included within.
     pub block_hash: Option<B256>,
@@ -27,7 +27,7 @@ pub struct TransactionReceipt {
     /// The price paid post-execution by the transaction (i.e. base fee + priority fee). Both
     /// fields in 1559-style transactions are maximums (max fee + max priority fee), the amount
     /// that's actually paid by users can only be determined post-execution
-    #[serde(with = "alloy_serde::u64_hex_or_decimal")]
+    #[serde(with = "alloy_serde::u64_hex")]
     pub effective_gas_price: u64,
     /// Blob gas used by the eip-4844 transaction
     ///
@@ -65,6 +65,21 @@ impl AsRef<ReceiptEnvelope> for TransactionReceipt {
 }
 
 impl TransactionReceipt {
+    /// Returns the status of the transaction.
+    pub fn status(&self) -> bool {
+        match &self.inner {
+            ReceiptEnvelope::Eip1559(receipt)
+            | ReceiptEnvelope::Eip2930(receipt)
+            | ReceiptEnvelope::Eip4844(receipt)
+            | ReceiptEnvelope::Legacy(receipt) => receipt.receipt.status,
+        }
+    }
+
+    /// Returns the transaction type.
+    pub fn transaction_type(&self) -> TxType {
+        self.inner.tx_type()
+    }
+
     /// Calculates the address that will be created by the transaction, if any.
     ///
     /// Returns `None` if the transaction is not a contract creation (the `to` field is set), or if
@@ -74,5 +89,36 @@ impl TransactionReceipt {
             return None;
         }
         Some(self.from.create(nonce))
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    use alloy_consensus::{Receipt, ReceiptEnvelope, ReceiptWithBloom};
+    use alloy_primitives::{b256, bloom, Bloom};
+
+    use super::*;
+
+    #[test]
+    fn test_sanity() {
+        let json_str = r#"{"transactionHash":"0x21f6554c28453a01e7276c1db2fc1695bb512b170818bfa98fa8136433100616","blockHash":"0x4acbdefb861ef4adedb135ca52865f6743451bfbfa35db78076f881a40401a5e","blockNumber":"0x129f4b9","logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000200000000000000000040000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000400000800000000000000000000000000000000004000000000000000000800000000100000020000000000000000000080000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000010000000000000000000000000000","gasUsed":"0xbde1","contractAddress":null,"cumulativeGasUsed":"0xa42aec","transactionIndex":"0x7f","from":"0x9a53bfba35269414f3b2d20b52ca01b15932c7b2","to":"0xdac17f958d2ee523a2206206994597c13d831ec7","type":"0x2","effectiveGasPrice":"0xfb0f6e8c9","logs":[{"blockHash":"0x4acbdefb861ef4adedb135ca52865f6743451bfbfa35db78076f881a40401a5e","address":"0xdac17f958d2ee523a2206206994597c13d831ec7","logIndex":"0x118","data":"0x00000000000000000000000000000000000000000052b7d2dcc80cd2e4000000","removed":false,"topics":["0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925","0x0000000000000000000000009a53bfba35269414f3b2d20b52ca01b15932c7b2","0x00000000000000000000000039e5dbb9d2fead31234d7c647d6ce77d85826f76"],"blockNumber":"0x129f4b9","transactionIndex":"0x7f","transactionHash":"0x21f6554c28453a01e7276c1db2fc1695bb512b170818bfa98fa8136433100616"}],"status":"0x1"}"#;
+
+        let receipt: TransactionReceipt = serde_json::from_str(json_str).unwrap();
+        assert_eq!(
+            receipt.transaction_hash,
+            b256!("21f6554c28453a01e7276c1db2fc1695bb512b170818bfa98fa8136433100616")
+        );
+
+        const EXPECTED_BLOOM: Bloom = bloom!("00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000200000000000000000040000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000400000800000000000000000000000000000000004000000000000000000800000000100000020000000000000000000080000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000010000000000000000000000000000");
+        const EXPECTED_CGU: u64 = 0xa42aec;
+
+        assert!(matches!(
+            receipt.inner,
+            ReceiptEnvelope::Eip1559(ReceiptWithBloom {
+                receipt: Receipt { status: true, cumulative_gas_used: EXPECTED_CGU, .. },
+                logs_bloom: EXPECTED_BLOOM
+            })
+        ));
     }
 }

--- a/crates/rpc-types/src/eth/transaction/receipt.rs
+++ b/crates/rpc-types/src/eth/transaction/receipt.rs
@@ -14,8 +14,8 @@ pub struct TransactionReceipt {
     pub block_hash: Option<B256>,
     /// Number of the block this transaction was included within.
     pub block_number: Option<U256>,
-    /// Cumulative gas used within the block after this was executed.
-    pub cumulative_gas_used: U256,
+    // /// Cumulative gas used within the block after this was executed.
+    // pub cumulative_gas_used: U256,
     /// Gas used by this transaction alone.
     pub gas_used: Option<U256>,
     /// The price paid post-execution by the transaction (i.e. base fee + priority fee). Both

--- a/crates/serde/src/bool.rs
+++ b/crates/serde/src/bool.rs
@@ -1,0 +1,22 @@
+/// Serde serialization and deserialization for [`bool`] as `0x0` or `0x1`.
+pub mod quantity_bool {
+    use alloy_primitives::aliases::U1;
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    /// Deserializes a [`bool`] via a [U1] quantity.
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<bool, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        U1::deserialize(deserializer).map(|val| val.to())
+    }
+
+    /// Serializes a [`bool`] via a [U1] quantity.
+    pub fn serialize<S: Serializer>(val: &bool, s: S) -> Result<S::Ok, S::Error> {
+        if *val {
+            "0x1".serialize(s)
+        } else {
+            "0x0".serialize(s)
+        }
+    }
+}

--- a/crates/serde/src/lib.rs
+++ b/crates/serde/src/lib.rs
@@ -28,6 +28,10 @@ use serde::Serializer;
 pub mod json_u256;
 pub use self::json_u256::JsonU256;
 
+/// Helpers for dealing with booleans.
+mod bool;
+pub use self::bool::*;
+
 /// Helpers for dealing with numbers.
 pub mod num;
 pub use self::num::*;


### PR DESCRIPTION
Supersedes #395, closes #399

## Motivation

Prevent accidental divergence of consensus and rpc types by embedding the consensus type in the RPC type

## Solution

- [x] Embed `alloy_primitives::Log` into `alloy_rpc_types::Log`
- [x] Embed `alloy_consensus::ReceiptEnvelope` into `alloy_rpc_types::Receipt` 

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [x] Breaking changes
