### PR TITLE
feat(pubsub): set channel size

### DIFF
--- a/crates/rpc-client/src/client.rs
+++ b/crates/rpc-client/src/client.rs
@@ -305,5 +305,10 @@ mod pubsub_impl {
         pub fn channel_size(&self) -> usize {
             self.transport.channel_size()
         }
+
+        /// Set the channel size.
+        pub fn set_channel_size(&self, size: usize) {
+            self.transport.set_channel_size(size)
+        }
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

The `channel_size` for the pubsub frontend defaulted to `16` with no way to set from the `RpcClient` level. 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Change `channel_size: usize` to `channel_size: AtomicUsize` in `Pubsub<Frontend>` and add setter method in `RpcClientInner<PubsubFrontend>`

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
