### PR TITLE
fix: correctly serialize eth_call params

### DIFF
--- a/crates/contract/src/eth_call.rs
+++ b/crates/contract/src/eth_call.rs
@@ -22,7 +22,7 @@ mod private {
 
 /// An [`alloy_provider::EthCall`] with an abi decoder.
 #[must_use = "EthCall must be awaited to execute the call"]
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug)]
 pub struct EthCall<'req, 'state, 'coder, D, T, N>
 where
     T: Transport + Clone,
@@ -120,7 +120,7 @@ where
 /// Future for the [`EthCall`] type. This future wraps an RPC call with an abi
 /// decoder.
 #[must_use = "futures do nothing unless you `.await` or poll them"]
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug)]
 pub struct EthCallFut<'req, 'state, 'coder, D, T, N>
 where
     T: Transport + Clone,

--- a/crates/provider/Cargo.toml
+++ b/crates/provider/Cargo.toml
@@ -33,21 +33,23 @@ async-stream = "0.3"
 async-trait.workspace = true
 auto_impl.workspace = true
 dashmap = "5.5"
+futures-utils-wasm.workspace = true
 futures.workspace = true
 lru = "0.12"
+pin-project.workspace = true
 reqwest = { workspace = true, optional = true }
 serde_json.workspace = true
+serde.workspace = true
 tokio = { workspace = true, features = ["sync", "macros"] }
 tracing.workspace = true
 url = { workspace = true, optional = true }
-futures-utils-wasm.workspace = true
-pin-project.workspace = true
 
 [dev-dependencies]
 alloy-consensus = { workspace = true, features = ["std"] }
 alloy-node-bindings.workspace = true
 alloy-rpc-client = { workspace = true, features = ["reqwest"] }
 alloy-rlp.workspace = true
+alloy-sol-types.workspace = true
 alloy-signer.workspace = true
 alloy-signer-wallet.workspace = true
 alloy-transport-http = { workspace = true, features = ["reqwest"] }

--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -922,9 +922,11 @@ impl<T: Transport + Clone, N: Network> Provider<T, N> for RootProvider<T, N> {
 mod tests {
     use super::*;
     use crate::{ProviderBuilder, WalletProvider};
+    use alloy_network::TransactionBuilder;
     use alloy_node_bindings::Anvil;
     use alloy_primitives::{address, b256, bytes};
     use alloy_rpc_types::request::TransactionRequest;
+    use alloy_sol_types::SolValue;
 
     fn init_tracing() {
         let _ = tracing_subscriber::fmt::try_init();
@@ -1337,5 +1339,22 @@ mod tests {
 
         let count = provider.get_uncle_count(0.into()).await.unwrap();
         assert_eq!(count, 0);
+    }
+
+    #[tokio::test]
+    #[cfg(any(
+        feature = "reqwest-default-tls",
+        feature = "reqwest-rustls-tls",
+        feature = "reqwest-native-tls",
+    ))]
+    async fn call_mainnet() {
+        init_tracing();
+        let url = "https://eth-mainnet.alchemyapi.io/v2/jGiK5vwDfC3F4r0bqukm-W2GqgdrxdSr";
+        let provider = ProviderBuilder::new().on_http(url.parse().unwrap());
+        let req = TransactionRequest::default()
+            .with_to(address!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2")) // WETH
+            .with_input(bytes!("06fdde03")); // `name()`
+        let result = provider.call(&req).await.unwrap();
+        assert_eq!(String::abi_decode(&result, true).unwrap(), "Wrapped Ether");
     }
 }


### PR DESCRIPTION
`null` is invalid for state overrides, and also it's off spec so don't serialize it if `None`.
This requires a manual `serde::Serialize` implementation since `#[serde(skip_serializing_if)]` does not work on tuple structs.

Noticed in https://github.com/foundry-rs/foundry/pull/7990

Regressed in https://github.com/alloy-rs/alloy/pull/763