### PR TITLE
feat: set poll interval based on connected chain

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,8 @@ alloy-sol-types = { version = "0.7.2", default-features = false }
 
 alloy-rlp = { version = "0.3", default-features = false }
 
+alloy-chains = { version = "0.1.18", default-features = false }
+
 # ethereum
 ethereum_ssz_derive = "0.5"
 ethereum_ssz = "0.5"

--- a/crates/provider/Cargo.toml
+++ b/crates/provider/Cargo.toml
@@ -28,6 +28,7 @@ alloy-pubsub = { workspace = true, optional = true }
 alloy-transport.workspace = true
 alloy-primitives.workspace = true
 
+alloy-chains.workspace = true
 async-stream = "0.3"
 async-trait.workspace = true
 auto_impl.workspace = true

--- a/crates/provider/Cargo.toml
+++ b/crates/provider/Cargo.toml
@@ -28,7 +28,6 @@ alloy-pubsub = { workspace = true, optional = true }
 alloy-transport.workspace = true
 alloy-primitives.workspace = true
 
-alloy-chains = "0.1.18"
 async-stream = "0.3"
 async-trait.workspace = true
 auto_impl.workspace = true

--- a/crates/provider/Cargo.toml
+++ b/crates/provider/Cargo.toml
@@ -28,6 +28,7 @@ alloy-pubsub = { workspace = true, optional = true }
 alloy-transport.workspace = true
 alloy-primitives.workspace = true
 
+alloy-chains = "0.1.18"
 async-stream = "0.3"
 async-trait.workspace = true
 auto_impl.workspace = true

--- a/crates/provider/src/builder.rs
+++ b/crates/provider/src/builder.rs
@@ -5,6 +5,7 @@ use crate::{
     provider::SendableTx,
     Provider, RootProvider,
 };
+use alloy_chains::NamedChain;
 use alloy_network::{Ethereum, Network};
 use alloy_rpc_client::{BuiltInConnectionString, ClientBuilder, RpcClient};
 use alloy_transport::{BoxTransport, Transport, TransportError, TransportResult};
