### PR TITLE
feat: add Parlia genesis config for BSC

### DIFF
--- a/crates/genesis/src/lib.rs
+++ b/crates/genesis/src/lib.rs
@@ -423,6 +423,10 @@ pub struct ChainConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub clique: Option<CliqueConfig>,
 
+    /// Parlia parameters.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parlia: Option<ParliaConfig>,
+
     /// Additional fields specific to each chain.
     #[serde(flatten, default)]
     pub extra_fields: BTreeMap<String, serde_json::Value>,
@@ -532,6 +536,18 @@ pub struct EthashConfig {}
 /// Consensus configuration for Clique.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CliqueConfig {
+    /// Number of seconds between blocks to enforce.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub period: Option<u64>,
+
+    /// Epoch length to reset votes and checkpoints.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub epoch: Option<u64>,
+}
+
+/// Consensus configuration for Parlia.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ParliaConfig {
     /// Number of seconds between blocks to enforce.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub period: Option<u64>,

--- a/crates/genesis/src/lib.rs
+++ b/crates/genesis/src/lib.rs
@@ -546,13 +546,16 @@ pub struct CliqueConfig {
 }
 
 /// Consensus configuration for Parlia.
+/// Parlia is the consensus engine for BNB Smart Chain.
+/// For the general introduction: https://docs.bnbchain.org/docs/learn/consensus/
+/// For the specification: https://github.com/bnb-chain/bsc/blob/master/params/config.go#L558
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ParliaConfig {
     /// Number of seconds between blocks to enforce.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub period: Option<u64>,
 
-    /// Epoch length to reset votes and checkpoints.
+    /// Epoch length to update validator set.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub epoch: Option<u64>,
 }

--- a/crates/genesis/src/lib.rs
+++ b/crates/genesis/src/lib.rs
@@ -547,8 +547,8 @@ pub struct CliqueConfig {
 
 /// Consensus configuration for Parlia.
 /// Parlia is the consensus engine for BNB Smart Chain.
-/// For the general introduction: https://docs.bnbchain.org/docs/learn/consensus/
-/// For the specification: https://github.com/bnb-chain/bsc/blob/master/params/config.go#L558
+/// For the general introduction: <https://docs.bnbchain.org/docs/learn/consensus/>
+/// For the specification: <https://github.com/bnb-chain/bsc/blob/master/params/config.go#L558>
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ParliaConfig {
     /// Number of seconds between blocks to enforce.


### PR DESCRIPTION
## Motivation

BSC uses Parlia consensus engine. To support BSC genesis, Parlia config is added.

## Solution
Update genesis config to support Parlia.