### PR TITLE
feat: add important setters functions of `TransactionBuilder` in `CallBuilder`

### DIFF
--- a/crates/contract/src/call.rs
+++ b/crates/contract/src/call.rs
@@ -2,7 +2,7 @@ use crate::{CallDecoder, Error, EthCall, Result};
 use alloy_dyn_abi::{DynSolValue, JsonAbiExt};
 use alloy_json_abi::Function;
 use alloy_network::{Ethereum, Network, ReceiptResponse, TransactionBuilder};
-use alloy_primitives::{Address, Bytes, TxKind, U256};
+use alloy_primitives::{Address, Bytes, ChainId, TxKind, U256};
 use alloy_provider::{PendingTransactionBuilder, Provider};
 use alloy_rpc_types::{state::StateOverride, AccessList, BlobTransactionSidecar, BlockId};
 use alloy_sol_types::SolCall;
@@ -289,6 +289,12 @@ impl<T: Transport + Clone, P: Provider<T, N>, D: CallDecoder, N: Network> CallBu
         }
     }
 
+    /// Sets the `chain_id` field in the transaction to the provided value
+    pub fn chain_id(mut self, chain_id: ChainId) -> Self {
+        self.request.set_chain_id(chain_id);
+        self
+    }
+
     /// Sets the `from` field in the transaction to the provided value.
     pub fn from(mut self, from: Address) -> Self {
         self.request.set_from(from);
@@ -341,6 +347,12 @@ impl<T: Transport + Clone, P: Provider<T, N>, D: CallDecoder, N: Network> CallBu
     /// Sets the `max_priority_fee_per_gas` in the transaction to the provide value
     pub fn max_priority_fee_per_gas(mut self, max_priority_fee_per_gas: u128) -> Self {
         self.request.set_max_priority_fee_per_gas(max_priority_fee_per_gas);
+        self
+    }
+
+    /// Sets the `max_fee_per_blob_gas` in the transaction to the provided value
+    pub fn max_fee_per_blob_gas(mut self, max_fee_per_blob_gas: u128) -> Self {
+        self.request.set_max_fee_per_blob_gas(max_fee_per_blob_gas);
         self
     }
 
@@ -597,6 +609,16 @@ mod tests {
     }
 
     #[test]
+    fn change_chain_id() {
+        let call_builder = build_call_builder().chain_id(1337);
+        assert_eq!(
+            call_builder.request.chain_id.expect("chain_id should be set"),
+            1337,
+            "chain_id of request should be '1337'"
+        );
+    }
+
+    #[test]
     fn change_max_fee_per_gas() {
         let call_builder = build_call_builder().max_fee_per_gas(42);
         assert_eq!(
@@ -616,6 +638,16 @@ mod tests {
                 .expect("max_priority_fee_per_gas should be set"),
             45,
             "max_priority_fee_per_gas of request should be '45'"
+        );
+    }
+
+    #[test]
+    fn change_max_fee_per_blob_gas() {
+        let call_builder = build_call_builder().max_fee_per_blob_gas(50);
+        assert_eq!(
+            call_builder.request.max_fee_per_blob_gas.expect("max_fee_per_blob_gas should be set"),
+            50,
+            "max_fee_per_blob_gas of request should be '50'"
         );
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Missing important setters on CallBuilder: https://github.com/alloy-rs/alloy/issues/534

> According to [this post](https://ethereum.stackexchange.com/questions/94412/valueerror-code-32000-message-only-replay-protected-eip-155-transac) we need to specify the chain-id field, but I can't specify the chain-id in the [CallBuilder](https://github.com/alloy-rs/alloy/blob/8cb0307b9bdb6cef9058d2d1a2219c8d212a7421/crates/contract/src/call.rs#L191)

_Originally posted by @mattsse in https://github.com/alloy-rs/alloy/issues/527#issuecomment-2054062261_
            

## Solution

Add important setters functions of `TransactionBuilder` in `CallBuilder`

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
