### PR TITLE
fix: infinite loop while decoding a list of transactions

### DIFF
--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -392,6 +392,29 @@ mod tests {
     }
 
     #[test]
+    fn test_encode_decode_transaction_list() {
+        let signature = Signature::test_signature();
+        let tx = TxEnvelope::Eip1559(
+            TxEip1559 {
+                chain_id: 1u64,
+                nonce: 2,
+                max_fee_per_gas: 3,
+                max_priority_fee_per_gas: 4,
+                gas_limit: 5,
+                to: TxKind::Call(Address::left_padding_from(&[6])),
+                value: U256::from(7_u64),
+                input: Bytes::from(vec![8]),
+                access_list: Default::default(),
+            }
+            .into_signed(signature),
+        );
+        let transactions = vec![tx.clone(), tx];
+        let encoded = alloy_rlp::encode(&transactions);
+        let decoded = Vec::<TxEnvelope>::decode(&mut &encoded[..]).unwrap();
+        assert_eq!(transactions, decoded);
+    }
+
+    #[test]
     fn decode_encode_known_rpc_transaction() {
         // test data pulled from hive test that sends blob transactions
         let network_data_path =

--- a/crates/eips/src/eip2718.rs
+++ b/crates/eips/src/eip2718.rs
@@ -6,7 +6,7 @@
 use crate::alloc::{vec, vec::Vec};
 
 use alloy_primitives::{keccak256, Sealed, B256};
-use alloy_rlp::{BufMut, Header, EMPTY_STRING_CODE};
+use alloy_rlp::{Buf, BufMut, Header, EMPTY_STRING_CODE};
 use core::{
     fmt,
     fmt::{Display, Formatter},
@@ -102,7 +102,7 @@ pub trait Decodable2718: Sized {
         }
 
         let ty = buf[0];
-        let buf = &mut &buf[1..];
+        buf.advance(1);
         let tx = Self::typed_decode(ty, buf)?;
 
         let bytes_consumed = remaining_len - buf.len();


### PR DESCRIPTION
In `network_decode` the decoded bytes are not correctly consumed in the buffer which makes decoding break for anything that requires more decoding afterwards, and also makes it possible for the decoding to hang.