@@ -214,6 +215,18 @@ impl<L, F, N> ProviderBuilder<L, F, N> {
     /// ```
     pub fn network<Net: Network>(self) -> ProviderBuilder<L, F, Net> {
         ProviderBuilder { layer: self.layer, filler: self.filler, network: PhantomData }
+    }
+
+    /// Add a chain layer to the stack being built. The layer will set
+    /// the client's poll interval based on the average block time for this chain.
+    ///
+    /// Does nothing to the client with a local transport.
+    pub fn with_chain(
+        self,
+        chain: NamedChain,
+    ) -> ProviderBuilder<Stack<crate::layers::ChainLayer, L>, F, N> {
+        let chain_layer = crate::layers::ChainLayer::from(chain);
+        self.layer(chain_layer)
     }
 
     /// Finish the layer stack by providing a root [`Provider`], outputting

--- a/crates/provider/src/layers/chain.rs
+++ b/crates/provider/src/layers/chain.rs
@@ -1,0 +1,44 @@
+use alloy_chains::NamedChain;
+use alloy_network::Ethereum;
+use alloy_transport::Transport;
+use std::time::Duration;
+
+use crate::{Provider, ProviderLayer};
+
+/// A layer that wraps a [`NamedChain`]. The layer will be used to set
+/// the client's poll interval based on the average block time for this chain.
+///
+/// Does nothing to the client with a local transport.
+#[derive(Debug, Clone, Copy)]
+pub struct ChainLayer(NamedChain);
+
+impl ChainLayer {
+    /// Get the chain's average blocktime, if applicable.
+    pub fn average_blocktime_hint(&self) -> Option<Duration> {
+        self.0.average_blocktime_hint()
+    }
+}
+
+impl From<NamedChain> for ChainLayer {
+    fn from(chain: NamedChain) -> Self {
+        Self(chain)
+    }
+}
+
+impl<P, T> ProviderLayer<P, T, Ethereum> for ChainLayer
+where
+    P: Provider<T>,
+    T: Transport + Clone,
+{
+    type Provider = P;
+
+    fn layer(&self, inner: P) -> Self::Provider {
+        if !inner.client().is_local() {
+            if let Some(avg_block_time) = self.average_blocktime_hint() {
+                let poll_interval = avg_block_time.mul_f32(0.6);
+                inner.client().set_poll_interval(poll_interval);
+            }
+        }
+        inner
+    }
+}

--- a/crates/provider/src/layers/chain.rs
+++ b/crates/provider/src/layers/chain.rs
@@ -14,7 +14,7 @@ pub struct ChainLayer(NamedChain);
 
 impl ChainLayer {
     /// Get the chain's average blocktime, if applicable.
-    pub fn average_blocktime_hint(&self) -> Option<Duration> {
+    pub const fn average_blocktime_hint(&self) -> Option<Duration> {
         self.0.average_blocktime_hint()
     }
 }

--- a/crates/provider/src/layers/mod.rs
+++ b/crates/provider/src/layers/mod.rs
@@ -1,8 +1,11 @@
 //! Useful layer implementations for the provider. Currently this
-//! module contains the `AnvilLayer` and `AnvilProvider` types, when the anvil
-//! feature is enabled.
+//! module contains the `AnvilLayer`, `AnvilProvider` and `ChainLayer`
+//! types.
 
 #[cfg(any(test, feature = "anvil"))]
 mod anvil;
 #[cfg(any(test, feature = "anvil"))]
 pub use anvil::{AnvilLayer, AnvilProvider};
+
+mod chain;
+pub use chain::ChainLayer;

--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -5,7 +5,6 @@ use crate::{
     EthCall, PendingTransaction, PendingTransactionBuilder, PendingTransactionConfig, RootProvider,
     RpcWithBlock, SendableTx,
 };
-use alloy_chains::Chain;
 use alloy_eips::eip2718::Encodable2718;
 use alloy_json_rpc::{RpcError, RpcParam, RpcReturn};
 use alloy_network::{Ethereum, Network};
@@ -538,22 +537,9 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
         self.client().request("web3_clientVersion", ()).await
     }
 
-    /// Gets the chain ID. Sets the client's poll interval (if default)
-    /// to match the average block time for this chain.
-    async fn get_chain_id(&self) -> TransportResult<u64> {
-        self.client().request("eth_chainId", ()).map_resp(crate::utils::convert_u64).await.and_then(
-            |chain_id| {
-                let client = self.client();
-                if !client.is_custom_poll_interval() && !client.is_local() {
-                    let poll_interval = match Chain::from_id(chain_id).average_blocktime_hint() {
-                        Some(avg_block_time) => avg_block_time,
-                        None => client.poll_interval(),
-                    };
-                    client.set_poll_interval(poll_interval.as_millis() as u64);
-                }
-                Ok(chain_id)
-            },
-        )
+    /// Gets the chain ID.
+    fn get_chain_id(&self) -> RpcCall<T, (), U64, u64> {
+        self.client().request("eth_chainId", ()).map_resp(crate::utils::convert_u64)
     }
 
     /// Gets the network ID. Same as `eth_chainId`.

--- a/crates/rpc-client/src/client.rs
+++ b/crates/rpc-client/src/client.rs
@@ -86,7 +86,7 @@ impl<T> RpcClient<T> {
     ///
     /// Note: This will only set the poll interval for the client if it is the only reference to the
     /// inner client. If the reference is held by many, then it will not update the poll interval.
-    pub fn with_poll_interval(self, poll_interval: u64) -> Self {
+    pub fn with_poll_interval(self, poll_interval: Duration) -> Self {
         self.inner().set_poll_interval(poll_interval);
         self
     }
@@ -185,9 +185,10 @@ impl<T> RpcClientInner<T> {
         Duration::from_millis(self.poll_interval.load(Ordering::Relaxed))
     }
 
-    /// Set the poll interval for the client in milliseconds.
-    pub fn set_poll_interval(&self, poll_interval: u64) {
-        self.poll_interval.store(poll_interval, Ordering::Relaxed);
+    /// Set the poll interval for the client in milliseconds. Default:
+    /// 7s for remote and 250ms for local transports.
+    pub fn set_poll_interval(&self, poll_interval: Duration) {
+        self.poll_interval.store(poll_interval.as_millis() as u64, Ordering::Relaxed);
     }
 
     /// Returns a reference to the underlying transport.
@@ -344,9 +345,9 @@ mod tests {
 
     #[test]
     fn test_client_with_poll_interval() {
+        let poll_interval = Duration::from_millis(5_000);
         let client = RpcClient::new_http(reqwest::Url::parse("http://localhost").unwrap())
-            .with_poll_interval(5000);
-        // let client = client;
-        assert_eq!(client.poll_interval(), Duration::from_millis(5000));
+            .with_poll_interval(poll_interval);
+        assert_eq!(client.poll_interval(), poll_interval);
     }
 }

--- a/crates/rpc-client/src/client.rs
+++ b/crates/rpc-client/src/client.rs
@@ -6,7 +6,7 @@ use std::{
     borrow::Cow,
     ops::Deref,
     sync::{
-        atomic::{AtomicU64, Ordering},
+        atomic::{AtomicBool, AtomicU64, Ordering},
         Arc, Weak,
     },
     time::Duration,
@@ -82,7 +82,7 @@ impl<T> RpcClient<T> {
         &self.0
     }
 
-    /// Sets the poll interval for the client in milliseconds.
+    /// Sets custom poll interval for the client in milliseconds.
     ///
     /// Note: This will only set the poll interval for the client if it is the only reference to the
     /// inner client. If the reference is held by many, then it will not update the poll interval.
@@ -163,6 +163,8 @@ pub struct RpcClientInner<T> {
     pub(crate) id: AtomicU64,
     /// The poll interval for the client in milliseconds.
     pub(crate) poll_interval: AtomicU64,
+    /// `true` if the poll interval is custom.
+    pub(crate) is_custom_poll_interval: AtomicBool,
 }
 
 impl<T> RpcClientInner<T> {
@@ -177,17 +179,24 @@ impl<T> RpcClientInner<T> {
             is_local,
             id: AtomicU64::new(0),
             poll_interval: if is_local { AtomicU64::new(250) } else { AtomicU64::new(7000) },
+            is_custom_poll_interval: AtomicBool::new(false),
         }
     }
 
-    /// Returns the default poll interval (milliseconds) for the client.
+    /// Returns the poll interval (milliseconds) for the client.
     pub fn poll_interval(&self) -> Duration {
         Duration::from_millis(self.poll_interval.load(Ordering::Relaxed))
     }
 
-    /// Set the poll interval for the client in milliseconds.
+    /// Set custom poll interval for the client in milliseconds.
     pub fn set_poll_interval(&self, poll_interval: u64) {
         self.poll_interval.store(poll_interval, Ordering::Relaxed);
+        self.is_custom_poll_interval.store(true, Ordering::Relaxed);
+    }
+
+    /// Returns `true` if the poll interval is custom.
+    pub fn is_custom_poll_interval(&self) -> bool {
+        self.is_custom_poll_interval.load(Ordering::Relaxed)
     }
 
     /// Returns a reference to the underlying transport.
@@ -287,6 +296,7 @@ impl<T: Transport + Clone> RpcClientInner<T> {
             is_local: self.is_local,
             id: self.id,
             poll_interval: self.poll_interval,
+            is_custom_poll_interval: self.is_custom_poll_interval,
         }
     }
 }
@@ -346,7 +356,7 @@ mod tests {
     fn test_client_with_poll_interval() {
         let client = RpcClient::new_http(reqwest::Url::parse("http://localhost").unwrap())
             .with_poll_interval(5000);
-        // let client = client;
         assert_eq!(client.poll_interval(), Duration::from_millis(5000));
+        assert!(client.is_custom_poll_interval());
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Closes https://github.com/alloy-rs/alloy/issues/604

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Add `with_chain()` method to `ProviderBuilder`. The `ChainLayer` will fetch the average block time for the chain and set client's poll interval

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
