### PR TITLE
fix: build_4844 is missing the transaction sidecar #403

### DIFF
--- a/crates/network/src/ethereum/builder.rs
+++ b/crates/network/src/ethereum/builder.rs
@@ -234,8 +234,8 @@ fn build_2930(request: TransactionRequest) -> Result<TxEip2930, TransactionBuild
 }
 
 /// Build an EIP-4844 transaction.
-fn build_4844(request: TransactionRequest) -> Result<TxEip4844, TransactionBuilderError> {
-    Ok(TxEip4844 {
+fn build_4844(request: TransactionRequest) -> Result<(TxEip4844, BlobTransactionSidecar), TransactionBuilderError> {
+    Ok((TxEip4844 {
         chain_id: request.chain_id.unwrap_or(1),
         nonce: request.nonce.ok_or_else(|| TransactionBuilderError::MissingKey("nonce"))?,
         gas_limit: request.gas.ok_or_else(|| TransactionBuilderError::MissingKey("gas_limit"))?,
@@ -255,5 +255,7 @@ fn build_4844(request: TransactionRequest) -> Result<TxEip4844, TransactionBuild
             .max_fee_per_blob_gas
             .ok_or_else(|| TransactionBuilderError::MissingKey("max_fee_per_blob_gas"))?,
         input: request.input.into_input().unwrap_or_default(),
-    })
+    },
+    request.sidecar.unwrap()
+    ))
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
4844 transaction submitted with TransactionRequest doesn't attach sidecar. I've been having that issue when trying to submit blobs also I think resolves issue #403.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
