### PR TITLE
Implement `is_zero` method for `U64HexOrNumber`

### DIFF
--- a/crates/serde/src/num.rs
+++ b/crates/serde/src/num.rs
@@ -28,6 +28,11 @@ impl U64HexOrNumber {
     pub fn to(self) -> u64 {
         self.0.to()
     }
+
+    /// Checks if the wrapped value is zero.
+    pub fn is_zero(&self) -> bool {
+        self.0.is_zero()
+    }
 }
 
 impl From<u64> for U64HexOrNumber {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->


## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Implement `is_zero` method for `U64HexOrNumber`.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
