### PR TITLE
feat: add extra_fields to ChainConfig

### DIFF
--- a/crates/genesis/Cargo.toml
+++ b/crates/genesis/Cargo.toml
@@ -17,8 +17,6 @@ alloy-serde.workspace = true
 
 # serde
 serde.workspace = true
-
-[dev-dependencies]
 serde_json.workspace = true
 
 [features]

--- a/crates/genesis/src/lib.rs
+++ b/crates/genesis/src/lib.rs
@@ -20,7 +20,7 @@
 
 extern crate alloc;
 
-use alloc::collections::BTreeMap;
+use alloc::{collections::BTreeMap, string::String};
 
 use alloy_primitives::{Address, Bytes, B256, U256};
 use alloy_serde::{

--- a/crates/genesis/src/lib.rs
+++ b/crates/genesis/src/lib.rs
@@ -24,6 +24,7 @@ use alloc::collections::BTreeMap;
 
 use alloy_primitives::{Address, Bytes, B256, U256};
 use alloy_serde::{
+    json_value,
     num::{u128_opt_via_ruint, u128_via_ruint, u64_opt_via_ruint, u64_via_ruint},
     storage::deserialize_storage_map,
     ttd::deserialize_json_ttd_opt,
@@ -422,6 +423,10 @@ pub struct ChainConfig {
     /// Clique parameters.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub clique: Option<CliqueConfig>,
+
+    /// Additional fields specific to each chain.
+    #[serde(flatten, default)]
+    pub extra_fields: BTreeMap<String, json_value>,
 }
 
 impl ChainConfig {

--- a/crates/genesis/src/lib.rs
+++ b/crates/genesis/src/lib.rs
@@ -24,7 +24,6 @@ use alloc::{collections::BTreeMap, string::String};
 
 use alloy_primitives::{Address, Bytes, B256, U256};
 use alloy_serde::{
-    json_value,
     num::{u128_opt_via_ruint, u128_via_ruint, u64_opt_via_ruint, u64_via_ruint},
     storage::deserialize_storage_map,
     ttd::deserialize_json_ttd_opt,

--- a/crates/genesis/src/lib.rs
+++ b/crates/genesis/src/lib.rs
@@ -426,7 +426,7 @@ pub struct ChainConfig {
 
     /// Additional fields specific to each chain.
     #[serde(flatten, default)]
-    pub extra_fields: BTreeMap<String, json_value>,
+    pub extra_fields: BTreeMap<String, serde_json::Value>,
 }
 
 impl ChainConfig {

--- a/crates/genesis/src/lib.rs
+++ b/crates/genesis/src/lib.rs
@@ -1309,4 +1309,31 @@ mod tests {
         let gen2 = serde_json::from_str::<Genesis>(&s).unwrap();
         assert_eq!(gen, gen2);
     }
+
+    #[test]
+    fn parse_extra_fields() {
+        let geth_genesis = r#"
+    {
+        "difficulty": "0x20000",
+        "gasLimit": "0x1",
+        "alloc": {},
+        "config": {
+          "ethash": {},
+          "chainId": 1,
+          "string_field": "string_value",
+          "numeric_field": 7,
+          "object_field": {
+            "sub_field": "sub_value"
+          }
+        }
+    }
+    "#;
+        let genesis: Genesis = serde_json::from_str(geth_genesis).unwrap();
+        let actual_string_value = genesis.config.extra_fields.get("string_field").unwrap();
+        assert_eq!(actual_string_value, "string_value");
+        let actual_numeric_value = genesis.config.extra_fields.get("numeric_field").unwrap();
+        assert_eq!(actual_numeric_value, 7);
+        let actual_object_value = genesis.config.extra_fields.get("object_field").unwrap();
+        assert_eq!(actual_object_value, &serde_json::json!({"sub_field": "sub_value"}));
+    }
 }

--- a/crates/serde/src/lib.rs
+++ b/crates/serde/src/lib.rs
@@ -40,6 +40,8 @@ use serde::Serializer;
 
 use alloy_primitives::B256;
 
+pub use serde_json::Value as json_value;
+
 /// Serialize a byte vec as a hex string _without_ the "0x" prefix.
 ///
 /// This behaves the same as [`hex::encode`](alloy_primitives::hex::encode).

--- a/crates/serde/src/lib.rs
+++ b/crates/serde/src/lib.rs
@@ -40,7 +40,6 @@ use serde::Serializer;
 
 use alloy_primitives::B256;
 
-
 /// Serialize a byte vec as a hex string _without_ the "0x" prefix.
 ///
 /// This behaves the same as [`hex::encode`](alloy_primitives::hex::encode).

--- a/crates/serde/src/lib.rs
+++ b/crates/serde/src/lib.rs
@@ -40,7 +40,6 @@ use serde::Serializer;
 
 use alloy_primitives::B256;
 
-pub use serde_json::Value as json_value;
 
 /// Serialize a byte vec as a hex string _without_ the "0x" prefix.
 ///


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Towards https://github.com/paradigmxyz/reth/issues/7702

Currently fields specific to chains different from mainnet Ethereum (like those related to OP forks) are not being deserialized into ChainConfig. 

## Solution

Adds an `extra_fields` field to ChainConfig to gather the additional chain-specific information without polluting the top-level object. 

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
