### PR TITLE
debug_trace_block fix

### DIFF
--- a/crates/provider/src/ext/debug.rs
+++ b/crates/provider/src/ext/debug.rs
@@ -3,9 +3,7 @@ use crate::Provider;
 use alloy_network::Network;
 use alloy_primitives::{BlockNumber, TxHash, B256};
 use alloy_rpc_types::{BlockNumberOrTag, TransactionRequest};
-use alloy_rpc_types_trace::geth::{
-    GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace,
-};
+use alloy_rpc_types_trace::geth::{GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace, GethTraceBlockResponse};
 use alloy_transport::{Transport, TransportResult};
 
 /// Debug namespace rpc interface that gives access to several non-standard RPC methods.
@@ -42,7 +40,7 @@ pub trait DebugApi<N, T>: Send + Sync {
         &self,
         block: B256,
         trace_options: GethDebugTracingOptions,
-    ) -> TransportResult<Vec<GethTrace>>;
+    ) -> TransportResult<Vec<GethTraceBlockResponse>>;
 
     /// Same as `debug_trace_block_by_hash` but block is specified by number.
     ///
@@ -53,9 +51,9 @@ pub trait DebugApi<N, T>: Send + Sync {
     /// Not all nodes support this call.
     async fn debug_trace_block_by_number(
         &self,
-        block: BlockNumber,
+        block: BlockNumberOrTag,
         trace_options: GethDebugTracingOptions,
-    ) -> TransportResult<Vec<GethTrace>>;
+    ) -> TransportResult<Vec<GethTraceBlockResponse>>;
 
     /// Executes the given transaction without publishing it like `eth_call` and returns the trace
     /// of the execution.
@@ -111,15 +109,15 @@ where
         &self,
         block: B256,
         trace_options: GethDebugTracingOptions,
-    ) -> TransportResult<Vec<GethTrace>> {
+    ) -> TransportResult<Vec<GethTraceBlockResponse>> {
         self.client().request("debug_traceBlockByHash", (block, trace_options)).await
     }
 
     async fn debug_trace_block_by_number(
         &self,
-        block: BlockNumber,
+        block: BlockNumberOrTag,
         trace_options: GethDebugTracingOptions,
-    ) -> TransportResult<Vec<GethTrace>> {
+    ) -> TransportResult<Vec<GethTraceBlockResponse>> {
         self.client().request("debug_traceBlockByNumber", (block, trace_options)).await
     }
 

--- a/crates/rpc-types-trace/src/geth/mod.rs
+++ b/crates/rpc-types-trace/src/geth/mod.rs
@@ -1,7 +1,7 @@
 //! Geth tracing types.
 
 use crate::geth::mux::{MuxConfig, MuxFrame};
-use alloy_primitives::{Bytes, B256, U256};
+use alloy_primitives::{Bytes, B256, U256, TxHash};
 use alloy_rpc_types::{state::StateOverride, BlockOverrides};
 use serde::{de::DeserializeOwned, ser::SerializeMap, Deserialize, Serialize, Serializer};
 use std::{collections::BTreeMap, time::Duration};
@@ -535,6 +535,13 @@ fn serialize_string_storage_map_opt<S: Serializer>(
             m.end()
         }
     }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GethTraceBlockResponse {
+    pub tx_hash : TxHash,
+    pub result: GethTrace,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Motivation

Improperly described return types for debug_block_* functions and improperly encoded block number parameter for  debug_block_by_number

## Solution

debug_trace_block_by_number block parameter changed to BlockNumberOrTag for proper serialization 
debug_trace_block_by_number and debug_trace_block_by_hash return type changed to GethTraceBlockResponse

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes


Fix for this issue : https://github.com/alloy-rs/alloy/issues/657
