### PR TITLE
docs: fix 404s on docs site via absolute paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,30 +42,29 @@ This repository contains the following crates:
   - [`alloy-transport-ipc`] - IPC transport implementation
   - [`alloy-transport-ws`] - WS transport implementation
 
-[`alloy`]: crates/alloy
-[`alloy-consensus`]: crates/consensus
-[`alloy-contract`]: crates/contract
-[`alloy-eips`]: crates/eips
-[`alloy-genesis`]: crates/genesis
-[`alloy-json-rpc`]: crates/json-rpc
-[`alloy-network`]: crates/network
-[`alloy-node-bindings`]: crates/node-bindings
-[`alloy-provider`]: crates/provider
-[`alloy-pubsub`]: crates/pubsub
-[`alloy-rpc-client`]: crates/rpc-client
-[`alloy-rpc-types-engine`]: crates/rpc-types-engine
-[`alloy-rpc-types-trace`]: crates/rpc-types-trace
-[`alloy-rpc-types`]: crates/rpc-types
-[`alloy-signer`]: crates/signer
-[`alloy-signer-aws`]: crates/signer-aws
-[`alloy-signer-gcp`]: crates/signer-gcp
-[`alloy-signer-ledger`]: crates/signer-ledger
-[`alloy-signer-trezor`]: crates/signer-trezor
-[`alloy-transport`]: crates/transport
-[`alloy-transport-http`]: crates/transport-http
-[`alloy-transport-ipc`]: crates/transport-ipc
-[`alloy-transport-ws`]: crates/transport-ws
-
+[`alloy`]: https://github.com/alloy-rs/alloy/tree/main/crates/alloy
+[`alloy-consensus`]: https://github.com/alloy-rs/alloy/tree/main/crates/consensus
+[`alloy-contract`]: https://github.com/alloy-rs/alloy/tree/main/crates/contract
+[`alloy-eips`]: https://github.com/alloy-rs/alloy/tree/main/crates/eips
+[`alloy-genesis`]: https://github.com/alloy-rs/alloy/tree/main/crates/genesis
+[`alloy-json-rpc`]: https://github.com/alloy-rs/alloy/tree/main/crates/json-rpc
+[`alloy-network`]: https://github.com/alloy-rs/alloy/tree/main/crates/network
+[`alloy-node-bindings`]: https://github.com/alloy-rs/alloy/tree/main/crates/node-bindings
+[`alloy-provider`]: https://github.com/alloy-rs/alloy/tree/main/crates/provider
+[`alloy-pubsub`]: https://github.com/alloy-rs/alloy/tree/main/crates/pubsub
+[`alloy-rpc-client`]: https://github.com/alloy-rs/alloy/tree/main/crates/rpc-client
+[`alloy-rpc-types-engine`]: https://github.com/alloy-rs/alloy/tree/main/crates/rpc-types-engine
+[`alloy-rpc-types-trace`]: https://github.com/alloy-rs/alloy/tree/main/crates/rpc-types-trace
+[`alloy-rpc-types`]: https://github.com/alloy-rs/alloy/tree/main/crates/rpc-types
+[`alloy-signer`]: https://github.com/alloy-rs/alloy/tree/main/crates/signer
+[`alloy-signer-aws`]: https://github.com/alloy-rs/alloy/tree/main/crates/signer-aws
+[`alloy-signer-gcp`]: https://github.com/alloy-rs/alloy/tree/main/crates/signer-gcp
+[`alloy-signer-ledger`]: https://github.com/alloy-rs/alloy/tree/main/crates/signer-ledger
+[`alloy-signer-trezor`]: https://github.com/alloy-rs/alloy/tree/main/crates/signer-trezor
+[`alloy-transport`]: https://github.com/alloy-rs/alloy/tree/main/crates/transport
+[`alloy-transport-http`]: https://github.com/alloy-rs/alloy/tree/main/crates/transport-http
+[`alloy-transport-ipc`]: https://github.com/alloy-rs/alloy/tree/main/crates/transport-ipc
+[`alloy-transport-ws`]: https://github.com/alloy-rs/alloy/tree/main/crates/transport-ws
 [`alloy-core`]: https://docs.rs/alloy-core
 [publish-subscribe]: https://en.wikipedia.org/wiki/Publish%E2%80%93subscribe_pattern
 [AWS KMS]: https://aws.amazon.com/kms
@@ -104,6 +103,7 @@ Because these crates are primarily network-focused, we do not intend to support
 `no_std` for most of them at this time.
 
 The following crates support `no_std`:
+
 - alloy-eips
 - alloy-genesis
 - alloy-serde


### PR DESCRIPTION
## Motivation

Currently, the README uses relative paths rather than absolute paths. This leads to 404s in two places:

On https://alloy-rs.github.io/alloy/, where a link to e.g. alloy goes to https://alloy-rs.github.io/alloy/alloy/crates/alloy instead of https://github.com/alloy-rs/alloy/tree/main/crates/alloy

On the Alloy crate at https://github.com/alloy-rs/alloy/tree/main/crates/alloy, where a link to e.g. alloy-signer goes to https://github.com/alloy-rs/alloy/blob/main/crates/alloy/crates/signer instead of https://github.com/alloy-rs/alloy/tree/main/crates/signer

## Solution

This commit fixes both of these 404s by switching from relative paths to absolute paths. It also follows the same usage of absolute paths as [lib.rs](https://github.com/alloy-rs/alloy/blob/037dd4b20ec8533d6b6d5cf5e9489bbb182c18c6/crates/alloy/src/lib.rs#L197), making the README consistent with the rest of the documentation.

(In addition, a newline was added for consistency with other unordered lists, but that's not really worth commenting on)

## PR Checklist

- [ ] Added Tests
- [X] Added Documentation
- [ ] Breaking changes
