### PR TITLE
chore: rename `DepositReceipt` to `DepositRequest`

### DIFF
--- a/crates/eips/src/eip6110.rs
+++ b/crates/eips/src/eip6110.rs
@@ -21,7 +21,7 @@ pub const MAINNET_DEPOSIT_CONTRACT_ADDRESS: Address =
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "ssz", derive(ssz_derive::Encode, ssz_derive::Decode))]
-pub struct DepositReceipt {
+pub struct DepositRequest {
     /// Validator public key
     pub pubkey: FixedBytes<48>,
     /// Withdrawal credentials

--- a/crates/rpc-types-engine/src/lib.rs
+++ b/crates/rpc-types-engine/src/lib.rs
@@ -33,7 +33,7 @@ pub use self::{
 };
 
 #[doc(inline)]
-pub use alloy_eips::eip6110::DepositReceipt;
+pub use alloy_eips::eip6110::DepositRequest as DepositRequestV1;
 
 #[doc(inline)]
 pub use alloy_eips::eip7002::WithdrawalRequest as WithdrawalRequestV1;

--- a/crates/rpc-types-engine/src/payload.rs
+++ b/crates/rpc-types-engine/src/payload.rs
@@ -1,6 +1,6 @@
 //! Payload types.
 use alloy_consensus::{Blob, Bytes48};
-use alloy_eips::{eip6110::DepositReceipt, eip7002::WithdrawalRequest};
+use alloy_eips::{eip6110::DepositRequest, eip7002::WithdrawalRequest};
 use alloy_primitives::{Address, Bloom, Bytes, B256, B64, U256};
 use alloy_rpc_types::{transaction::BlobTransactionSidecar, Withdrawal};
 use serde::{ser::SerializeMap, Deserialize, Deserializer, Serialize, Serializer};
@@ -404,18 +404,18 @@ impl ssz::Encode for ExecutionPayloadV3 {
 ///
 /// See also: <https://github.com/ethereum/execution-apis/blob/main/src/engine/prague.md#ExecutionPayloadV4>
 ///
-/// This structure has the syntax of ExecutionPayloadV3 and appends the new fields: depositReceipts
-/// and exits.
+/// This structure has the syntax of ExecutionPayloadV3 and appends the new fields: depositRequests
+/// and withdrawalRequests.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ExecutionPayloadV4 {
     /// Inner V3 payload
     #[serde(flatten)]
     pub payload_inner: ExecutionPayloadV3,
-    /// Array of deposits.
+    /// Array of deposit requests.
     ///
-    /// This maps directly to the Deposits defined in [EIP-6110](https://eips.ethereum.org/EIPS/eip-6110).
-    pub deposit_receipts: Vec<DepositReceipt>,
+    /// This maps directly to the deposit requests defined in [EIP-6110](https://eips.ethereum.org/EIPS/eip-6110).
+    pub deposit_requests: Vec<DepositRequest>,
     /// Array of execution layer triggerable withdrawal requests.
     ///
     /// See [EIP-7002](https://eips.ethereum.org/EIPS/eip-7002).


### PR DESCRIPTION
## Motivation

Similar to #672, EIP-6110 has been changed to work with EIP-7685, which also included changes to the engine API spec, renaming deposit receipts to deposit requests.

## Solution

- Rename `DepositReceipt` to `DepositRequest`
- Re-export `DepositRequest` as `DepositRequestV1` in line with the engine API spec

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
