### PR TITLE
Derive default implementation for rpc `Block`

### DIFF
--- a/crates/rpc-types/src/eth/block.rs
+++ b/crates/rpc-types/src/eth/block.rs
@@ -16,7 +16,7 @@ use serde::{
 use std::{collections::BTreeMap, fmt, num::ParseIntError, ops::Deref, str::FromStr};
 
 /// Block representation
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Block {
     /// Header of the block.
@@ -51,7 +51,7 @@ impl Block {
 }
 
 /// Block header representation.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
 #[serde(rename_all = "camelCase")]
 pub struct Header {
     /// Hash of the block
@@ -155,6 +155,12 @@ pub enum BlockTransactions {
     Full(Vec<Transaction>),
     /// Special case for uncle response.
     Uncle,
+}
+
+impl Default for BlockTransactions {
+    fn default() -> Self {
+        BlockTransactions::Hashes(Vec::default())
+    }
 }
 
 impl BlockTransactions {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

This pull request adds a default implementation for the rpc `Block` struct.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
