### PR TITLE
Prestwich/signer multiplex

### DIFF
--- a/crates/network/src/any/builder.rs
+++ b/crates/network/src/any/builder.rs
@@ -130,6 +130,6 @@ impl TransactionBuilder<AnyNetwork> for WithOtherFields<TransactionRequest> {
         self,
         signer: &S,
     ) -> BuilderResult<alloy_consensus::TxEnvelope> {
-        Ok(signer.sign_transaction(self.build_unsigned()?).await?)
+        Ok(signer.sign_request(self.build_unsigned()?.into()).await?)
     }
 }

--- a/crates/network/src/any/builder.rs
+++ b/crates/network/src/any/builder.rs
@@ -130,6 +130,6 @@ impl TransactionBuilder<AnyNetwork> for WithOtherFields<TransactionRequest> {
         self,
         signer: &S,
     ) -> BuilderResult<alloy_consensus::TxEnvelope> {
-        Ok(signer.sign_request(self.build_unsigned()?.into()).await?)
+        Ok(signer.sign_request(self).await?)
     }
 }

--- a/crates/network/src/ethereum/builder.rs
+++ b/crates/network/src/ethereum/builder.rs
@@ -148,7 +148,7 @@ impl TransactionBuilder<Ethereum> for TransactionRequest {
         self,
         signer: &S,
     ) -> BuilderResult<<Ethereum as Network>::TxEnvelope> {
-        Ok(signer.sign_transaction(self.build_unsigned()?).await?)
+        Ok(signer.sign_request(self).await?)
     }
 }
 

--- a/crates/network/src/ethereum/signer.rs
+++ b/crates/network/src/ethereum/signer.rs
@@ -1,16 +1,23 @@
 use crate::{Network, NetworkSigner, TxSigner};
 use alloy_consensus::{SignableTransaction, TxEnvelope, TypedTransaction};
+use alloy_primitives::Address;
 use alloy_signer::Signature;
 use async_trait::async_trait;
-use std::sync::Arc;
+use std::{collections::BTreeMap, sync::Arc};
 
 /// A signer capable of signing any transaction for the Ethereum network.
 #[derive(Clone)]
-pub struct EthereumSigner(Arc<dyn TxSigner<Signature> + Send + Sync>);
+pub struct EthereumSigner {
+    default: Address,
+    secp_signers: BTreeMap<Address, Arc<dyn TxSigner<Signature> + Send + Sync>>,
+}
 
 impl std::fmt::Debug for EthereumSigner {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_tuple("EthereumSigner").finish()
+        f.debug_struct("EthereumSigner")
+            .field("default_signer", &self.default)
+            .field("credentials", &self.secp_signers.len())
+            .finish()
     }
 }
 
@@ -24,19 +31,66 @@ where
 }
 
 impl EthereumSigner {
-    /// Create a new Ethereum signer.
+    /// Create a new signer with the given signer as the default signer.
     pub fn new<S>(signer: S) -> Self
     where
         S: TxSigner<Signature> + Send + Sync + 'static,
     {
-        Self(Arc::new(signer))
+        let mut this = Self { default: Default::default(), secp_signers: BTreeMap::new() };
+        this.register_signer(signer);
+        this
+    }
+
+    /// Register a new signer on this object. This signer will be used to sign
+    /// [`TransactionRequest`] and [`TypedTransaction`] object that specify the
+    /// signer's address in the `from` field.
+    ///
+    /// [`TransactionRequest`]: alloy_rpc_types::TransactionRequest
+    pub fn register_signer<S>(&mut self, signer: S)
+    where
+        S: TxSigner<Signature> + Send + Sync + 'static,
+    {
+        self.secp_signers.insert(signer.address(), Arc::new(signer));
+    }
+
+    /// Register a new signer on this object, and set it as the default signer.
+    /// This signer will be used to sign [`TransactionRequest`] and
+    /// [`TypedTransaction`] objects that do not specify a signer address in the
+    /// `from` field.
+    pub fn register_default_signer<S>(&mut self, signer: S)
+    where
+        S: TxSigner<Signature> + Send + Sync + 'static,
+    {
+        self.default = signer.address();
+        self.register_signer(signer);
+    }
+
+    /// Get the default signer.
+    pub fn default_signer(&self) -> Arc<dyn TxSigner<Signature> + Send + Sync + 'static> {
+        self.secp_signers.get(&self.default).map(|s| Arc::clone(s)).expect("invalid signer")
+    }
+
+    /// Get the signer for the given address.
+    pub fn signer_by_address(
+        &self,
+        address: Address,
+    ) -> Option<Arc<dyn TxSigner<Signature> + Send + Sync + 'static>> {
+        self.secp_signers.get(&address).map(|s| Arc::clone(s))
     }
 
     async fn sign_transaction_inner(
         &self,
+        sender: Option<Address>,
         tx: &mut dyn SignableTransaction<Signature>,
     ) -> alloy_signer::Result<Signature> {
-        self.0.sign_transaction(tx).await
+        let address = sender.unwrap_or_else(|| self.default);
+
+        self.signer_by_address(address)
+            .ok_or_else(|| {
+                alloy_signer::Error::other(format!("Missing signing credential for {}", address))
+            })?
+            .sign_transaction(tx)
+            .await
     }
 }
 
