### PR TITLE
Add link to docs to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Alloy connects applications to blockchains.
 
 Alloy is a rewrite of [`ethers-rs`] from the ground up, with exciting new
-features, high performance, and excellent docs.
+features, high performance, and excellent [docs](alloy-rs.github.io/alloy/).
 
 [`ethers-rs`] will continue to be maintained until we have achieved
 feature-parity in Alloy. No action is currently needed from devs.


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

While the GH repo's site is the docs page, that is off-center (and not rendered when viewing the repository via a cloned local view). I had to be explicitly told the docs site existed due to not noticing that location (nor any other which may or may not exist). Ideally, the README includes the link *somewhere*.

## Solution

This adds a link in a location with no changes to layout.

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
