### PR TITLE
perf: remove getBlock request in feeHistory

### DIFF
--- a/crates/provider/src/provider.rs
+++ b/crates/provider/src/provider.rs
@@ -837,9 +837,11 @@ pub trait Provider<N: Network, T: Transport + Clone = BoxTransport>: Send + Sync
             )
             .await?;
 
+        // if the base fee of the Latest block is 0 then we need check if the latest block even has
+        // a base fee/supports EIP1559
         let base_fee_per_gas = match fee_history.latest_block_base_fee() {
-            Some(base_fee) => base_fee,
-            None => {
+            Some(base_fee) if !base_fee.is_zero() => base_fee,
+            _ => {
                 // empty response, fetch basefee from latest block directly
                 self.get_block_by_number(BlockNumberOrTag::Latest, false)
                     .await?

--- a/crates/provider/src/provider.rs
+++ b/crates/provider/src/provider.rs
@@ -829,20 +829,26 @@ pub trait Provider<N: Network, T: Transport + Clone = BoxTransport>: Send + Sync
         &self,
         estimator: Option<EstimatorFunction>,
     ) -> TransportResult<Eip1559Estimation> {
-        let (bf, fee_history) = futures::try_join!(
-            self.get_block_by_number(BlockNumberOrTag::Latest, false),
-            self.get_fee_history(
+        let fee_history = self
+            .get_fee_history(
                 U256::from(utils::EIP1559_FEE_ESTIMATION_PAST_BLOCKS),
                 BlockNumberOrTag::Latest,
                 &[utils::EIP1559_FEE_ESTIMATION_REWARD_PERCENTILE],
             )
-        )?;
+            .await?;
 
-        let base_fee_per_gas = bf
-            .ok_or(RpcError::NullResp)?
-            .header
-            .base_fee_per_gas
-            .ok_or(RpcError::UnsupportedFeature("eip1559"))?;
+        let base_fee_per_gas = match fee_history.latest_block_base_fee() {
+            Some(base_fee) => base_fee,
+            None => {
+                // empty response, fetch basefee from latest block directly
+                self.get_block_by_number(BlockNumberOrTag::Latest, false)
+                    .await?
+                    .ok_or(RpcError::NullResp)?
+                    .header
+                    .base_fee_per_gas
+                    .ok_or(RpcError::UnsupportedFeature("eip1559"))?
+            }
+        };
 
         Ok(estimator.unwrap_or(utils::eip1559_default_estimator)(
             base_fee_per_gas,

--- a/crates/rpc-types/src/eth/fee.rs
+++ b/crates/rpc-types/src/eth/fee.rs
@@ -64,6 +64,13 @@ pub struct FeeHistory {
 }
 
 impl FeeHistory {
+    /// Returns the base fee of the requested block in the `eth_feeHistory` request.
+    pub fn latest_block_base_fee(&self) -> Option<U256> {
+        // the base fee of what is considered the "latest" block is the second last element in the
+        // list
+        self.base_fee_per_gas.iter().rev().skip(1).next().copied()
+    }
+
     /// Returns the base fee of the next block.
     pub fn next_block_base_fee(&self) -> Option<U256> {
         self.base_fee_per_gas.last().copied()
@@ -72,9 +79,25 @@ impl FeeHistory {
     /// Returns the blob base fee of the next block.
     ///
     /// If the next block is pre- EIP-4844, this will return `None`.
-    pub fn next_blob_base_fee(&self) -> Option<U256> {
+    pub fn next_block_blob_base_fee(&self) -> Option<U256> {
         self.base_fee_per_blob_gas
             .last()
+            .filter(|fee| {
+                // skip zero value that is returned for pre-EIP-4844 blocks
+                !fee.is_zero()
+            })
+            .copied()
+    }
+
+    /// Returns the blob fee of the requested block in the `eth_feeHistory` request.
+    pub fn latest_block_blob_base_fee(&self) -> Option<U256> {
+        // the base fee of what is considered the "latest" block is the second last element in the
+        // list
+        self.base_fee_per_blob_gas
+            .iter()
+            .rev()
+            .skip(1)
+            .next()
             .filter(|fee| {
                 // skip zero value that is returned for pre-EIP-4844 blocks
                 !fee.is_zero()

--- a/crates/rpc-types/src/eth/fee.rs
+++ b/crates/rpc-types/src/eth/fee.rs
@@ -89,7 +89,7 @@ impl FeeHistory {
             .copied()
     }
 
-    /// Returns the blob fee of the requested block in the `eth_feeHistory` request.
+    /// Returns the blob fee of the latest block in the `eth_feeHistory` request.
     pub fn latest_block_blob_base_fee(&self) -> Option<U256> {
         // the blob fee requested block is the second last element in the list
         self.base_fee_per_blob_gas

--- a/crates/rpc-types/src/eth/fee.rs
+++ b/crates/rpc-types/src/eth/fee.rs
@@ -66,9 +66,9 @@ pub struct FeeHistory {
 impl FeeHistory {
     /// Returns the base fee of the requested block in the `eth_feeHistory` request.
     pub fn latest_block_base_fee(&self) -> Option<U256> {
-        // the base fee of what is considered the "latest" block is the second last element in the
+        // the base fee of requested block is the second last element in the
         // list
-        self.base_fee_per_gas.iter().rev().skip(1).next().copied()
+        self.base_fee_per_gas.iter().rev().nth(1).copied()
     }
 
     /// Returns the base fee of the next block.
@@ -91,13 +91,11 @@ impl FeeHistory {
 
     /// Returns the blob fee of the requested block in the `eth_feeHistory` request.
     pub fn latest_block_blob_base_fee(&self) -> Option<U256> {
-        // the base fee of what is considered the "latest" block is the second last element in the
-        // list
+        // the blob fee requested block is the second last element in the list
         self.base_fee_per_blob_gas
             .iter()
             .rev()
-            .skip(1)
-            .next()
+            .nth(1)
             .filter(|fee| {
                 // skip zero value that is returned for pre-EIP-4844 blocks
                 !fee.is_zero()

--- a/crates/rpc-types/src/eth/fee.rs
+++ b/crates/rpc-types/src/eth/fee.rs
@@ -64,7 +64,7 @@ pub struct FeeHistory {
 }
 
 impl FeeHistory {
-    /// Returns the base fee of the requested block in the `eth_feeHistory` request.
+    /// Returns the base fee of the latest block in the `eth_feeHistory` request.
     pub fn latest_block_base_fee(&self) -> Option<U256> {
         // the base fee of requested block is the second last element in the
         // list


### PR DESCRIPTION
the basefee of the "Latest" block is the second last entry in the vec, if the feeHistory response is correct then we don't need to fetch the block.

this keeps the block request as fallback but perhaps we should just error here?

see MM for ref:

https://github.com/MetaMask/core/blob/main/packages/gas-fee-controller/src/fetchGasEstimatesViaEthFeeHistory/calculateGasFeeEstimatesForPriorityLevels.ts#L62