### PR TITLE
fix: signer filler now propagates missing keys from builder

### DIFF
--- a/crates/network/src/transaction/builder.rs
+++ b/crates/network/src/transaction/builder.rs
@@ -289,6 +289,12 @@ pub trait TransactionBuilder<N: Network>: Default + Sized + Send + Sync + 'stati
     /// returning a list of missing keys.
     fn complete_type(&self, ty: N::TxType) -> Result<(), Vec<&'static str>>;
 
+    /// Check if all necessary keys are present to build the currently-preferred
+    /// transaction type, returning a list of missing keys.
+    fn complete_preferred(&self) -> Result<(), Vec<&'static str>> {
+        self.complete_type(self.output_tx_type())
+    }
+
     /// Assert that the builder prefers a certain transaction type. This does
     /// not indicate that the builder is ready to build. This function uses a
     /// `dbg_assert_eq!` to check the builder status, and will have no affect

--- a/crates/provider/src/fillers/mod.rs
+++ b/crates/provider/src/fillers/mod.rs
@@ -40,7 +40,7 @@ pub enum FillerControlFlow {
     /// lists, this variant contains a list of `(name, missing)` tuples. When
     /// absorbing another control flow, if both are missing, the missing lists
     /// are combined.
-    Missing(Vec<(&'static str, &'static [&'static str])>),
+    Missing(Vec<(&'static str, Vec<&'static str>)>),
     /// The filler is ready to fill in the transaction request.
     Ready,
     /// The filler has filled in all properties that it can fill.
@@ -76,12 +76,12 @@ impl FillerControlFlow {
     }
 
     /// Creates a new `Missing` control flow.
-    pub fn missing(name: &'static str, missing: &'static [&'static str]) -> Self {
+    pub fn missing(name: &'static str, missing: Vec<&'static str>) -> Self {
         Self::Missing(vec![(name, missing)])
     }
 
     /// Returns true if the filler is missing a required property.
-    pub fn as_missing(&self) -> Option<&[(&'static str, &'static [&'static str])]> {
+    pub fn as_missing(&self) -> Option<&[(&'static str, Vec<&'static str>)]> {
         match self {
             Self::Missing(missing) => Some(missing),
             _ => None,

--- a/crates/provider/src/fillers/nonce.rs
+++ b/crates/provider/src/fillers/nonce.rs
@@ -54,7 +54,7 @@ impl<N: Network> TxFiller<N> for NonceFiller {
             return FillerControlFlow::Finished;
         }
         if tx.from().is_none() {
-            return FillerControlFlow::missing("NonceManager", &["from"]);
+            return FillerControlFlow::missing("NonceManager", vec!["from"]);
         }
         FillerControlFlow::Ready
     }

--- a/crates/provider/src/fillers/signer.rs
+++ b/crates/provider/src/fillers/signer.rs
@@ -62,12 +62,9 @@ where
             return FillerControlFlow::Ready;
         }
 
-        if tx.can_build() {
-            FillerControlFlow::Ready
-        } else {
-            // Blocked by #431
-            // https://github.com/alloy-rs/alloy/pull/431
-            FillerControlFlow::Missing(vec![("Signer", &["TODO"])])
+        match tx.complete_preferred() {
+            Ok(_) => FillerControlFlow::Ready,
+            Err(e) => FillerControlFlow::Missing(vec![("Signer", e)]),
         }
     }
 


### PR DESCRIPTION

## Motivation

Followup to #431 

## Solution

Signer now uses the tx builder to give lists of missing keys

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [x] Breaking changes
