### PR TITLE
feat(rpc): trace requests and responses

### DIFF
--- a/crates/json-rpc/Cargo.toml
+++ b/crates/json-rpc/Cargo.toml
@@ -16,3 +16,4 @@ alloy-primitives = { workspace = true, features = ["std", "serde"] }
 serde.workspace = true
 serde_json = { workspace = true, features = ["std", "raw_value"] }
 thiserror.workspace = true
+tracing.workspace = true

--- a/crates/json-rpc/src/lib.rs
+++ b/crates/json-rpc/src/lib.rs
@@ -82,6 +82,12 @@
 #![deny(unused_must_use, rust_2018_idioms)]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
+#[macro_use]
+extern crate tracing;
+
+use serde::{de::DeserializeOwned, Serialize};
+use std::fmt::Debug;
+
 mod common;
 pub use common::Id;
 
@@ -108,15 +114,13 @@ pub use result::{
     transform_response, transform_result, try_deserialize_ok, BorrowedRpcResult, RpcResult,
 };
 
-use serde::{de::DeserializeOwned, Serialize};
-
 /// An object that can be used as a JSON-RPC parameter.
 ///
 /// This marker trait is blanket-implemented for every qualifying type. It is
 /// used to indicate that a type can be used as a JSON-RPC parameter.
-pub trait RpcParam: Serialize + Clone + Send + Sync + Unpin {}
+pub trait RpcParam: Serialize + Clone + Debug + Send + Sync + Unpin {}
 
-impl<T> RpcParam for T where T: Serialize + Clone + Send + Sync + Unpin {}
+impl<T> RpcParam for T where T: Serialize + Clone + Debug + Send + Sync + Unpin {}
 
 /// An object that can be used as a JSON-RPC return value.
 ///
@@ -128,9 +132,9 @@ impl<T> RpcParam for T where T: Serialize + Clone + Send + Sync + Unpin {}
 /// We add the `'static` lifetime bound to indicate that the type can't borrow.
 /// This is a simplification that makes it easier to use the types in client
 /// code. It is not suitable for use in server code.
-pub trait RpcReturn: DeserializeOwned + Send + Sync + Unpin + 'static {}
+pub trait RpcReturn: DeserializeOwned + Debug + Send + Sync + Unpin + 'static {}
 
-impl<T> RpcReturn for T where T: DeserializeOwned + Send + Sync + Unpin + 'static {}
+impl<T> RpcReturn for T where T: DeserializeOwned + Debug + Send + Sync + Unpin + 'static {}
 
 /// An object that can be used as a JSON-RPC parameter and return value.
 ///

--- a/crates/json-rpc/src/result.rs
+++ b/crates/json-rpc/src/result.rs
@@ -62,6 +62,10 @@ where
     ErrResp: RpcReturn,
 {
     let json = result?;
-    let text = json.borrow().get();
-    serde_json::from_str(text).map_err(|err| RpcError::deser_err(err, text))
+    let json = json.borrow().get();
+    trace!(ty=%std::any::type_name::<T>(), json, "deserializing response");
+    serde_json::from_str(json)
+        .inspect(|response| trace!(?response, "deserialized response"))
+        .inspect_err(|err| trace!(?err, "failed to deserialize response"))
+        .map_err(|err| RpcError::deser_err(err, json))
 }


### PR DESCRIPTION
There is currently no way of knowing what raw data we are sending and receiving.
Add `trace!` calls around the `RpcClient` future for this, as well as a simpler `debug!` for just the method and ID, as the raw data could be very verbose.

Running `test_send_tx` with `alloy=debug`, I think this verbosity is fair for debug:
![image](https://github.com/alloy-rs/alloy/assets/57450786/ca4fb487-85ad-4b7d-97b2-c8949fa1a7ee)