### PR TITLE
feat: `no_std` Engine RPC types

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ The following crates support `no_std`:
 - alloy-genesis
 - alloy-serde
 - alloy-consensus
+- alloy-rpc-types-engine
 
 If you would like to add `no_std` support to a crate, please make sure to update
 `scripts/check_no_std.sh` as well.

--- a/crates/alloy/Cargo.toml
+++ b/crates/alloy/Cargo.toml
@@ -69,6 +69,7 @@ std = [
     "alloy-genesis?/std",
     "alloy-serde?/std",
     "alloy-consensus?/std",
+    "alloy-rpc-types-engine?/std"
 ]
 
 # configuration

--- a/crates/eip7547/Cargo.toml
+++ b/crates/eip7547/Cargo.toml
@@ -13,7 +13,7 @@ exclude.workspace = true
 
 [dependencies]
 alloy-primitives = { workspace = true, features = ["rlp", "serde"] }
-alloy-rpc-types-engine = { workspace = true }
+alloy-rpc-types-engine = { workspace = true, features = ["std"] }
 alloy-serde = { workspace = true }
 
 # serde

--- a/crates/rpc-client/src/builtin.rs
+++ b/crates/rpc-client/src/builtin.rs
@@ -1,7 +1,9 @@
-use std::{path::PathBuf, str::FromStr};
-
 use alloy_json_rpc::RpcError;
 use alloy_transport::{BoxTransport, BoxTransportConnect, TransportError, TransportErrorKind};
+use std::str::FromStr;
+
+#[cfg(feature = "ipc")]
+use std::path::PathBuf;
 
 #[cfg(feature = "pubsub")]
 use alloy_pubsub::PubSubConnect;

--- a/crates/rpc-types-engine/Cargo.toml
+++ b/crates/rpc-types-engine/Cargo.toml
@@ -13,9 +13,9 @@ exclude.workspace = true
 
 [dependencies]
 # ethereum
-alloy-rlp = { workspace = true, features = ["arrayvec", "derive"] }
+alloy-rlp = { workspace = true, features = ["derive"] }
 alloy-primitives = { workspace = true, features = ["rlp", "serde"] }
-alloy-consensus = { workspace = true, features = ["std"] }
+alloy-consensus.workspace = true
 alloy-rpc-types.workspace = true
 alloy-serde.workspace = true
 
@@ -24,15 +24,16 @@ ethereum_ssz_derive = { workspace = true, optional = true }
 ethereum_ssz = { workspace = true, optional = true }
 
 serde = { workspace = true, features = ["derive"] }
-thiserror.workspace = true
+thiserror = { workspace = true, optional = true }
 
 # jsonrpsee
 jsonrpsee-types = { version = "0.22", optional = true }
 alloy-eips = { workspace= true, optional = true }
 
 [features]
-jsonrpsee-types = ["dep:jsonrpsee-types"]
-ssz = ["dep:ethereum_ssz", "dep:ethereum_ssz_derive", "alloy-primitives/ssz", "alloy-rpc-types/ssz", "dep:alloy-eips", "alloy-eips/ssz"]
+std = ["alloy-consensus/std", "alloy-rlp/arrayvec", "dep:thiserror"]
+jsonrpsee-types = ["std", "dep:jsonrpsee-types"]
+ssz = ["std", "dep:ethereum_ssz", "dep:ethereum_ssz_derive", "alloy-primitives/ssz", "alloy-rpc-types/ssz", "dep:alloy-eips", "alloy-eips/ssz"]
 kzg = ["alloy-consensus/kzg"]
 
 [dev-dependencies]

--- a/crates/rpc-types-engine/src/cancun.rs
+++ b/crates/rpc-types-engine/src/cancun.rs
@@ -3,6 +3,9 @@
 
 use alloy_primitives::B256;
 
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 /// Fields introduced in `engine_newPayloadV3` that are not present in the `ExecutionPayload` RPC
 /// object.
 ///

--- a/crates/rpc-types-engine/src/forkchoice.rs
+++ b/crates/rpc-types-engine/src/forkchoice.rs
@@ -34,19 +34,20 @@ pub struct ForkchoiceState {
 ///
 /// These are considered hard RPC errors and are _not_ returned as [PayloadStatus] or
 /// [PayloadStatusEnum::Invalid].
-#[derive(Clone, Copy, Debug, PartialEq, Eq, thiserror::Error)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "std", derive(thiserror::Error))]
 pub enum ForkchoiceUpdateError {
     /// The forkchoice update has been processed, but the requested contained invalid
     /// [PayloadAttributes](crate::PayloadAttributes).
     ///
     /// This is returned as an error because the payload attributes are invalid and the payload is not valid, See <https://github.com/ethereum/execution-apis/blob/6709c2a795b707202e93c4f2867fa0bf2640a84f/src/engine/paris.md#engine_forkchoiceupdatedv1>
-    #[error("invalid payload attributes")]
+    #[cfg_attr(feature = "std", error("invalid payload attributes"))]
     UpdatedInvalidPayloadAttributes,
     /// The given [ForkchoiceState] is invalid or inconsistent.
-    #[error("invalid forkchoice state")]
+    #[cfg_attr(feature = "std", error("invalid forkchoice state"))]
     InvalidState,
     /// Thrown when a forkchoice final block does not exist in the database.
-    #[error("final block not available in database")]
+    #[cfg_attr(feature = "std", error("final block not available in database"))]
     UnknownFinalBlock,
 }
 

--- a/crates/rpc-types-engine/src/lib.rs
+++ b/crates/rpc-types-engine/src/lib.rs
@@ -19,6 +19,10 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![deny(unused_must_use, rust_2018_idioms)]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
 
 mod cancun;
 mod forkchoice;

--- a/crates/rpc-types-engine/src/optimism.rs
+++ b/crates/rpc-types-engine/src/optimism.rs
@@ -2,6 +2,9 @@ use crate::{BlobsBundleV1, ExecutionPayloadV3, PayloadAttributes};
 use alloy_primitives::{Bytes, B256, U256};
 use serde::{Deserialize, Serialize};
 
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 /// Optimism Payload Attributes
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/scripts/check_no_std.sh
+++ b/scripts/check_no_std.sh
@@ -6,6 +6,7 @@ no_std_packages=(
     alloy-genesis
     alloy-serde
     alloy-consensus
+    alloy-rpc-types-engine
 )
 
 for package in "${no_std_packages[@]}"; do


### PR DESCRIPTION
## Overview

Makes `alloy-rpc-types-engine` no_std compatible.

_note_: Not ready for review; no_std `alloy-rpc-types` will be stacked beneath this PR