### PR TITLE
chore: update to geth 1.14

### DIFF
--- a/.github/scripts/install_test_binaries.sh
+++ b/.github/scripts/install_test_binaries.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
-# Installs Solc and Geth binaries
+# Installs Geth binary
 # Note: intended for use only with CI (x86_64 Ubuntu, MacOS or Windows)
 set -e
 
-GETH_BUILD=${GETH_BUILD:-"1.13.15-c5ba367e"}
+GETH_BUILD=${GETH_BUILD:-"1.14.0-87246f3c"}
 
 BIN_DIR=${BIN_DIR:-"$HOME/bin"}
 

--- a/crates/node-bindings/src/geth.rs
+++ b/crates/node-bindings/src/geth.rs
@@ -103,6 +103,7 @@ impl GethInstance {
     }
 
     /// Returns the private key used to configure clique on this instance
+    #[deprecated = "clique support was removed in geth >=1.14"]
     pub fn clique_private_key(&self) -> &Option<SigningKey> {
         &self.clique_private_key
     }
@@ -301,6 +302,7 @@ impl Geth {
     ///
     /// The address derived from this private key will be used to set the `miner.etherbase` field
     /// on the node.
+    #[deprecated = "clique support was removed in geth >=1.14"]
     pub fn set_clique_private_key<T: Into<SigningKey>>(mut self, private_key: T) -> Self {
         self.clique_private_key = Some(private_key.into());
         self
@@ -726,6 +728,8 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "fails on geth >=1.14"]
+    #[allow(deprecated)]
     fn clique_correctly_configured() {
         run_with_tempdir(|temp_dir_path| {
             let private_key = SigningKey::random(&mut rand::thread_rng());


### PR DESCRIPTION
Clique support was removed, see https://github.com/ethereum/go-ethereum/releases/tag/v1.14.0