### PR TITLE
Move block hash types to alloy-eips

### DIFF
--- a/crates/eips/Cargo.toml
+++ b/crates/eips/Cargo.toml
@@ -16,8 +16,9 @@ alloy-primitives = { workspace = true, features = ["rlp"], default-features = fa
 alloy-rlp = { workspace = true, features = ["derive"], default-features = false }
 alloy-serde.workspace = true
 
-# serde
+# misc
 serde = { workspace = true, default-features = false, optional = true }
+thiserror.workspace = true
 
 # kzg
 derive_more = { workspace = true, optional = true }

--- a/crates/eips/Cargo.toml
+++ b/crates/eips/Cargo.toml
@@ -12,13 +12,16 @@ repository.workspace = true
 exclude.workspace = true
 
 [dependencies]
-alloy-primitives = { workspace = true, features = ["rlp"], default-features = false }
-alloy-rlp = { workspace = true, features = ["derive"], default-features = false }
+alloy-primitives = { workspace = true, features = [
+  "rlp",
+], default-features = false }
+alloy-rlp = { workspace = true, features = [
+  "derive",
+], default-features = false }
 alloy-serde.workspace = true
 
-# misc
+# serde
 serde = { workspace = true, default-features = false, optional = true }
-thiserror.workspace = true
 
 # kzg
 derive_more = { workspace = true, optional = true }
@@ -35,7 +38,11 @@ proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
 
 [dev-dependencies]
-alloy-primitives = { workspace = true, features = ["rand", "serde", "arbitrary"] }
+alloy-primitives = { workspace = true, features = [
+  "rand",
+  "serde",
+  "arbitrary",
+] }
 arbitrary = { workspace = true, features = ["derive"] }
 proptest = { workspace = true }
 proptest-derive = { workspace = true }
@@ -43,14 +50,25 @@ serde_json.workspace = true
 
 [features]
 default = ["std"]
-std = ["alloy-primitives/std", "alloy-rlp/std", "serde?/std", "c-kzg?/std", "once_cell?/std"]
+std = [
+  "alloy-primitives/std",
+  "alloy-rlp/std",
+  "serde?/std",
+  "c-kzg?/std",
+  "once_cell?/std",
+]
 serde = ["dep:serde", "alloy-primitives/serde", "c-kzg?/serde"]
 kzg = ["dep:derive_more", "dep:c-kzg", "dep:once_cell"]
-ssz = ["std", "dep:ethereum_ssz", "dep:ethereum_ssz_derive", "alloy-primitives/ssz"]
+ssz = [
+  "std",
+  "dep:ethereum_ssz",
+  "dep:ethereum_ssz_derive",
+  "alloy-primitives/ssz",
+]
 arbitrary = [
-    "std",
-    "dep:arbitrary",
-    "dep:proptest-derive",
-    "dep:proptest",
-    "alloy-primitives/arbitrary",
+  "std",
+  "dep:arbitrary",
+  "dep:proptest-derive",
+  "dep:proptest",
+  "alloy-primitives/arbitrary",
 ]

--- a/crates/eips/Cargo.toml
+++ b/crates/eips/Cargo.toml
@@ -12,12 +12,8 @@ repository.workspace = true
 exclude.workspace = true
 
 [dependencies]
-alloy-primitives = { workspace = true, features = [
-  "rlp",
-], default-features = false }
-alloy-rlp = { workspace = true, features = [
-  "derive",
-], default-features = false }
+alloy-primitives = { workspace = true, features = ["rlp"], default-features = false }
+alloy-rlp = { workspace = true, features = ["derive"], default-features = false }
 alloy-serde.workspace = true
 
 # serde
@@ -38,11 +34,7 @@ proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
 
 [dev-dependencies]
-alloy-primitives = { workspace = true, features = [
-  "rand",
-  "serde",
-  "arbitrary",
-] }
+alloy-primitives = { workspace = true, features = ["rand", "serde", "arbitrary"] }
 arbitrary = { workspace = true, features = ["derive"] }
 proptest = { workspace = true }
 proptest-derive = { workspace = true }
@@ -50,25 +42,14 @@ serde_json.workspace = true
 
 [features]
 default = ["std"]
-std = [
-  "alloy-primitives/std",
-  "alloy-rlp/std",
-  "serde?/std",
-  "c-kzg?/std",
-  "once_cell?/std",
-]
+std = ["alloy-primitives/std", "alloy-rlp/std", "serde?/std", "c-kzg?/std", "once_cell?/std"]
 serde = ["dep:serde", "alloy-primitives/serde", "c-kzg?/serde"]
 kzg = ["dep:derive_more", "dep:c-kzg", "dep:once_cell"]
-ssz = [
-  "std",
-  "dep:ethereum_ssz",
-  "dep:ethereum_ssz_derive",
-  "alloy-primitives/ssz",
-]
+ssz = ["std", "dep:ethereum_ssz", "dep:ethereum_ssz_derive", "alloy-primitives/ssz"]
 arbitrary = [
-  "std",
-  "dep:arbitrary",
-  "dep:proptest-derive",
-  "dep:proptest",
-  "alloy-primitives/arbitrary",
+    "std",
+    "dep:arbitrary",
+    "dep:proptest-derive",
+    "dep:proptest",
+    "alloy-primitives/arbitrary",
 ]

--- a/crates/eips/src/eip1898.rs
+++ b/crates/eips/src/eip1898.rs
@@ -614,7 +614,8 @@ impl From<(BlockHash, BlockNumber)> for BlockNumHash {
 }
 
 /// Either a block hash _or_ a block number
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     any(test, feature = "arbitrary"),
     derive(proptest_derive::Arbitrary, arbitrary::Arbitrary)
@@ -707,7 +708,7 @@ impl fmt::Display for BlockHashOrNumber {
 /// Error thrown when parsing a [BlockHashOrNumber] from a string.
 #[derive(Debug)]
 pub struct ParseBlockHashOrNumberError {
-    input: String,
+    input: alloc::string::String,
     parse_int_error: ParseIntError,
     hex_error: alloy_primitives::hex::FromHexError,
 }
@@ -729,6 +730,8 @@ impl FromStr for BlockHashOrNumber {
     type Err = ParseBlockHashOrNumberError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
+        #[allow(unused_imports)]
+        use alloc::string::ToString;
         match u64::from_str(s) {
             Ok(val) => Ok(val.into()),
             Err(pares_int_error) => match B256::from_str(s) {

--- a/crates/eips/src/eip1898.rs
+++ b/crates/eips/src/eip1898.rs
@@ -1,6 +1,7 @@
 //! [EIP-1898]: https://eips.ethereum.org/EIPS/eip-1898
 
-use alloy_primitives::{hex::FromHexError, ruint::ParseError, B256, U64};
+use alloy_primitives::{hex::FromHexError, ruint::ParseError, BlockHash, BlockNumber, B256, U64};
+use alloy_rlp::{bytes, Decodable, Encodable, Error as RlpError};
 use core::{
     fmt::{self, Debug, Display, Formatter},
     num::ParseIntError,
@@ -552,6 +553,180 @@ impl FromStr for BlockId {
                 .parse::<u64>()
                 .map_err(ParseBlockIdError::ParseIntError)
                 .map(|n| BlockId::Number(n.into())),
+        }
+    }
+}
+
+/// Block number and hash.
+#[derive(Clone, Copy, Default, PartialEq, Eq, Hash)]
+pub struct BlockNumHash {
+    /// Block number
+    pub number: BlockNumber,
+    /// Block hash
+    pub hash: BlockHash,
+}
+
+/// Block number and hash of the forked block.
+pub type ForkBlock = BlockNumHash;
+
+impl fmt::Debug for BlockNumHash {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("").field(&self.number).field(&self.hash).finish()
+    }
+}
+
+impl fmt::Display for BlockNumHash {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "BlockNumHash{{ number: {}, hash: {} }}", self.number, self.hash)
+    }
+}
+
+impl BlockNumHash {
+    /// Creates a new `BlockNumHash` from a block number and hash.
+    pub const fn new(number: BlockNumber, hash: BlockHash) -> Self {
+        Self { number, hash }
+    }
+
+    /// Consumes `Self` and returns [`BlockNumber`], [`BlockHash`]
+    pub const fn into_components(self) -> (BlockNumber, BlockHash) {
+        (self.number, self.hash)
+    }
+
+    /// Returns whether or not the block matches the given [BlockHashOrNumber].
+    pub fn matches_block_or_num(&self, block: &BlockHashOrNumber) -> bool {
+        match block {
+            BlockHashOrNumber::Hash(hash) => self.hash == *hash,
+            BlockHashOrNumber::Number(number) => self.number == *number,
+        }
+    }
+}
+
+impl From<(BlockNumber, BlockHash)> for BlockNumHash {
+    fn from(val: (BlockNumber, BlockHash)) -> Self {
+        BlockNumHash { number: val.0, hash: val.1 }
+    }
+}
+
+impl From<(BlockHash, BlockNumber)> for BlockNumHash {
+    fn from(val: (BlockHash, BlockNumber)) -> Self {
+        BlockNumHash { hash: val.0, number: val.1 }
+    }
+}
+
+/// Either a block hash _or_ a block number
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[cfg_attr(
+    any(test, feature = "arbitrary"),
+    derive(proptest_derive::Arbitrary, arbitrary::Arbitrary)
+)]
+pub enum BlockHashOrNumber {
+    /// A block hash
+    Hash(B256),
+    /// A block number
+    Number(u64),
+}
+
+// === impl BlockHashOrNumber ===
+
+impl BlockHashOrNumber {
+    /// Returns the block number if it is a [`BlockHashOrNumber::Number`].
+    #[inline]
+    pub const fn as_number(self) -> Option<u64> {
+        match self {
+            BlockHashOrNumber::Hash(_) => None,
+            BlockHashOrNumber::Number(num) => Some(num),
+        }
+    }
+}
+
+impl From<B256> for BlockHashOrNumber {
+    fn from(value: B256) -> Self {
+        BlockHashOrNumber::Hash(value)
+    }
+}
+
+impl From<u64> for BlockHashOrNumber {
+    fn from(value: u64) -> Self {
+        BlockHashOrNumber::Number(value)
+    }
+}
+
+impl From<U64> for BlockHashOrNumber {
+    fn from(value: U64) -> Self {
+        value.to::<u64>().into()
+    }
+}
+
+/// Allows for RLP encoding of either a block hash or block number
+impl Encodable for BlockHashOrNumber {
+    fn encode(&self, out: &mut dyn bytes::BufMut) {
+        match self {
+            Self::Hash(block_hash) => block_hash.encode(out),
+            Self::Number(block_number) => block_number.encode(out),
+        }
+    }
+    fn length(&self) -> usize {
+        match self {
+            Self::Hash(block_hash) => block_hash.length(),
+            Self::Number(block_number) => block_number.length(),
+        }
+    }
+}
+
+/// Allows for RLP decoding of a block hash or block number
+impl Decodable for BlockHashOrNumber {
+    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        let header: u8 = *buf.first().ok_or(RlpError::InputTooShort)?;
+        // if the byte string is exactly 32 bytes, decode it into a Hash
+        // 0xa0 = 0x80 (start of string) + 0x20 (32, length of string)
+        if header == 0xa0 {
+            // strip the first byte, parsing the rest of the string.
+            // If the rest of the string fails to decode into 32 bytes, we'll bubble up the
+            // decoding error.
+            let hash = B256::decode(buf)?;
+            Ok(Self::Hash(hash))
+        } else {
+            // a block number when encoded as bytes ranges from 0 to any number of bytes - we're
+            // going to accept numbers which fit in less than 64 bytes.
+            // Any data larger than this which is not caught by the Hash decoding should error and
+            // is considered an invalid block number.
+            Ok(Self::Number(u64::decode(buf)?))
+        }
+    }
+}
+
+impl fmt::Display for BlockHashOrNumber {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Hash(hash) => write!(f, "{}", hash),
+            Self::Number(num) => write!(f, "{}", num),
+        }
+    }
+}
+
+/// Error thrown when parsing a [BlockHashOrNumber] from a string.
+#[derive(Debug, thiserror::Error)]
+#[error("failed to parse {input:?} as a number: {parse_int_error} or hash: {hex_error}")]
+pub struct ParseBlockHashOrNumberError {
+    input: String,
+    parse_int_error: ParseIntError,
+    hex_error: alloy_primitives::hex::FromHexError,
+}
+
+impl FromStr for BlockHashOrNumber {
+    type Err = ParseBlockHashOrNumberError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match u64::from_str(s) {
+            Ok(val) => Ok(val.into()),
+            Err(pares_int_error) => match B256::from_str(s) {
+                Ok(val) => Ok(val.into()),
+                Err(hex_error) => Err(ParseBlockHashOrNumberError {
+                    input: s.to_string(),
+                    parse_int_error: pares_int_error,
+                    hex_error,
+                }),
+            },
         }
     }
 }

