### PR TITLE
chore: add OtsReceipt type

### DIFF
--- a/crates/rpc-types-trace/src/otterscan.rs
+++ b/crates/rpc-types-trace/src/otterscan.rs
@@ -1,9 +1,12 @@
+//! Otterscan specific types for RPC responses.
+//!
+//! <https://www.quicknode.com/docs/ethereum/ots_getBlockTransactions>
+//! <https://github.com/otterscan/otterscan/blob/develop/docs/custom-jsonrpc.md>
+
 #![allow(missing_docs)]
 
-use alloy_primitives::{Address, Bytes, U256};
-use alloy_rpc_types::{
-    serde_helpers::u64_hex, Block, BlockTransactions, Rich, Transaction, TransactionReceipt,
-};
+use alloy_primitives::{Address, Bloom, Bytes, U256};
+use alloy_rpc_types::{Block, BlockTransactions, Rich, Transaction, TransactionReceipt};
 use serde::{Deserialize, Serialize};
 
 /// Operation type enum for `InternalOperation` struct
@@ -59,6 +62,18 @@ pub struct OtsBlock {
     pub transaction_count: usize,
 }
 
+impl From<Block> for OtsBlock {
+    fn from(block: Block) -> Self {
+        let transaction_count = match &block.transactions {
+            BlockTransactions::Full(t) => t.len(),
+            BlockTransactions::Hashes(t) => t.len(),
+            BlockTransactions::Uncle => 0,
+        };
+
+        Self { block, transaction_count }
+    }
+}
+
 /// Custom struct for otterscan `getBlockDetails` RPC response
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -68,14 +83,52 @@ pub struct BlockDetails {
     pub total_fees: U256,
 }
 
+impl From<Rich<Block>> for BlockDetails {
+    fn from(rich_block: Rich<Block>) -> Self {
+        Self {
+            block: rich_block.inner.into(),
+            issuance: Default::default(),
+            total_fees: U256::default(),
+        }
+    }
+}
+
 /// Custom transaction receipt struct for otterscan `OtsBlockTransactions` struct
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct OtsTransactionReceipt {
+    /// The transaction receipt.
+    ///
+    /// Note: the otterscan API sets all log fields to null.
     #[serde(flatten)]
-    pub receipt: TransactionReceipt,
-    #[serde(with = "u64_hex")]
-    pub timestamp: u64,
+    pub receipt: TransactionReceipt<OtsReceipt>,
+    #[serde(default, with = "alloy_serde::u64_hex_opt")]
+    pub timestamp: Option<u64>,
+}
+
+/// The receipt of a transaction.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OtsReceipt {
+    /// If transaction is executed successfully.
+    ///
+    /// This is the `statusCode`
+    #[serde(with = "alloy_serde::quantity_bool")]
+    pub status: bool,
+    /// Gas used
+    #[serde(with = "alloy_serde::u64_hex")]
+    pub cumulative_gas_used: u64,
+    /// Log send from contracts.
+    ///
+    /// Note: this is set to null,
+    pub logs: Option<Vec<alloy_primitives::Log>>,
+    /// The bloom filter.
+    ///
+    /// Note: this is set to null
+    pub logs_bloom: Option<Bloom>,
+    /// The transaction type.
+    #[serde(with = "alloy_serde::num::u8_hex")]
+    pub r#type: u8,
 }
 
 /// Custom struct for otterscan `getBlockTransactions` RPC response
@@ -103,24 +156,29 @@ pub struct ContractCreator {
     pub creator: Address,
 }
 
-impl From<Block> for OtsBlock {
-    fn from(block: Block) -> Self {
-        let transaction_count = match &block.transactions {
-            BlockTransactions::Full(t) => t.len(),
-            BlockTransactions::Hashes(t) => t.len(),
-            BlockTransactions::Uncle => 0,
-        };
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-        Self { block, transaction_count }
-    }
-}
+    #[test]
+    fn test_otterscan_receipt() {
+        let s = r#"{
+      "blockHash": "0xf05aa8b73b005314684595adcff8e6149917b3239b6316247ce5e88eba9fd3f5",
+      "blockNumber": "0x1106fe7",
+      "contractAddress": null,
+      "cumulativeGasUsed": "0x95fac3",
+      "effectiveGasPrice": "0x2e9f0055d",
+      "from": "0x793abeea78d94c14b884a56788f549836a35db65",
+      "gasUsed": "0x14427",
+      "logs": null,
+      "logsBloom": null,
+      "status": "0x1",
+      "to": "0x06450dee7fd2fb8e39061434babcfc05599a6fb8",
+      "transactionHash": "0xd3cead022cbb5d6d18091f8b375e3a3896ec139e986144b9448290d55837275a",
+      "transactionIndex": "0x90",
+      "type": "0x2"
+    }"#;
 
-impl From<Rich<Block>> for BlockDetails {
-    fn from(rich_block: Rich<Block>) -> Self {
-        Self {
-            block: rich_block.inner.into(),
-            issuance: Default::default(),
-            total_fees: U256::default(),
-        }
+        let _receipt: OtsTransactionReceipt = serde_json::from_str(s).unwrap();
     }
 }


### PR DESCRIPTION
adds a new receipt type for otterscan, which is supposed to emit logs and bloom as None.

there are still a few differences, e.g. the logsBloom of the header is also none, which can get pretty ugly because we'd need to duplicate all types effectively or manually impl serde.

can track this separately in case someone wants to make this 100% right.