### PR TITLE
`alloy_rpc_types_engine`: expose inner `B64` from `PayloadId`

### DIFF
--- a/crates/rpc-types-engine/src/payload.rs
+++ b/crates/rpc-types-engine/src/payload.rs
@@ -12,7 +12,7 @@ pub type ExecutionPayloadBodiesV1 = Vec<Option<ExecutionPayloadBodyV1>>;
 
 /// And 8-byte identifier for an execution payload.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct PayloadId(B64);
+pub struct PayloadId(pub B64);
 
 // === impl PayloadId ===
 


### PR DESCRIPTION
There is currently no way to access the inner `B64` of the `PayloadId` type.

This means you cannot reuse the computation that derives the payload bytes.

My use case is a custom payload builder on top of `reth` that attaches additional payload builder attributes beyond what the Engine API provides: https://github.com/ralexstokes/mev-rs/blob/main/mev-build-rs/src/payload/builder_attributes.rs#L71-L77

I would like to use the same `PayloadId` that `reth` natively provides and simply mix in new data into the payload id by mixing in new data, e.g. https://github.com/ralexstokes/mev-rs/blob/0d283373445c36a6287f1c51599ddd662fbe7c2a/mev-build-rs/src/payload/builder_attributes.rs#L47

Without this, I have to locally vendor the same computation as `reth` and also pass around the bytes along with the `PayloadId` type (see return signature here: https://github.com/ralexstokes/mev-rs/blob/0d283373445c36a6287f1c51599ddd662fbe7c2a/mev-build-rs/src/payload/builder_attributes.rs#L17)
