### PR TITLE
fix(rpc-types): accept `Address` in `to` builder method for TxReq

### DIFF
--- a/crates/rpc-types/src/eth/transaction/request.rs
+++ b/crates/rpc-types/src/eth/transaction/request.rs
@@ -143,8 +143,8 @@ impl TransactionRequest {
 
     /// Sets the recipient address for the transaction.
     #[inline]
-    pub const fn to(mut self, to: Option<Address>) -> Self {
-        self.to = to;
+    pub const fn to(mut self, to: Address) -> Self {
+        self.to = Some(to);
         self
     }
 


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

The `to` builder method for `TransactionRequest` takes `Option<Address>` as arg. This is inconsistent with other builder methods. 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Use `Address` type for arg and wrap it in `Some` inside the method

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
