### PR TITLE
fix: override txtype during submission prep

### DIFF
--- a/crates/network/src/ethereum/builder.rs
+++ b/crates/network/src/ethereum/builder.rs
@@ -155,6 +155,7 @@ impl TransactionBuilder<Ethereum> for TransactionRequest {
     }
 
     fn prep_for_submission(&mut self) {
+        self.transaction_type = Some(self.preferred_type() as u8);
         self.trim_conflicting_keys();
         self.populate_blob_hashes();
     }

--- a/crates/network/src/transaction/builder.rs
+++ b/crates/network/src/transaction/builder.rs
@@ -259,7 +259,8 @@ pub trait TransactionBuilder<N: Network>: Default + Sized + Send + Sync + 'stati
     /// the builder is not ready to build.
     fn output_tx_type_checked(&self) -> Option<N::TxType>;
 
-    /// Trim any conflicting keys
+    /// Trim any conflicting keys and populate any computed fields (like blob
+    /// hashes).
     ///
     /// This is useful for transaction requests that have multiple conflicting
     /// fields. While these may be buildable, they may not be submitted to the


### PR DESCRIPTION
Followup to #552 

## Motivation

We don't want to rely on users to set the correct tx type pre-submission. We assume that other tx characteristics are more important than tx type, and essentially treat the tx type as a computed property

## Solution

Modify `prep_for_submission` to override user-specified `tx_type` 

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
