### PR TITLE
chore: document how state overrides work in `call` and `call_raw`

### DIFF
--- a/crates/contract/src/call.rs
+++ b/crates/contract/src/call.rs
@@ -347,6 +347,7 @@ impl<T: Transport + Clone, P: Provider<T, N>, D: CallDecoder, N: Network> CallBu
     }
 
     /// Queries the blockchain via an `eth_call` without submitting a transaction to the network.
+    /// If state overrides are set, they will be applied to the call.
     ///
     /// Returns the decoded the output by using the provided decoder.
     /// If this is not desired, use [`call_raw`](Self::call_raw) to get the raw output data.
@@ -356,6 +357,7 @@ impl<T: Transport + Clone, P: Provider<T, N>, D: CallDecoder, N: Network> CallBu
     }
 
     /// Queries the blockchain via an `eth_call` without submitting a transaction to the network.
+    /// If state overrides are set, they will be applied to the call.
     ///
     /// Does not decode the output of the call, returning the raw output data instead.
     ///

--- a/crates/contract/src/call.rs
+++ b/crates/contract/src/call.rs
@@ -347,7 +347,7 @@ impl<T: Transport + Clone, P: Provider<T, N>, D: CallDecoder, N: Network> CallBu
     }
 
     /// Queries the blockchain via an `eth_call` without submitting a transaction to the network.
-    /// If state overrides are set, they will be applied to the call.
+    /// If [`state overrides`](Self::state) are set, they will be applied to the call.
     ///
     /// Returns the decoded the output by using the provided decoder.
     /// If this is not desired, use [`call_raw`](Self::call_raw) to get the raw output data.
@@ -357,7 +357,7 @@ impl<T: Transport + Clone, P: Provider<T, N>, D: CallDecoder, N: Network> CallBu
     }
 
     /// Queries the blockchain via an `eth_call` without submitting a transaction to the network.
-    /// If state overrides are set, they will be applied to the call.
+    /// If [`state overrides`](Self::state) are set, they will be applied to the call.
     ///
     /// Does not decode the output of the call, returning the raw output data instead.
     ///


### PR DESCRIPTION
## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Added a clarifying comment in regards to how state overrides are applied in `call` and `call_raw`.

Closes #517 as it is not necessary to implement a new method.

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