@@ -46,22 +100,30 @@ impl<N> NetworkSigner<N> for EthereumSigner
 where
     N: Network<UnsignedTx = TypedTransaction, TxEnvelope = TxEnvelope>,
 {
-    async fn sign_transaction(&self, tx: TypedTransaction) -> alloy_signer::Result<TxEnvelope> {
+    fn default_signer(&self) -> Address {
+        self.default
+    }
+
+    async fn sign_transaction_from(
+        &self,
+        sender: Option<Address>,
+        tx: TypedTransaction,
+    ) -> alloy_signer::Result<TxEnvelope> {
         match tx {
             TypedTransaction::Legacy(mut t) => {
-                let sig = self.sign_transaction_inner(&mut t).await?;
+                let sig = self.sign_transaction_inner(sender, &mut t).await?;
                 Ok(t.into_signed(sig).into())
             }
             TypedTransaction::Eip2930(mut t) => {
-                let sig = self.sign_transaction_inner(&mut t).await?;
+                let sig = self.sign_transaction_inner(sender, &mut t).await?;
                 Ok(t.into_signed(sig).into())
             }
             TypedTransaction::Eip1559(mut t) => {
-                let sig = self.sign_transaction_inner(&mut t).await?;
+                let sig = self.sign_transaction_inner(sender, &mut t).await?;
                 Ok(t.into_signed(sig).into())
             }
             TypedTransaction::Eip4844(mut t) => {
-                let sig = self.sign_transaction_inner(&mut t).await?;
+                let sig = self.sign_transaction_inner(sender, &mut t).await?;
                 Ok(t.into_signed(sig).into())
             }
         }

--- a/crates/network/src/ethereum/signer.rs
+++ b/crates/network/src/ethereum/signer.rs
@@ -69,7 +69,7 @@ impl EthereumSigner {
 
     /// Get the default signer.
     pub fn default_signer(&self) -> Arc<dyn TxSigner<Signature> + Send + Sync + 'static> {
-        self.secp_signers.get(&self.default).map(Arc::clone).expect("invalid signer")
+        self.secp_signers.get(&self.default).cloned().expect("invalid signer")
     }
 
     /// Get the signer for the given address.
@@ -77,7 +77,7 @@ impl EthereumSigner {
         &self,
         address: Address,
     ) -> Option<Arc<dyn TxSigner<Signature> + Send + Sync + 'static>> {
-        self.secp_signers.get(&address).map(Arc::clone)
+        self.secp_signers.get(&address).cloned()
     }
 
     async fn sign_transaction_inner(

--- a/crates/network/src/ethereum/signer.rs
+++ b/crates/network/src/ethereum/signer.rs
@@ -37,7 +37,7 @@ impl EthereumSigner {
         S: TxSigner<Signature> + Send + Sync + 'static,
     {
         let mut this = Self { default: Default::default(), secp_signers: BTreeMap::new() };
-        this.register_signer(signer);
+        this.register_default_signer(signer);
         this
     }
 

--- a/crates/network/src/ethereum/signer.rs
+++ b/crates/network/src/ethereum/signer.rs
@@ -82,14 +82,12 @@ impl EthereumSigner {
 
     async fn sign_transaction_inner(
         &self,
-        sender: Option<Address>,
+        sender: Address,
         tx: &mut dyn SignableTransaction<Signature>,
     ) -> alloy_signer::Result<Signature> {
-        let address = sender.unwrap_or(self.default);
-
-        self.signer_by_address(address)
+        self.signer_by_address(sender)
             .ok_or_else(|| {
-                alloy_signer::Error::other(format!("Missing signing credential for {}", address))
+                alloy_signer::Error::other(format!("Missing signing credential for {}", sender))
             })?
             .sign_transaction(tx)
             .await
@@ -116,7 +114,7 @@ where
 
     async fn sign_transaction_from(
         &self,
-        sender: Option<Address>,
+        sender: Address,
         tx: TypedTransaction,
     ) -> alloy_signer::Result<TxEnvelope> {
         match tx {

--- a/crates/network/src/ethereum/signer.rs
+++ b/crates/network/src/ethereum/signer.rs
@@ -57,6 +57,8 @@ impl EthereumSigner {
     /// This signer will be used to sign [`TransactionRequest`] and
     /// [`TypedTransaction`] objects that do not specify a signer address in the
     /// `from` field.
+    ///
+    /// [`TransactionRequest`]: alloy_rpc_types::TransactionRequest
     pub fn register_default_signer<S>(&mut self, signer: S)
     where
         S: TxSigner<Signature> + Send + Sync + 'static,
@@ -67,7 +69,7 @@ impl EthereumSigner {
 
     /// Get the default signer.
     pub fn default_signer(&self) -> Arc<dyn TxSigner<Signature> + Send + Sync + 'static> {
-        self.secp_signers.get(&self.default).map(|s| Arc::clone(s)).expect("invalid signer")
+        self.secp_signers.get(&self.default).map(Arc::clone).expect("invalid signer")
     }
 
     /// Get the signer for the given address.
@@ -75,7 +77,7 @@ impl EthereumSigner {
         &self,
         address: Address,
     ) -> Option<Arc<dyn TxSigner<Signature> + Send + Sync + 'static>> {
-        self.secp_signers.get(&address).map(|s| Arc::clone(s))
+        self.secp_signers.get(&address).map(Arc::clone)
     }
 
     async fn sign_transaction_inner(
@@ -83,7 +85,7 @@ impl EthereumSigner {
         sender: Option<Address>,
         tx: &mut dyn SignableTransaction<Signature>,
     ) -> alloy_signer::Result<Signature> {
-        let address = sender.unwrap_or_else(|| self.default);
+        let address = sender.unwrap_or(self.default);
 
         self.signer_by_address(address)
             .ok_or_else(|| {

--- a/crates/network/src/ethereum/signer.rs
+++ b/crates/network/src/ethereum/signer.rs
@@ -110,8 +110,8 @@ where
         self.secp_signers.contains_key(address)
     }
 
-    fn signers(&self) -> impl Iterator<Item = &Address> {
-        self.secp_signers.keys()
+    fn signers(&self) -> impl Iterator<Item = Address> {
+        self.secp_signers.keys().copied()
     }
 
     async fn sign_transaction_from(

--- a/crates/network/src/ethereum/signer.rs
+++ b/crates/network/src/ethereum/signer.rs
@@ -106,6 +106,14 @@ where
         self.default
     }
 
+    fn is_signer_for(&self, address: &Address) -> bool {
+        self.secp_signers.contains_key(address)
+    }
+
+    fn signers(&self) -> impl Iterator<Item = &Address> {
+        self.secp_signers.keys()
+    }
+
     async fn sign_transaction_from(
         &self,
         sender: Option<Address>,

--- a/crates/network/src/transaction/signer.rs
+++ b/crates/network/src/transaction/signer.rs
@@ -22,6 +22,12 @@ pub trait NetworkSigner<N: Network>: std::fmt::Debug + Send + Sync {
     /// specified.
     fn default_signer(&self) -> Address;
 
+    /// Return true if the signer contains a credential for the given address.
+    fn is_signer_for(&self, address: &Address) -> bool;
+
+    /// Return an iterator of all signer addresses.
+    fn signers(&self) -> impl Iterator<Item = &Address>;
+
     /// Asynchronously sign an unsigned transaction, with a specified
     /// credential.
     async fn sign_transaction_from(

--- a/crates/network/src/transaction/signer.rs
+++ b/crates/network/src/transaction/signer.rs
@@ -26,7 +26,7 @@ pub trait NetworkSigner<N: Network>: std::fmt::Debug + Send + Sync {
     fn is_signer_for(&self, address: &Address) -> bool;
 
     /// Return an iterator of all signer addresses.
-    fn signers(&self) -> impl Iterator<Item = &Address>;
+    fn signers(&self) -> impl Iterator<Item = Address>;
 
     /// Asynchronously sign an unsigned transaction, with a specified
     /// credential.

--- a/crates/network/src/transaction/signer.rs
+++ b/crates/network/src/transaction/signer.rs
@@ -6,9 +6,14 @@ use futures_utils_wasm::impl_future;
 
 /// A signer capable of signing any transaction for the given network.
 ///
-/// Network crate authors should implement this trait on a type capable of signing any transaction
-/// (regardless of signature type) on a given network. Signer crate authors should instead implement
-/// [`TxSigner`] to signify signing capability for specific signature types.
+/// Network crate authors should implement this trait on a type capable of
+/// signing any transaction (regardless of signature type) on a given network.
+/// Signer crate authors should instead implement [`TxSigner`] to signify
+/// signing capability for specific signature types.
+///
+/// Network signers are expected to contain one or more signing credentials,
+/// keyed by signing address. The default signer address should be used when
+/// no specific signer address is specified.
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait NetworkSigner<N: Network>: std::fmt::Debug + Send + Sync {
@@ -33,7 +38,8 @@ pub trait NetworkSigner<N: Network>: std::fmt::Debug + Send + Sync {
         self.sign_transaction_from(None, tx)
     }
 
-    /// Asynchronously sign a transaction request.
+    /// Asynchronously sign a transaction request, using the sender specified
+    /// in the `from` field.
     async fn sign_request(
         &self,
         request: N::TransactionRequest,

--- a/crates/signer-aws/src/signer.rs
+++ b/crates/signer-aws/src/signer.rs
@@ -96,6 +96,10 @@ pub enum AwsSignerError {
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl alloy_network::TxSigner<Signature> for AwsSigner {
+    fn address(&self) -> Address {
+        self.address
+    }
+
     #[inline]
     async fn sign_transaction(
         &self,

--- a/crates/signer-gcp/src/signer.rs
+++ b/crates/signer-gcp/src/signer.rs
@@ -148,6 +148,10 @@ pub enum GcpSignerError {
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl alloy_network::TxSigner<Signature> for GcpSigner {
+    fn address(&self) -> Address {
+        self.address
+    }
+
     #[inline]
     async fn sign_transaction(
         &self,

--- a/crates/signer-ledger/src/signer.rs
+++ b/crates/signer-ledger/src/signer.rs
@@ -31,6 +31,10 @@ pub struct LedgerSigner {
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl alloy_network::TxSigner<Signature> for LedgerSigner {
+    fn address(&self) -> Address {
+        self.address
+    }
+
     #[inline]
     async fn sign_transaction(
         &self,

--- a/crates/signer-trezor/src/signer.rs
+++ b/crates/signer-trezor/src/signer.rs
@@ -67,6 +67,10 @@ impl Signer for TrezorSigner {
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl alloy_network::TxSigner<Signature> for TrezorSigner {
+    fn address(&self) -> Address {
+        self.address
+    }
+
     #[inline]
     async fn sign_transaction(
         &self,

--- a/crates/signer-wallet/src/lib.rs
+++ b/crates/signer-wallet/src/lib.rs
@@ -179,6 +179,10 @@ impl<D> TxSigner<Signature> for Wallet<D>
 where
     D: PrehashSigner<(ecdsa::Signature, RecoveryId)> + Send + Sync,
 {
+    fn address(&self) -> Address {
+        self.address
+    }
+
     async fn sign_transaction(
         &self,
         tx: &mut dyn SignableTransaction<Signature>,
@@ -191,6 +195,10 @@ impl<D> TxSignerSync<Signature> for Wallet<D>
 where
     D: PrehashSigner<(ecdsa::Signature, RecoveryId)>,
 {
+    fn address(&self) -> Address {
+        self.address
+    }
+
     fn sign_transaction_sync(
         &self,
         tx: &mut dyn SignableTransaction<Signature>,


### PR DESCRIPTION
Resolves signer filler not setting from and failing to sign

## Motivation

Unblock foundry dev

## Solution

- `NetworkSigner<N>` is now expected to contain a store of credentials, by address.
- `NetworkSigner<N>` now selects credentials based on request `from` field
- `NetworkSigner<N>` allows user-specified sender when signing

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [x] Breaking changes
