### PR TITLE
Update typo in README

### DIFF
--- a/crates/signer-wallet/README.md
+++ b/crates/signer-wallet/README.md
@@ -1,4 +1,4 @@
-# alloy-signer-wallets
+# alloy-signer-wallet
 
 Local wallet implementations:
 - [K256 private key](./src/private_key.rs)


### PR DESCRIPTION
## Motivation

The name of the crate is [alloy-signer-wallet](https://github.com/alloy-rs/alloy/blob/89f14f9db5afb98d13d9d760b0615f4b10c5b6c4/crates/signer-wallet/Cargo.toml#L2) but it was named here as "alloy-signer-wallets"

## Solution

Changed the name so that when users import it to their projects they directly have the right name.

## PR Checklist

Not breaking changes
