### PR TITLE
feat: add prague engine types

### DIFF
--- a/crates/eips/src/eip6110.rs
+++ b/crates/eips/src/eip6110.rs
@@ -1,0 +1,34 @@
+//! Contains Deposit types, first introduced in the Prague hardfork: <https://github.com/ethereum/execution-apis/blob/main/src/engine/prague.md>
+//!
+//! See also [EIP-6110](https://eips.ethereum.org/EIPS/eip-6110): Supply validator deposits on chain
+// Provides validator deposits as a list of deposit operations added to the Execution Layer block
+
+use alloy_primitives::{address, Address, FixedBytes, B256};
+use alloy_rlp::{RlpDecodable, RlpEncodable};
+
+/// Mainnet deposit contract address.
+pub const MAINNET_DEPOSIT_CONTRACT_ADDRESS: Address =
+    address!("00000000219ab540356cbb839cbe05303d7705fa");
+
+/// This structure maps onto the deposit object from [EIP-6110](https://eips.ethereum.org/EIPS/eip-6110).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, RlpEncodable, RlpDecodable)]
+#[cfg_attr(
+    any(test, feature = "arbitrary"),
+    derive(proptest_derive::Arbitrary, arbitrary::Arbitrary)
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ssz", derive(ssz_derive::Encode, ssz_derive::Decode))]
+pub struct Deposit {
+    /// Validator public key
+    pub pubkey: FixedBytes<48>,
+    /// Withdrawal credentials
+    pub withdrawal_credentials: B256,
+    /// Amount in GWEI
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::u64_hex"))]
+    pub amount: u64,
+    /// Deposit signature
+    pub signature: FixedBytes<96>,
+    /// Deposit index
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::u64_hex"))]
+    pub index: u64,
+}

--- a/crates/eips/src/eip6110.rs
+++ b/crates/eips/src/eip6110.rs
@@ -1,7 +1,8 @@
 //! Contains Deposit types, first introduced in the Prague hardfork: <https://github.com/ethereum/execution-apis/blob/main/src/engine/prague.md>
 //!
 //! See also [EIP-6110](https://eips.ethereum.org/EIPS/eip-6110): Supply validator deposits on chain
-// Provides validator deposits as a list of deposit operations added to the Execution Layer block
+//!
+//! Provides validator deposits as a list of deposit operations added to the Execution Layer block.
 
 use alloy_primitives::{address, Address, FixedBytes, B256};
 use alloy_rlp::{RlpDecodable, RlpEncodable};

