### PR TITLE
fix: allow empty `to` field in `can_build`

### DIFF
--- a/crates/network/src/ethereum/builder.rs
+++ b/crates/network/src/ethereum/builder.rs
@@ -136,7 +136,7 @@ impl TransactionBuilder<Ethereum> for TransactionRequest {
 
         let eip1559 = self.max_fee_per_gas.is_some() && self.max_priority_fee_per_gas.is_some();
 
-        let eip4844 = eip1559 && self.sidecar.is_some();
+        let eip4844 = eip1559 && self.sidecar.is_some() && self.to.is_some();
         common && (legacy || eip2930 || eip1559 || eip4844)
     }
 

--- a/crates/network/src/ethereum/builder.rs
+++ b/crates/network/src/ethereum/builder.rs
@@ -121,7 +121,7 @@ impl TransactionBuilder<Ethereum> for TransactionRequest {
         // value and data may be None. If they are, they will be set to default.
         // gas fields and nonce may be None, if they are, they will be populated
         // with default values by the RPC server
-        self.to.is_some() && self.from.is_some()
+        self.from.is_some()
     }
 
     fn can_build(&self) -> bool {
@@ -129,7 +129,7 @@ impl TransactionBuilder<Ethereum> for TransactionRequest {
         // values.
 
         // chain_id and from may be none.
-        let common = self.to.is_some() && self.gas.is_some() && self.nonce.is_some();
+        let common = self.gas.is_some() && self.nonce.is_some();
 
         let legacy = self.gas_price.is_some();
         let eip2930 = legacy && self.access_list().is_some();


### PR DESCRIPTION
## Motivation

`to` is required to be Some only for EIP-4844 txses

## Solution


## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
