### PR TITLE
fix: add check before allocation in `SimpleCoder::decode_one()`

### DIFF
--- a/crates/consensus/src/transaction/eip4844/builder.rs
+++ b/crates/consensus/src/transaction/eip4844/builder.rs
@@ -6,7 +6,7 @@ use c_kzg::{KzgCommitment, KzgProof};
 use alloc::vec::Vec;
 
 use super::utils::WholeFe;
-use alloy_eips::eip4844::{BYTES_PER_BLOB, FIELD_ELEMENTS_PER_BLOB};
+use alloy_eips::eip4844::{BYTES_PER_BLOB, FIELD_ELEMENTS_PER_BLOB, MAX_BLOBS_PER_BLOCK};
 use core::cmp;
 
 /// A builder for creating a [`BlobTransactionSidecar`].
@@ -194,6 +194,11 @@ impl SimpleCoder {
         // if no more bytes is 0, we're done
         if num_bytes == 0 {
             return Ok(None);
+        }
+
+        // if there are too many bytes
+        if num_bytes > BYTES_PER_BLOB * MAX_BLOBS_PER_BLOCK {
+            return Err(());
         }
 
         let mut res = Vec::with_capacity(num_bytes);


### PR DESCRIPTION
### Motivation

Resolves #682

Since even things like [Paradigm's ExEx Rollup](https://github.com/paradigmxyz/reth/blob/main/examples/exex/rollup/src/main.rs) rely on `SimpleCoder` in `examples`, it makes sense to add extra checks against potential attackers who might allocate too much memory.

