### PR TITLE
feat: re-export and more http aliases

### DIFF
--- a/crates/transport-http/src/hyper_transport.rs
+++ b/crates/transport-http/src/hyper_transport.rs
@@ -11,13 +11,13 @@ use std::task;
 use tower::Service;
 use tracing::{debug, debug_span, trace, Instrument};
 
-/// A [`hyper`](::hyper) HTTP client.
+/// A [`hyper`] HTTP client.
 pub type HyperClient = hyper_util::client::legacy::Client<
     hyper_util::client::legacy::connect::HttpConnector,
     http_body_util::Full<::hyper::body::Bytes>,
 >;
 
-/// An [`Http`] transport using [`hyper`](::hyper).
+/// An [`Http`] transport using [`hyper`].
 pub type HyperTransport = Http<HyperClient>;
 
 impl<C, B> Http<Client<C, Full<B>>>

--- a/crates/transport-http/src/hyper_transport.rs
+++ b/crates/transport-http/src/hyper_transport.rs
@@ -11,6 +11,15 @@ use std::task;
 use tower::Service;
 use tracing::{debug, debug_span, trace, Instrument};
 
+/// A [`hyper`](::hyper) HTTP client.
+pub type HyperClient = hyper_util::client::legacy::Client<
+    hyper_util::client::legacy::connect::HttpConnector,
+    http_body_util::Full<::hyper::body::Bytes>,
+>;
+
+/// An [`Http`] transport using [`hyper`](::hyper).
+pub type HyperTransport = Http<HyperClient>;
+
 impl<C, B> Http<Client<C, Full<B>>>
 where
     C: Connect + Clone + Send + Sync + 'static,

--- a/crates/transport-http/src/lib.rs
+++ b/crates/transport-http/src/lib.rs
@@ -15,21 +15,28 @@
 #![deny(unused_must_use, rust_2018_idioms)]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
-use alloy_transport::utils::guess_local_url;
-use url::Url;
-
-#[cfg(all(not(target_arch = "wasm32"), feature = "hyper"))]
-mod hyper;
-
-/// A [`hyper`](::hyper) HTTP client.
-#[cfg(all(not(target_arch = "wasm32"), feature = "hyper"))]
-pub type HyperClient = hyper_util::client::legacy::Client<
-    hyper_util::client::legacy::connect::HttpConnector,
-    http_body_util::Full<::hyper::body::Bytes>,
->;
+#[cfg(feature = "reqwest")]
+mod reqwest_transport;
+#[cfg(feature = "reqwest")]
+#[doc(inline)]
+pub use reqwest_transport::*;
 
 #[cfg(feature = "reqwest")]
-mod reqwest;
+pub use reqwest;
+
+#[cfg(all(not(target_arch = "wasm32"), feature = "hyper"))]
+mod hyper_transport;
+#[cfg(all(not(target_arch = "wasm32"), feature = "hyper"))]
+#[doc(inline)]
+pub use hyper_transport::*;
+
+#[cfg(all(not(target_arch = "wasm32"), feature = "hyper"))]
+pub use hyper;
+#[cfg(all(not(target_arch = "wasm32"), feature = "hyper"))]
+pub use hyper_util;
+
+use alloy_transport::utils::guess_local_url;
+use url::Url;
 
 /// An Http transport.
 ///

--- a/crates/transport-http/src/reqwest_transport.rs
+++ b/crates/transport-http/src/reqwest_transport.rs
@@ -6,10 +6,10 @@ use tower::Service;
 use tracing::{debug, debug_span, trace, Instrument};
 use url::Url;
 
-/// Rexported from [`reqwest`](::reqwest).
+/// Rexported from [`reqwest`].
 pub use reqwest::Client;
 
-/// An [`Http`] transport using [`reqwest`](::reqwest).
+/// An [`Http`] transport using [`reqwest`].
 pub type ReqwestTransport = Http<Client>;
 
 impl Http<Client> {

--- a/crates/transport-http/src/reqwest_transport.rs
+++ b/crates/transport-http/src/reqwest_transport.rs
@@ -6,7 +6,13 @@ use tower::Service;
 use tracing::{debug, debug_span, trace, Instrument};
 use url::Url;
 
-impl Http<reqwest::Client> {
+/// Rexported from [`reqwest`](::reqwest).
+pub use reqwest::Client;
+
+/// An [`Http`] transport using [`reqwest`](::reqwest).
+pub type ReqwestTransport = Http<Client>;
+
+impl Http<Client> {
     /// Create a new [`Http`] transport.
     pub fn new(url: Url) -> Self {
         Self { client: Default::default(), url }


### PR DESCRIPTION


## Motivation

Supersedes #715 


## Solution

Re-export reqwest and hyper for downstream user convenience. Add type aliases for

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
