### PR TITLE
move beacon API types from github.com/paradigmxyz/reth to a new crate in alloy

### DIFF
--- a/crates/rpc-types-beacon/Cargo.toml
+++ b/crates/rpc-types-beacon/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "rpc-types-beacon"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+exclude.workspace = true
+
+[dependencies]
+# ethereum
+alloy-rpc-types.workspace = true
+alloy-rpc-types-trace.workspace = true
+alloy-rpc-types-anvil.workspace = true
+alloy-rpc-types-engine.workspace = true
+alloy-primitives = "0.7.2"
+serde = "1.0.200"
+serde_with = "3.8.1"
+serde_json = "1.0.116"

--- a/crates/rpc-types-beacon/src/beacon/constants.rs
+++ b/crates/rpc-types-beacon/src/beacon/constants.rs
@@ -1,0 +1,17 @@
+/// The Domain Separation Tag for hash_to_point in Ethereum beacon chain BLS12-381 signatures.
+///
+/// This is also the name of the ciphersuite that defines beacon chain BLS signatures.
+///
+/// See:
+/// <https://github.com/ethereum/consensus-specs/blob/ffa95b7b72149960c5aded5c95fb40d64bcab199/specs/phase0/beacon-chain.md#bls-signatures>
+/// <https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-04>
+pub const BLS_DST_SIG: &[u8] = b"BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_";
+
+/// The number of bytes in a BLS12-381 public key.
+pub const BLS_PUBLIC_KEY_BYTES_LEN: usize = 48;
+
+/// The number of bytes in a BLS12-381 secret key.
+pub const BLS_SECRET_KEY_BYTES_LEN: usize = 32;
+
+/// The number of bytes in a BLS12-381 signature.
+pub const BLS_SIGNATURE_BYTES_LEN: usize = 96;

--- a/crates/rpc-types-beacon/src/beacon/events/attestation.rs
+++ b/crates/rpc-types-beacon/src/beacon/events/attestation.rs
@@ -1,0 +1,30 @@
+use alloy_primitives::B256;
+use serde::{Deserialize, Serialize};
+use serde_with::{serde_as, DisplayFromStr};
+
+#[serde_as]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AttestationData {
+    #[serde_as(as = "DisplayFromStr")]
+    pub slot: u64,
+    #[serde_as(as = "DisplayFromStr")]
+    pub index: u64,
+    pub beacon_block_root: B256,
+    pub source: Source,
+    pub target: Target,
+}
+
+#[serde_as]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Source {
+    #[serde_as(as = "DisplayFromStr")]
+    pub epoch: u64,
+    pub root: B256,
+}
+#[serde_as]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Target {
+    #[serde_as(as = "DisplayFromStr")]
+    pub epoch: u64,
+    pub root: B256,
+}

--- a/crates/rpc-types-beacon/src/beacon/events/light_client_finality.rs
+++ b/crates/rpc-types-beacon/src/beacon/events/light_client_finality.rs
@@ -1,0 +1,54 @@
+use alloy_primitives::{Bytes, B256};
+use serde::{Deserialize, Serialize};
+use serde_with::{serde_as, DisplayFromStr};
+
+#[serde_as]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LightClientFinalityData {
+    pub attested_header: AttestedHeader,
+    pub finalized_header: FinalizedHeader,
+    pub finality_branch: Vec<String>,
+    pub sync_aggregate: SyncAggregate,
+    #[serde_as(as = "DisplayFromStr")]
+    pub signature_slot: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AttestedHeader {
+    pub beacon: Beacon,
+}
+
+#[serde_as]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Beacon {
+    #[serde_as(as = "DisplayFromStr")]
+    pub slot: u64,
+    #[serde_as(as = "DisplayFromStr")]
+    pub proposer_index: u64,
+    pub parent_root: B256,
+    pub state_root: B256,
+    pub body_root: B256,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FinalizedHeader {
+    pub beacon: Beacon2,
+}
+
+#[serde_as]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Beacon2 {
+    #[serde_as(as = "DisplayFromStr")]
+    pub slot: u64,
+    #[serde_as(as = "DisplayFromStr")]
+    pub proposer_index: u64,
+    pub parent_root: B256,
+    pub state_root: B256,
+    pub body_root: B256,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SyncAggregate {
+    pub sync_committee_bits: Bytes,
+    pub sync_committee_signature: Bytes,
+}

