### PR TITLE
Add arbitrary derive for Withdrawal

### DIFF
--- a/crates/eips/src/eip4895.rs
+++ b/crates/eips/src/eip4895.rs
@@ -10,6 +10,10 @@ pub const GWEI_TO_WEI: u64 = 1_000_000_000;
 
 /// Withdrawal represents a validator withdrawal from the consensus layer.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, RlpEncodable, RlpDecodable)]
+#[cfg_attr(
+    all(any(test, feature = "arbitrary"), feature = "std"),
+    derive(proptest_derive::Arbitrary, arbitrary::Arbitrary)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "ssz", derive(ssz_derive::Encode, ssz_derive::Decode))]
 pub struct Withdrawal {


### PR DESCRIPTION
Add arbitrary derive for Withdrawal, so we can do proptest in codec implementation.