### PR TITLE
chore: move blob validation to sidecar

### DIFF
--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -18,7 +18,6 @@ alloy-eips.workspace = true
 alloy-serde = { workspace = true, optional = true }
 
 # kzg
-thiserror = { workspace = true, optional = true }
 c-kzg = { workspace = true, features = ["serde"], optional = true }
 
 # arbitrary
@@ -40,6 +39,6 @@ serde_json.workspace = true
 default = ["std"]
 std = ["alloy-eips/std", "c-kzg?/std"]
 k256 = ["alloy-primitives/k256"]
-kzg = ["dep:c-kzg", "dep:thiserror", "alloy-eips/kzg", "std"]
+kzg = ["dep:c-kzg", "alloy-eips/kzg", "std"]
 arbitrary = ["std", "dep:arbitrary", "alloy-eips/arbitrary"]
 serde = ["dep:serde", "alloy-primitives/serde", "dep:alloy-serde", "alloy-eips/serde"]

--- a/crates/consensus/src/transaction/eip4844.rs
+++ b/crates/consensus/src/transaction/eip4844.rs
@@ -92,11 +92,9 @@ impl TxEip4844Variant {
     pub fn validate(
         &self,
         proof_settings: &c_kzg::KzgSettings,
-    ) -> Result<(), alloy_eips::eip4844::BlobTransactionValidationError> {
+    ) -> Result<(), BlobTransactionValidationError> {
         match self {
-            TxEip4844Variant::TxEip4844(_) => {
-                Err(alloy_eips::eip4844::BlobTransactionValidationError::MissingSidecar)
-            }
+            TxEip4844Variant::TxEip4844(_) => Err(BlobTransactionValidationError::MissingSidecar),
             TxEip4844Variant::TxEip4844WithSidecar(tx) => tx.validate_blob(proof_settings),
         }
     }
@@ -396,8 +394,8 @@ impl TxEip4844 {
     /// Verifies that the given blob data, commitments, and proofs are all valid for this
     /// transaction.
     ///
-    /// Takes as input the [KzgSettings], which should contain the parameters derived from the
-    /// KZG trusted setup.
+    /// Takes as input the [KzgSettings](c_kzg::KzgSettings), which should contain the parameters
+    /// derived from the KZG trusted setup.
     ///
     /// This ensures that the blob transaction payload has the same number of blob data elements,
     /// commitments, and proofs. Each blob data element is verified against its commitment and
@@ -411,7 +409,7 @@ impl TxEip4844 {
         &self,
         sidecar: &BlobTransactionSidecar,
         proof_settings: &c_kzg::KzgSettings,
-    ) -> Result<(), alloy_eips::eip4844::BlobTransactionValidationError> {
+    ) -> Result<(), BlobTransactionValidationError> {
         sidecar.validate(&self.blob_versioned_hashes, proof_settings)
     }
 

--- a/crates/consensus/src/transaction/eip4844.rs
+++ b/crates/consensus/src/transaction/eip4844.rs
@@ -13,42 +13,14 @@ use core::mem;
 #[doc(inline)]
 pub use alloy_eips::eip4844::BlobTransactionSidecar;
 
+#[cfg(feature = "kzg")]
+#[doc(inline)]
+pub use alloy_eips::eip4844::BlobTransactionValidationError;
+
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
 pub use alloy_eips::eip4844::{Blob, Bytes48};
-
-#[cfg(feature = "kzg")]
-use c_kzg::{KzgCommitment, KzgProof, KzgSettings};
-#[cfg(feature = "kzg")]
-use std::ops::Deref;
-
-/// An error that can occur when validating a [TxEip4844Variant].
-#[derive(Debug, thiserror::Error)]
-#[cfg(feature = "kzg")]
-pub enum BlobTransactionValidationError {
-    /// Proof validation failed.
-    #[error("invalid KZG proof")]
-    InvalidProof,
-    /// An error returned by [`c_kzg`].
-    #[error("KZG error: {0:?}")]
-    KZGError(#[from] c_kzg::Error),
-    /// The inner transaction is not a blob transaction.
-    #[error("unable to verify proof for non blob transaction: {0}")]
-    NotBlobTransaction(u8),
-    /// Using a standalone [TxEip4844] instead of the [TxEip4844WithSidecar] variant, which
-    /// includes the sidecar for validation.
-    #[error("eip4844 tx variant without sidecar being used for verification. Please use the TxEip4844WithSidecar variant, which includes the sidecar")]
-    MissingSidecar,
-    /// The versioned hash is incorrect.
-    #[error("wrong versioned hash: have {have}, expected {expected}")]
-    WrongVersionedHash {
-        /// The versioned hash we got
-        have: B256,
-        /// The versioned hash we expected
-        expected: B256,
-    },
-}
 
 /// [EIP-4844 Blob Transaction](https://eips.ethereum.org/EIPS/eip-4844#blob-transaction)
 ///
@@ -119,10 +91,12 @@ impl TxEip4844Variant {
     #[cfg(feature = "kzg")]
     pub fn validate(
         &self,
-        proof_settings: &KzgSettings,
-    ) -> Result<(), BlobTransactionValidationError> {
+        proof_settings: &c_kzg::KzgSettings,
+    ) -> Result<(), alloy_eips::eip4844::BlobTransactionValidationError> {
         match self {
-            TxEip4844Variant::TxEip4844(_) => Err(BlobTransactionValidationError::MissingSidecar),
+            TxEip4844Variant::TxEip4844(_) => {
+                Err(alloy_eips::eip4844::BlobTransactionValidationError::MissingSidecar)
+            }
             TxEip4844Variant::TxEip4844WithSidecar(tx) => tx.validate_blob(proof_settings),
         }
     }
@@ -436,56 +410,9 @@ impl TxEip4844 {
     pub fn validate_blob(
         &self,
         sidecar: &BlobTransactionSidecar,
-        proof_settings: &KzgSettings,
-    ) -> Result<(), BlobTransactionValidationError> {
-        // Ensure the versioned hashes and commitments have the same length.
-        if self.blob_versioned_hashes.len() != sidecar.commitments.len() {
-            return Err(c_kzg::Error::MismatchLength(format!(
-                "There are {} versioned commitment hashes and {} commitments",
-                self.blob_versioned_hashes.len(),
-                sidecar.commitments.len()
-            ))
-            .into());
-        }
-
-        // calculate versioned hashes by zipping & iterating
-        for (versioned_hash, commitment) in
-            self.blob_versioned_hashes.iter().zip(sidecar.commitments.iter())
-        {
-            let commitment = KzgCommitment::from(*commitment.deref());
-
-            // calculate & verify versioned hash
-            let calculated_versioned_hash =
-                alloy_eips::eip4844::kzg_to_versioned_hash(commitment.as_slice());
-            if *versioned_hash != calculated_versioned_hash {
-                return Err(BlobTransactionValidationError::WrongVersionedHash {
-                    have: *versioned_hash,
-                    expected: calculated_versioned_hash,
-                });
-            }
-        }
-
-        // SAFETY: ALL types have the same size
-        let res = unsafe {
-            KzgProof::verify_blob_kzg_proof_batch(
-                // blobs
-                std::mem::transmute::<&[Blob], &[c_kzg::Blob]>(sidecar.blobs.as_slice()),
-                // commitments
-                std::mem::transmute::<&[Bytes48], &[c_kzg::Bytes48]>(
-                    sidecar.commitments.as_slice(),
-                ),
-                // proofs
-                std::mem::transmute::<&[Bytes48], &[c_kzg::Bytes48]>(sidecar.proofs.as_slice()),
-                proof_settings,
-            )
-        }
-        .map_err(BlobTransactionValidationError::KZGError)?;
-
-        if res {
-            Ok(())
-        } else {
-            Err(BlobTransactionValidationError::InvalidProof)
-        }
+        proof_settings: &c_kzg::KzgSettings,
+    ) -> Result<(), alloy_eips::eip4844::BlobTransactionValidationError> {
+        sidecar.validate(&self.blob_versioned_hashes, proof_settings)
     }
 
     /// Decodes the inner [TxEip4844Variant] fields from RLP bytes.
@@ -800,7 +727,7 @@ impl TxEip4844WithSidecar {
     #[cfg(feature = "kzg")]
     pub fn validate_blob(
         &self,
-        proof_settings: &KzgSettings,
+        proof_settings: &c_kzg::KzgSettings,
     ) -> Result<(), BlobTransactionValidationError> {
         self.tx.validate_blob(&self.sidecar, proof_settings)
     }

--- a/crates/eips/src/eip4844/mod.rs
+++ b/crates/eips/src/eip4844/mod.rs
@@ -11,7 +11,7 @@ pub mod trusted_setup_points;
 
 /// Contains sidecar related types
 mod sidecar;
-pub use sidecar::BlobTransactionSidecar;
+pub use sidecar::*;
 
 use alloy_primitives::{b256, FixedBytes, B256, U256};
 

--- a/crates/eips/src/eip4844/sidecar.rs
+++ b/crates/eips/src/eip4844/sidecar.rs
@@ -189,8 +189,7 @@ pub enum BlobTransactionValidationError {
     KZGError(c_kzg::Error),
     /// The inner transaction is not a blob transaction.
     NotBlobTransaction(u8),
-    /// Using a standalone [TxEip4844] instead of the [TxEip4844WithSidecar] variant, which
-    /// includes the sidecar for validation.
+    /// Error variant for thrown by EIP-4844 tx variants without a sidecar.
     MissingSidecar,
     /// The versioned hash is incorrect.
     WrongVersionedHash {

--- a/crates/eips/src/eip4844/sidecar.rs
+++ b/crates/eips/src/eip4844/sidecar.rs
@@ -37,7 +37,7 @@ impl BlobTransactionSidecar {
         commitments: Vec<c_kzg::Bytes48>,
         proofs: Vec<c_kzg::Bytes48>,
     ) -> Self {
-        // transmutes the vec of items, see also [std::mem::transmute](https://doc.rust-lang.org/std/mem/fn.transmute.html)
+        // transmutes the vec of items, see also [core::mem::transmute](https://doc.rust-lang.org/std/mem/fn.transmute.html)
         unsafe fn transmute_vec<U, T>(input: Vec<T>) -> Vec<U> {
             let mut v = core::mem::ManuallyDrop::new(input);
             Vec::from_raw_parts(v.as_mut_ptr() as *mut U, v.len(), v.capacity())
@@ -49,6 +49,72 @@ impl BlobTransactionSidecar {
             let commitments = transmute_vec::<Bytes48, c_kzg::Bytes48>(commitments);
             let proofs = transmute_vec::<Bytes48, c_kzg::Bytes48>(proofs);
             Self { blobs, commitments, proofs }
+        }
+    }
+
+    /// Verifies that the versioned hashes are valid for this sidecar's blob data, commitments, and
+    /// proofs.
+    ///
+    /// Takes as input the [KzgSettings](c_kzg::KzgSettings), which should contain the parameters
+    /// derived from the KZG trusted setup.
+    ///
+    /// This ensures that the blob transaction payload has the same number of blob data elements,
+    /// commitments, and proofs. Each blob data element is verified against its commitment and
+    /// proof.
+    ///
+    /// Returns [BlobTransactionValidationError::InvalidProof] if any blob KZG proof in the response
+    /// fails to verify, or if the versioned hashes in the transaction do not match the actual
+    /// commitment versioned hashes.
+    #[cfg(feature = "kzg")]
+    pub fn validate(
+        &self,
+        blob_versioned_hashes: &[B256],
+        proof_settings: &c_kzg::KzgSettings,
+    ) -> Result<(), BlobTransactionValidationError> {
+        // Ensure the versioned hashes and commitments have the same length.
+        if blob_versioned_hashes.len() != self.commitments.len() {
+            return Err(c_kzg::Error::MismatchLength(format!(
+                "There are {} versioned commitment hashes and {} commitments",
+                blob_versioned_hashes.len(),
+                self.commitments.len()
+            ))
+            .into());
+        }
+
+        // calculate versioned hashes by zipping & iterating
+        for (versioned_hash, commitment) in
+            blob_versioned_hashes.iter().zip(self.commitments.iter())
+        {
+            let commitment = c_kzg::KzgCommitment::from(commitment.0);
+
+            // calculate & verify versioned hash
+            let calculated_versioned_hash = kzg_to_versioned_hash(commitment.as_slice());
+            if *versioned_hash != calculated_versioned_hash {
+                return Err(BlobTransactionValidationError::WrongVersionedHash {
+                    have: *versioned_hash,
+                    expected: calculated_versioned_hash,
+                });
+            }
+        }
+
+        // SAFETY: ALL types have the same size
+        let res = unsafe {
+            c_kzg::KzgProof::verify_blob_kzg_proof_batch(
+                // blobs
+                core::mem::transmute::<&[Blob], &[c_kzg::Blob]>(self.blobs.as_slice()),
+                // commitments
+                core::mem::transmute::<&[Bytes48], &[c_kzg::Bytes48]>(self.commitments.as_slice()),
+                // proofs
+                core::mem::transmute::<&[Bytes48], &[c_kzg::Bytes48]>(self.proofs.as_slice()),
+                proof_settings,
+            )
+        }
+        .map_err(BlobTransactionValidationError::KZGError)?;
+
+        if res {
+            Ok(())
+        } else {
+            Err(BlobTransactionValidationError::InvalidProof)
         }
     }
 
@@ -110,5 +176,68 @@ impl Decodable for BlobTransactionSidecar {
             commitments: Decodable::decode(buf)?,
             proofs: Decodable::decode(buf)?,
         })
+    }
+}
+
+/// An error that can occur when validating a [BlobTransactionSidecar::validate].
+#[derive(Debug)]
+#[cfg(feature = "kzg")]
+pub enum BlobTransactionValidationError {
+    /// Proof validation failed.
+    InvalidProof,
+    /// An error returned by [`c_kzg`].
+    KZGError(c_kzg::Error),
+    /// The inner transaction is not a blob transaction.
+    NotBlobTransaction(u8),
+    /// Using a standalone [TxEip4844] instead of the [TxEip4844WithSidecar] variant, which
+    /// includes the sidecar for validation.
+    MissingSidecar,
+    /// The versioned hash is incorrect.
+    WrongVersionedHash {
+        /// The versioned hash we got
+        have: B256,
+        /// The versioned hash we expected
+        expected: B256,
+    },
+}
+
+#[cfg(all(feature = "kzg", feature = "std"))]
+impl std::error::Error for BlobTransactionValidationError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            BlobTransactionValidationError::InvalidProof { .. } => None,
+            BlobTransactionValidationError::KZGError(source) => Some(source),
+            BlobTransactionValidationError::NotBlobTransaction { .. } => None,
+            BlobTransactionValidationError::MissingSidecar { .. } => None,
+            BlobTransactionValidationError::WrongVersionedHash { .. } => None,
+        }
+    }
+}
+
+#[cfg(feature = "kzg")]
+impl core::fmt::Display for BlobTransactionValidationError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            BlobTransactionValidationError::InvalidProof => f.write_str("invalid KZG proof"),
+            BlobTransactionValidationError::KZGError(err) => {
+                write!(f, "KZG error: {:?}", err)
+            }
+            BlobTransactionValidationError::NotBlobTransaction(err) => {
+                write!(f, "unable to verify proof for non blob transaction: {}", err)
+            }
+            BlobTransactionValidationError::MissingSidecar => {
+                f.write_str("eip4844 tx variant without sidecar being used for verification.")
+            }
+            BlobTransactionValidationError::WrongVersionedHash { have, expected } => {
+                write!(f, "wrong versioned hash: have {}, expected {}", have, expected)
+            }
+        }
+    }
+}
+
+#[cfg(feature = "kzg")]
+impl From<c_kzg::Error> for BlobTransactionValidationError {
+    fn from(source: c_kzg::Error) -> Self {
+        BlobTransactionValidationError::KZGError(source)
     }
 }


### PR DESCRIPTION
closes #675

this makes it easier to reuse blob validation, for example in reth.

the `MissingSidecar` error variant no longer fits, but it's also not worth rolling an additional error type for this case imo