### PR TITLE
TypeTransaction conversion trait impls

### DIFF
--- a/crates/consensus/src/signed.rs
+++ b/crates/consensus/src/signed.rs
@@ -33,8 +33,8 @@ impl<T, Sig> Signed<T, Sig> {
         (self.tx, self.signature, self.hash)
     }
 
-    /// Returns the transaction.
-    pub fn owned_tx(self) -> T {
+    /// Returns the transaction without signature.
+    pub fn strip_signature(self) -> T {
         self.tx
     }
 }

--- a/crates/consensus/src/signed.rs
+++ b/crates/consensus/src/signed.rs
@@ -32,6 +32,11 @@ impl<T, Sig> Signed<T, Sig> {
     pub fn into_parts(self) -> (T, Sig, B256) {
         (self.tx, self.signature, self.hash)
     }
+
+    /// Returns the transaction.
+    pub fn owned_tx(self) -> T {
+        self.tx
+    }
 }
 
 impl<T: SignableTransaction<Sig>, Sig> Signed<T, Sig> {

--- a/crates/consensus/src/transaction/typed.rs
+++ b/crates/consensus/src/transaction/typed.rs
@@ -1,4 +1,4 @@
-use crate::{Transaction, TxEip1559, TxEip2930, TxEip4844Variant, TxLegacy, TxType};
+use crate::{Transaction, TxEip1559, TxEip2930, TxEip4844Variant, TxEnvelope, TxLegacy, TxType};
 use alloy_primitives::TxKind;
 
 /// The TypedTransaction enum represents all Ethereum transaction request types.
@@ -47,6 +47,17 @@ impl From<TxEip1559> for TypedTransaction {
 impl From<TxEip4844Variant> for TypedTransaction {
     fn from(tx: TxEip4844Variant) -> Self {
         Self::Eip4844(tx)
+    }
+}
+
+impl From<TxEnvelope> for TypedTransaction {
+    fn from(envelope: TxEnvelope) -> Self {
+        match envelope {
+            TxEnvelope::Legacy(tx) => Self::Legacy(tx.owned_tx()),
+            TxEnvelope::Eip2930(tx) => Self::Eip2930(tx.owned_tx()),
+            TxEnvelope::Eip1559(tx) => Self::Eip1559(tx.owned_tx()),
+            TxEnvelope::Eip4844(tx) => Self::Eip4844(tx.owned_tx()),
+        }
     }
 }
 

--- a/crates/consensus/src/transaction/typed.rs
+++ b/crates/consensus/src/transaction/typed.rs
@@ -53,10 +53,10 @@ impl From<TxEip4844Variant> for TypedTransaction {
 impl From<TxEnvelope> for TypedTransaction {
     fn from(envelope: TxEnvelope) -> Self {
         match envelope {
-            TxEnvelope::Legacy(tx) => Self::Legacy(tx.owned_tx()),
-            TxEnvelope::Eip2930(tx) => Self::Eip2930(tx.owned_tx()),
-            TxEnvelope::Eip1559(tx) => Self::Eip1559(tx.owned_tx()),
-            TxEnvelope::Eip4844(tx) => Self::Eip4844(tx.owned_tx()),
+            TxEnvelope::Legacy(tx) => Self::Legacy(tx.strip_signature()),
+            TxEnvelope::Eip2930(tx) => Self::Eip2930(tx.strip_signature()),
+            TxEnvelope::Eip1559(tx) => Self::Eip1559(tx.strip_signature()),
+            TxEnvelope::Eip4844(tx) => Self::Eip4844(tx.strip_signature()),
         }
     }
 }

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -55,7 +55,7 @@ pub trait Network: Clone + Copy + Sized + Send + Sync + 'static {
     type TxEnvelope: Eip2718Envelope;
 
     /// An enum over the various transaction types.
-    type UnsignedTx;
+    type UnsignedTx: From<Self::TxEnvelope>;
 
     /// The network receipt envelope type.
     type ReceiptEnvelope: Eip2718Envelope;
@@ -65,7 +65,11 @@ pub trait Network: Clone + Copy + Sized + Send + Sync + 'static {
     // -- JSON RPC types --
 
     /// The JSON body of a transaction request.
-    type TransactionRequest: RpcObject + TransactionBuilder<Self> + std::fmt::Debug;
+    type TransactionRequest: RpcObject
+        + TransactionBuilder<Self>
+        + std::fmt::Debug
+        + From<Self::TxEnvelope>
+        + From<Self::UnsignedTx>;
     /// The JSON body of a transaction response.
     type TransactionResponse: RpcObject;
     /// The JSON body of a transaction receipt.

--- a/crates/rpc-types/Cargo.toml
+++ b/crates/rpc-types/Cargo.toml
@@ -16,10 +16,10 @@ exclude.workspace = true
 alloy-rlp = { workspace = true, features = ["arrayvec", "derive"] }
 alloy-primitives = { workspace = true, features = ["rlp", "serde", "std"] }
 alloy-serde.workspace = true
-alloy-genesis.workspace=true
+alloy-genesis.workspace = true
 
 alloy-consensus = { workspace = true, features = ["std", "serde"] }
-alloy-eips = {workspace = true, features = ["std", "serde"]}
+alloy-eips = { workspace = true, features = ["std", "serde"] }
 
 itertools.workspace = true
 serde = { workspace = true, features = ["derive"] }
@@ -42,13 +42,19 @@ arbitrary = [
     "dep:proptest-derive",
     "dep:proptest",
     "alloy-primitives/arbitrary",
-    "alloy-eips/arbitrary"
+    "alloy-eips/arbitrary",
 ]
 jsonrpsee-types = ["dep:jsonrpsee-types"]
 ssz = ["alloy-primitives/ssz", "alloy-eips/ssz"]
+k256 = ["alloy-consensus/k256"]
 
 [dev-dependencies]
-alloy-primitives = { workspace = true, features = ["rand", "rlp", "serde", "arbitrary"] }
+alloy-primitives = { workspace = true, features = [
+    "rand",
+    "rlp",
+    "serde",
+    "arbitrary",
+] }
 alloy-consensus = { workspace = true, features = ["std", "arbitrary"] }
 
 arbitrary = { workspace = true, features = ["derive"] }

--- a/crates/rpc-types/src/eth/transaction/request.rs
+++ b/crates/rpc-types/src/eth/transaction/request.rs
@@ -364,10 +364,70 @@ impl From<TypedTransaction> for TransactionRequest {
 impl From<TxEnvelope> for TransactionRequest {
     fn from(envelope: TxEnvelope) -> TransactionRequest {
         match envelope {
-            TxEnvelope::Legacy(tx) => tx.strip_signature().into(),
-            TxEnvelope::Eip2930(tx) => tx.strip_signature().into(),
-            TxEnvelope::Eip1559(tx) => tx.strip_signature().into(),
-            TxEnvelope::Eip4844(tx) => tx.strip_signature().into(),
+            TxEnvelope::Legacy(tx) => {
+                #[cfg(feature = "k256")]
+                {
+                    if let Ok(signer) = tx.recover_signer() {
+                        let tx: TransactionRequest = tx.strip_signature().into();
+                        tx.from(signer)
+                    } else {
+                        tx.strip_signature().into()
+                    }
+                }
+
+                #[cfg(not(feature = "k256"))]
+                {
+                    tx.strip_signature().into()
+                }
+            }
+            TxEnvelope::Eip2930(tx) => {
+                #[cfg(feature = "k256")]
+                {
+                    if let Ok(signer) = tx.recover_signer() {
+                        let tx: TransactionRequest = tx.strip_signature().into();
+                        tx.from(signer)
+                    } else {
+                        tx.strip_signature().into()
+                    }
+                }
+
+                #[cfg(not(feature = "k256"))]
+                {
+                    tx.strip_signature().into()
+                }
+            }
+            TxEnvelope::Eip1559(tx) => {
+                #[cfg(feature = "k256")]
+                {
+                    if let Ok(signer) = tx.recover_signer() {
+                        let tx: TransactionRequest = tx.strip_signature().into();
+                        tx.from(signer)
+                    } else {
+                        tx.strip_signature().into()
+                    }
+                }
+
+                #[cfg(not(feature = "k256"))]
+                {
+                    tx.strip_signature().into()
+                }
+            }
+            TxEnvelope::Eip4844(tx) => {
+                #[cfg(feature = "k256")]
+                {
+                    if let Ok(signer) = tx.recover_signer() {
+                        let tx: TransactionRequest = tx.strip_signature().into();
+                        tx.from(signer)
+                    } else {
+                        tx.strip_signature().into()
+                    }
+                }
+
+                #[cfg(not(feature = "k256"))]
+                {
+                    tx.strip_signature().into()
+                }
+            }
             _ => Default::default(),
         }
     }

--- a/crates/rpc-types/src/eth/transaction/request.rs
+++ b/crates/rpc-types/src/eth/transaction/request.rs
@@ -364,10 +364,10 @@ impl From<TypedTransaction> for TransactionRequest {
 impl From<TxEnvelope> for TransactionRequest {
     fn from(envelope: TxEnvelope) -> TransactionRequest {
         match envelope {
-            TxEnvelope::Legacy(tx) => tx.owned_tx().into(),
-            TxEnvelope::Eip2930(tx) => tx.owned_tx().into(),
-            TxEnvelope::Eip1559(tx) => tx.owned_tx().into(),
-            TxEnvelope::Eip4844(tx) => tx.owned_tx().into(),
+            TxEnvelope::Legacy(tx) => tx.strip_signature().into(),
+            TxEnvelope::Eip2930(tx) => tx.strip_signature().into(),
+            TxEnvelope::Eip1559(tx) => tx.strip_signature().into(),
+            TxEnvelope::Eip4844(tx) => tx.strip_signature().into(),
             _ => Default::default(),
         }
     }

--- a/crates/rpc-types/src/eth/transaction/request.rs
+++ b/crates/rpc-types/src/eth/transaction/request.rs
@@ -367,11 +367,12 @@ impl From<TxEnvelope> for TransactionRequest {
             TxEnvelope::Legacy(tx) => {
                 #[cfg(feature = "k256")]
                 {
-                    if let Ok(signer) = tx.recover_signer() {
-                        let tx: TransactionRequest = tx.strip_signature().into();
-                        tx.from(signer)
+                    let from = tx.recover_signer().ok();
+                    let tx: TransactionRequest = tx.strip_signature().into();
+                    if let Some(from) = from {
+                        tx.from(from)
                     } else {
-                        tx.strip_signature().into()
+                        tx
                     }
                 }
 
@@ -383,11 +384,12 @@ impl From<TxEnvelope> for TransactionRequest {
             TxEnvelope::Eip2930(tx) => {
                 #[cfg(feature = "k256")]
                 {
-                    if let Ok(signer) = tx.recover_signer() {
-                        let tx: TransactionRequest = tx.strip_signature().into();
-                        tx.from(signer)
+                    let from = tx.recover_signer().ok();
+                    let tx: TransactionRequest = tx.strip_signature().into();
+                    if let Some(from) = from {
+                        tx.from(from)
                     } else {
-                        tx.strip_signature().into()
+                        tx
                     }
                 }
 
@@ -399,11 +401,12 @@ impl From<TxEnvelope> for TransactionRequest {
             TxEnvelope::Eip1559(tx) => {
                 #[cfg(feature = "k256")]
                 {
-                    if let Ok(signer) = tx.recover_signer() {
-                        let tx: TransactionRequest = tx.strip_signature().into();
-                        tx.from(signer)
+                    let from = tx.recover_signer().ok();
+                    let tx: TransactionRequest = tx.strip_signature().into();
+                    if let Some(from) = from {
+                        tx.from(from)
                     } else {
-                        tx.strip_signature().into()
+                        tx
                     }
                 }
 
@@ -415,11 +418,12 @@ impl From<TxEnvelope> for TransactionRequest {
             TxEnvelope::Eip4844(tx) => {
                 #[cfg(feature = "k256")]
                 {
-                    if let Ok(signer) = tx.recover_signer() {
-                        let tx: TransactionRequest = tx.strip_signature().into();
-                        tx.from(signer)
+                    let from = tx.recover_signer().ok();
+                    let tx: TransactionRequest = tx.strip_signature().into();
+                    if let Some(from) = from {
+                        tx.from(from)
                     } else {
-                        tx.strip_signature().into()
+                        tx
                     }
                 }
 

--- a/crates/rpc-types/src/eth/transaction/request.rs
+++ b/crates/rpc-types/src/eth/transaction/request.rs
@@ -1,9 +1,13 @@
 //! Alloy basic Transaction Request type.
 
 use crate::{eth::transaction::AccessList, BlobTransactionSidecar, Transaction};
-use alloy_primitives::{Address, Bytes, ChainId, B256, U256};
+use alloy_consensus::{
+    TxEip1559, TxEip2930, TxEip4844, TxEip4844Variant, TxEip4844WithSidecar, TxEnvelope, TxLegacy,
+    TypedTransaction,
+};
+use alloy_primitives::{Address, Bytes, ChainId, TxKind, B256, U256};
 use serde::{Deserialize, Serialize};
-use std::hash::Hash;
+use std::{hash::Hash, ops::Add};
 
 /// Represents _all_ transaction requests to/from RPC.
 #[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
@@ -235,6 +239,137 @@ impl From<Option<Bytes>> for TransactionInput {
 impl From<Transaction> for TransactionRequest {
     fn from(tx: Transaction) -> TransactionRequest {
         tx.into_request()
+    }
+}
+
+impl From<TxLegacy> for TransactionRequest {
+    fn from(tx: TxLegacy) -> TransactionRequest {
+        TransactionRequest {
+            from: None,
+            to: if let TxKind::Call(to) = tx.to { Some(to) } else { None },
+            gas_price: Some(tx.gas_price),
+            gas: Some(tx.gas_limit),
+            value: Some(tx.value),
+            input: TransactionInput::from(tx.input),
+            nonce: Some(tx.nonce),
+            chain_id: tx.chain_id,
+            transaction_type: Some(0),
+            ..Default::default()
+        }
+    }
+}
+
+impl From<TxEip2930> for TransactionRequest {
+    fn from(tx: TxEip2930) -> TransactionRequest {
+        TransactionRequest {
+            from: None,
+            to: if let TxKind::Call(to) = tx.to { Some(to) } else { None },
+            gas_price: Some(tx.gas_price),
+            gas: Some(tx.gas_limit),
+            value: Some(tx.value),
+            input: TransactionInput::from(tx.input),
+            nonce: Some(tx.nonce),
+            chain_id: Some(tx.chain_id),
+            transaction_type: Some(1),
+            access_list: Some(tx.access_list),
+            ..Default::default()
+        }
+    }
+}
+
+impl From<TxEip1559> for TransactionRequest {
+    fn from(tx: TxEip1559) -> TransactionRequest {
+        TransactionRequest {
+            from: None,
+            to: if let TxKind::Call(to) = tx.to { Some(to) } else { None },
+            max_fee_per_gas: Some(tx.max_fee_per_gas),
+            max_priority_fee_per_gas: Some(tx.max_priority_fee_per_gas),
+            gas: Some(tx.gas_limit),
+            value: Some(tx.value),
+            input: TransactionInput::from(tx.input),
+            nonce: Some(tx.nonce),
+            chain_id: Some(tx.chain_id),
+            transaction_type: Some(2),
+            access_list: Some(tx.access_list),
+            ..Default::default()
+        }
+    }
+}
+
+impl From<TxEip4844> for TransactionRequest {
+    fn from(tx: TxEip4844) -> TransactionRequest {
+        TransactionRequest {
+            from: None,
+            to: Some(tx.to),
+            max_fee_per_blob_gas: Some(tx.max_fee_per_blob_gas),
+            gas: Some(tx.gas_limit),
+            max_fee_per_gas: Some(tx.max_fee_per_gas),
+            max_priority_fee_per_gas: Some(tx.max_priority_fee_per_gas),
+            value: Some(tx.value),
+            input: TransactionInput::from(tx.input),
+            nonce: Some(tx.nonce),
+            chain_id: Some(tx.chain_id),
+            transaction_type: Some(3),
+            access_list: Some(tx.access_list),
+            blob_versioned_hashes: Some(tx.blob_versioned_hashes),
+            ..Default::default()
+        }
+    }
+}
+
+impl From<TxEip4844WithSidecar> for TransactionRequest {
+    fn from(tx: TxEip4844WithSidecar) -> TransactionRequest {
+        let sidecar = tx.sidecar;
+        let tx = tx.tx;
+        TransactionRequest {
+            from: None,
+            to: Some(tx.to),
+            max_fee_per_blob_gas: Some(tx.max_fee_per_blob_gas),
+            gas: Some(tx.gas_limit),
+            max_fee_per_gas: Some(tx.max_fee_per_gas),
+            max_priority_fee_per_gas: Some(tx.max_priority_fee_per_gas),
+            value: Some(tx.value),
+            input: TransactionInput::from(tx.input),
+            nonce: Some(tx.nonce),
+            chain_id: Some(tx.chain_id),
+            transaction_type: Some(3),
+            access_list: Some(tx.access_list),
+            blob_versioned_hashes: Some(tx.blob_versioned_hashes),
+            sidecar: Some(sidecar),
+            ..Default::default()
+        }
+    }
+}
+
+impl From<TxEip4844Variant> for TransactionRequest {
+    fn from(tx: TxEip4844Variant) -> TransactionRequest {
+        match tx {
+            TxEip4844Variant::TxEip4844(tx) => tx.into(),
+            TxEip4844Variant::TxEip4844WithSidecar(tx) => tx.into(),
+        }
+    }
+}
+
+impl From<TypedTransaction> for TransactionRequest {
+    fn from(tx: TypedTransaction) -> TransactionRequest {
+        match tx {
+            TypedTransaction::Legacy(tx) => tx.into(),
+            TypedTransaction::Eip2930(tx) => tx.into(),
+            TypedTransaction::Eip1559(tx) => tx.into(),
+            TypedTransaction::Eip4844(tx) => tx.into(),
+        }
+    }
+}
+
+impl From<TxEnvelope> for TransactionRequest {
+    fn from(envelope: TxEnvelope) -> TransactionRequest {
+        match envelope {
+            TxEnvelope::Legacy(tx) => tx.owned_tx().into(),
+            TxEnvelope::Eip2930(tx) => tx.owned_tx().into(),
+            TxEnvelope::Eip1559(tx) => tx.owned_tx().into(),
+            TxEnvelope::Eip4844(tx) => tx.owned_tx().into(),
+            _ => Default::default(),
+        }
     }
 }
 

--- a/crates/rpc-types/src/eth/transaction/request.rs
+++ b/crates/rpc-types/src/eth/transaction/request.rs
@@ -7,7 +7,7 @@ use alloy_consensus::{
 };
 use alloy_primitives::{Address, Bytes, ChainId, TxKind, B256, U256};
 use serde::{Deserialize, Serialize};
-use std::{hash::Hash, ops::Add};
+use std::hash::Hash;
 
 /// Represents _all_ transaction requests to/from RPC.
 #[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]

--- a/crates/rpc-types/src/with_other.rs
+++ b/crates/rpc-types/src/with_other.rs
@@ -1,4 +1,5 @@
-use crate::other::OtherFields;
+use crate::{other::OtherFields, TransactionRequest};
+use alloy_consensus::{TxEnvelope, TypedTransaction};
 use serde::{Deserialize, Serialize};
 use std::ops::{Deref, DerefMut};
 
@@ -18,6 +19,18 @@ impl<T> WithOtherFields<T> {
     /// Create a new `Extra`.
     pub fn new(inner: T) -> Self {
         Self { inner, other: OtherFields::default() }
+    }
+}
+
+impl From<TypedTransaction> for WithOtherFields<TransactionRequest> {
+    fn from(tx: TypedTransaction) -> Self {
+        Self::new(tx.into())
+    }
+}
+
+impl From<TxEnvelope> for WithOtherFields<TransactionRequest> {
+    fn from(envelope: TxEnvelope) -> Self {
+        Self::new(envelope.into())
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Ref #438 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Add `From` bounds to `UnsignedTx` and `TransactionRequest` types in `Network`.

Satisfy bounds by implementing the following:

- `From<TypedTransaction> for TransactionRequest`
- `From<TxEnvelope> for TransactionRequest`
- `From<TypedTransaction> for WithOtherFields<TransactionRequest>`
- `From<TxEnvelope> for WithOtherFields<TransactionRequest>`

To accomplish the above, implemented

- `From<TxLegacy> for TransactionRequest`
- `From<TxEip2930> for TransactionRequest`
- `From<TxEip1559> for TransactionRequest`
- `From<TxEip4844Variant> for TransactionRequest`

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
