### PR TITLE
chore: remove rlp encoding for `Request`

### DIFF
--- a/crates/consensus/src/request.rs
+++ b/crates/consensus/src/request.rs
@@ -3,7 +3,7 @@ use alloy_eips::{
     eip7002::WithdrawalRequest,
     eip7685::{Decodable7685, Eip7685Error, Encodable7685},
 };
-use alloy_rlp::{Decodable, Encodable, Header};
+use alloy_rlp::{Decodable, Encodable};
 
 /// Ethereum execution layer requests.
 ///
@@ -90,18 +90,5 @@ impl Decodable7685 for Request {
             1 => Self::WithdrawalRequest(WithdrawalRequest::decode(buf)?),
             ty => return Err(Eip7685Error::UnexpectedType(ty)),
         })
-    }
-}
-
-impl Encodable for Request {
-    fn encode(&self, out: &mut dyn alloy_rlp::BufMut) {
-        self.encoded_7685().encode(out)
-    }
-}
-
-impl Decodable for Request {
-    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
-        let mut data = Header::decode_bytes(buf, false)?;
-        Ok(Self::decode_7685(&mut data)?)
     }
 }


### PR DESCRIPTION
the EIP was a bit ambigious here, apparently we are not supposed to also RLP encode the result of the
EIP-7685 encoding. instead, to compute the request root, we should just stuff the EIP-7685 encoded request
into a list and RLP encode that list

this simply removes the unneeded RLP encoding. we could also have kept it around and simply do a `self.encode_7685(buf)`, but I think that would break expectations around how RLP works (geth does this)

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
