### PR TITLE
refactor: make optional BlockId params required in provider functions

### DIFF
--- a/crates/contract/src/call.rs
+++ b/crates/contract/src/call.rs
@@ -190,7 +190,7 @@ impl CallDecoder for () {
 #[must_use = "call builders do nothing unless you `.call`, `.send`, or `.await` them"]
 pub struct CallBuilder<T, P, D, N: Network = Ethereum> {
     request: N::TransactionRequest,
-    block: Option<BlockId>,
+    block: BlockId,
     state: Option<StateOverride>,
     /// The provider.
     // NOTE: This is public due to usage in `sol!`, please avoid changing it.
@@ -262,7 +262,7 @@ impl<T: Transport + Clone, P: Provider<T, N>, D: CallDecoder, N: Network> CallBu
             request: <N::TransactionRequest>::default().with_input(input),
             decoder,
             provider,
-            block: None,
+            block: BlockId::default(),
             state: None,
             transport: PhantomData,
         }
@@ -322,7 +322,7 @@ impl<T: Transport + Clone, P: Provider<T, N>, D: CallDecoder, N: Network> CallBu
 
     /// Sets the `block` field for sending the tx to the chain
     pub const fn block(mut self, block: BlockId) -> Self {
-        self.block = Some(block);
+        self.block = block;
         self
     }
 

--- a/crates/provider/src/fillers/gas.rs
+++ b/crates/provider/src/fillers/gas.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use alloy_json_rpc::RpcError;
 use alloy_network::{Network, TransactionBuilder};
-use alloy_rpc_types::BlockNumberOrTag;
+use alloy_rpc_types::{BlockId, BlockNumberOrTag};
 use alloy_transport::{Transport, TransportResult};
 use futures::FutureExt;
 
@@ -84,7 +84,7 @@ impl GasFiller {
         let gas_limit_fut = if let Some(gas_limit) = tx.gas_limit() {
             async move { Ok(gas_limit) }.left_future()
         } else {
-            async { provider.estimate_gas(tx, None).await }.right_future()
+            async { provider.estimate_gas(tx, BlockId::default()).await }.right_future()
         };
 
         let (gas_price, gas_limit) = futures::try_join!(gas_price_fut, gas_limit_fut)?;
@@ -105,7 +105,7 @@ impl GasFiller {
         let gas_limit_fut = if let Some(gas_limit) = tx.gas_limit() {
             async move { Ok(gas_limit) }.left_future()
         } else {
-            async { provider.estimate_gas(tx, None).await }.right_future()
+            async { provider.estimate_gas(tx, BlockId::default()).await }.right_future()
         };
 
         let eip1559_fees_fut = if let (Some(max_fee_per_gas), Some(max_priority_fee_per_gas)) =
@@ -135,7 +135,7 @@ impl GasFiller {
         let gas_limit_fut = if let Some(gas_limit) = tx.gas_limit() {
             async move { Ok(gas_limit) }.left_future()
         } else {
-            async { provider.estimate_gas(tx, None).await }.right_future()
+            async { provider.estimate_gas(tx, BlockId::default()).await }.right_future()
         };
 
         let eip1559_fees_fut = if let (Some(max_fee_per_gas), Some(max_priority_fee_per_gas)) =

--- a/crates/provider/src/fillers/nonce.rs
+++ b/crates/provider/src/fillers/nonce.rs
@@ -5,6 +5,7 @@ use crate::{
 };
 use alloy_network::{Network, TransactionBuilder};
 use alloy_primitives::Address;
+use alloy_rpc_types::BlockId;
 use alloy_transport::{Transport, TransportResult};
 use dashmap::DashMap;
 use std::sync::Arc;
@@ -103,7 +104,8 @@ impl NonceFiller {
             }
             None => {
                 // initialize the nonce if we haven't seen this account before
-                let initial_nonce = provider.get_transaction_count(from, None).await?;
+                let initial_nonce =
+                    provider.get_transaction_count(from, BlockId::default()).await?;
                 *nonce = Some(initial_nonce);
                 Ok(initial_nonce)
             }


### PR DESCRIPTION
## Motivation

This issue #514 

## Solution

Make the `BlockId` optional and use the default value if it's `None`.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [x] Breaking changes
