### PR TITLE
add `with_base_fee` for `TransactionInfo`

### DIFF
--- a/crates/rpc-types/src/eth/transaction/common.rs
+++ b/crates/rpc-types/src/eth/transaction/common.rs
@@ -19,6 +19,14 @@ pub struct TransactionInfo {
     pub base_fee: Option<u128>,
 }
 
+impl TransactionInfo {
+    /// Returns a new [`TransactionInfo`] with the provided base fee.
+    pub fn with_base_fee(mut self, base_fee: u128) -> Self {
+        self.base_fee = Some(base_fee);
+        self
+    }
+}
+
 impl From<&Transaction> for TransactionInfo {
     fn from(tx: &Transaction) -> Self {
         Self {

--- a/crates/rpc-types/src/eth/transaction/common.rs
+++ b/crates/rpc-types/src/eth/transaction/common.rs
@@ -21,7 +21,7 @@ pub struct TransactionInfo {
 
 impl TransactionInfo {
     /// Returns a new [`TransactionInfo`] with the provided base fee.
-    pub fn with_base_fee(mut self, base_fee: u128) -> Self {
+    pub const fn with_base_fee(mut self, base_fee: u128) -> Self {
         self.base_fee = Some(base_fee);
         self
     }


### PR DESCRIPTION
For situation where `TransactionInfo` is built from `Transaction`, `base_fee` field is set to `None`. As a result, it is interesting to have a `with_base_fee` method implemented in order to consume the created `TransactionInfo` instance and populate its `base_fee` field.