### PR TITLE
Revert "chore: remove outdated license"

### DIFF
--- a/crates/provider/src/builder.rs
+++ b/crates/provider/src/builder.rs
@@ -386,3 +386,29 @@ impl<L, F> ProviderBuilder<L, F, Ethereum> {
         (this.on_http(url).unwrap(), anvil)
     }
 }
+
+// Copyright (c) 2019 Tower Contributors
+
+// Permission is hereby granted, free of charge, to any
+// person obtaining a copy of this software and associated
+// documentation files (the "Software"), to deal in the
+// Software without restriction, including without
+// limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software
+// is furnished to do so, subject to the following
+// conditions:
+
+// The above copyright notice and this permission notice
+// shall be included in all copies or substantial portions
+// of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+// ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+// TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+// SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+// IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
Reverts alloy-rs/alloy#510

License is not outdated, it applies to code in the file which was copy-pasted from the tower project and reproducing the license text is necessary to comply with the license terms