### PR TITLE
feat: Add methods to JwtSecret to read and write from filesystem

### DIFF
--- a/crates/rpc-types-engine/Cargo.toml
+++ b/crates/rpc-types-engine/Cargo.toml
@@ -57,3 +57,5 @@ arbitrary = { workspace = true, features = ["derive"] }
 rand.workspace = true
 serde_json.workspace = true
 similar-asserts.workspace = true
+tempfile.workspace = true
+assert_matches.workspace = true

--- a/crates/rpc-types-engine/src/jwt.rs
+++ b/crates/rpc-types-engine/src/jwt.rs
@@ -4,7 +4,7 @@ use alloy_primitives::hex;
 use jsonwebtoken::{
     decode, errors::ErrorKind, get_current_timestamp, Algorithm, DecodingKey, Validation,
 };
-use rand::random;
+use rand::{random, Rng};
 use serde::{Deserialize, Serialize};
 use std::{fs, path::Path, str::FromStr, time::Duration};
 use thiserror::Error;
@@ -135,7 +135,7 @@ impl JwtSecret {
 
     /// Creates a random [`JwtSecret`] and tries to store it at the specified path. I/O errors might
     /// occur during write operations in the form of a [`JwtError`]
-    pub fn try_create(fpath: &Path) -> Result<Self, JwtError> {
+    pub fn try_create_random(fpath: &Path) -> Result<Self, JwtError> {
         if let Some(dir) = fpath.parent() {
             // Create parent directory
             fs::create_dir_all(dir)?
@@ -183,7 +183,7 @@ impl JwtSecret {
 
     /// Generates a random [`JwtSecret`] containing a hex-encoded 256 bit secret key.
     pub fn random() -> Self {
-        let random_bytes: [u8; 32] = random();
+        let random_bytes: [u8; 32] = rand::thread_rng().gen();
         let secret = hex::encode(random_bytes);
         JwtSecret::from_hex(secret).unwrap()
     }

--- a/crates/rpc-types-engine/src/jwt.rs
+++ b/crates/rpc-types-engine/src/jwt.rs
@@ -46,7 +46,7 @@ pub enum JwtError {
     #[error("JWT decoding error: {0}")]
     JwtDecodingError(String),
 
-    /// Error variant for failed directory creation operation with additional path context.
+    /// An error occurred while creating a directory to store the JWT.
     #[error("failed to create dir {path:?}: {source}")]
     CreateDir {
         /// The source `io::Error`.
@@ -55,7 +55,7 @@ pub enum JwtError {
         path: PathBuf,
     },
 
-    /// Error variant for failed read operation with additional path context.
+    /// An error occurred while reading the JWT from a file.
     #[error("failed to read from {path:?}: {source}")]
     Read {
         /// The source `io::Error`.
@@ -64,7 +64,7 @@ pub enum JwtError {
         path: PathBuf,
     },
 
-    /// Error variant for failed write operation with additional path context.
+    /// An error occurred while writing the JWT to a file.
     #[error("failed to write to {path:?}: {source}")]
     Write {
         /// The source `io::Error`.
@@ -403,7 +403,7 @@ mod tests {
     #[test]
     fn ephemeral_secret_created() {
         let fpath: &Path = Path::new("secret0.hex");
-        assert!(!fs::metadata(fpath).is_ok());
+        assert!(fs::metadata(fpath).is_err());
         JwtSecret::try_create_random(fpath).expect("A secret file should be created");
         assert!(fs::metadata(fpath).is_ok());
         fs::remove_file(fpath).unwrap();
@@ -412,10 +412,10 @@ mod tests {
     #[test]
     fn valid_secret_provided() {
         let fpath = Path::new("secret1.hex");
-        assert!(!fs::metadata(fpath).is_ok());
+        assert!(fs::metadata(fpath).is_err());
 
         let secret = JwtSecret::random();
-        fs::write(fpath, &hex(&secret)).unwrap();
+        fs::write(fpath, hex(&secret)).unwrap();
 
         match JwtSecret::from_file(fpath) {
             Ok(gen_secret) => {
@@ -442,7 +442,7 @@ mod tests {
         let fpath = Path::new("secret3.hex");
         let result = JwtSecret::from_file(fpath);
         assert_matches!(result, Err(JwtError::Read {source: _,path }) if path == fpath.to_path_buf());
-        assert!(!fs::metadata(fpath).is_ok());
+        assert!(fs::metadata(fpath).is_err());
     }
 
     #[test]

--- a/crates/rpc-types-engine/src/jwt.rs
+++ b/crates/rpc-types-engine/src/jwt.rs
@@ -38,6 +38,10 @@ pub enum JwtError {
     #[error("IAT (issued-at) claim is not within ±60 seconds from the current time")]
     InvalidIssuanceTimestamp,
 
+    /// The Authorization header is missing or invalid in the context of JWT validation.
+    #[error("Authorization header is missing or invalid")]
+    MissingOrInvalidAuthorizationHeader,
+
     /// An error occurred during JWT decoding.
     #[error("JWT decoding error: {0}")]
     JwtDecodingError(String),

--- a/crates/rpc-types-engine/src/jwt.rs
+++ b/crates/rpc-types-engine/src/jwt.rs
@@ -6,8 +6,7 @@ use jsonwebtoken::{
 };
 use rand::random;
 use serde::{Deserialize, Serialize};
-use std::{fs, str::FromStr, time::Duration};
-use std::path::Path;
+use std::{fs, path::Path, str::FromStr, time::Duration};
 use thiserror::Error;
 
 /// Errors returned by the [`JwtSecret`]
@@ -215,8 +214,8 @@ impl FromStr for JwtSecret {
 
 #[cfg(test)]
 mod tests {
-    use assert_matches::assert_matches;
     use super::*;
+    use assert_matches::assert_matches;
     use jsonwebtoken::{encode, EncodingKey, Header};
     use std::time::{SystemTime, UNIX_EPOCH};
     use tempfile::tempdir;
@@ -408,7 +407,7 @@ mod tests {
     fn provided_file_not_exists() {
         let fpath = Path::new("secret3.hex");
         let result = JwtSecret::from_file(fpath);
-        assert_matches!(result,Err(JwtError::IOError(_)));
+        assert_matches!(result, Err(JwtError::IOError(_)));
         assert!(!exists(fpath));
     }
 
@@ -442,5 +441,4 @@ mod tests {
     fn delete(path: &Path) {
         fs::remove_file(path).unwrap();
     }
-
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Adding `from_file` and `try_create` methods to `JwtSecret`. These method allow the caller to read and write from the filesystem. This change should help fully deprecate and remove the `JwtSecret` struct defined in Reth (see https://github.com/paradigmxyz/reth/issues/8276). 
## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

The implementation and tests are ported over from Reth into Alloy.
## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
