### PR TITLE
fix: workaround for `WithOtherFields`

### DIFF
--- a/crates/rpc-types/src/with_other.rs
+++ b/crates/rpc-types/src/with_other.rs
@@ -74,14 +74,13 @@ where
         }
 
         let mut helper = WithOtherFieldsHelper::deserialize(deserializer)?;
-        let inner_serialzed = serde_json::to_value(&helper.inner).map_err(D::Error::custom)?;
-        match &inner_serialzed {
-            Value::Object(map) => {
-                for key in map.keys() {
-                    helper.other.remove(key);
-                }
+        // remove all fields present in the inner struct from the other fields, this is to avoid
+        // duplicate fields in the catch all other fields because serde flatten does not exclude
+        // already deserialized fields when deserializing the other fields.
+        if let Value::Object(map) = serde_json::to_value(&helper.inner).map_err(D::Error::custom)? {
+            for key in map.keys() {
+                helper.other.remove(key);
             }
-            _ => {}
         }
 
         Ok(WithOtherFields { inner: helper.inner, other: helper.other })

--- a/crates/rpc-types/src/with_other.rs
+++ b/crates/rpc-types/src/with_other.rs
@@ -75,13 +75,11 @@ where
 
         let mut helper = WithOtherFieldsHelper::deserialize(deserializer)?;
         let inner_serialzed = serde_json::to_value(&helper.inner).map_err(D::Error::custom)?;
-        let inner_keys = match &inner_serialzed {
-            Value::Object(map) => map.keys().collect::<Vec<_>>(),
-            _ => Vec::new(),
-        };
-
-        for key in inner_keys {
-            helper.other.remove(key);
+        match &inner_serialzed {
+            Value::Object(map) => for key in map.keys() {
+                helper.other.remove(key);
+            },
+            _ => {},
         }
 
         Ok(WithOtherFields { inner: helper.inner, other: helper.other })

--- a/crates/rpc-types/src/with_other.rs
+++ b/crates/rpc-types/src/with_other.rs
@@ -87,3 +87,33 @@ where
         Ok(WithOtherFields { inner: helper.inner, other: helper.other })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use super::*;
+    use serde_json::json;
+
+    #[derive(Serialize, Deserialize)]
+    struct Inner {
+        a: u64,
+    }
+
+    #[derive(Serialize, Deserialize)]
+    struct InnerWrapper {
+        #[serde(flatten)]
+        inner: Inner,
+    }
+
+    #[test]
+    fn test_correct_other() {
+        let with_other: WithOtherFields<InnerWrapper> =
+            serde_json::from_str("{\"a\": 1, \"b\": 2}").unwrap();
+        assert_eq!(with_other.inner.inner.a, 1);
+        assert_eq!(
+            with_other.other,
+            OtherFields::new(BTreeMap::from_iter(vec![("b".to_string(), json!(2))]))
+        );
+    }
+}

--- a/crates/rpc-types/src/with_other.rs
+++ b/crates/rpc-types/src/with_other.rs
@@ -76,10 +76,12 @@ where
         let mut helper = WithOtherFieldsHelper::deserialize(deserializer)?;
         let inner_serialzed = serde_json::to_value(&helper.inner).map_err(D::Error::custom)?;
         match &inner_serialzed {
-            Value::Object(map) => for key in map.keys() {
-                helper.other.remove(key);
-            },
-            _ => {},
+            Value::Object(map) => {
+                for key in map.keys() {
+                    helper.other.remove(key);
+                }
+            }
+            _ => {}
         }
 
         Ok(WithOtherFields { inner: helper.inner, other: helper.other })


### PR DESCRIPTION
## Motivation

Ref https://github.com/serde-rs/serde/issues/1909

ref #493

Currently deserializing `WithOtherFields<T>` where `T` is a struct with multiple levels of fields with `serde(flatten)`, the resulted object would have fields of the `inner` struct duplicated in `other`. Example of this behavior is a deserialization of `AnyTransactionReceipt`:
<details>
<summary>resulted receipt</summary>

```rust
WithOtherFields {
    inner: TransactionReceipt {
        inner: AnyReceiptEnvelope {
            inner: ReceiptWithBloom {
                receipt: Receipt {
                    status: true,
                    cumulative_gas_used: 1586930,
                    logs: [
                        Log {
                            inner: Log {
                                address: 0x13b82c379e4209acc43005f0b2b661945557f56e,
                                data: LogData {
                                    topics: [
                                        0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0,
                                        0x00000000000000000000000045fa3ec833b6a0bf1ab27c8dd33ae03baacc3aa4,
                                        0x0000000000000000000000006c1e90f219de736167036e9abde81ec8cd7b2daf,
                                    ],
                                    data: 0x,
                                },
                            },
                            block_hash: Some(
                                0xc97a0a94ff0fb5eea6614aa4ea708cb237f1dd0b0e651e7547dc8aa07043f16d,
                            ),
                            block_number: Some(
                                168738165,
                            ),
                            block_timestamp: None,
                            transaction_hash: Some(
                                0xfd0aa3e177ce6cf3eb74387b5284bddf212238ed42872bbab395e95c68d98137,
                            ),
                            transaction_index: Some(
                                3,
                            ),
                            log_index: Some(
                                2,
                            ),
                            removed: false,
                        },
                    ],
                },
                logs_bloom: 0x00000000000000000000000000000000000000000000000000800000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000100000000000000000000000000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000020000000000200000000000000000020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000840000000080000000000000400000000000000,
            },
            type: 2,
        },
        transaction_hash: 0xfd0aa3e177ce6cf3eb74387b5284bddf212238ed42872bbab395e95c68d98137,
        transaction_index: 3,
        block_hash: Some(
            0xc97a0a94ff0fb5eea6614aa4ea708cb237f1dd0b0e651e7547dc8aa07043f16d,
        ),
        block_number: Some(
            168738165,
        ),
        gas_used: 458688,
        effective_gas_price: 100000000,
        blob_gas_used: None,
        blob_gas_price: None,
        from: 0x45fa3ec833b6a0bf1ab27c8dd33ae03baacc3aa4,
        to: Some(
            0x13b82c379e4209acc43005f0b2b661945557f56e,
        ),
        contract_address: None,
        state_root: None,
    },
    other: OtherFields {
        inner: {
            "blockHash": String("0xc97a0a94ff0fb5eea6614aa4ea708cb237f1dd0b0e651e7547dc8aa07043f16d"),
            "blockNumber": String("0xa0ebd75"),
            "contractAddress": Null,
            "cumulativeGasUsed": String("0x1836f2"),
            "effectiveGasPrice": String("0x5f5e100"),
            "from": String("0x45fa3ec833b6a0bf1ab27c8dd33ae03baacc3aa4"),
            "gasUsed": String("0x6ffc0"),
            "gasUsedForL1": String("0x68fc3"),
            "l1BlockNumber": String("0x12177f1"),
            "logs": Array [
                Object {
                    "address": String("0x13b82c379e4209acc43005f0b2b661945557f56e"),
                    "blockHash": String("0xc97a0a94ff0fb5eea6614aa4ea708cb237f1dd0b0e651e7547dc8aa07043f16d"),
                    "blockNumber": String("0xa0ebd75"),
                    "data": String("0x"),
                    "logIndex": String("0x2"),
                    "removed": Bool(false),
                    "topics": Array [
                        String("0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0"),
                        String("0x00000000000000000000000045fa3ec833b6a0bf1ab27c8dd33ae03baacc3aa4"),
                        String("0x0000000000000000000000006c1e90f219de736167036e9abde81ec8cd7b2daf"),
                    ],
                    "transactionHash": String("0xfd0aa3e177ce6cf3eb74387b5284bddf212238ed42872bbab395e95c68d98137"),
                    "transactionIndex": String("0x3"),
                },
            ],
            "logsBloom": String("0x00000000000000000000000000000000000000000000000000800000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000100000000000000000000000000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000020000000000200000000000000000020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000840000000080000000000000400000000000000"),
            "status": String("0x1"),
            "to": String("0x13b82c379e4209acc43005f0b2b661945557f56e"),
            "transactionHash": String("0xfd0aa3e177ce6cf3eb74387b5284bddf212238ed42872bbab395e95c68d98137"),
            "transactionIndex": String("0x3"),
            "type": String("0x2"),
        },
    },
}
```


</details>

## Solution

This PR implements a workaround which serializes `inner` and removes all duplicating keys after deserialization

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
