### PR TITLE
docs: add required softwares to run tests in Contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,7 +138,7 @@ cargo test --no-default-features
 cargo +nightly clippy --all-features
 ```
 
-> You need to have [geth v1.13.x](https://geth.ethereum.org/downloads) and [Anvil latest version](https://book.getfoundry.sh/getting-started/installation) to be able to run the tests
+> You need to have [geth](https://geth.ethereum.org/downloads) and [Anvil latest version](https://book.getfoundry.sh/getting-started/installation) to be run the tests
 
 ### Tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,7 +138,7 @@ cargo test --no-default-features
 cargo +nightly clippy --all-features
 ```
 
-> You need to have [geth](https://geth.ethereum.org/downloads) and [Anvil latest version](https://book.getfoundry.sh/getting-started/installation) to be run the tests
+> You need to have [geth](https://geth.ethereum.org/downloads) and [Anvil](https://book.getfoundry.sh/getting-started/installation) to be able to run the tests
 
 ### Tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,6 +138,8 @@ cargo test --no-default-features
 cargo +nightly clippy --all-features
 ```
 
+> You need to have [geth v1.13.x](https://geth.ethereum.org/downloads) and [Anvil latest version](https://book.getfoundry.sh/getting-started/installation) to be able to run the tests
+
 ### Tests
 
 If the change being proposed alters code (as opposed to only documentation for


### PR DESCRIPTION
## Motivation

I was unable to run the tests for alloy (Cf #626) it was due to missing the `geth` and `Anvil` software.

## Solution

I have added the requirements in the `Contributing.md` file so that other developers can directly see that they are needed.

I specified `geth v1.13.x` because testsuite doesn't work for now on latest geth version: `geth v1.14.0`

But the testsuite may work in future geth release, I am not sure that fixing the version to `1.13.x` is a good idea because we will have to change it manually every time we upgrade. And anyways, when we run `cargo test` with `geth v1.14.0` it tells us to use `geth v1.13.x

## PR Checklist

Only Text modification no code change
