### PR TITLE
Add new variants to `ConversionError`

### DIFF
--- a/crates/rpc-types/src/eth/transaction/error.rs
+++ b/crates/rpc-types/src/eth/transaction/error.rs
@@ -37,4 +37,25 @@ pub enum ConversionError {
     /// Missing `blobVersionedHashes` field for EIP-4844 transaction.
     #[error("missing `blobVersionedHashes` field for EIP-4844 transaction")]
     MissingBlobVersionedHashes,
+    /// Missing full transactions required for block decoding
+    #[error("missing full transactions required for block decoding")]
+    MissingFullTransactions,
+    /// Base fee per gas conversion error
+    #[error("base fee per gas conversion error")]
+    BaseFeePerGasConversion,
+    /// Gas limit conversion error
+    #[error("gas limit conversion error")]
+    GasLimitConversion,
+    /// Gas used conversion error
+    #[error("gas used conversion error")]
+    GasUsedConversion,
+    /// Missing block number
+    #[error("missing block number")]
+    MissingBlockNumber,
+    /// Block number conversion error
+    #[error("block number conversion error")]
+    BlockNumberConversion,
+    /// Timestamp conversion error
+    #[error("timestamp conversion error")]
+    TimestampConversion,
 }

--- a/crates/rpc-types/src/eth/transaction/error.rs
+++ b/crates/rpc-types/src/eth/transaction/error.rs
@@ -1,3 +1,5 @@
+use std::num::TryFromIntError;
+
 /// Error variants when converting from [crate::Transaction] to [alloy_consensus::Signed]
 /// transaction.
 #[derive(Debug, thiserror::Error)]
@@ -40,22 +42,16 @@ pub enum ConversionError {
     /// Missing full transactions required for block decoding
     #[error("missing full transactions required for block decoding")]
     MissingFullTransactions,
-    /// Base fee per gas conversion error
-    #[error("base fee per gas conversion error")]
-    BaseFeePerGasConversion,
-    /// Gas limit conversion error
-    #[error("gas limit conversion error")]
-    GasLimitConversion,
-    /// Gas used conversion error
-    #[error("gas used conversion error")]
-    GasUsedConversion,
+    /// Base fee per gas integer conversion error
+    #[error("base fee per gas integer conversion error")]
+    BaseFeePerGasConversion(TryFromIntError),
+    /// Gas limit integer conversion error
+    #[error("gas limit integer conversion error")]
+    GasLimitConversion(TryFromIntError),
+    /// Gas used integer conversion error
+    #[error("gas used integer conversion error")]
+    GasUsedConversion(TryFromIntError),
     /// Missing block number
     #[error("missing block number")]
     MissingBlockNumber,
-    /// Block number conversion error
-    #[error("block number conversion error")]
-    BlockNumberConversion,
-    /// Timestamp conversion error
-    #[error("timestamp conversion error")]
-    TimestampConversion,
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->


## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

The `ConversionError` enum was incomplete until now, not allowing to handle all errors that could arise from converting Block and Header rpc to Block and Header primitives respectively.

Indeed, other errors can arise and are added here as conversion impossibilities or missing fields.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