--- a/crates/rpc-types-beacon/src/beacon/events/light_client_optimistic.rs
+++ b/crates/rpc-types-beacon/src/beacon/events/light_client_optimistic.rs
@@ -1,0 +1,24 @@
+use crate::beacon::header::BeaconBlockHeader;
+use alloy_primitives::Bytes;
+use serde::{Deserialize, Serialize};
+use serde_with::{serde_as, DisplayFromStr};
+
+#[serde_as]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LightClientOptimisticData {
+    pub attested_header: AttestedHeader,
+    pub sync_aggregate: SyncAggregate,
+    #[serde_as(as = "DisplayFromStr")]
+    pub signature_slot: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AttestedHeader {
+    pub beacon: BeaconBlockHeader,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SyncAggregate {
+    pub sync_committee_bits: Bytes,
+    pub sync_committee_signature: Bytes,
+}

--- a/crates/rpc-types-beacon/src/beacon/events/mod.rs
+++ b/crates/rpc-types-beacon/src/beacon/events/mod.rs
@@ -1,0 +1,403 @@
+//! Support for the Beacon API events
+//!
+//! See also [ethereum-beacon-API eventstream](https://ethereum.github.io/beacon-APIs/#/Events/eventstream)
+
+use alloy_primitives::{Address, Bytes, B256};
+use alloy_rpc_types_engine::PayloadAttributes;
+use attestation::AttestationData;
+use light_client_finality::LightClientFinalityData;
+use light_client_optimistic::LightClientOptimisticData;
+use serde::{Deserialize, Serialize};
+use serde_with::{serde_as, DisplayFromStr};
+
+pub mod attestation;
+pub mod light_client_finality;
+pub mod light_client_optimistic;
+
+/// Topic variant for the eventstream API
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BeaconNodeEventTopic {
+    PayloadAttributes,
+    Head,
+    Block,
+    Attestation,
+    VoluntaryExit,
+    BlsToExecutionChange,
+    FinalizedCheckpoint,
+    ChainReorg,
+    ContributionAndProof,
+    LightClientFinalityUpdate,
+    LightClientOptimisticUpdate,
+    BlobSidecar,
+}
+
+impl BeaconNodeEventTopic {
+    /// Returns the identifier value for the eventstream query
+    pub fn query_value(&self) -> &'static str {
+        match self {
+            BeaconNodeEventTopic::PayloadAttributes => "payload_attributes",
+            BeaconNodeEventTopic::Head => "head",
+            BeaconNodeEventTopic::Block => "block",
+            BeaconNodeEventTopic::Attestation => "attestation",
+            BeaconNodeEventTopic::VoluntaryExit => "voluntary_exit",
+            BeaconNodeEventTopic::BlsToExecutionChange => "bls_to_execution_change",
+            BeaconNodeEventTopic::FinalizedCheckpoint => "finalized_checkpoint",
+            BeaconNodeEventTopic::ChainReorg => "chain_reorg",
+            BeaconNodeEventTopic::ContributionAndProof => "contribution_and_proof",
+            BeaconNodeEventTopic::LightClientFinalityUpdate => "light_client_finality_update",
+            BeaconNodeEventTopic::LightClientOptimisticUpdate => "light_client_optimistic_update",
+            BeaconNodeEventTopic::BlobSidecar => "blob_sidecar",
+        }
+    }
+}
+
+/// Event for the `payload_attributes` topic of the beacon API node event stream.
+///
+/// This event gives block builders and relays sufficient information to construct or verify a block
+/// at `proposal_slot`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PayloadAttributesEvent {
+    /// the identifier of the beacon hard fork at `proposal_slot`, e.g `"bellatrix"`, `"capella"`.
+    pub version: String,
+    /// Wrapped data of the event.
+    pub data: PayloadAttributesData,
+}
+
+/// Event for the `Head` topic of the beacon API node event stream.
+///
+/// The node has finished processing, resulting in a new head. previous_duty_dependent_root is
+/// \`get_block_root_at_slot(state, compute_start_slot_at_epoch(epoch - 1) - 1)\` and
+/// current_duty_dependent_root is \`get_block_root_at_slot(state,
+/// compute_start_slot_at_epoch(epoch)
+/// - 1)\`. Both dependent roots use the genesis block root in the case of underflow.
+#[serde_as]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HeadEvent {
+    #[serde_as(as = "DisplayFromStr")]
+    pub slot: u64,
+    pub block: B256,
+    pub state: B256,
+    pub epoch_transition: bool,
+    pub previous_duty_dependent_root: B256,
+    pub current_duty_dependent_root: B256,
+    pub execution_optimistic: bool,
+}
+
+/// Event for the `Block` topic of the beacon API node event stream.
+///
+/// The node has received a valid block (from P2P or API)
+#[serde_as]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BlockEvent {
+    #[serde_as(as = "DisplayFromStr")]
+    pub slot: u64,
+    pub block: B256,
+    pub execution_optimistic: bool,
+}
+
+/// Event for the `Attestation` topic of the beacon API node event stream.
+///
+/// The node has received a valid attestation (from P2P or API)
+#[serde_as]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AttestationEvent {
+    pub aggregation_bits: Bytes,
+    pub signature: Bytes,
+    pub data: AttestationData,
+}
+
+/// Event for the `VoluntaryExit` topic of the beacon API node event stream.
+///
+/// The node has received a valid voluntary exit (from P2P or API)
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VoluntaryExitEvent {
+    pub message: VoluntaryExitMessage,
+    pub signature: Bytes,
+}
+
+#[serde_as]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VoluntaryExitMessage {
+    #[serde_as(as = "DisplayFromStr")]
+    pub epoch: u64,
+    #[serde_as(as = "DisplayFromStr")]
+    pub validator_index: u64,
+}
+
+/// Event for the `BlsToExecutionChange` topic of the beacon API node event stream.
+///
+/// The node has received a BLS to execution change (from P2P or API)
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BlsToExecutionChangeEvent {
+    pub message: BlsToExecutionChangeMessage,
+    pub signature: Bytes,
+}
+
+#[serde_as]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BlsToExecutionChangeMessage {
+    #[serde_as(as = "DisplayFromStr")]
+    pub validator_index: u64,
+    pub from_bls_pubkey: String,
+    pub to_execution_address: Address,
+}
+
+/// Event for the `Deposit` topic of the beacon API node event stream.
+///
+/// Finalized checkpoint has been updated
+#[serde_as]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FinalizedCheckpointEvent {
+    pub block: B256,
+    pub state: B256,
+    #[serde_as(as = "DisplayFromStr")]
+    pub epoch: u64,
+    pub execution_optimistic: bool,
+}
+
+/// Event for the `ChainReorg` topic of the beacon API node event stream.
+///
+/// The node has reorganized its chain
+#[serde_as]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChainReorgEvent {
+    #[serde_as(as = "DisplayFromStr")]
+    pub slot: u64,
+    #[serde_as(as = "DisplayFromStr")]
+    pub depth: u64,
+    pub old_head_block: B256,
+    pub new_head_block: B256,
+    pub old_head_state: B256,
+    pub new_head_state: B256,
+    #[serde_as(as = "DisplayFromStr")]
+    pub epoch: u64,
+    pub execution_optimistic: bool,
+}
+
+/// Event for the `ContributionAndProof` topic of the beacon API node event stream.
+///
+/// The node has received a valid sync committee SignedContributionAndProof (from P2P or API)
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ContributionAndProofEvent {
+    pub message: ContributionAndProofMessage,
+    pub signature: Bytes,
+}
+
+#[serde_as]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ContributionAndProofMessage {
+    #[serde_as(as = "DisplayFromStr")]
+    pub aggregator_index: u64,
+    pub contribution: Contribution,
+    pub selection_proof: Bytes,
+}
+
+#[serde_as]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Contribution {
+    #[serde_as(as = "DisplayFromStr")]
+    pub slot: u64,
+    pub beacon_block_root: B256,
+    #[serde_as(as = "DisplayFromStr")]
+    pub subcommittee_index: u64,
+    pub aggregation_bits: Bytes,
+    pub signature: Bytes,
+}
+
+/// Event for the `LightClientFinalityUpdate` topic of the beacon API node event stream.
+///
+/// The node's latest known `LightClientFinalityUpdate` has been updated
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LightClientFinalityUpdateEvent {
+    pub version: String,
+    pub data: LightClientFinalityData,
+}
+
+/// Event for the `LightClientOptimisticUpdate` topic of the beacon API node event stream.
+///
+/// The node's latest known `LightClientOptimisticUpdate` has been updated
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LightClientOptimisticUpdateEvent {
+    pub version: String,
+    pub data: LightClientOptimisticData,
+}
+
+/// Event for the `BlobSidecar` topic of the beacon API node event stream.
+///
+/// The node has received a BlobSidecar (from P2P or API) that passes all gossip validations on the
+/// blob_sidecar_{subnet_id} topic
+#[serde_as]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BlobSidecarEvent {
+    pub block_root: B256,
+    #[serde_as(as = "DisplayFromStr")]
+    pub index: u64,
+    #[serde_as(as = "DisplayFromStr")]
+    pub slot: u64,
+    pub kzg_commitment: Bytes,
+    pub versioned_hash: B256,
+}
+
+impl PayloadAttributesEvent {
+    /// Returns the payload attributes
+    pub fn attributes(&self) -> &PayloadAttributes {
+        &self.data.payload_attributes
+    }
+}
+
+/// Data of the event that contains the payload attributes
+#[serde_as]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PayloadAttributesData {
+    /// The slot at which a block using these payload attributes may be built
+    #[serde_as(as = "DisplayFromStr")]
+    pub proposal_slot: u64,
+    /// the beacon block root of the parent block to be built upon.
+    pub parent_block_root: B256,
+    /// the execution block number of the parent block.
+    #[serde_as(as = "DisplayFromStr")]
+    pub parent_block_number: u64,
+    /// the execution block hash of the parent block.
+    pub parent_block_hash: B256,
+    /// The execution block number of the parent block.
+    /// the validator index of the proposer at `proposal_slot` on the chain identified by
+    /// `parent_block_root`.
+    #[serde_as(as = "DisplayFromStr")]
+    pub proposer_index: u64,
+    /// Beacon API encoding of `PayloadAttributesV<N>` as defined by the `execution-apis`
+    /// specification
+    ///
+    /// Note: this uses the beacon API format which uses snake-case and quoted decimals rather than
+    /// big-endian hex.
+    #[serde(with = "crate::beacon::payload::beacon_api_payload_attributes")]
+    pub payload_attributes: PayloadAttributes,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serde_payload_attributes_event() {
+        let s = r#"{"version":"capella","data":{"proposal_slot":"173332","proposer_index":"649112","parent_block_root":"0x5a49069647f6bf8f25d76b55ce920947654ade4ba1c6ab826d16712dd62b42bf","parent_block_number":"161093","parent_block_hash":"0x608b3d140ecb5bbcd0019711ac3704ece7be8e6d100816a55db440c1bcbb0251","payload_attributes":{"timestamp":"1697982384","prev_randao":"0x3142abd98055871ebf78f0f8e758fd3a04df3b6e34d12d09114f37a737f8f01e","suggested_fee_recipient":"0x0000000000000000000000000000000000000001","withdrawals":[{"index":"2461612","validator_index":"853570","address":"0x778f5f13c4be78a3a4d7141bcb26999702f407cf","amount":"45016211"},{"index":"2461613","validator_index":"853571","address":"0x778f5f13c4be78a3a4d7141bcb26999702f407cf","amount":"5269785"},{"index":"2461614","validator_index":"853572","address":"0x778f5f13c4be78a3a4d7141bcb26999702f407cf","amount":"5275106"},{"index":"2461615","validator_index":"853573","address":"0x778f5f13c4be78a3a4d7141bcb26999702f407cf","amount":"5235962"},{"index":"2461616","validator_index":"853574","address":"0x778f5f13c4be78a3a4d7141bcb26999702f407cf","amount":"5252171"},{"index":"2461617","validator_index":"853575","address":"0x778f5f13c4be78a3a4d7141bcb26999702f407cf","amount":"5221319"},{"index":"2461618","validator_index":"853576","address":"0x778f5f13c4be78a3a4d7141bcb26999702f407cf","amount":"5260879"},{"index":"2461619","validator_index":"853577","address":"0x778f5f13c4be78a3a4d7141bcb26999702f407cf","amount":"5285244"},{"index":"2461620","validator_index":"853578","address":"0x778f5f13c4be78a3a4d7141bcb26999702f407cf","amount":"5266681"},{"index":"2461621","validator_index":"853579","address":"0x778f5f13c4be78a3a4d7141bcb26999702f407cf","amount":"5271322"},{"index":"2461622","validator_index":"853580","address":"0x778f5f13c4be78a3a4d7141bcb26999702f407cf","amount":"5231327"},{"index":"2461623","validator_index":"853581","address":"0x778f5f13c4be78a3a4d7141bcb26999702f407cf","amount":"5276761"},{"index":"2461624","validator_index":"853582","address":"0x778f5f13c4be78a3a4d7141bcb26999702f407cf","amount":"5246244"},{"index":"2461625","validator_index":"853583","address":"0x778f5f13c4be78a3a4d7141bcb26999702f407cf","amount":"5261011"},{"index":"2461626","validator_index":"853584","address":"0x778f5f13c4be78a3a4d7141bcb26999702f407cf","amount":"5276477"},{"index":"2461627","validator_index":"853585","address":"0x778f5f13c4be78a3a4d7141bcb26999702f407cf","amount":"5275319"}]}}}"#;
+
+        let event: PayloadAttributesEvent =
+            serde_json::from_str::<PayloadAttributesEvent>(s).unwrap();
+        let input = serde_json::from_str::<serde_json::Value>(s).unwrap();
+        let json = serde_json::to_value(event).unwrap();
+        assert_eq!(input, json);
+    }
+    #[test]
+    fn serde_head_event() {
+        let s = r#"{"slot":"10", "block":"0x9a2fefd2fdb57f74993c7780ea5b9030d2897b615b89f808011ca5aebed54eaf", "state":"0x600e852a08c1200654ddf11025f1ceacb3c2e74bdd5c630cde0838b2591b69f9", "epoch_transition":false, "previous_duty_dependent_root":"0x5e0043f107cb57913498fbf2f99ff55e730bf1e151f02f221e977c91a90a0e91", "current_duty_dependent_root":"0x5e0043f107cb57913498fbf2f99ff55e730bf1e151f02f221e977c91a90a0e91", "execution_optimistic": false}"#;
+
+        let event: HeadEvent = serde_json::from_str::<HeadEvent>(s).unwrap();
+        let input = serde_json::from_str::<serde_json::Value>(s).unwrap();
+        let json = serde_json::to_value(event).unwrap();
+        assert_eq!(input, json);
+    }
+
+    #[test]
+    fn serde_block_event() {
+        let s = r#"{"slot":"10", "block":"0x9a2fefd2fdb57f74993c7780ea5b9030d2897b615b89f808011ca5aebed54eaf", "execution_optimistic": false}"#;
+
+        let event: BlockEvent = serde_json::from_str::<BlockEvent>(s).unwrap();
+        let input = serde_json::from_str::<serde_json::Value>(s).unwrap();
+        let json = serde_json::to_value(event).unwrap();
+        assert_eq!(input, json);
+    }
+    #[test]
+    fn serde_attestation_event() {
+        let s = r#"{"aggregation_bits":"0x01", "signature":"0x1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505cc411d61252fb6cb3fa0017b679f8bb2305b26a285fa2737f175668d0dff91cc1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505", "data":{"slot":"1", "index":"1", "beacon_block_root":"0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2", "source":{"epoch":"1", "root":"0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2"}, "target":{"epoch":"1", "root":"0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2"}}}"#;
+
+        let event: AttestationEvent = serde_json::from_str::<AttestationEvent>(s).unwrap();
+        let input = serde_json::from_str::<serde_json::Value>(s).unwrap();
+        let json = serde_json::to_value(event).unwrap();
+        assert_eq!(input, json);
+    }
+
+    #[test]
+    fn serde_voluntary_exit_event() {
+        let s = r#"{"message":{"epoch":"1", "validator_index":"1"}, "signature":"0x1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505cc411d61252fb6cb3fa0017b679f8bb2305b26a285fa2737f175668d0dff91cc1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505"}"#;
+
+        let event: VoluntaryExitEvent = serde_json::from_str::<VoluntaryExitEvent>(s).unwrap();
+        let input = serde_json::from_str::<serde_json::Value>(s).unwrap();
+        let json = serde_json::to_value(event).unwrap();
+        assert_eq!(input, json);
+    }
+
+    #[test]
+    fn serde_bls_to_execution_change_event() {
+        let s = r#"{"message":{"validator_index":"1", "from_bls_pubkey":"0x933ad9491b62059dd065b560d256d8957a8c402cc6e8d8ee7290ae11e8f7329267a8811c397529dac52ae1342ba58c95", "to_execution_address":"0x9be8d619c56699667c1fedcd15f6b14d8b067f72"}, "signature":"0x1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505cc411d61252fb6cb3fa0017b679f8bb2305b26a285fa2737f175668d0dff91cc1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505"}"#;
+
+        let event: BlsToExecutionChangeEvent =
+            serde_json::from_str::<BlsToExecutionChangeEvent>(s).unwrap();
+        let input = serde_json::from_str::<serde_json::Value>(s).unwrap();
+        let json = serde_json::to_value(event).unwrap();
+        assert_eq!(input, json);
+    }
+
+    #[test]
+    fn serde_finalize_checkpoint_event() {
+        let s = r#"{"block":"0x9a2fefd2fdb57f74993c7780ea5b9030d2897b615b89f808011ca5aebed54eaf", "state":"0x600e852a08c1200654ddf11025f1ceacb3c2e74bdd5c630cde0838b2591b69f9", "epoch":"2", "execution_optimistic": false }"#;
+
+        let event: FinalizedCheckpointEvent =
+            serde_json::from_str::<FinalizedCheckpointEvent>(s).unwrap();
+        let input = serde_json::from_str::<serde_json::Value>(s).unwrap();
+        let json = serde_json::to_value(event).unwrap();
+        assert_eq!(input, json);
+    }
+
+    #[test]
+    fn serde_chain_reorg_event() {
+        let s = r#"{"slot":"200", "depth":"50", "old_head_block":"0x9a2fefd2fdb57f74993c7780ea5b9030d2897b615b89f808011ca5aebed54eaf", "new_head_block":"0x76262e91970d375a19bfe8a867288d7b9cde43c8635f598d93d39d041706fc76", "old_head_state":"0x9a2fefd2fdb57f74993c7780ea5b9030d2897b615b89f808011ca5aebed54eaf", "new_head_state":"0x600e852a08c1200654ddf11025f1ceacb3c2e74bdd5c630cde0838b2591b69f9", "epoch":"2", "execution_optimistic": false}"#;
+
+        let event: ChainReorgEvent = serde_json::from_str::<ChainReorgEvent>(s).unwrap();
+        let input = serde_json::from_str::<serde_json::Value>(s).unwrap();
+        let json = serde_json::to_value(event).unwrap();
+        assert_eq!(input, json);
+    }
+
+    #[test]
+    fn serde_contribution_and_proof_event() {
+        let s = r#"{"message": {"aggregator_index": "997", "contribution": {"slot": "168097", "beacon_block_root": "0x56f1fd4262c08fa81e27621c370e187e621a67fc80fe42340b07519f84b42ea1", "subcommittee_index": "0", "aggregation_bits": "0xffffffffffffffffffffffffffffffff", "signature": "0x85ab9018e14963026476fdf784cc674da144b3dbdb47516185438768774f077d882087b90ad642469902e782a8b43eed0cfc1b862aa9a473b54c98d860424a702297b4b648f3f30bdaae8a8b7627d10d04cb96a2cc8376af3e54a9aa0c8145e3"}, "selection_proof": "0x87c305f04bfe5db27c2b19fc23e00d7ac496ec7d3e759cbfdd1035cb8cf6caaa17a36a95a08ba78c282725e7b66a76820ca4eb333822bd399ceeb9807a0f2926c67ce67cfe06a0b0006838203b493505a8457eb79913ce1a3bcd1cc8e4ef30ed"}, "signature": "0xac118511474a94f857300b315c50585c32a713e4452e26a6bb98cdb619936370f126ed3b6bb64469259ee92e69791d9e12d324ce6fd90081680ce72f39d85d50b0ff977260a8667465e613362c6d6e6e745e1f9323ec1d6f16041c4e358839ac"}"#;
+
+        let event: ContributionAndProofEvent =
+            serde_json::from_str::<ContributionAndProofEvent>(s).unwrap();
+        let input = serde_json::from_str::<serde_json::Value>(s).unwrap();
+        let json = serde_json::to_value(event).unwrap();
+        assert_eq!(input, json);
+    }
+
+    #[test]
+    fn serde_light_client_finality_update_event() {
+        let s = r#"{"version":"phase0", "data": {"attested_header": {"beacon": {"slot":"1", "proposer_index":"1", "parent_root":"0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2", "state_root":"0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2", "body_root":"0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2"}}, "finalized_header": {"beacon": {"slot":"1", "proposer_index":"1", "parent_root":"0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2", "state_root":"0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2", "body_root":"0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2"}}, "finality_branch": ["0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2", "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2", "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2", "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2", "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2", "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2"], "sync_aggregate": {"sync_committee_bits":"0x01", "sync_committee_signature":"0x1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505cc411d61252fb6cb3fa0017b679f8bb2305b26a285fa2737f175668d0dff91cc1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505"}, "signature_slot":"1"}}"#;
+
+        let event: LightClientFinalityUpdateEvent =
+            serde_json::from_str::<LightClientFinalityUpdateEvent>(s).unwrap();
+        let input = serde_json::from_str::<serde_json::Value>(s).unwrap();
+        let json = serde_json::to_value(event).unwrap();
+        assert_eq!(input, json);
+    }
+    #[test]
+    fn serde_light_client_optimistic_update_event() {
+        let s = r#"{"version":"phase0", "data": {"attested_header": {"beacon": {"slot":"1", "proposer_index":"1", "parent_root":"0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2", "state_root":"0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2", "body_root":"0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2"}}, "sync_aggregate": {"sync_committee_bits":"0x01", "sync_committee_signature":"0x1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505cc411d61252fb6cb3fa0017b679f8bb2305b26a285fa2737f175668d0dff91cc1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505"}, "signature_slot":"1"}}"#;
+
+        let event: LightClientOptimisticUpdateEvent =
+            serde_json::from_str::<LightClientOptimisticUpdateEvent>(s).unwrap();
+        let input = serde_json::from_str::<serde_json::Value>(s).unwrap();
+        let json = serde_json::to_value(event).unwrap();
+        assert_eq!(input, json);
+    }
+
+    #[test]
+    fn serde_blob_sidecar_event() {
+        let s = r#"{"block_root": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2", "index": "1", "slot": "1", "kzg_commitment": "0x1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505cc411d61252fb6cb3fa0017b679f8bb2305b26a285fa2737f175668d0dff91cc1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505", "versioned_hash": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2"}"#;
+
+        let event: BlobSidecarEvent = serde_json::from_str::<BlobSidecarEvent>(s).unwrap();
+        let input = serde_json::from_str::<serde_json::Value>(s).unwrap();
+        let json = serde_json::to_value(event).unwrap();
+        assert_eq!(input, json);
+    }
+}