--- a/crates/eips/src/eip1898.rs
+++ b/crates/eips/src/eip1898.rs
@@ -558,7 +558,7 @@ impl FromStr for BlockId {
 }
 
 /// Block number and hash.
-#[derive(Clone, Copy, Default, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
 pub struct BlockNumHash {
     /// Block number
     pub number: BlockNumber,
@@ -568,18 +568,6 @@ pub struct BlockNumHash {
 
 /// Block number and hash of the forked block.
 pub type ForkBlock = BlockNumHash;
-
-impl fmt::Debug for BlockNumHash {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("").field(&self.number).field(&self.hash).finish()
-    }
-}
-
-impl fmt::Display for BlockNumHash {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "BlockNumHash{{ number: {}, hash: {} }}", self.number, self.hash)
-    }
-}
 
 impl BlockNumHash {
     /// Creates a new `BlockNumHash` from a block number and hash.
@@ -734,11 +722,11 @@ impl FromStr for BlockHashOrNumber {
         use alloc::string::ToString;
         match u64::from_str(s) {
             Ok(val) => Ok(val.into()),
-            Err(pares_int_error) => match B256::from_str(s) {
+            Err(parse_int_error) => match B256::from_str(s) {
                 Ok(val) => Ok(val.into()),
                 Err(hex_error) => Err(ParseBlockHashOrNumberError {
                     input: s.to_string(),
-                    parse_int_error: pares_int_error,
+                    parse_int_error,
                     hex_error,
                 }),
             },

--- a/crates/eips/src/eip1898.rs
+++ b/crates/eips/src/eip1898.rs
@@ -705,13 +705,25 @@ impl fmt::Display for BlockHashOrNumber {
 }
 
 /// Error thrown when parsing a [BlockHashOrNumber] from a string.
-#[derive(Debug, thiserror::Error)]
-#[error("failed to parse {input:?} as a number: {parse_int_error} or hash: {hex_error}")]
+#[derive(Debug)]
 pub struct ParseBlockHashOrNumberError {
     input: String,
     parse_int_error: ParseIntError,
     hex_error: alloy_primitives::hex::FromHexError,
 }
+
+impl fmt::Display for ParseBlockHashOrNumberError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "failed to parse {:?} as a number: {} or hash: {}",
+            self.input, self.parse_int_error, self.hex_error
+        )
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for ParseBlockHashOrNumberError {}
 
 impl FromStr for BlockHashOrNumber {
     type Err = ParseBlockHashOrNumberError;

--- a/crates/eips/src/lib.rs
+++ b/crates/eips/src/lib.rs
@@ -23,7 +23,9 @@ pub mod eip1559;
 pub use eip1559::calc_next_block_base_fee;
 
 pub mod eip1898;
-pub use eip1898::{BlockId, BlockNumberOrTag, RpcBlockHash};
+pub use eip1898::{
+    BlockHashOrNumber, BlockId, BlockNumHash, BlockNumberOrTag, ForkBlock, RpcBlockHash,
+};
 
 pub mod eip2718;
 


### PR DESCRIPTION
Closes #633.

* removed `thiserror::Error` derive for `ParseBlockHashOrNumberError` since other errors in `alloy-eips` doesn't rely on `thiserror` it at all.