### PR TITLE
chore: rearrange field order

### DIFF
--- a/crates/rpc-trace-types/src/geth/mod.rs
+++ b/crates/rpc-trace-types/src/geth/mod.rs
@@ -69,18 +69,23 @@ pub struct StructLog {
     /// cost for executing op
     #[serde(rename = "gasCost")]
     pub gas_cost: u64,
-    /// ref <https://github.com/ethereum/go-ethereum/blob/366d2169fbc0e0f803b68c042b77b6b480836dbc/eth/tracers/logger/logger.go#L450-L452>
+    /// Current call depth
+    pub depth: u64,
+    /// Error message if any
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub memory: Option<Vec<String>>,
-    /// Size of memory.
-    #[serde(default, rename = "memSize", skip_serializing_if = "Option::is_none")]
-    pub memory_size: Option<u64>,
+    pub error: Option<String>,
     /// EVM stack
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub stack: Option<Vec<U256>>,
     /// Last call's return data. Enabled via enableReturnData
     #[serde(default, rename = "returnData", skip_serializing_if = "Option::is_none")]
     pub return_data: Option<Bytes>,
+    /// ref <https://github.com/ethereum/go-ethereum/blob/366d2169fbc0e0f803b68c042b77b6b480836dbc/eth/tracers/logger/logger.go#L450-L452>
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub memory: Option<Vec<String>>,
+    /// Size of memory.
+    #[serde(default, rename = "memSize", skip_serializing_if = "Option::is_none")]
+    pub memory_size: Option<u64>,
     /// Storage slots of current contract read from and written to. Only emitted for SLOAD and
     /// SSTORE. Disabled via disableStorage
     #[serde(
@@ -89,14 +94,9 @@ pub struct StructLog {
         serialize_with = "serialize_string_storage_map_opt"
     )]
     pub storage: Option<BTreeMap<B256, B256>>,
-    /// Current call depth
-    pub depth: u64,
     /// Refund counter
     #[serde(default, rename = "refund", skip_serializing_if = "Option::is_none")]
     pub refund_counter: Option<u64>,
-    /// Error message if any
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub error: Option<String>,
 }
 
 /// Tracing response objects


### PR DESCRIPTION
rearrange field order to match geth's order, makes it easier to compare output

https://github.com/ethereum/go-ethereum/blob/767b00b0b514771a663f3362dd0310fc28d40c25/eth/tracers/logger/logger.go#L423-L437