### PR TITLE
fix: add back transaction type

### DIFF
--- a/crates/rpc-types/src/eth/transaction/mod.rs
+++ b/crates/rpc-types/src/eth/transaction/mod.rs
@@ -163,6 +163,7 @@ impl Transaction {
             nonce: Some(self.nonce),
             chain_id: self.chain_id,
             access_list: self.access_list,
+            transaction_type: self.transaction_type,
             max_fee_per_gas: self.max_fee_per_gas,
             max_priority_fee_per_gas: self.max_priority_fee_per_gas,
             max_fee_per_blob_gas: self.max_fee_per_blob_gas,


### PR DESCRIPTION
this is part of the spec and should remain, was removed in https://github.com/alloy-rs/alloy/pull/431

https://ethereum.github.io/execution-apis/api-documentation/


this could also be used to determine the preferred txtype but would like to fix that separately