### PR TITLE
feat: Export inner encoding / decoding functions from `Tx*` types

### DIFF
--- a/crates/consensus/src/transaction/eip1559.rs
+++ b/crates/consensus/src/transaction/eip1559.rs
@@ -117,8 +117,8 @@ impl TxEip1559 {
         })
     }
 
-    /// Encodes only the transaction's fields into the desired buffer, without a RLP header.
-    pub(crate) fn fields_len(&self) -> usize {
+    /// Outputs the length of the transaction's fields, without a RLP header.
+    pub fn fields_len(&self) -> usize {
         let mut len = 0;
         len += self.chain_id.length();
         len += self.nonce.length();
@@ -175,8 +175,8 @@ impl TxEip1559 {
     }
 
     /// Inner encoding function that is used for both rlp [`Encodable`] trait and for calculating
-    /// hash that for eip2718 does not require a rlp header
-    pub(crate) fn encode_with_signature(
+    /// hash that for eip2718 does not require a rlp header.
+    pub fn encode_with_signature(
         &self,
         signature: &Signature,
         out: &mut dyn BufMut,
@@ -200,7 +200,7 @@ impl TxEip1559 {
     /// header.
     ///
     /// This __does__ expect the bytes to start with a list header and include a signature.
-    pub(crate) fn decode_signed_fields(buf: &mut &[u8]) -> alloy_rlp::Result<Signed<Self>> {
+    pub fn decode_signed_fields(buf: &mut &[u8]) -> alloy_rlp::Result<Signed<Self>> {
         let header = Header::decode(buf)?;
         if !header.list {
             return Err(alloy_rlp::Error::UnexpectedString);

--- a/crates/consensus/src/transaction/eip1559.rs
+++ b/crates/consensus/src/transaction/eip1559.rs
@@ -118,6 +118,7 @@ impl TxEip1559 {
     }
 
     /// Outputs the length of the transaction's fields, without a RLP header.
+    #[doc(hidden)]
     pub fn fields_len(&self) -> usize {
         let mut len = 0;
         len += self.chain_id.length();
@@ -176,6 +177,7 @@ impl TxEip1559 {
 
     /// Inner encoding function that is used for both rlp [`Encodable`] trait and for calculating
     /// hash that for eip2718 does not require a rlp header.
+    #[doc(hidden)]
     pub fn encode_with_signature(
         &self,
         signature: &Signature,
@@ -200,6 +202,7 @@ impl TxEip1559 {
     /// header.
     ///
     /// This __does__ expect the bytes to start with a list header and include a signature.
+    #[doc(hidden)]
     pub fn decode_signed_fields(buf: &mut &[u8]) -> alloy_rlp::Result<Signed<Self>> {
         let header = Header::decode(buf)?;
         if !header.list {

--- a/crates/consensus/src/transaction/eip2930.rs
+++ b/crates/consensus/src/transaction/eip2930.rs
@@ -98,7 +98,7 @@ impl TxEip2930 {
     }
 
     /// Outputs the length of the transaction's fields, without a RLP header.
-    pub(crate) fn fields_len(&self) -> usize {
+    pub fn fields_len(&self) -> usize {
         let mut len = 0;
         len += self.chain_id.length();
         len += self.nonce.length();
@@ -154,7 +154,7 @@ impl TxEip2930 {
 
     /// Inner encoding function that is used for both rlp [`Encodable`] trait and for calculating
     /// hash that for eip2718 does not require a rlp header
-    pub(crate) fn encode_with_signature(
+    pub fn encode_with_signature(
         &self,
         signature: &Signature,
         out: &mut dyn BufMut,
@@ -190,7 +190,7 @@ impl TxEip2930 {
     /// header.
     ///
     /// This __does__ expect the bytes to start with a list header and include a signature.
-    pub(crate) fn decode_signed_fields(buf: &mut &[u8]) -> alloy_rlp::Result<Signed<Self>> {
+    pub fn decode_signed_fields(buf: &mut &[u8]) -> alloy_rlp::Result<Signed<Self>> {
         let header = Header::decode(buf)?;
         if !header.list {
             return Err(alloy_rlp::Error::UnexpectedString);

--- a/crates/consensus/src/transaction/eip2930.rs
+++ b/crates/consensus/src/transaction/eip2930.rs
@@ -98,6 +98,7 @@ impl TxEip2930 {
     }
 
     /// Outputs the length of the transaction's fields, without a RLP header.
+    #[doc(hidden)]
     pub fn fields_len(&self) -> usize {
         let mut len = 0;
         len += self.chain_id.length();
@@ -154,6 +155,7 @@ impl TxEip2930 {
 
     /// Inner encoding function that is used for both rlp [`Encodable`] trait and for calculating
     /// hash that for eip2718 does not require a rlp header
+    #[doc(hidden)]
     pub fn encode_with_signature(
         &self,
         signature: &Signature,
@@ -190,6 +192,7 @@ impl TxEip2930 {
     /// header.
     ///
     /// This __does__ expect the bytes to start with a list header and include a signature.
+    #[doc(hidden)]
     pub fn decode_signed_fields(buf: &mut &[u8]) -> alloy_rlp::Result<Signed<Self>> {
         let header = Header::decode(buf)?;
         if !header.list {

--- a/crates/consensus/src/transaction/eip4844.rs
+++ b/crates/consensus/src/transaction/eip4844.rs
@@ -148,6 +148,7 @@ impl TxEip4844Variant {
     }
 
     /// Outputs the length of the transaction's fields, without a RLP header.
+    #[doc(hidden)]
     pub fn fields_len(&self) -> usize {
         match self {
             TxEip4844Variant::TxEip4844(tx) => tx.fields_len(),
@@ -161,6 +162,7 @@ impl TxEip4844Variant {
     ///
     /// If `with_header` is `true`, the following will be encoded:
     /// `rlp(tx_type (0x03) || rlp([transaction_payload_body, blobs, commitments, proofs]))`
+    #[doc(hidden)]
     pub fn encode_with_signature(
         &self,
         signature: &Signature,
@@ -203,6 +205,7 @@ impl TxEip4844Variant {
     /// header.
     ///
     /// This __does__ expect the bytes to start with a list header and include a signature.
+    #[doc(hidden)]
     pub fn decode_signed_fields(buf: &mut &[u8]) -> alloy_rlp::Result<Signed<Self>> {
         let mut current_buf = *buf;
         let _header = Header::decode(&mut current_buf)?;
@@ -517,6 +520,7 @@ impl TxEip4844 {
     }
 
     /// Outputs the length of the transaction's fields, without a RLP header.
+    #[doc(hidden)]
     pub fn fields_len(&self) -> usize {
         let mut len = 0;
         len += self.chain_id.length();
@@ -595,6 +599,7 @@ impl TxEip4844 {
 
     /// Inner encoding function that is used for both rlp [`Encodable`] trait and for calculating
     /// hash that for eip2718 does not require a rlp header
+    #[doc(hidden)]
     pub fn encode_with_signature(
         &self,
         signature: &Signature,
@@ -631,6 +636,7 @@ impl TxEip4844 {
     /// header.
     ///
     /// This __does__ expect the bytes to start with a list header and include a signature.
+    #[doc(hidden)]
     pub fn decode_signed_fields(buf: &mut &[u8]) -> alloy_rlp::Result<Signed<Self>> {
         let header = Header::decode(buf)?;
         if !header.list {
@@ -865,6 +871,7 @@ impl TxEip4844WithSidecar {
     /// This __does__ expect the bytes to start with a list header and include a signature.
     ///
     /// This is the inverse of [TxEip4844WithSidecar::encode_with_signature_fields].
+    #[doc(hidden)]
     pub fn decode_signed_fields(buf: &mut &[u8]) -> alloy_rlp::Result<Signed<Self>> {
         let header = Header::decode(buf)?;
         if !header.list {

--- a/crates/consensus/src/transaction/legacy.rs
+++ b/crates/consensus/src/transaction/legacy.rs
@@ -75,6 +75,7 @@ impl TxLegacy {
 
     /// Outputs the length of the transaction's fields, without a RLP header or length of the
     /// eip155 fields.
+    #[doc(hidden)]
     pub fn fields_len(&self) -> usize {
         let mut len = 0;
         len += self.nonce.length();
@@ -153,6 +154,7 @@ impl TxLegacy {
     /// header.
     ///
     /// This __does__ expect the bytes to start with a list header and include a signature.
+    #[doc(hidden)]
     pub fn decode_signed_fields(buf: &mut &[u8]) -> alloy_rlp::Result<Signed<Self>> {
         let header = Header::decode(buf)?;
         if !header.list {

--- a/crates/consensus/src/transaction/legacy.rs
+++ b/crates/consensus/src/transaction/legacy.rs
@@ -75,7 +75,7 @@ impl TxLegacy {
 
     /// Outputs the length of the transaction's fields, without a RLP header or length of the
     /// eip155 fields.
-    pub(crate) fn fields_len(&self) -> usize {
+    pub fn fields_len(&self) -> usize {
         let mut len = 0;
         len += self.nonce.length();
         len += self.gas_price.length();
@@ -153,7 +153,7 @@ impl TxLegacy {
     /// header.
     ///
     /// This __does__ expect the bytes to start with a list header and include a signature.
-    pub(crate) fn decode_signed_fields(buf: &mut &[u8]) -> alloy_rlp::Result<Signed<Self>> {
+    pub fn decode_signed_fields(buf: &mut &[u8]) -> alloy_rlp::Result<Signed<Self>> {
         let header = Header::decode(buf)?;
         if !header.list {
             return Err(alloy_rlp::Error::UnexpectedString);


### PR DESCRIPTION
## Overview

Exports a few of the `Tx*` types' inner encoding & decoding functions for use in the `op-alloy-consensus` wrapper. Doing so allows us to re-use all of these types in the expanded transaction envelope enum.