### PR TITLE
Use the same way to both serialize and deserialize `OptimismPayloadAttributes::gas_limit`.

### DIFF
--- a/crates/rpc-types-engine/src/optimism.rs
+++ b/crates/rpc-types-engine/src/optimism.rs
@@ -19,7 +19,7 @@ pub struct OptimismPayloadAttributes {
     /// If set, this sets the exact gas limit the block produced with.
     #[serde(
         skip_serializing_if = "Option::is_none",
-        deserialize_with = "alloy_serde::u64_hex_opt::deserialize"
+        with = "alloy_serde::u64_hex_opt"
     )]
     pub gas_limit: Option<u64>,
 }


### PR DESCRIPTION
## Motivation

Although I understand that `op-reth` only ever deserializes this structure; my use case is to serialize this struct and pass it to `op-geth`. The latter expects it to be hex.
