### PR TITLE
fix: dont use fuse::select_next_some

### DIFF
--- a/crates/provider/src/heart.rs
+++ b/crates/provider/src/heart.rs
@@ -506,7 +506,7 @@ impl<S: Stream<Item = Block> + Unpin + 'static> Heartbeat<S> {
                     },
 
                     // Wake up to handle new blocks.
-                    block = self.stream.select_next_some() => {
+                    Some(block) = self.stream.next() => {
                         self.handle_new_block(block, &latest);
                     },
 


### PR DESCRIPTION
closes https://github.com/foundry-rs/foundry/issues/7652

SelectNextSome over `Fuse` will panic

Fuse will return 
```rust
        if *this.done {
            return Poll::Ready(None);
        }
```

but selectsome will panic if the underlying stream already returned None once


```rust
        if let Some(item) = ready!(self.stream.poll_next_unpin(cx)) {
            Poll::Ready(item)
        } else {
            debug_assert!(self.stream.is_terminated());
            cx.waker().wake_by_ref();
            Poll::Pending
        }
```