--- a/crates/rpc-types-beacon/src/beacon/header.rs
+++ b/crates/rpc-types-beacon/src/beacon/header.rs
@@ -1,0 +1,125 @@
+//! Beacon block header types.
+//!
+//! See also <https://ethereum.github.io/beacon-APIs/#/Beacon/getBlockHeaders>
+
+use alloy_primitives::{Bytes, B256};
+use serde::{Deserialize, Serialize};
+use serde_with::{serde_as, DisplayFromStr};
+
+/// The response to a request for beacon block headers: `getBlockHeaders`
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HeadersResponse {
+    /// True if the response references an unverified execution payload. Optimistic information may
+    /// be invalidated at a later time. If the field is not present, assume the False value.
+    pub execution_optimistic: bool,
+    /// True if the response references the finalized history of the chain, as determined by fork
+    /// choice. If the field is not present, additional calls are necessary to compare the epoch of
+    /// the requested information with the finalized checkpoint.
+    pub finalized: bool,
+    /// Container for the header data.
+    pub data: Vec<HeaderData>,
+}
+
+/// The response to a request for a __single__ beacon block header: `headers/{id}`
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HeaderResponse {
+    /// True if the response references an unverified execution payload. Optimistic information may
+    /// be invalidated at a later time. If the field is not present, assume the False value.
+    pub execution_optimistic: bool,
+    /// True if the response references the finalized history of the chain, as determined by fork
+    /// choice. If the field is not present, additional calls are necessary to compare the epoch of
+    /// the requested information with the finalized checkpoint.
+    pub finalized: bool,
+    /// Container for the header data.
+    pub data: HeaderData,
+}
+
+/// Container type for a beacon block header.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HeaderData {
+    /// root hash of the block
+    pub root: B256,
+    /// Whether the block is part of the canonical chain
+    pub canonical: bool,
+    /// The `SignedBeaconBlockHeader` object envelope from the CL spec.
+    pub header: Header,
+}
+
+/// [BeaconBlockHeader] with a signature.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Header {
+    /// The `BeaconBlockHeader` object from the CL spec.
+    pub message: BeaconBlockHeader,
+    pub signature: Bytes,
+}
+
+/// The header of a beacon block.
+#[serde_as]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BeaconBlockHeader {
+    /// The slot to which this block corresponds.
+    #[serde_as(as = "DisplayFromStr")]
+    pub slot: u64,
+    /// Index of validator in validator registry.
+    #[serde_as(as = "DisplayFromStr")]
+    pub proposer_index: u64,
+    /// The signing merkle root of the parent BeaconBlock.
+    pub parent_root: B256,
+    /// The tree hash merkle root of the BeaconState for the BeaconBlock.
+    pub state_root: B256,
+    /// The tree hash merkle root of the BeaconBlockBody for the BeaconBlock
+    pub body_root: B256,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serde_headers_response() {
+        let s = r#"{
+  "execution_optimistic": false,
+  "finalized": false,
+  "data": [
+    {
+      "root": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+      "canonical": true,
+      "header": {
+        "message": {
+          "slot": "1",
+          "proposer_index": "1",
+          "parent_root": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+          "state_root": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+          "body_root": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2"
+        },
+        "signature": "0x1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505cc411d61252fb6cb3fa0017b679f8bb2305b26a285fa2737f175668d0dff91cc1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505"
+      }
+    }
+  ]
+}"#;
+        let _header_response: HeadersResponse = serde_json::from_str(s).unwrap();
+    }
+
+    #[test]
+    fn serde_header_response() {
+        let s = r#"{
+  "execution_optimistic": false,
+  "finalized": false,
+  "data": {
+    "root": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+    "canonical": true,
+    "header": {
+      "message": {
+        "slot": "1",
+        "proposer_index": "1",
+        "parent_root": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+        "state_root": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+        "body_root": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2"
+      },
+      "signature": "0x1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505cc411d61252fb6cb3fa0017b679f8bb2305b26a285fa2737f175668d0dff91cc1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505"
+    }
+  }
+}"#;
+        let _header_response: HeaderResponse = serde_json::from_str(s).unwrap();
+    }
+}

