### PR TITLE
feat: add MaybeCancunPayloadFields::as_ref

### DIFF
--- a/crates/rpc-types-engine/src/cancun.rs
+++ b/crates/rpc-types-engine/src/cancun.rs
@@ -43,6 +43,11 @@ impl MaybeCancunPayloadFields {
     pub fn versioned_hashes(&self) -> Option<&Vec<B256>> {
         self.fields.as_ref().map(|fields| &fields.versioned_hashes)
     }
+
+    /// Returns a reference to the inner fields.
+    pub const fn as_ref(&self) -> Option<&CancunPayloadFields> {
+        self.fields.as_ref()
+    }
 }
 
 impl From<CancunPayloadFields> for MaybeCancunPayloadFields {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

Towards https://github.com/paradigmxyz/reth/pull/7993

## Motivation

When using `MaybeCancunPayloadFields` to check the existence of cancun fields, calling `inner` consumes self and forces to clone the container under some circumstances.

## Solution

Add an `as_ref` that doesn't consume self and returns a reference to the inner fields. 

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
