### PR TITLE
feat: `no_std` rpc types

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ The following crates support `no_std`:
 - alloy-genesis
 - alloy-serde
 - alloy-consensus
+- alloy-rpc-types
 
 If you would like to add `no_std` support to a crate, please make sure to update
 `scripts/check_no_std.sh` as well.

--- a/crates/rpc-types/Cargo.toml
+++ b/crates/rpc-types/Cargo.toml
@@ -13,19 +13,20 @@ exclude.workspace = true
 
 [dependencies]
 # ethereum
-alloy-rlp = { workspace = true, features = ["arrayvec", "derive"] }
-alloy-primitives = { workspace = true, features = ["rlp", "serde", "std"] }
+alloy-rlp = { workspace = true, features = ["derive"] }
+alloy-primitives = { workspace = true, features = ["rlp", "serde"] }
 alloy-serde.workspace = true
 alloy-genesis.workspace = true
+alloy-consensus = { workspace = true, features = ["serde"] }
+alloy-eips = { workspace = true, features = ["serde"] }
 
-alloy-consensus = { workspace = true, features = ["std", "serde"] }
-alloy-eips = { workspace = true, features = ["std", "serde"] }
-
+hashbrown = { version = "0.14", default-features = false, features = ["serde"] }
 itertools.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
-thiserror.workspace = true
 
+# std
+thiserror = { workspace = true, optional = true }
 
 # arbitrary
 arbitrary = { version = "1.3", features = ["derive"], optional = true }
@@ -37,15 +38,23 @@ jsonrpsee-types = { version = "0.22", optional = true }
 alloy-sol-types.workspace = true
 
 [features]
+std = [
+    "alloy-rlp/arrayvec",
+    "alloy-primitives/std",
+    "alloy-consensus/std",
+    "alloy-eips/std",
+    "dep:thiserror"
+]
 arbitrary = [
+    "std",
     "dep:arbitrary",
     "dep:proptest-derive",
     "dep:proptest",
     "alloy-primitives/arbitrary",
     "alloy-eips/arbitrary",
 ]
-jsonrpsee-types = ["dep:jsonrpsee-types"]
-ssz = ["alloy-primitives/ssz", "alloy-eips/ssz"]
+jsonrpsee-types = ["std", "dep:jsonrpsee-types"]
+ssz = ["std", "alloy-primitives/ssz", "alloy-eips/ssz"]
 k256 = ["alloy-consensus/k256"]
 
 [dev-dependencies]

--- a/crates/rpc-types/src/eth/account.rs
+++ b/crates/rpc-types/src/eth/account.rs
@@ -2,6 +2,9 @@ use alloy_primitives::{Address, Bytes, B256, B512, U256, U64};
 use alloy_serde::storage::JsonStorageKey;
 use serde::{Deserialize, Serialize};
 
+#[cfg(not(feature = "std"))]
+use alloc::{string::String, vec::Vec};
+
 /// Account information.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AccountInfo {

--- a/crates/rpc-types/src/eth/admin.rs
+++ b/crates/rpc-types/src/eth/admin.rs
@@ -1,11 +1,13 @@
 //! Types for the admin api
 use alloy_genesis::ChainConfig;
 use alloy_primitives::{B256, U256};
+use core::net::{IpAddr, SocketAddr};
 use serde::{Deserialize, Serialize};
-use std::{
-    collections::BTreeMap,
-    net::{IpAddr, SocketAddr},
-};
+
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, collections::BTreeMap, string::String, vec::Vec};
+#[cfg(feature = "std")]
+use std::collections::BTreeMap;
 
 /// This includes general information about a running node, spanning networking and protocol
 /// details.

--- a/crates/rpc-types/src/eth/call.rs
+++ b/crates/rpc-types/src/eth/call.rs
@@ -2,6 +2,13 @@ use crate::{request::TransactionRequest, BlockId, BlockOverrides};
 use alloy_primitives::Bytes;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
+#[cfg(not(feature = "std"))]
+use alloc::{
+    format,
+    string::{String, ToString},
+    vec::Vec,
+};
+
 /// Bundle of transactions
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default, rename_all = "camelCase")]