--- a/crates/rpc-types-beacon/src/beacon/mod.rs
+++ b/crates/rpc-types-beacon/src/beacon/mod.rs
@@ -1,0 +1,19 @@
+//! Types for the Ethereum 2.0 RPC protocol (beacon chain).
+
+#![allow(missing_docs)]
+
+use alloy_primitives::FixedBytes;
+use constants::{BLS_PUBLIC_KEY_BYTES_LEN, BLS_SIGNATURE_BYTES_LEN};
+
+pub mod constants;
+/// Beacon API events support.
+pub mod events;
+pub mod header;
+pub mod payload;
+pub mod withdrawals;
+
+/// BLS signature type
+pub type BlsSignature = FixedBytes<BLS_SIGNATURE_BYTES_LEN>;
+
+/// BLS public key type
+pub type BlsPublicKey = FixedBytes<BLS_PUBLIC_KEY_BYTES_LEN>;

--- a/crates/rpc-types-beacon/src/beacon/payload.rs
+++ b/crates/rpc-types-beacon/src/beacon/payload.rs
@@ -1,0 +1,567 @@
+//! Payload support for the beacon API.
+//!
+//! Internal helper module to deserialize/serialize the payload attributes for the beacon API, which
+//! uses snake case and quoted decimals.
+//!
+//! This is necessary because we don't want to allow a mixture of both formats, hence `serde`
+//! aliases are not an option.
+//!
+//! See also <https://github.com/ethereum/consensus-specs/blob/master/specs/deneb/beacon-chain.md#executionpayload>
+
+#![allow(missing_docs)]
+
+use crate::{
+    beacon::{withdrawals::BeaconWithdrawal, BlsPublicKey},
+    Withdrawal,
+};
+use alloy_primitives::{Address, Bloom, Bytes, B256, U256};
+use alloy_rpc_types_engine::{
+    ExecutionPayload, ExecutionPayloadV1, ExecutionPayloadV2, ExecutionPayloadV3,
+};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde_with::{serde_as, DeserializeAs, DisplayFromStr, SerializeAs};
+use std::borrow::Cow;
+
+/// Response object of GET `/eth/v1/builder/header/{slot}/{parent_hash}/{pubkey}`
+///
+/// See also <https://ethereum.github.io/builder-specs/#/Builder/getHeader>
+#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GetExecutionPayloadHeaderResponse {
+    pub version: String,
+    pub data: ExecutionPayloadHeaderData,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExecutionPayloadHeaderData {
+    pub message: ExecutionPayloadHeaderMessage,
+    pub signature: Bytes,
+}
+
+#[serde_as]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExecutionPayloadHeaderMessage {
+    pub header: ExecutionPayloadHeader,
+    #[serde_as(as = "DisplayFromStr")]
+    pub value: U256,
+    pub pubkey: BlsPublicKey,
+}
+
+/// The header of the execution payload.
+#[serde_as]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExecutionPayloadHeader {
+    pub parent_hash: B256,
+    pub fee_recipient: Address,
+    pub state_root: B256,
+    pub receipts_root: B256,
+    pub logs_bloom: Bloom,
+    pub prev_randao: B256,
+    #[serde_as(as = "DisplayFromStr")]
+    pub block_number: String,
+    #[serde_as(as = "DisplayFromStr")]
+    pub gas_limit: u64,
+    #[serde_as(as = "DisplayFromStr")]
+    pub gas_used: u64,
+    #[serde_as(as = "DisplayFromStr")]
+    pub timestamp: u64,
+    pub extra_data: Bytes,
+    #[serde_as(as = "DisplayFromStr")]
+    pub base_fee_per_gas: U256,
+    pub block_hash: B256,
+    pub transactions_root: B256,
+}
+
+#[serde_as]
+#[derive(Serialize, Deserialize)]
+struct BeaconPayloadAttributes {
+    #[serde_as(as = "DisplayFromStr")]
+    timestamp: u64,
+    prev_randao: B256,
+    suggested_fee_recipient: Address,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde_as(as = "Option<Vec<BeaconWithdrawal>>")]
+    withdrawals: Option<Vec<Withdrawal>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    parent_beacon_block_root: Option<B256>,
+}
+
+/// Optimism Payload Attributes
+#[serde_as]
+#[derive(Serialize, Deserialize)]
+struct BeaconOptimismPayloadAttributes {
+    #[serde(flatten)]
+    payload_attributes: BeaconPayloadAttributes,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    transactions: Option<Vec<Bytes>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    no_tx_pool: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    gas_limit: Option<u64>,
+}
+
+/// A helper module for serializing and deserializing optimism payload attributes for the beacon
+/// API.
+///
+/// See docs for [beacon_api_payload_attributes].
+pub mod beacon_api_payload_attributes_optimism {
+    use super::*;
+    use alloy_rpc_types_engine::{OptimismPayloadAttributes, PayloadAttributes};
+
+    /// Serialize the payload attributes for the beacon API.
+    pub fn serialize<S>(
+        payload_attributes: &OptimismPayloadAttributes,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let beacon_api_payload_attributes = BeaconPayloadAttributes {
+            timestamp: payload_attributes.payload_attributes.timestamp,
+            prev_randao: payload_attributes.payload_attributes.prev_randao,
+            suggested_fee_recipient: payload_attributes.payload_attributes.suggested_fee_recipient,
+            withdrawals: payload_attributes.payload_attributes.withdrawals.clone(),
+            parent_beacon_block_root: payload_attributes
+                .payload_attributes
+                .parent_beacon_block_root,
+        };
+
+        let op_beacon_api_payload_attributes = BeaconOptimismPayloadAttributes {
+            payload_attributes: beacon_api_payload_attributes,
+            transactions: payload_attributes.transactions.clone(),
+            no_tx_pool: payload_attributes.no_tx_pool,
+            gas_limit: payload_attributes.gas_limit,
+        };
+
+        op_beacon_api_payload_attributes.serialize(serializer)
+    }
+
+    /// Deserialize the payload attributes for the beacon API.
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<OptimismPayloadAttributes, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let beacon_api_payload_attributes =
+            BeaconOptimismPayloadAttributes::deserialize(deserializer)?;
+        Ok(OptimismPayloadAttributes {
+            payload_attributes: PayloadAttributes {
+                timestamp: beacon_api_payload_attributes.payload_attributes.timestamp,
+                prev_randao: beacon_api_payload_attributes.payload_attributes.prev_randao,
+                suggested_fee_recipient: beacon_api_payload_attributes
+                    .payload_attributes
+                    .suggested_fee_recipient,
+                withdrawals: beacon_api_payload_attributes.payload_attributes.withdrawals,
+                parent_beacon_block_root: beacon_api_payload_attributes
+                    .payload_attributes
+                    .parent_beacon_block_root,
+            },
+            transactions: beacon_api_payload_attributes.transactions,
+            no_tx_pool: beacon_api_payload_attributes.no_tx_pool,
+            gas_limit: beacon_api_payload_attributes.gas_limit,
+        })
+    }
+}
+
+/// A helper module for serializing and deserializing the payload attributes for the beacon API.
+///
+/// The beacon API encoded object has equivalent fields to the
+/// [PayloadAttributes](crate::engine::PayloadAttributes) with two differences:
+/// 1) `snake_case` identifiers must be used rather than `camelCase`;
+/// 2) integers must be encoded as quoted decimals rather than big-endian hex.
+pub mod beacon_api_payload_attributes {
+    use super::*;
+    use alloy_rpc_types_engine::PayloadAttributes;
+
+    /// Serialize the payload attributes for the beacon API.
+    pub fn serialize<S>(
+        payload_attributes: &PayloadAttributes,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let beacon_api_payload_attributes = BeaconPayloadAttributes {
+            timestamp: payload_attributes.timestamp,
+            prev_randao: payload_attributes.prev_randao,
+            suggested_fee_recipient: payload_attributes.suggested_fee_recipient,
+            withdrawals: payload_attributes.withdrawals.clone(),
+            parent_beacon_block_root: payload_attributes.parent_beacon_block_root,
+        };
+        beacon_api_payload_attributes.serialize(serializer)
+    }
+
+    /// Deserialize the payload attributes for the beacon API.
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<PayloadAttributes, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let beacon_api_payload_attributes = BeaconPayloadAttributes::deserialize(deserializer)?;
+        Ok(PayloadAttributes {
+            timestamp: beacon_api_payload_attributes.timestamp,
+            prev_randao: beacon_api_payload_attributes.prev_randao,
+            suggested_fee_recipient: beacon_api_payload_attributes.suggested_fee_recipient,
+            withdrawals: beacon_api_payload_attributes.withdrawals,
+            parent_beacon_block_root: beacon_api_payload_attributes.parent_beacon_block_root,
+        })
+    }
+}
+
+#[serde_as]
+#[derive(Debug, Serialize, Deserialize)]
+struct BeaconExecutionPayloadV1<'a> {
+    parent_hash: Cow<'a, B256>,
+    fee_recipient: Cow<'a, Address>,
+    state_root: Cow<'a, B256>,
+    receipts_root: Cow<'a, B256>,
+    logs_bloom: Cow<'a, Bloom>,
+    prev_randao: Cow<'a, B256>,
+    #[serde_as(as = "DisplayFromStr")]
+    block_number: u64,
+    #[serde_as(as = "DisplayFromStr")]
+    gas_limit: u64,
+    #[serde_as(as = "DisplayFromStr")]
+    gas_used: u64,
+    #[serde_as(as = "DisplayFromStr")]
+    timestamp: u64,
+    extra_data: Cow<'a, Bytes>,
+    #[serde_as(as = "DisplayFromStr")]
+    base_fee_per_gas: U256,
+    block_hash: Cow<'a, B256>,
+    transactions: Cow<'a, Vec<Bytes>>,
+}
+
+impl<'a> From<BeaconExecutionPayloadV1<'a>> for ExecutionPayloadV1 {
+    fn from(payload: BeaconExecutionPayloadV1<'a>) -> Self {
+        let BeaconExecutionPayloadV1 {
+            parent_hash,
+            fee_recipient,
+            state_root,
+            receipts_root,
+            logs_bloom,
+            prev_randao,
+            block_number,
+            gas_limit,
+            gas_used,
+            timestamp,
+            extra_data,
+            base_fee_per_gas,
+            block_hash,
+            transactions,
+        } = payload;
+        ExecutionPayloadV1 {
+            parent_hash: parent_hash.into_owned(),
+            fee_recipient: fee_recipient.into_owned(),
+            state_root: state_root.into_owned(),
+            receipts_root: receipts_root.into_owned(),
+            logs_bloom: logs_bloom.into_owned(),
+            prev_randao: prev_randao.into_owned(),
+            block_number,
+            gas_limit,
+            gas_used,
+            timestamp,
+            extra_data: extra_data.into_owned(),
+            base_fee_per_gas,
+            block_hash: block_hash.into_owned(),
+            transactions: transactions.into_owned(),
+        }
+    }
+}
+
+impl<'a> From<&'a ExecutionPayloadV1> for BeaconExecutionPayloadV1<'a> {
+    fn from(value: &'a ExecutionPayloadV1) -> Self {
+        let ExecutionPayloadV1 {
+            parent_hash,
+            fee_recipient,
+            state_root,
+            receipts_root,
+            logs_bloom,
+            prev_randao,
+            block_number,
+            gas_limit,
+            gas_used,
+            timestamp,
+            extra_data,
+            base_fee_per_gas,
+            block_hash,
+            transactions,
+        } = value;
+
+        BeaconExecutionPayloadV1 {
+            parent_hash: Cow::Borrowed(parent_hash),
+            fee_recipient: Cow::Borrowed(fee_recipient),
+            state_root: Cow::Borrowed(state_root),
+            receipts_root: Cow::Borrowed(receipts_root),
+            logs_bloom: Cow::Borrowed(logs_bloom),
+            prev_randao: Cow::Borrowed(prev_randao),
+            block_number: *block_number,
+            gas_limit: *gas_limit,
+            gas_used: *gas_used,
+            timestamp: *timestamp,
+            extra_data: Cow::Borrowed(extra_data),
+            base_fee_per_gas: *base_fee_per_gas,
+            block_hash: Cow::Borrowed(block_hash),
+            transactions: Cow::Borrowed(transactions),
+        }
+    }
+}
+
+/// A helper serde module to convert from/to the Beacon API which uses quoted decimals rather than
+/// big-endian hex.
+pub mod beacon_payload_v1 {
+    use super::*;
+
+    /// Serialize the payload attributes for the beacon API.
+    pub fn serialize<S>(
+        payload_attributes: &ExecutionPayloadV1,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        BeaconExecutionPayloadV1::from(payload_attributes).serialize(serializer)
+    }
+
+    /// Deserialize the payload attributes for the beacon API.
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<ExecutionPayloadV1, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        BeaconExecutionPayloadV1::deserialize(deserializer).map(Into::into)
+    }
+}
+
+#[serde_as]
+#[derive(Debug, Serialize, Deserialize)]
+struct BeaconExecutionPayloadV2<'a> {
+    /// Inner V1 payload
+    #[serde(flatten)]
+    payload_inner: BeaconExecutionPayloadV1<'a>,
+    /// Array of [`Withdrawal`] enabled with V2
+    /// See <https://github.com/ethereum/execution-apis/blob/6709c2a795b707202e93c4f2867fa0bf2640a84f/src/engine/shanghai.md#executionpayloadv2>
+    #[serde_as(as = "Vec<BeaconWithdrawal>")]
+    withdrawals: Vec<Withdrawal>,
+}
+
+impl<'a> From<BeaconExecutionPayloadV2<'a>> for ExecutionPayloadV2 {
+    fn from(payload: BeaconExecutionPayloadV2<'a>) -> Self {
+        let BeaconExecutionPayloadV2 { payload_inner, withdrawals } = payload;
+        ExecutionPayloadV2 { payload_inner: payload_inner.into(), withdrawals }
+    }
+}
+
+impl<'a> From<&'a ExecutionPayloadV2> for BeaconExecutionPayloadV2<'a> {
+    fn from(value: &'a ExecutionPayloadV2) -> Self {
+        let ExecutionPayloadV2 { payload_inner, withdrawals } = value;
+        BeaconExecutionPayloadV2 {
+            payload_inner: payload_inner.into(),
+            withdrawals: withdrawals.clone(),
+        }
+    }
+}
+
+/// A helper serde module to convert from/to the Beacon API which uses quoted decimals rather than
+/// big-endian hex.
+pub mod beacon_payload_v2 {
+    use super::*;
+
+    /// Serialize the payload attributes for the beacon API.
+    pub fn serialize<S>(
+        payload_attributes: &ExecutionPayloadV2,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        BeaconExecutionPayloadV2::from(payload_attributes).serialize(serializer)
+    }
+
+    /// Deserialize the payload attributes for the beacon API.
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<ExecutionPayloadV2, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        BeaconExecutionPayloadV2::deserialize(deserializer).map(Into::into)
+    }
+}
+
+#[serde_as]
+#[derive(Debug, Serialize, Deserialize)]
+struct BeaconExecutionPayloadV3<'a> {
+    /// Inner V1 payload
+    #[serde(flatten)]
+    payload_inner: BeaconExecutionPayloadV2<'a>,
+    #[serde_as(as = "DisplayFromStr")]
+    blob_gas_used: u64,
+    #[serde_as(as = "DisplayFromStr")]
+    excess_blob_gas: u64,
+}
+
+impl<'a> From<BeaconExecutionPayloadV3<'a>> for ExecutionPayloadV3 {
+    fn from(payload: BeaconExecutionPayloadV3<'a>) -> Self {
+        let BeaconExecutionPayloadV3 { payload_inner, blob_gas_used, excess_blob_gas } = payload;
+        ExecutionPayloadV3 { payload_inner: payload_inner.into(), blob_gas_used, excess_blob_gas }
+    }
+}
+
+impl<'a> From<&'a ExecutionPayloadV3> for BeaconExecutionPayloadV3<'a> {
+    fn from(value: &'a ExecutionPayloadV3) -> Self {
+        let ExecutionPayloadV3 { payload_inner, blob_gas_used, excess_blob_gas } = value;
+        BeaconExecutionPayloadV3 {
+            payload_inner: payload_inner.into(),
+            blob_gas_used: *blob_gas_used,
+            excess_blob_gas: *excess_blob_gas,
+        }
+    }
+}
+
+/// A helper serde module to convert from/to the Beacon API which uses quoted decimals rather than
+/// big-endian hex.
+pub mod beacon_payload_v3 {
+    use super::*;
+
+    /// Serialize the payload attributes for the beacon API.
+    pub fn serialize<S>(
+        payload_attributes: &ExecutionPayloadV3,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        BeaconExecutionPayloadV3::from(payload_attributes).serialize(serializer)
+    }
+
+    /// Deserialize the payload attributes for the beacon API.
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<ExecutionPayloadV3, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        BeaconExecutionPayloadV3::deserialize(deserializer).map(Into::into)
+    }
+}
+
+/// Represents all possible payload versions.
+#[derive(Debug, Serialize)]
+#[serde(untagged)]
+enum BeaconExecutionPayload<'a> {
+    /// V1 payload
+    V1(BeaconExecutionPayloadV1<'a>),
+    /// V2 payload
+    V2(BeaconExecutionPayloadV2<'a>),
+    /// V3 payload
+    V3(BeaconExecutionPayloadV3<'a>),
+}
+
+// Deserializes untagged ExecutionPayload by trying each variant in falling order
+impl<'de> Deserialize<'de> for BeaconExecutionPayload<'de> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum BeaconExecutionPayloadDesc<'a> {
+            V3(BeaconExecutionPayloadV3<'a>),
+            V2(BeaconExecutionPayloadV2<'a>),
+            V1(BeaconExecutionPayloadV1<'a>),
+        }
+        match BeaconExecutionPayloadDesc::deserialize(deserializer)? {
+            BeaconExecutionPayloadDesc::V3(payload) => Ok(Self::V3(payload)),
+            BeaconExecutionPayloadDesc::V2(payload) => Ok(Self::V2(payload)),
+            BeaconExecutionPayloadDesc::V1(payload) => Ok(Self::V1(payload)),
+        }
+    }
+}
+
+impl<'a> From<BeaconExecutionPayload<'a>> for ExecutionPayload {
+    fn from(payload: BeaconExecutionPayload<'a>) -> Self {
+        match payload {
+            BeaconExecutionPayload::V1(payload) => {
+                ExecutionPayload::V1(ExecutionPayloadV1::from(payload))
+            }
+            BeaconExecutionPayload::V2(payload) => {
+                ExecutionPayload::V2(ExecutionPayloadV2::from(payload))
+            }
+            BeaconExecutionPayload::V3(payload) => {
+                ExecutionPayload::V3(ExecutionPayloadV3::from(payload))
+            }
+        }
+    }
+}
+
+impl<'a> From<&'a ExecutionPayload> for BeaconExecutionPayload<'a> {
+    fn from(value: &'a ExecutionPayload) -> Self {
+        match value {
+            ExecutionPayload::V1(payload) => {
+                BeaconExecutionPayload::V1(BeaconExecutionPayloadV1::from(payload))
+            }
+            ExecutionPayload::V2(payload) => {
+                BeaconExecutionPayload::V2(BeaconExecutionPayloadV2::from(payload))
+            }
+            ExecutionPayload::V3(payload) => {
+                BeaconExecutionPayload::V3(BeaconExecutionPayloadV3::from(payload))
+            }
+        }
+    }
+}
+
+impl<'a> SerializeAs<ExecutionPayload> for BeaconExecutionPayload<'a> {
+    fn serialize_as<S>(source: &ExecutionPayload, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        beacon_payload::serialize(source, serializer)
+    }
+}
+
+impl<'de> DeserializeAs<'de, ExecutionPayload> for BeaconExecutionPayload<'de> {
+    fn deserialize_as<D>(deserializer: D) -> Result<ExecutionPayload, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        beacon_payload::deserialize(deserializer)
+    }
+}
+
+pub mod beacon_payload {
+    use super::*;
+
+    /// Serialize the payload attributes for the beacon API.
+    pub fn serialize<S>(
+        payload_attributes: &ExecutionPayload,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        BeaconExecutionPayload::from(payload_attributes).serialize(serializer)
+    }
+
+    /// Deserialize the payload attributes for the beacon API.
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<ExecutionPayload, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        BeaconExecutionPayload::deserialize(deserializer).map(Into::into)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serde_get_payload_header_response() {
+        let s = r#"{"version":"bellatrix","data":{"message":{"header":{"parent_hash":"0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2","fee_recipient":"0xabcf8e0d4e9587369b2301d0790347320302cc09","state_root":"0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2","receipts_root":"0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2","logs_bloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","prev_randao":"0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2","block_number":"1","gas_limit":"1","gas_used":"1","timestamp":"1","extra_data":"0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2","base_fee_per_gas":"1","block_hash":"0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2","transactions_root":"0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2"},"value":"1","pubkey":"0x93247f2209abcacf57b75a51dafae777f9dd38bc7053d1af526f220a7489a6d3a2753e5f3e8b1cfe39b56f43611df74a"},"signature":"0x1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505cc411d61252fb6cb3fa0017b679f8bb2305b26a285fa2737f175668d0dff91cc1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505"}}"#;
+        let resp: GetExecutionPayloadHeaderResponse = serde_json::from_str(s).unwrap();
+        let json: serde_json::Value = serde_json::from_str(s).unwrap();
+        assert_eq!(json, serde_json::to_value(resp).unwrap());
+    }
+
+    #[test]
+    fn serde_payload_header() {
+        let s = r#"{"parent_hash":"0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2","fee_recipient":"0xabcf8e0d4e9587369b2301d0790347320302cc09","state_root":"0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2","receipts_root":"0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2","logs_bloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","prev_randao":"0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2","block_number":"1","gas_limit":"1","gas_used":"1","timestamp":"1","extra_data":"0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2","base_fee_per_gas":"1","block_hash":"0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2","transactions_root":"0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2"}"#;
+        let header: ExecutionPayloadHeader = serde_json::from_str(s).unwrap();
+        let json: serde_json::Value = serde_json::from_str(s).unwrap();
+        assert_eq!(json, serde_json::to_value(header).unwrap());
+    }
+}

