### PR TITLE
fix: account for requests root in header mem size

### DIFF
--- a/crates/consensus/src/header.rs
+++ b/crates/consensus/src/header.rs
@@ -239,6 +239,7 @@ impl Header {
         mem::size_of::<Option<u128>>() + // blob gas used
         mem::size_of::<Option<u128>>() + // excess blob gas
         mem::size_of::<Option<B256>>() + // parent beacon block root
+        mem::size_of::<Option<B256>>() + // requests root
         self.extra_data.len() // extra data
     }
 


### PR DESCRIPTION
I forgot to add `requests_root` to `Header::size`

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
