### PR TITLE
fix(provider/debug): arg type in debug_trace_call

### DIFF
--- a/crates/provider/src/debug.rs
+++ b/crates/provider/src/debug.rs
@@ -3,7 +3,9 @@ use crate::Provider;
 use alloy_network::Network;
 use alloy_primitives::{BlockNumber, TxHash, B256};
 use alloy_rpc_types::{BlockNumberOrTag, TransactionRequest};
-use alloy_rpc_types_trace::geth::{GethDebugTracingOptions, GethTrace};
+use alloy_rpc_types_trace::geth::{
+    GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace,
+};
 use alloy_transport::{Transport, TransportResult};
 
 /// Debug namespace rpc interface that gives access to several non-standard RPC methods.
@@ -71,7 +73,7 @@ pub trait DebugApi<N, T>: Send + Sync {
         &self,
         tx: TransactionRequest,
         block: BlockNumberOrTag,
-        trace_options: GethDebugTracingOptions,
+        trace_options: GethDebugTracingCallOptions,
     ) -> TransportResult<GethTrace>;
 
     /// Same as `debug_trace_call` but it used to run and trace multiple transactions at once.
@@ -85,7 +87,7 @@ pub trait DebugApi<N, T>: Send + Sync {
         &self,
         txs: Vec<TransactionRequest>,
         block: BlockNumberOrTag,
-        trace_options: GethDebugTracingOptions,
+        trace_options: GethDebugTracingCallOptions,
     ) -> TransportResult<Vec<GethTrace>>;
 }
 
@@ -125,7 +127,7 @@ where
         &self,
         tx: TransactionRequest,
         block: BlockNumberOrTag,
-        trace_options: GethDebugTracingOptions,
+        trace_options: GethDebugTracingCallOptions,
     ) -> TransportResult<GethTrace> {
         self.client().request("debug_traceCall", (tx, block, trace_options)).await
     }
@@ -134,7 +136,7 @@ where
         &self,
         txs: Vec<TransactionRequest>,
         block: BlockNumberOrTag,
-        trace_options: GethDebugTracingOptions,
+        trace_options: GethDebugTracingCallOptions,
     ) -> TransportResult<Vec<GethTrace>> {
         self.client().request("debug_traceCallMany", (txs, block, trace_options)).await
     }
@@ -194,7 +196,7 @@ mod test {
             .max_priority_fee_per_gas(gas_price + 1);
 
         let trace = provider
-            .debug_trace_call(tx, BlockNumberOrTag::Latest, GethDebugTracingOptions::default())
+            .debug_trace_call(tx, BlockNumberOrTag::Latest, GethDebugTracingCallOptions::default())
             .await
             .unwrap();
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

`debug_trace_call` was taking the `GethDebugTracingOptions` as `trace_options` whereas it should be `GethDebugTracingCallOptions`

closes https://github.com/alloy-rs/alloy/issues/579

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Replace with `GethDebugTracingCallOptions`

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
