### PR TITLE
fix: `FeeHistory` deserialization

### DIFF
--- a/crates/rpc-types/src/eth/fee.rs
+++ b/crates/rpc-types/src/eth/fee.rs
@@ -116,3 +116,27 @@ impl FeeHistory {
             .copied()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use similar_asserts::assert_eq;
+
+    use crate::FeeHistory;
+
+    #[test]
+    fn test_fee_history_serde() {
+        let sample = r#"{"baseFeePerGas":["0x342770c0","0x2da282a8"],"gasUsedRatio":[0.0],"baseFeePerBlobGas":["0x0","0x0"],"blobGasUsedRatio":[0.0],"oldestBlock":"0x1"}"#;
+        let fee_history: FeeHistory = serde_json::from_str(&sample).unwrap();
+        let expected = FeeHistory {
+            base_fee_per_blob_gas: vec![0, 0],
+            base_fee_per_gas: vec![875000000, 765625000],
+            blob_gas_used_ratio: vec![0.0],
+            gas_used_ratio: vec![0.0],
+            oldest_block: 1,
+            reward: None,
+        };
+
+        assert_eq!(fee_history, expected);
+        assert_eq!(serde_json::to_string(&fee_history).unwrap(), sample);
+    }
+}

--- a/crates/rpc-types/src/eth/fee.rs
+++ b/crates/rpc-types/src/eth/fee.rs
@@ -56,7 +56,7 @@ pub struct FeeHistory {
     #[serde(
         default,
         skip_serializing_if = "Vec::is_empty",
-        // with = "alloy_serde::num::u128_vec_via_ruint"
+        with = "alloy_serde::num::u128_vec_via_ruint"
     )]
     pub base_fee_per_blob_gas: Vec<u128>,
     /// An array of block blob gas used ratios. These are calculated as the ratio of gasUsed and

--- a/crates/rpc-types/src/eth/fee.rs
+++ b/crates/rpc-types/src/eth/fee.rs
@@ -126,7 +126,7 @@ mod tests {
     #[test]
     fn test_fee_history_serde() {
         let sample = r#"{"baseFeePerGas":["0x342770c0","0x2da282a8"],"gasUsedRatio":[0.0],"baseFeePerBlobGas":["0x0","0x0"],"blobGasUsedRatio":[0.0],"oldestBlock":"0x1"}"#;
-        let fee_history: FeeHistory = serde_json::from_str(&sample).unwrap();
+        let fee_history: FeeHistory = serde_json::from_str(sample).unwrap();
         let expected = FeeHistory {
             base_fee_per_blob_gas: vec![0, 0],
             base_fee_per_gas: vec![875000000, 765625000],


### PR DESCRIPTION
## Motivation

We are not using correct serde impl for `base_fee_per_blob_gas`, thus any `FeeHistory` requests to client impls which have this field in response are failing to get deserialized

## Solution

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