--- a/crates/eips/src/eip6110.rs
+++ b/crates/eips/src/eip6110.rs
@@ -24,7 +24,7 @@ pub struct Deposit {
     pub pubkey: FixedBytes<48>,
     /// Withdrawal credentials
     pub withdrawal_credentials: B256,
-    /// Amount in GWEI
+    /// Amount of ether deposited in gwei
     #[cfg_attr(feature = "serde", serde(with = "alloy_serde::u64_hex"))]
     pub amount: u64,
     /// Deposit signature

--- a/crates/eips/src/lib.rs
+++ b/crates/eips/src/lib.rs
@@ -31,6 +31,7 @@ pub mod eip4788;
 pub mod eip4844;
 pub use eip4844::{calc_blob_gasprice, calc_excess_blob_gas};
 
+pub mod eip6110;
 pub mod merge;
 
 pub mod eip4895;

--- a/crates/rpc-types-engine/Cargo.toml
+++ b/crates/rpc-types-engine/Cargo.toml
@@ -18,6 +18,7 @@ alloy-primitives = { workspace = true, features = ["rlp", "serde"] }
 alloy-consensus = { workspace = true, features = ["std"] }
 alloy-rpc-types.workspace = true
 alloy-serde.workspace = true
+alloy-eips = { workspace = true, features = ["serde"] }
 
 # ssz
 ethereum_ssz_derive = { workspace = true, optional = true }
@@ -28,11 +29,10 @@ thiserror.workspace = true
 
 # jsonrpsee
 jsonrpsee-types = { version = "0.22", optional = true }
-alloy-eips = { workspace= true, optional = true }
 
 [features]
 jsonrpsee-types = ["dep:jsonrpsee-types"]
-ssz = ["dep:ethereum_ssz", "dep:ethereum_ssz_derive", "alloy-primitives/ssz", "alloy-rpc-types/ssz", "dep:alloy-eips", "alloy-eips/ssz"]
+ssz = ["dep:ethereum_ssz", "dep:ethereum_ssz_derive", "alloy-primitives/ssz", "alloy-rpc-types/ssz",  "alloy-eips/ssz"]
 kzg = ["alloy-consensus/kzg"]
 
 [dev-dependencies]

--- a/crates/rpc-types-engine/src/exit.rs
+++ b/crates/rpc-types-engine/src/exit.rs
@@ -13,7 +13,7 @@ pub struct ExitV1 {
     pub pubkey: FixedBytes<48>,
     /// Withdrawal credentials
     pub withdrawal_credentials: B256,
-    /// Amount in GWEI
+    /// Amount of withdrawn ether in gwei
     #[serde(with = "alloy_serde::u64_hex")]
     pub amount: u64,
     /// Deposit signature

--- a/crates/rpc-types-engine/src/exit.rs
+++ b/crates/rpc-types-engine/src/exit.rs
@@ -1,0 +1,24 @@
+//! Contains Exit types, first introduced in the Prague hardfork: <https://github.com/ethereum/execution-apis/blob/main/src/engine/prague.md>
+//!
+//! See also [EIP-6110](https://eips.ethereum.org/EIPS/eip-6110).
+
+use alloy_primitives::{FixedBytes, B256};
+use serde::{Deserialize, Serialize};
+
+/// This structure maps onto the exit object
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExitV1 {
+    /// Validator public key
+    pub pubkey: FixedBytes<48>,
+    /// Withdrawal credentials
+    pub withdrawal_credentials: B256,
+    /// Amount in GWEI
+    #[serde(with = "alloy_serde::u64_hex")]
+    pub amount: u64,
+    /// Deposit signature
+    pub signature: FixedBytes<96>,
+    /// Deposit index
+    #[serde(with = "alloy_serde::u64_hex")]
+    pub index: u64,
+}

--- a/crates/rpc-types-engine/src/lib.rs
+++ b/crates/rpc-types-engine/src/lib.rs
@@ -21,12 +21,16 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 mod cancun;
+mod exit;
 mod forkchoice;
 mod optimism;
 pub mod payload;
 mod transition;
 
-pub use self::{cancun::*, forkchoice::*, optimism::*, payload::*, transition::*};
+pub use self::{cancun::*, exit::*, forkchoice::*, optimism::*, payload::*, transition::*};
+
+#[doc(inline)]
+pub use alloy_eips::eip6110::Deposit;
 
 /// The list of all supported Engine capabilities available over the engine endpoint.
 pub const CAPABILITIES: [&str; 12] = [

--- a/crates/rpc-types-engine/src/payload.rs
+++ b/crates/rpc-types-engine/src/payload.rs
@@ -424,7 +424,7 @@ pub struct ExecutionPayloadV4 {
 impl ExecutionPayloadV4 {
     /// Returns the withdrawals for the payload.
     pub const fn withdrawals(&self) -> &Vec<Withdrawal> {
-        &self.payload_inner.withdrawals()
+        self.payload_inner.withdrawals()
     }
 
     /// Returns the timestamp for the payload.


### PR DESCRIPTION
adds payload v4 type for https://github.com/ethereum/execution-apis/blob/main/src/engine/prague.md#depositreceiptv1

also adds https://eips.ethereum.org/EIPS/eip-6110 Deposit type


This does not yet enable V4 as supported variant to the payload enum, this will follow once reth is ready for this

ref https://github.com/paradigmxyz/reth/issues/7363