### PR TITLE
fix(provider): uncle methods for block hash

### DIFF
--- a/crates/provider/src/provider.rs
+++ b/crates/provider/src/provider.rs
@@ -813,10 +813,12 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
     }
 
     /// Gets an uncle block through the tag [BlockId] and index [U64].
-    async fn get_uncle(&self, tag: BlockId, idx: U64) -> TransportResult<Option<Block>> {
+    async fn get_uncle(&self, tag: BlockId, idx: u64) -> TransportResult<Option<Block>> {
         match tag {
             BlockId::Hash(hash) => {
-                self.client().request("eth_getUncleByBlockHashAndIndex", (hash, idx)).await
+                self.client()
+                    .request("eth_getUncleByBlockHashAndIndex", (hash.block_hash, idx))
+                    .await
             }
             BlockId::Number(number) => {
                 self.client().request("eth_getUncleByBlockNumberAndIndex", (number, idx)).await
@@ -829,7 +831,7 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
         match tag {
             BlockId::Hash(hash) => self
                 .client()
-                .request("eth_getUncleCountByBlockHash", (hash,))
+                .request("eth_getUncleCountByBlockHash", (hash.block_hash,))
                 .await
                 .map(|count: U64| count.to::<u64>()),
             BlockId::Number(number) => self

--- a/crates/provider/src/provider.rs
+++ b/crates/provider/src/provider.rs
@@ -812,7 +812,7 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
         self.client().request("eth_getBlockReceipts", (block,)).await
     }
 
-    /// Gets an uncle block through the tag [BlockId] and index [U64].
+    /// Gets an uncle block through the tag [BlockId] and index [u64].
     async fn get_uncle(&self, tag: BlockId, idx: u64) -> TransportResult<Option<Block>> {
         match tag {
             BlockId::Hash(hash) => {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

`get_uncle` and `get_uncle_count` failed when `BlockId::Hash` was passed as the tag as the `RpcBlockHash` was being passed to the params directly instead of only the actual `block_hash`.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Pass actual `block_hash` and not the type.
Also, changed `idx: U64` -> `u64`. 


<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
