### PR TITLE
feat: add eth mainnet EL requests envelope

### DIFF
--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -27,6 +27,9 @@ pub use header::{Header, EMPTY_OMMER_ROOT_HASH, EMPTY_ROOT_HASH};
 mod receipt;
 pub use receipt::{AnyReceiptEnvelope, Receipt, ReceiptEnvelope, ReceiptWithBloom, TxReceipt};
 
+mod request;
+pub use request::Request;
+
 mod transaction;
 pub use transaction::{
     eip4844_utils, Blob, BlobTransactionSidecar, Bytes48, SidecarBuilder, SidecarCoder,

--- a/crates/consensus/src/request.rs
+++ b/crates/consensus/src/request.rs
@@ -21,6 +21,18 @@ pub enum Request {
     WithdrawalRequest(WithdrawalRequest),
 }
 
+impl From<DepositRequest> for Request {
+    fn from(v: DepositRequest) -> Self {
+        Self::DepositRequest(v)
+    }
+}
+
+impl From<WithdrawalRequest> for Request {
+    fn from(v: WithdrawalRequest) -> Self {
+        Self::WithdrawalRequest(v)
+    }
+}
+
 impl Encodable7685 for Request {
     fn request_type(&self) -> u8 {
         match self {

--- a/crates/consensus/src/request.rs
+++ b/crates/consensus/src/request.rs
@@ -1,0 +1,46 @@
+use alloy_eips::{
+    eip6110::DepositRequest,
+    eip7002::WithdrawalRequest,
+    eip7685::{Decodable7685, Eip7685Error, Encodable7685},
+};
+use alloy_rlp::{Decodable, Encodable};
+
+/// Ethereum execution layer requests.
+///
+/// See also [EIP-7685](https://eips.ethereum.org/EIPS/eip-7685).
+pub enum Request {
+    /// An [EIP-6110] deposit request.
+    ///
+    /// [EIP-6110]: https://eips.ethereum.org/EIPS/eip-6110
+    DepositRequest(DepositRequest),
+    /// An [EIP-7002] withdrawal request.
+    ///
+    /// [EIP-7002]: https://eips.ethereum.org/EIPS/eip-7002
+    WithdrawalRequest(WithdrawalRequest),
+}
+
+impl Encodable7685 for Request {
+    fn request_type(&self) -> u8 {
+        match self {
+            Self::DepositRequest(_) => 0,
+            Self::WithdrawalRequest(_) => 1,
+        }
+    }
+
+    fn encode_payload_7685(&self, out: &mut dyn alloy_rlp::BufMut) {
+        match self {
+            Self::DepositRequest(deposit) => deposit.encode(out),
+            Self::WithdrawalRequest(withdrawal) => withdrawal.encode(out),
+        }
+    }
+}
+
+impl Decodable7685 for Request {
+    fn typed_decode(ty: u8, buf: &mut &[u8]) -> Result<Self, alloy_eips::eip7685::Eip7685Error> {
+        Ok(match ty {
+            0 => Self::DepositRequest(DepositRequest::decode(buf)?),
+            1 => Self::WithdrawalRequest(WithdrawalRequest::decode(buf)?),
+            ty => return Err(Eip7685Error::UnexpectedType(ty)),
+        })
+    }
+}

--- a/crates/consensus/src/request.rs
+++ b/crates/consensus/src/request.rs
@@ -8,6 +8,8 @@ use alloy_rlp::{Decodable, Encodable};
 /// Ethereum execution layer requests.
 ///
 /// See also [EIP-7685](https://eips.ethereum.org/EIPS/eip-7685).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[non_exhaustive]
 pub enum Request {
     /// An [EIP-6110] deposit request.
     ///

--- a/crates/consensus/src/request.rs
+++ b/crates/consensus/src/request.rs
@@ -35,12 +35,12 @@ impl From<WithdrawalRequest> for Request {
 
 impl Request {
     /// Whether this is a [`DepositRequest`].
-    pub fn is_deposit_request(&self) -> bool {
+    pub const fn is_deposit_request(&self) -> bool {
         matches!(self, Self::DepositRequest(_))
     }
 
     /// Whether this is a [`WithdrawalRequest`].
-    pub fn is_withdrawal_request(&self) -> bool {
+    pub const fn is_withdrawal_request(&self) -> bool {
         matches!(self, Self::WithdrawalRequest(_))
     }
 

--- a/crates/consensus/src/request.rs
+++ b/crates/consensus/src/request.rs
@@ -33,6 +33,34 @@ impl From<WithdrawalRequest> for Request {
     }
 }
 
+impl Request {
+    /// Whether this is a [`DepositRequest`].
+    pub fn is_deposit_request(&self) -> bool {
+        matches!(self, Self::DepositRequest(_))
+    }
+
+    /// Whether this is a [`WithdrawalRequest`].
+    pub fn is_withdrawal_request(&self) -> bool {
+        matches!(self, Self::WithdrawalRequest(_))
+    }
+
+    /// Return the inner [`DepositRequest`], or `None` of this is not a deposit request.
+    pub const fn as_deposit_request(&self) -> Option<&DepositRequest> {
+        match self {
+            Self::DepositRequest(req) => Some(req),
+            _ => None,
+        }
+    }
+
+    /// Return the inner [`WithdrawalRequest`], or `None` if this is not a withdrawal request.
+    pub const fn as_withdrawal_request(&self) -> Option<&WithdrawalRequest> {
+        match self {
+            Self::WithdrawalRequest(req) => Some(req),
+            _ => None,
+        }
+    }
+}
+
 impl Encodable7685 for Request {
     fn request_type(&self) -> u8 {
         match self {

--- a/crates/eips/src/eip6110.rs
+++ b/crates/eips/src/eip6110.rs
@@ -14,7 +14,7 @@ pub const MAINNET_DEPOSIT_CONTRACT_ADDRESS: Address =
     address!("00000000219ab540356cbb839cbe05303d7705fa");
 
 /// This structure maps onto the deposit object from [EIP-6110](https://eips.ethereum.org/EIPS/eip-6110).
-#[derive(Clone, Copy, Debug, PartialEq, Eq, RlpEncodable, RlpDecodable)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, RlpEncodable, RlpDecodable)]
 #[cfg_attr(
     any(test, feature = "arbitrary"),
     derive(proptest_derive::Arbitrary, arbitrary::Arbitrary)

--- a/crates/eips/src/eip7002.rs
+++ b/crates/eips/src/eip7002.rs
@@ -8,7 +8,7 @@ use alloy_rlp::{RlpDecodable, RlpEncodable};
 /// Represents an execution layer triggerable withdrawal request.
 ///
 /// See [EIP-7002](https://eips.ethereum.org/EIPS/eip-7002).
-#[derive(Clone, Copy, Debug, PartialEq, Eq, RlpEncodable, RlpDecodable)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, RlpEncodable, RlpDecodable)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(


### PR DESCRIPTION
Adds a 7685 envelope for mainnet EL request types. The current ones for Prague are EIP-6110 deposits and EIP-7002 withdrawals.

Depends on #704 and #705

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
