### PR TITLE
fix: eip1559 estimator

### DIFF
--- a/crates/provider/src/utils.rs
+++ b/crates/provider/src/utils.rs
@@ -47,7 +47,10 @@ pub fn eip1559_default_estimator(
     let max_priority_fee_per_gas = estimate_priority_fee(rewards);
     let potential_max_fee = base_fee_per_gas * EIP1559_BASE_FEE_MULTIPLIER;
 
-    Eip1559Estimation { max_fee_per_gas: potential_max_fee, max_priority_fee_per_gas }
+    Eip1559Estimation {
+        max_fee_per_gas: potential_max_fee + max_priority_fee_per_gas,
+        max_priority_fee_per_gas,
+    }
 }
 
 #[cfg(test)]
@@ -88,7 +91,7 @@ mod tests {
         assert_eq!(
             super::eip1559_default_estimator(base_fee_per_gas, &rewards),
             Eip1559Estimation {
-                max_fee_per_gas: 2_000_000_000_u128,
+                max_fee_per_gas: 202_000_000_000_u128,
                 max_priority_fee_per_gas: 200_000_000_000_u128
             }
         );

--- a/crates/provider/src/utils.rs
+++ b/crates/provider/src/utils.rs
@@ -95,5 +95,20 @@ mod tests {
                 max_priority_fee_per_gas: 200_000_000_000_u128
             }
         );
+
+        let base_fee_per_gas = 0u128;
+        let rewards = vec![
+            vec![200_000_000_000_u128],
+            vec![200_000_000_000_u128],
+            vec![300_000_000_000_u128],
+        ];
+
+        assert_eq!(
+            super::eip1559_default_estimator(base_fee_per_gas, &rewards),
+            Eip1559Estimation {
+                max_fee_per_gas: 200_000_000_000_u128,
+                max_priority_fee_per_gas: 200_000_000_000_u128
+            }
+        );
     }
 }


### PR DESCRIPTION
## Motivation

ref https://github.com/foundry-rs/foundry/issues/7620

currently we are not accounting for an edge case when estimated priority fee is higher than base fee. baseFee*2 is usually enough, but in the mentioned PR anvil was started with 0 baseFee, thus baseFee was always estimated as zero

## Solution


## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
