### PR TITLE
Clarify installation instructions for alloy

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,18 @@ feature-parity in Alloy. No action is currently needed from devs.
 [telegram-badge]: https://img.shields.io/endpoint?color=neon&style=for-the-badge&url=https%3A%2F%2Ftg.sumanjay.workers.dev%2Fethers_rs
 [telegram-url]: https://t.me/ethers_rs
 
+## Installation
+
+Currently, Alloy is not hosted on [crates.io](https://crates.io), the Rust package registry.
+
+To incorporate Alloy into your project, you will need to specify the GitHub repository as the source. This can be achieved by executing the following command in your terminal:
+
+```sh
+cargo add alloy --git https://github.com/alloy-rs/alloy
+```
+
+After incorporating Alloy, you may wish to utilize specific features of the crate. These features can be enabled through modifications in your project's `Cargo.toml` file. A comprehensive list of available features can be found at [this GitHub link](https://github.com/alloy-rs/alloy/blob/35cbf35164f31d2de1b84b2a8a9986e5b9b1560f/crates/alloy/Cargo.toml#L89). 
+
 ## Overview
 
 This repository contains the following crates:


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

When I stumbled upon this repository after seeing that ethers-rs was being deprecated I struggled for a couple of hours trying to understand why my installation was failing when doing `cargo install`. Had it been clear in the repo documentation that the crates are not available on the Rust package repository I would have saved myself some time. 

In the telegram chat I also received a pastebin link for all the different features that are available in the crate. Personally, I think that sharing pastebin links is not a good practice given that they can be used by malicious actors to spread malware etc. Therefore it is better to clearly state this in the main repo for clarity purposes.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

I added a section explaining that the repo is currently not available on crates.io and how a developer can add it to their project as well as a permalink to the different exported features by the crate.

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
