### PR TITLE
Temp get_uncle fix

### DIFF
--- a/crates/provider/src/provider.rs
+++ b/crates/provider/src/provider.rs
@@ -814,6 +814,7 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
 
     /// Gets an uncle block through the tag [BlockId] and index [u64].
     async fn get_uncle(&self, tag: BlockId, idx: u64) -> TransportResult<Option<Block>> {
+        let idx = U64::from(idx);
         match tag {
             BlockId::Hash(hash) => {
                 self.client()

--- a/crates/provider/src/provider.rs
+++ b/crates/provider/src/provider.rs
@@ -813,8 +813,7 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
     }
 
     /// Gets an uncle block through the tag [BlockId] and index [u64].
-    async fn get_uncle(&self, tag: BlockId, idx: u64) -> TransportResult<Option<Block>> {
-        let idx = U64::from(idx);
+    async fn get_uncle(&self, tag: BlockId, idx: U64) -> TransportResult<Option<Block>> {
         match tag {
             BlockId::Hash(hash) => {
                 self.client()

--- a/crates/provider/src/provider.rs
+++ b/crates/provider/src/provider.rs
@@ -813,7 +813,8 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
     }
 
     /// Gets an uncle block through the tag [BlockId] and index [u64].
-    async fn get_uncle(&self, tag: BlockId, idx: U64) -> TransportResult<Option<Block>> {
+    async fn get_uncle(&self, tag: BlockId, idx: u64) -> TransportResult<Option<Block>> {
+        let idx = U64::from(idx);
         match tag {
             BlockId::Hash(hash) => {
                 self.client()


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Passing the primitive type for the `idx` leads to the following error:
```bash
server returned an error response: error code -32602: invalid argument 1: json: cannot unmarshal non-string into Go value of type hexutil.Uint
```
in the anvil integration test: https://github.com/yash-atreya/foundry/blob/cfeffd5f5cd7c4225ddd3f35ab1c2618648200db/crates/anvil/tests/it/fork.rs#L852

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Temp fix is to rollback to non-primitive type `U64`.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
