### PR TITLE
Improve `watch_pending_transaction`

### DIFF
--- a/crates/network/src/any/mod.rs
+++ b/crates/network/src/any/mod.rs
@@ -3,6 +3,7 @@ use core::fmt;
 use crate::{Network, ReceiptResponse};
 use alloy_consensus::TxType;
 use alloy_eips::eip2718::Eip2718Error;
+use alloy_primitives::B256;
 use alloy_rpc_types::{
     AnyTransactionReceipt, Header, Transaction, TransactionRequest, WithOtherFields,
 };
@@ -79,5 +80,13 @@ impl Network for AnyNetwork {
 impl ReceiptResponse for AnyTransactionReceipt {
     fn contract_address(&self) -> Option<alloy_primitives::Address> {
         self.contract_address
+    }
+
+    fn block_number(&self) -> Option<u64> {
+        self.block_number
+    }
+
+    fn transaction_hash(&self) -> B256 {
+        self.transaction_hash
     }
 }

--- a/crates/network/src/ethereum/mod.rs
+++ b/crates/network/src/ethereum/mod.rs
@@ -1,6 +1,7 @@
 use crate::{Network, ReceiptResponse};
 
 mod builder;
+use alloy_primitives::B256;
 
 mod signer;
 pub use signer::EthereumSigner;
@@ -34,5 +35,13 @@ impl Network for Ethereum {
 impl ReceiptResponse for alloy_rpc_types::TransactionReceipt {
     fn contract_address(&self) -> Option<alloy_primitives::Address> {
         self.contract_address
+    }
+
+    fn block_number(&self) -> Option<u64> {
+        self.block_number
+    }
+
+    fn transaction_hash(&self) -> B256 {
+        self.transaction_hash
     }
 }

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -17,7 +17,7 @@
 
 use alloy_eips::eip2718::{Eip2718Envelope, Eip2718Error};
 use alloy_json_rpc::RpcObject;
-use alloy_primitives::Address;
+use alloy_primitives::{Address, B256};
 use core::fmt::{Debug, Display};
 
 mod transaction;
@@ -42,6 +42,12 @@ pub use alloy_eips::eip2718;
 pub trait ReceiptResponse {
     /// Address of the created contract, or `None` if the transaction was not a deployment.
     fn contract_address(&self) -> Option<Address>;
+
+    /// Number of block in which transaction was included.
+    fn block_number(&self) -> Option<u64>;
+
+    /// Hash of the transaction.
+    fn transaction_hash(&self) -> B256;
 }
 
 /// Captures type info for network-specific RPC requests/responses.

--- a/crates/provider/src/fillers/signer.rs
+++ b/crates/provider/src/fillers/signer.rs
@@ -114,11 +114,11 @@ mod tests {
         let local_hash = *pending.tx_hash();
         assert_eq!(local_hash, node_hash);
 
-        let local_hash2 = pending.await.unwrap();
-        assert_eq!(local_hash2, node_hash);
+        let receipt = pending.await.unwrap();
+        assert_eq!(receipt.transaction_hash, node_hash);
 
         let receipt =
-            provider.get_transaction_receipt(local_hash2).await.unwrap().expect("no receipt");
+            provider.get_transaction_receipt(local_hash).await.unwrap().expect("no receipt");
         let receipt_hash = receipt.transaction_hash;
         assert_eq!(receipt_hash, node_hash);
     }

--- a/crates/rpc-client/src/lib.rs
+++ b/crates/rpc-client/src/lib.rs
@@ -31,7 +31,7 @@ mod call;
 pub use call::RpcCall;
 
 mod client;
-pub use client::{ClientRef, RpcClient, WeakClient};
+pub use client::{ClientRef, RpcClient, RpcClientInner, WeakClient};
 
 mod poller;
 pub use poller::{PollChannel, PollerBuilder};


### PR DESCRIPTION
## Motivation

Closes #389

Now when receiving pending transaction, it is placed in `unconfirmed` map firstly, and then we start to check for it in new blocks and try to perform a sing `eth_getTransactionReceipt` request with it. That way, if tx is actually pending, we will remove it from `unconfirmed` once it is getting included into some of the future blocks, and if it is not pending, we will successfuly fetch receipt for it instead of waiting indefinitely.

This also updates `TxWatcher` to return transaction receipt, to implement this we now start polling for receipt once tx gets enough confirmations

## Solution

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