--- a/crates/rpc-types-beacon/src/beacon/withdrawals.rs
+++ b/crates/rpc-types-beacon/src/beacon/withdrawals.rs
@@ -1,0 +1,70 @@
+use crate::Withdrawal;
+use alloy_primitives::Address;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde_with::{serde_as, DeserializeAs, DisplayFromStr, SerializeAs};
+
+/// Same as [Withdrawal] but respects the Beacon API format which uses snake-case and quoted
+/// decimals.
+#[serde_as]
+#[derive(Serialize, Deserialize, Clone)]
+pub(crate) struct BeaconWithdrawal {
+    #[serde_as(as = "DisplayFromStr")]
+    index: u64,
+    #[serde_as(as = "DisplayFromStr")]
+    validator_index: u64,
+    address: Address,
+    #[serde_as(as = "DisplayFromStr")]
+    amount: u64,
+}
+
+impl SerializeAs<Withdrawal> for BeaconWithdrawal {
+    fn serialize_as<S>(source: &Withdrawal, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        beacon_withdrawals::serialize(source, serializer)
+    }
+}
+
+impl<'de> DeserializeAs<'de, Withdrawal> for BeaconWithdrawal {
+    fn deserialize_as<D>(deserializer: D) -> Result<Withdrawal, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        beacon_withdrawals::deserialize(deserializer)
+    }
+}
+
+/// A helper serde module to convert from/to the Beacon API which uses quoted decimals rather than
+/// big-endian hex.
+pub mod beacon_withdrawals {
+    use super::*;
+
+    /// Serialize the payload attributes for the beacon API.
+    pub fn serialize<S>(payload_attributes: &Withdrawal, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let withdrawal = BeaconWithdrawal {
+            index: payload_attributes.index,
+            validator_index: payload_attributes.validator_index,
+            address: payload_attributes.address,
+            amount: payload_attributes.amount,
+        };
+        withdrawal.serialize(serializer)
+    }
+
+    /// Deserialize the payload attributes for the beacon API.
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Withdrawal, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let withdrawal = BeaconWithdrawal::deserialize(deserializer)?;
+        Ok(Withdrawal {
+            index: withdrawal.index,
+            validator_index: withdrawal.validator_index,
+            address: withdrawal.address,
+            amount: withdrawal.amount,
+        })
+    }
+}

--- a/crates/rpc-types-beacon/src/lib.rs
+++ b/crates/rpc-types-beacon/src/lib.rs
@@ -1,0 +1,26 @@
+//! Reth RPC type definitions.
+//!
+//! Provides all relevant types for the various RPC endpoints, grouped by namespace.
+
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
+    html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",
+    issue_tracker_base_url = "https://github.com/paradigmxyz/reth/issues/"
+)]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+
+pub mod beacon;
+
+// re-export for convenience
+pub use alloy_rpc_types::serde_helpers;
+
+// Ethereum specific rpc types coming from alloy.
+pub use alloy_rpc_types::*;
+
+pub mod trace {
+    //! RPC types for trace endpoints and inspectors.
+    pub use alloy_rpc_types_trace::*;
+}
+
+// Anvil specific rpc types coming from alloy.
+pub use alloy_rpc_types_anvil as anvil;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
https://github.com/paradigmxyz/reth/issues/8094
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Moved the ```beacon``` crate to ```rpc-types-beacon```
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist
- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
