### PR TITLE
chore: reexport receipt types

### DIFF
--- a/crates/rpc-types/src/eth/transaction/mod.rs
+++ b/crates/rpc-types/src/eth/transaction/mod.rs
@@ -21,6 +21,7 @@ pub mod optimism;
 pub use optimism::OptimismTransactionReceiptFields;
 
 mod receipt;
+pub use alloy_consensus::{Receipt, ReceiptEnvelope, ReceiptWithBloom};
 pub use receipt::TransactionReceipt;
 
 pub mod request;


### PR DESCRIPTION
makes it possible to create a rpc receipt without importing additional crate