### PR TITLE
Reexport the `reqwest`.

### DIFF
--- a/crates/alloy/src/lib.rs
+++ b/crates/alloy/src/lib.rs
@@ -66,7 +66,7 @@ macro_rules! sol {
 /* --------------------------------------- Main re-exports -------------------------------------- */
 
 #[cfg(feature = "reqwest")]
-use reqwest as _;
+pub use reqwest;
 
 #[cfg(feature = "hyper")]
 use hyper as _;


### PR DESCRIPTION
The `reqwest` library is used by the `alloy` library. This means that the related types leak into other codes.

## Motivation

The type leakage is a problem in the rest of the code. For example we can have
```
RootProvider<alloy::transports::http::Http<Client>>
```

This can be done via adding a `reqwest` in the `Cargo.toml` file but it has to match the version used in `alloy` and that is an unfortunate dependency.

## Solution

Replace `use reqwest as _` by `pub use reqwest`.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
