### PR TITLE
Specific Configs to GethDebugTracerConfig + generic config build method for GethDebugTracingOptions

### DIFF
--- a/crates/rpc-types-trace/src/geth/mod.rs
+++ b/crates/rpc-types-trace/src/geth/mod.rs
@@ -268,6 +268,24 @@ impl From<serde_json::Value> for GethDebugTracerConfig {
     }
 }
 
+impl From<CallConfig> for GethDebugTracerConfig {
+    fn from(value: CallConfig) -> Self {
+        GethDebugTracerConfig(serde_json::to_value(value).expect("is serializable"))
+    }
+}
+
+impl From<PreStateConfig> for GethDebugTracerConfig {
+    fn from(value: PreStateConfig) -> Self {
+        GethDebugTracerConfig(serde_json::to_value(value).expect("is serializable"))
+    }
+}
+
+impl From<MuxConfig> for GethDebugTracerConfig {
+    fn from(value: MuxConfig) -> Self {
+        GethDebugTracerConfig(serde_json::to_value(value).expect("is serializable"))
+    }
+}
+
 /// Bindings for additional `debug_traceTransaction` options
 ///
 /// See <https://geth.ethereum.org/docs/rpc/ns-debug#debug_tracetransaction>
@@ -311,17 +329,12 @@ impl GethDebugTracingOptions {
         self
     }
 
-    /// Configures a [CallConfig]
-    pub fn call_config(mut self, config: CallConfig) -> Self {
-        self.tracer_config =
-            GethDebugTracerConfig(serde_json::to_value(config).expect("is serializable"));
-        self
-    }
-
-    /// Configures a [PreStateConfig]
-    pub fn prestate_config(mut self, config: PreStateConfig) -> Self {
-        self.tracer_config =
-            GethDebugTracerConfig(serde_json::to_value(config).expect("is serializable"));
+    /// Sets the tracer config
+    pub fn with_config<T>(mut self, config: T) -> Self
+    where
+        T: Into<GethDebugTracerConfig>,
+    {
+        self.tracer_config = config.into();
         self
     }
 }

--- a/crates/rpc-types-trace/src/geth/mod.rs
+++ b/crates/rpc-types-trace/src/geth/mod.rs
@@ -329,6 +329,18 @@ impl GethDebugTracingOptions {
         self
     }
 
+    /// Configures a [CallConfig]
+    pub fn with_call_config(mut self, config: CallConfig) -> Self {
+        self.tracer_config = config.into();
+        self
+    }
+
+    /// Configures a [PreStateConfig]
+    pub fn with_prestate_config(mut self, config: PreStateConfig) -> Self {
+        self.tracer_config = config.into();
+        self
+    }
+
     /// Sets the tracer config
     pub fn with_config<T>(mut self, config: T) -> Self
     where

--- a/crates/rpc-types-trace/src/geth/mux.rs
+++ b/crates/rpc-types-trace/src/geth/mux.rs
@@ -61,18 +61,11 @@ mod tests {
         let call_config = CallConfig { only_top_call: Some(true), with_log: Some(true) };
         let prestate_config = PreStateConfig { diff_mode: Some(true) };
 
-        opts.tracing_options.tracer_config = serde_json::to_value(MuxConfig(HashMap::from([
+        opts.tracing_options.tracer_config = MuxConfig(HashMap::from([
             (GethDebugBuiltInTracerType::FourByteTracer, None),
-            (
-                GethDebugBuiltInTracerType::CallTracer,
-                Some(GethDebugTracerConfig(serde_json::to_value(call_config).unwrap())),
-            ),
-            (
-                GethDebugBuiltInTracerType::PreStateTracer,
-                Some(GethDebugTracerConfig(serde_json::to_value(prestate_config).unwrap())),
-            ),
-        ])))
-        .unwrap()
+            (GethDebugBuiltInTracerType::CallTracer, Some(call_config.into())),
+            (GethDebugBuiltInTracerType::PreStateTracer, Some(prestate_config.into())),
+        ]))
         .into();
 
         assert_eq!(


### PR DESCRIPTION
## Motivation

1. Simpler conversion from specific tracer config to GethDebugTracerConfig
2. Single config build method on GethDebugTracingOptions that covers all configs 

## Solution

1. Impl From for CallConfig, PreStateConfig, MuxConfig
2. Introduce generic build method for trace configs on GethDebugTracingOptions

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
