### PR TITLE
refactor: improve eth_call internals

### DIFF
--- a/crates/provider/src/provider/call.rs
+++ b/crates/provider/src/provider/call.rs
@@ -70,16 +70,9 @@ where
     }
 
     fn poll_running(&mut self, cx: &mut std::task::Context<'_>) -> Poll<TransportResult<Bytes>> {
-        let Self::Running(mut call) = std::mem::replace(self, Self::Polling) else {
-            unreachable!("bad state")
-        };
+        let Self::Running(ref mut call) = self else { unreachable!("bad state") };
 
-        if let Ready(res) = call.poll_unpin(cx) {
-            Ready(res)
-        } else {
-            *self = Self::Running(call);
-            Poll::Pending
-        }
+        call.poll_unpin(cx)
     }
 }
 


### PR DESCRIPTION


## Motivation

Closes #761 

## Solution

- Ensure the option is propagated to the internal `RpcCall` future params
- drive-by improvements
    - remove redundant inner type
    - add polling state to simplify taking ownership of data
    - remove unnecessary nesting in future creation
    - `is_*` functions to remove weird inline `matches!`

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
