### PR TITLE
export batch waiter

### DIFF
--- a/crates/rpc-client/src/lib.rs
+++ b/crates/rpc-client/src/lib.rs
@@ -19,7 +19,7 @@
 extern crate tracing;
 
 mod batch;
-pub use batch::BatchRequest;
+pub use batch::{BatchRequest, Waiter};
 
 mod builder;
 pub use builder::ClientBuilder;


### PR DESCRIPTION
## Motivation
Export the `Waiter` struct to enable specifying it as a return type. e.g. a helper function that adds requests via the `BatchRequest<_, _>::add_call` function and returns a `Vec<Waiter<_>>`. The response can then be awaited using `join_all`. 

## Solution
Export the `Waiter` struct from the "rpc-client/src/lib.rs" file

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
