### PR TITLE
chore: rm PathBuf import

### DIFF
--- a/crates/rpc-client/src/builtin.rs
+++ b/crates/rpc-client/src/builtin.rs
@@ -1,4 +1,4 @@
-use std::{path::PathBuf, str::FromStr};
+use std::{str::FromStr};
 
 use alloy_json_rpc::RpcError;
 use alloy_transport::{BoxTransport, BoxTransportConnect, TransportError, TransportErrorKind};
@@ -18,7 +18,7 @@ pub enum BuiltInConnectionString {
     Ws(url::Url, Option<alloy_transport::Authorization>),
     /// IPC transport.
     #[cfg(feature = "ipc")]
-    Ipc(PathBuf),
+    Ipc(std::path::PathBuf),
 }
 
 impl BoxTransportConnect for BuiltInConnectionString {

--- a/crates/rpc-client/src/builtin.rs
+++ b/crates/rpc-client/src/builtin.rs
@@ -1,4 +1,4 @@
-use std::{str::FromStr};
+use std::str::FromStr;
 
 use alloy_json_rpc::RpcError;
 use alloy_transport::{BoxTransport, BoxTransportConnect, TransportError, TransportErrorKind};


### PR DESCRIPTION
silences warning if ipc feature not enabled