### PR TITLE
refactor around `TxEip4844Variant`

### DIFF
--- a/crates/consensus/src/transaction/eip4844.rs
+++ b/crates/consensus/src/transaction/eip4844.rs
@@ -40,7 +40,7 @@ pub enum TxEip4844Variant {
 
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for TxEip4844Variant {
-    fn deserialize<D>(deserializer: D) -> Result<TxEip4844Variant, D::Error>
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -55,32 +55,28 @@ impl<'de> serde::Deserialize<'de> for TxEip4844Variant {
         let tx = TxEip4844SerdeHelper::deserialize(deserializer)?;
 
         if let Some(sidecar) = tx.sidecar {
-            Ok(TxEip4844Variant::TxEip4844WithSidecar(TxEip4844WithSidecar::from_tx_and_sidecar(
-                tx.tx, sidecar,
-            )))
+            Ok(TxEip4844WithSidecar::from_tx_and_sidecar(tx.tx, sidecar).into())
         } else {
-            Ok(TxEip4844Variant::TxEip4844(tx.tx))
+            Ok(tx.tx.into())
         }
     }
 }
 
 impl From<TxEip4844WithSidecar> for TxEip4844Variant {
     fn from(tx: TxEip4844WithSidecar) -> Self {
-        TxEip4844Variant::TxEip4844WithSidecar(tx)
+        Self::TxEip4844WithSidecar(tx)
     }
 }
 
 impl From<TxEip4844> for TxEip4844Variant {
     fn from(tx: TxEip4844) -> Self {
-        TxEip4844Variant::TxEip4844(tx)
+        Self::TxEip4844(tx)
     }
 }
 
 impl From<(TxEip4844, BlobTransactionSidecar)> for TxEip4844Variant {
     fn from((tx, sidecar): (TxEip4844, BlobTransactionSidecar)) -> Self {
-        TxEip4844Variant::TxEip4844WithSidecar(TxEip4844WithSidecar::from_tx_and_sidecar(
-            tx, sidecar,
-        ))
+        TxEip4844WithSidecar::from_tx_and_sidecar(tx, sidecar).into()
     }
 }
 
@@ -94,8 +90,8 @@ impl TxEip4844Variant {
         proof_settings: &c_kzg::KzgSettings,
     ) -> Result<(), BlobTransactionValidationError> {
         match self {
-            TxEip4844Variant::TxEip4844(_) => Err(BlobTransactionValidationError::MissingSidecar),
-            TxEip4844Variant::TxEip4844WithSidecar(tx) => tx.validate_blob(proof_settings),
+            Self::TxEip4844(_) => Err(BlobTransactionValidationError::MissingSidecar),
+            Self::TxEip4844WithSidecar(tx) => tx.validate_blob(proof_settings),
         }
     }
 
@@ -107,8 +103,8 @@ impl TxEip4844Variant {
     /// Get access to the inner tx [TxEip4844].
     pub const fn tx(&self) -> &TxEip4844 {
         match self {
-            TxEip4844Variant::TxEip4844(tx) => tx,
-            TxEip4844Variant::TxEip4844WithSidecar(tx) => tx.tx(),
+            Self::TxEip4844(tx) => tx,
+            Self::TxEip4844WithSidecar(tx) => tx.tx(),
         }
     }
 
@@ -116,8 +112,8 @@ impl TxEip4844Variant {
     #[doc(hidden)]
     pub fn fields_len(&self) -> usize {
         match self {
-            TxEip4844Variant::TxEip4844(tx) => tx.fields_len(),
-            TxEip4844Variant::TxEip4844WithSidecar(tx) => tx.tx().fields_len(),
+            Self::TxEip4844(tx) => tx.fields_len(),
+            Self::TxEip4844WithSidecar(tx) => tx.tx().fields_len(),
         }
     }
 
@@ -135,8 +131,8 @@ impl TxEip4844Variant {
         with_header: bool,
     ) {
         let payload_length = match self {
-            TxEip4844Variant::TxEip4844(tx) => tx.fields_len() + signature.rlp_vrs_len(),
-            TxEip4844Variant::TxEip4844WithSidecar(tx) => {
+            Self::TxEip4844(tx) => tx.fields_len() + signature.rlp_vrs_len(),
+            Self::TxEip4844WithSidecar(tx) => {
                 let payload_length = tx.tx().fields_len() + signature.rlp_vrs_len();
                 let inner_header = Header { list: true, payload_length };
                 inner_header.length() + payload_length + tx.sidecar().fields_len()
@@ -155,10 +151,10 @@ impl TxEip4844Variant {
         out.put_u8(self.tx_type() as u8);
 
         match self {
-            TxEip4844Variant::TxEip4844(tx) => {
+            Self::TxEip4844(tx) => {
                 tx.encode_with_signature_fields(signature, out);
             }
-            TxEip4844Variant::TxEip4844WithSidecar(tx) => {
+            Self::TxEip4844WithSidecar(tx) => {
                 tx.encode_with_signature_fields(signature, out);
             }
         }
@@ -187,33 +183,29 @@ impl TxEip4844Variant {
         if header.list {
             let tx = TxEip4844WithSidecar::decode_signed_fields(buf)?;
             let (tx, signature, hash) = tx.into_parts();
-            return Ok(Signed::new_unchecked(
-                TxEip4844Variant::TxEip4844WithSidecar(tx),
-                signature,
-                hash,
-            ));
+            return Ok(Signed::new_unchecked(tx.into(), signature, hash));
         }
 
         // Since there is not a second list header, this is a historical 4844 transaction without a
         // sidecar.
         let tx = TxEip4844::decode_signed_fields(buf)?;
         let (tx, signature, hash) = tx.into_parts();
-        Ok(Signed::new_unchecked(TxEip4844Variant::TxEip4844(tx), signature, hash))
+        Ok(Signed::new_unchecked(tx.into(), signature, hash))
     }
 }
 
 impl Transaction for TxEip4844Variant {
     fn chain_id(&self) -> Option<ChainId> {
         match self {
-            TxEip4844Variant::TxEip4844(tx) => Some(tx.chain_id),
-            TxEip4844Variant::TxEip4844WithSidecar(tx) => Some(tx.tx().chain_id),
+            Self::TxEip4844(tx) => Some(tx.chain_id),
+            Self::TxEip4844WithSidecar(tx) => Some(tx.tx().chain_id),
         }
     }
 
     fn gas_limit(&self) -> u128 {
         match self {
-            TxEip4844Variant::TxEip4844(tx) => tx.gas_limit,
-            TxEip4844Variant::TxEip4844WithSidecar(tx) => tx.tx().gas_limit,
+            Self::TxEip4844(tx) => tx.gas_limit,
+            Self::TxEip4844WithSidecar(tx) => tx.tx().gas_limit,
         }
     }
 
@@ -223,30 +215,30 @@ impl Transaction for TxEip4844Variant {
 
     fn input(&self) -> &[u8] {
         match self {
-            TxEip4844Variant::TxEip4844(tx) => tx.input.as_ref(),
-            TxEip4844Variant::TxEip4844WithSidecar(tx) => tx.tx().input.as_ref(),
+            Self::TxEip4844(tx) => tx.input.as_ref(),
+            Self::TxEip4844WithSidecar(tx) => tx.tx().input.as_ref(),
         }
     }
 
     fn nonce(&self) -> u64 {
         match self {
-            TxEip4844Variant::TxEip4844(tx) => tx.nonce,
-            TxEip4844Variant::TxEip4844WithSidecar(tx) => tx.tx().nonce,
+            Self::TxEip4844(tx) => tx.nonce,
+            Self::TxEip4844WithSidecar(tx) => tx.tx().nonce,
         }
     }
 
     fn to(&self) -> TxKind {
         match self {
-            TxEip4844Variant::TxEip4844(tx) => tx.to,
-            TxEip4844Variant::TxEip4844WithSidecar(tx) => tx.tx.to,
+            Self::TxEip4844(tx) => tx.to,
+            Self::TxEip4844WithSidecar(tx) => tx.tx.to,
         }
         .into()
     }
 
     fn value(&self) -> U256 {
         match self {
-            TxEip4844Variant::TxEip4844(tx) => tx.value,
-            TxEip4844Variant::TxEip4844WithSidecar(tx) => tx.tx.value,
+            Self::TxEip4844(tx) => tx.value,
+            Self::TxEip4844WithSidecar(tx) => tx.tx.value,
         }
     }
 }
@@ -254,10 +246,10 @@ impl Transaction for TxEip4844Variant {
 impl SignableTransaction<Signature> for TxEip4844Variant {
     fn set_chain_id(&mut self, chain_id: ChainId) {
         match self {
-            TxEip4844Variant::TxEip4844(ref mut inner) => {
+            Self::TxEip4844(ref mut inner) => {
                 inner.chain_id = chain_id;
             }
-            TxEip4844Variant::TxEip4844WithSidecar(ref mut inner) => {
+            Self::TxEip4844WithSidecar(ref mut inner) => {
                 inner.tx.chain_id = chain_id;
             }
         }

--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -128,18 +128,14 @@ impl From<Signed<TxEip4844Variant>> for TxEnvelope {
 impl From<Signed<TxEip4844>> for TxEnvelope {
     fn from(v: Signed<TxEip4844>) -> Self {
         let (tx, signature, hash) = v.into_parts();
-        Self::Eip4844(Signed::new_unchecked(TxEip4844Variant::TxEip4844(tx), signature, hash))
+        Self::Eip4844(Signed::new_unchecked(tx.into(), signature, hash))
     }
 }
 
 impl From<Signed<TxEip4844WithSidecar>> for TxEnvelope {
     fn from(v: Signed<TxEip4844WithSidecar>) -> Self {
         let (tx, signature, hash) = v.into_parts();
-        Self::Eip4844(Signed::new_unchecked(
-            TxEip4844Variant::TxEip4844WithSidecar(tx),
-            signature,
-            hash,
-        ))
+        Self::Eip4844(Signed::new_unchecked(tx.into(), signature, hash))
     }
 }
 

--- a/crates/rpc-types/src/eth/transaction/mod.rs
+++ b/crates/rpc-types/src/eth/transaction/mod.rs
@@ -267,7 +267,7 @@ impl TryFrom<Transaction> for Signed<TxEip4844Variant> {
     fn try_from(tx: Transaction) -> Result<Self, Self::Error> {
         let tx: Signed<TxEip4844> = tx.try_into()?;
         let (inner, signature, _) = tx.into_parts();
-        let tx = TxEip4844Variant::TxEip4844(inner);
+        let tx: TxEip4844Variant = inner.into();
 
         Ok(tx.into_signed(signature))
     }


### PR DESCRIPTION
Summary of the refactors made:
- Use `Self` instead of `TxEip4844Variant` where possible
- Use `From` implementation where possible