### PR TITLE
Fix: enable `ws` flag for `provider-ws` and `ipc` flag for `provider-ipc` in `alloy` prelude crate

### DIFF
--- a/crates/alloy/Cargo.toml
+++ b/crates/alloy/Cargo.toml
@@ -98,8 +98,8 @@ node-bindings = ["dep:alloy-node-bindings"]
 # providers
 providers = ["dep:alloy-provider"]
 provider-http = ["providers", "transport-http"]
-provider-ws = ["providers", "alloy-provider?/pubsub", "transport-ws"]
-provider-ipc = ["providers", "alloy-provider?/pubsub", "transport-ipc"]
+provider-ws = ["providers", "alloy-provider?/ws", "transport-ws"]
+provider-ipc = ["providers", "alloy-provider?/ipc", "transport-ipc"]
 
 # pubsub
 pubsub = [


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Enables the `ws` and `ipc` flags on the `provider` crate through the `alloy` prelude to enable `on_ws` and `on_ipc` available on the `ProviderBuilder`.

This was missed in #391 as the examples did not use the methods.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

The `ws` and `ipc` flag enable the `pubsub` flag internally, no change in behaviour is expected.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