--- a/crates/rpc-types/src/eth/fee.rs
+++ b/crates/rpc-types/src/eth/fee.rs
@@ -1,5 +1,8 @@
 use serde::{Deserialize, Serialize};
 
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 /// Internal struct to calculate reward percentiles
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct TxGasAndReward {
@@ -10,13 +13,13 @@ pub struct TxGasAndReward {
 }
 
 impl PartialOrd for TxGasAndReward {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
         Some(self.cmp(other))
     }
 }
 
 impl Ord for TxGasAndReward {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
         // compare only the reward
         // see:
         // <https://github.com/ethereum/go-ethereum/blob/ee8e83fa5f6cb261dad2ed0a7bbcde4930c41e6c/eth/gasprice/feehistory.go#L85>

--- a/crates/rpc-types/src/eth/index.rs
+++ b/crates/rpc-types/src/eth/index.rs
@@ -1,9 +1,12 @@
 use alloy_primitives::U256;
+use core::fmt;
 use serde::{
     de::{Error, Visitor},
     Deserialize, Deserializer, Serialize, Serializer,
 };
-use std::fmt;
+
+#[cfg(not(feature = "std"))]
+use alloc::{format, string::String};
 
 /// A hex encoded or decimal index that's intended to be used as a rust index, hence it's
 /// deserialized into a `usize`.

--- a/crates/rpc-types/src/eth/log.rs
+++ b/crates/rpc-types/src/eth/log.rs
@@ -126,11 +126,13 @@ impl<T> AsMut<T> for Log<T> {
 
 #[cfg(test)]
 mod tests {
-    use alloy_primitives::{Address, Bytes};
-
     use super::*;
+    use alloy_primitives::{Address, Bytes};
     use arbitrary::Arbitrary;
     use rand::Rng;
+
+    #[cfg(not(feature = "std"))]
+    use alloc::vec;
 
     #[test]
     fn log_arbitrary() {

--- a/crates/rpc-types/src/eth/other.rs
+++ b/crates/rpc-types/src/eth/other.rs
@@ -1,10 +1,15 @@
 //! Support for capturing other fields
+use core::ops::{Deref, DerefMut};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::Map;
-use std::{
-    collections::BTreeMap,
-    ops::{Deref, DerefMut},
+
+#[cfg(not(feature = "std"))]
+use alloc::{
+    collections::{self, BTreeMap},
+    string::String,
 };
+#[cfg(feature = "std")]
+use std::collections::{self, BTreeMap};
 
 /// A type that is supposed to capture additional fields that are not native to ethereum but included in ethereum adjacent networks, for example fields the [optimism `eth_getTransactionByHash` request](https://docs.alchemy.com/alchemy/apis/optimism/eth-gettransactionbyhash) returns additional fields that this type will capture
 ///
@@ -122,7 +127,7 @@ impl AsRef<BTreeMap<String, serde_json::Value>> for OtherFields {
 
 impl IntoIterator for OtherFields {
     type Item = (String, serde_json::Value);
-    type IntoIter = std::collections::btree_map::IntoIter<String, serde_json::Value>;
+    type IntoIter = collections::btree_map::IntoIter<String, serde_json::Value>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.inner.into_iter()
@@ -131,7 +136,7 @@ impl IntoIterator for OtherFields {
 
 impl<'a> IntoIterator for &'a OtherFields {
     type Item = (&'a String, &'a serde_json::Value);
-    type IntoIter = std::collections::btree_map::Iter<'a, String, serde_json::Value>;
+    type IntoIter = collections::btree_map::Iter<'a, String, serde_json::Value>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.as_ref().iter()

--- a/crates/rpc-types/src/eth/pubsub.rs
+++ b/crates/rpc-types/src/eth/pubsub.rs
@@ -7,6 +7,9 @@ use crate::{
 use alloy_primitives::B256;
 use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
 
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, format};
+
 /// Subscription result.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
 #[serde(untagged)]

--- a/crates/rpc-types/src/eth/raw_log.rs
+++ b/crates/rpc-types/src/eth/raw_log.rs
@@ -3,6 +3,9 @@
 use alloy_primitives::{Address, Bloom, Bytes, B256};
 use alloy_rlp::{RlpDecodable, RlpEncodable};
 
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 /// Ethereum Log
 #[derive(Clone, Debug, Default, PartialEq, Eq, RlpDecodable, RlpEncodable)]
 pub struct Log {

--- a/crates/rpc-types/src/eth/state.rs
+++ b/crates/rpc-types/src/eth/state.rs
@@ -1,8 +1,8 @@
 //! bindings for state overrides in eth_call
 
 use alloy_primitives::{Address, Bytes, B256, U256, U64};
+use hashbrown::HashMap;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 
 /// A set of account overrides
 pub type StateOverride = HashMap<Address, AccountOverride>;

--- a/crates/rpc-types/src/eth/syncing.rs
+++ b/crates/rpc-types/src/eth/syncing.rs
@@ -1,5 +1,9 @@
 use alloy_primitives::{B512, U256, U64};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+#[cfg(not(feature = "std"))]
+use alloc::{collections::BTreeMap, string::String, vec::Vec};
+#[cfg(feature = "std")]
 use std::collections::BTreeMap;
 
 /// Syncing info

--- a/crates/rpc-types/src/eth/transaction/error.rs
+++ b/crates/rpc-types/src/eth/transaction/error.rs
@@ -1,40 +1,50 @@
 /// Error variants when converting from [crate::Transaction] to [alloy_consensus::Signed]
 /// transaction.
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug)]
+#[cfg_attr(feature = "std", derive(thiserror::Error))]
 #[allow(missing_copy_implementations)]
 #[allow(missing_docs)]
 pub enum ConversionError {
     /// Error during EIP-2718 transaction coding.
-    #[error(transparent)]
-    Eip2718Error(#[from] alloy_eips::eip2718::Eip2718Error),
+    #[cfg_attr(feature = "std", error(transparent))]
+    Eip2718Error(#[cfg_attr(feature = "std", from)] alloy_eips::eip2718::Eip2718Error),
     /// [`alloy_primitives::SignatureError`].
-    #[error(transparent)]
-    SignatureError(#[from] alloy_primitives::SignatureError),
+    #[cfg_attr(feature = "std", error(transparent))]
+    SignatureError(#[cfg_attr(feature = "std", from)] alloy_primitives::SignatureError),
     /// Missing signature for transaction.
-    #[error("missing signature for transaction")]
+    #[cfg_attr(feature = "std", error("missing signature for transaction"))]
     MissingSignature,
     /// Missing `chainId` field for EIP-1559 transaction.
-    #[error("missing `chainId` field for EIP-155 transaction")]
+    #[cfg_attr(feature = "std", error("missing `chainId` field for EIP-155 transaction"))]
     MissingChainId,
     /// Missing `gasPrice` field for Legacy transaction.
-    #[error("missing `gasPrice` field for Legacy transaction")]
+    #[cfg_attr(feature = "std", error("missing `gasPrice` field for Legacy transaction"))]
     MissingGasPrice,
     /// Missing `accessList` field for EIP-2930 transaction.
-    #[error("missing `accessList` field for EIP-2930 transaction")]
+    #[cfg_attr(feature = "std", error("missing `accessList` field for EIP-2930 transaction"))]
     MissingAccessList,
     /// Missing `maxFeePerGas` field for EIP-1559 transaction.
-    #[error("missing `maxFeePerGas` field for EIP-1559 transaction")]
+    #[cfg_attr(feature = "std", error("missing `maxFeePerGas` field for EIP-1559 transaction"))]
     MissingMaxFeePerGas,
     /// Missing `maxPriorityFeePerGas` field for EIP-1559 transaction.
-    #[error("missing `maxPriorityFeePerGas` field for EIP-1559 transaction")]
+    #[cfg_attr(
+        feature = "std",
+        error("missing `maxPriorityFeePerGas` field for EIP-1559 transaction")
+    )]
     MissingMaxPriorityFeePerGas,
     /// Missing `maxFeePerBlobGas` field for EIP-1559 transaction.
-    #[error("missing `maxFeePerBlobGas` field for EIP-1559 transaction")]
+    #[cfg_attr(
+        feature = "std",
+        error("missing `maxFeePerBlobGas` field for EIP-1559 transaction")
+    )]
     MissingMaxFeePerBlobGas,
     /// Missing `to` field for EIP-4844 transaction.
-    #[error("missing `to` field for EIP-4844 transaction")]
+    #[cfg_attr(feature = "std", error("missing `to` field for EIP-4844 transaction"))]
     MissingTo,
     /// Missing `blobVersionedHashes` field for EIP-4844 transaction.
-    #[error("missing `blobVersionedHashes` field for EIP-4844 transaction")]
+    #[cfg_attr(
+        feature = "std",
+        error("missing `blobVersionedHashes` field for EIP-4844 transaction")
+    )]
     MissingBlobVersionedHashes,
 }

--- a/crates/rpc-types/src/eth/transaction/optimism.rs
+++ b/crates/rpc-types/src/eth/transaction/optimism.rs
@@ -71,6 +71,9 @@ impl From<OptimismTransactionReceiptFields> for OtherFields {
 mod l1_fee_scalar_serde {
     use serde::{de, Deserialize};
 
+    #[cfg(not(feature = "std"))]
+    use alloc::string::{String, ToString};
+
     pub(super) fn serialize<S>(value: &Option<f64>, s: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -98,6 +101,9 @@ mod l1_fee_scalar_serde {
 mod tests {
     use super::*;
     use serde_json::{json, Value};
+
+    #[cfg(not(feature = "std"))]
+    use alloc::string::ToString;
 
     #[test]
     fn serialize_empty_optimism_transaction_receipt_fields_struct() {

--- a/crates/rpc-types/src/eth/transaction/receipt.rs
+++ b/crates/rpc-types/src/eth/transaction/receipt.rs
@@ -137,6 +137,9 @@ mod test {
     use arbitrary::Arbitrary;
     use rand::Rng;
 
+    #[cfg(not(feature = "std"))]
+    use alloc::vec;
+
     #[test]
     fn transaction_receipt_arbitrary() {
         let mut bytes = [0u8; 1024];

--- a/crates/rpc-types/src/eth/transaction/signature.rs
+++ b/crates/rpc-types/src/eth/transaction/signature.rs
@@ -2,6 +2,9 @@
 use alloy_primitives::U256;
 use serde::{Deserialize, Serialize};
 
+#[cfg(not(feature = "std"))]
+use alloc::{format, string::String};
+
 /// Container type for all signature fields in RPC
 #[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -78,7 +81,7 @@ impl TryFrom<Signature> for alloy_primitives::Signature {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::str::FromStr;
+    use core::str::FromStr;
 
     #[test]
     fn deserialize_without_parity() {

--- a/crates/rpc-types/src/eth/txpool.rs
+++ b/crates/rpc-types/src/eth/txpool.rs
@@ -2,11 +2,21 @@
 
 use crate::Transaction;
 use alloy_primitives::{Address, U256, U64};
+use core::{fmt, str::FromStr};
 use serde::{
     de::{self, Deserializer, Visitor},
     Deserialize, Serialize,
 };
-use std::{collections::BTreeMap, fmt, str::FromStr};
+
+#[cfg(not(feature = "std"))]
+use alloc::{
+    collections::BTreeMap,
+    format,
+    string::{String, ToString},
+    vec::Vec,
+};
+#[cfg(feature = "std")]
+use std::collections::BTreeMap;
 
 /// Transaction summary as found in the Txpool Inspection property.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/crates/rpc-types/src/eth/work.rs
+++ b/crates/rpc-types/src/eth/work.rs
@@ -1,9 +1,9 @@
 use alloy_primitives::{B256, U256};
+use core::fmt;
 use serde::{
     de::{Error, SeqAccess, Visitor},
     Deserialize, Deserializer, Serialize, Serializer,
 };
-use std::fmt;
 
 /// The result of an `eth_getWork` request
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]

--- a/crates/rpc-types/src/lib.rs
+++ b/crates/rpc-types/src/lib.rs
@@ -18,6 +18,10 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![deny(unused_must_use, rust_2018_idioms)]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
 
 mod eth;
 

--- a/crates/rpc-types/src/with_other.rs
+++ b/crates/rpc-types/src/with_other.rs
@@ -1,8 +1,8 @@
 use crate::{other::OtherFields, TransactionRequest};
 use alloy_consensus::{TxEnvelope, TypedTransaction};
+use core::ops::{Deref, DerefMut};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::ops::{Deref, DerefMut};
 
 /// Wrapper allowing to catch all fields missing on the inner struct while
 /// deserialize.
@@ -89,10 +89,13 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
-
     use super::*;
     use serde_json::json;
+
+    #[cfg(not(feature = "std"))]
+    use alloc::{collections::BTreeMap, string::ToString, vec};
+    #[cfg(feature = "std")]
+    use std::collections::BTreeMap;
 
     #[derive(Serialize, Deserialize)]
     struct Inner {

--- a/scripts/check_no_std.sh
+++ b/scripts/check_no_std.sh
@@ -6,6 +6,7 @@ no_std_packages=(
     alloy-genesis
     alloy-serde
     alloy-consensus
+    alloy-rpc-types
 )
 
 for package in "${no_std_packages[@]}"; do


### PR DESCRIPTION
## Overview

Adds `no_std` capability to `alloy-rpc-types`