### PR TITLE
fix: include `alloy-contract?/pubsub` in `pubsub` feature

### DIFF
--- a/crates/alloy/Cargo.toml
+++ b/crates/alloy/Cargo.toml
@@ -105,6 +105,7 @@ provider-ipc = ["providers", "alloy-provider?/ipc", "transport-ipc"]
 # pubsub
 pubsub = [
     "dep:alloy-pubsub",
+    "alloy-contract?/pubsub",
     "alloy-provider?/pubsub",
     "alloy-rpc-client?/pubsub",
 ]


### PR DESCRIPTION
### Motivation

This fixes the compilation of the following code:
```rust
let my_event_filter = contract.MyEvent_filter().subscribe().await?;
```
```toml
alloy = { git = "https://github.com/alloy-rs/alloy", branch = "main", features = ["contract", "pubsub"] }
```