### PR TITLE
feat: allow to only fill a transaction request

### DIFF
--- a/crates/provider/src/fillers/mod.rs
+++ b/crates/provider/src/fillers/mod.rs
@@ -237,6 +237,14 @@ where
     ) -> FillProvider<JoinFill<F, Other>, P, T, N> {
         self.filler.join_with(other).layer(self.inner)
     }
+
+    /// Fills the transaction request, using the configured fillers
+    pub async fn fill(&self, tx: N::TransactionRequest) -> TransportResult<SendableTx<N>>
+    where
+        N::TxEnvelope: Clone,
+    {
+        self.filler.prepare_and_fill(self, SendableTx::Builder(tx)).await
+    }
 }
 
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

This PR follows a discussion in the tg channel about the need to apply all fillers to a transaction request without sending it, for instance to be able to build a Flashbot bundle.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Adds a fill() method on `FillProvider` that just call inner filler prepare_and_fill().

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
