### PR TITLE
feat: handle 4844 fee

### DIFF
--- a/crates/provider/src/layers/gas.rs
+++ b/crates/provider/src/layers/gas.rs
@@ -146,6 +146,19 @@ where
 
         Ok(())
     }
+
+    /// There are a few ways to obtain the blob base fee for an EIP-4844 transaction:
+    ///
+    /// * `eth_blobBaseFee`: Returns the fee for the next block directly.
+    /// * `eth_feeHistory`: Returns the same info as for the EIP-1559 fees.
+    /// * retrieving it from the "pending" block directly.
+    ///
+    /// At the time of this writing support for EIP-4844 fees is lacking, hence we're defaulting to requesting the fee from the "pending" block.
+    async fn handle_eip4844_tx(&self, tx: &mut N::TransactionRequest) -> Result<(), TransportError> {
+        // TODO fetch block and set blob fee
+
+        todo!()
+    }
 }
 
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]

--- a/crates/provider/src/layers/gas.rs
+++ b/crates/provider/src/layers/gas.rs
@@ -4,6 +4,7 @@ use crate::{
 use alloy_json_rpc::RpcError;
 use alloy_network::{Network, TransactionBuilder};
 use alloy_primitives::U256;
+use alloy_rpc_types::BlockNumberOrTag;
 use alloy_transport::{Transport, TransportError, TransportResult};
 use async_trait::async_trait;
 use futures::FutureExt;
@@ -153,11 +154,27 @@ where
     /// * `eth_feeHistory`: Returns the same info as for the EIP-1559 fees.
     /// * retrieving it from the "pending" block directly.
     ///
-    /// At the time of this writing support for EIP-4844 fees is lacking, hence we're defaulting to requesting the fee from the "pending" block.
-    async fn handle_eip4844_tx(&self, tx: &mut N::TransactionRequest) -> Result<(), TransportError> {
-        // TODO fetch block and set blob fee
+    /// At the time of this writing support for EIP-4844 fees is lacking, hence we're defaulting to
+    /// requesting the fee from the "pending" block.
+    async fn handle_eip4844_tx(
+        &self,
+        tx: &mut N::TransactionRequest,
+    ) -> Result<(), TransportError> {
+        // TODO this can be optimized together with 1559 dynamic fees once blob fee support on
+        // eth_feeHistory is more widely supported
+        if tx.get_blob_sidecar().is_some() && tx.max_fee_per_blob_gas().is_none() {
+            let next_blob_fee = self
+                .inner
+                .get_block_by_number(BlockNumberOrTag::Latest, false)
+                .await?
+                .ok_or(RpcError::NullResp)?
+                .header
+                .next_block_blob_fee()
+                .ok_or(RpcError::UnsupportedFeature("eip4844"))?;
+            tx.set_max_fee_per_blob_gas(U256::from(next_blob_fee));
+        }
 
-        todo!()
+        Ok(())
     }
 }
 
@@ -182,6 +199,9 @@ where
             // Populate the following gas_limit, max_fee_per_gas and max_priority_fee_per_gas fields
             // if unset.
             self.handle_eip1559_tx(&mut tx).await?;
+            // TODO: this can be done more elegantly once we can set EIP-1559 and EIP-4844 fields
+            // with a single eth_feeHistory request
+            self.handle_eip4844_tx(&mut tx).await?;
         } else {
             // Assume its a legacy tx
             // Populate only the gas_limit field if unset.

--- a/crates/rpc-types/src/eth/block.rs
+++ b/crates/rpc-types/src/eth/block.rs
@@ -3,6 +3,7 @@
 #![allow(unknown_lints, non_local_definitions)]
 
 use crate::{other::OtherFields, Transaction, Withdrawal};
+use alloy_eips::{calc_blob_gasprice, calc_excess_blob_gas};
 use alloy_primitives::{
     ruint::ParseError, Address, BlockHash, BlockNumber, Bloom, Bytes, B256, B64, U256, U64,
 };
@@ -115,6 +116,32 @@ pub struct Header {
     /// Parent beacon block root
     #[serde(skip_serializing_if = "Option::is_none")]
     pub parent_beacon_block_root: Option<B256>,
+}
+
+impl Header {
+    /// Returns the blob fee for _this_ block according to the EIP-4844 spec.
+    ///
+    /// Returns `None` if `excess_blob_gas` is None
+    pub fn blob_fee(&self) -> Option<u128> {
+        self.excess_blob_gas.map(|gas| calc_blob_gasprice(gas.to()))
+    }
+
+    /// Returns the blob fee for the next block according to the EIP-4844 spec.
+    ///
+    /// Returns `None` if `excess_blob_gas` is None.
+    ///
+    /// See also [Self::next_block_excess_blob_gas]
+    pub fn next_block_blob_fee(&self) -> Option<u128> {
+        self.next_block_excess_blob_gas().map(calc_blob_gasprice)
+    }
+
+    /// Calculate excess blob gas for the next block according to the EIP-4844
+    /// spec.
+    ///
+    /// Returns a `None` if no excess blob gas is set, no EIP-4844 support
+    pub fn next_block_excess_blob_gas(&self) -> Option<u64> {
+        Some(calc_excess_blob_gas(self.excess_blob_gas?.to(), self.blob_gas_used?.to()))
+    }
 }
 
 /// Block Transactions depending on the boolean attribute of `eth_getBlockBy*`,


### PR DESCRIPTION
~~blocked by https://github.com/alloy-rs/alloy/pull/411~~

ref #403

closes #377

This is not ideal but this at least sets a blob fee value for 4844 txs (txs with a sidecar)

This is not ideal for a few reasons:
* This does not estimate an appropriate blob fee and instead uses the value of the next block, if blob space is congested this will not result in timely inclusion (to do this we really need eth_feeHistory)
* Once all clients serve blob fee data in eth_feeHistory this can all be done with one eth_feeHistory request

I think we should consider customizing the gas layer so a custom estimator can be configured

cc @anna-carroll