### PR TITLE
feat: add iter on FilterSet

### DIFF
--- a/crates/rpc-types/src/eth/filter.rs
+++ b/crates/rpc-types/src/eth/filter.rs
@@ -7,7 +7,10 @@ use serde::{
     Deserialize, Deserializer, Serialize, Serializer,
 };
 use std::{
-    collections::HashSet,
+    collections::{
+        hash_set::{IntoIter, Iter},
+        HashSet,
+    },
     hash::Hash,
     ops::{Range, RangeFrom, RangeTo},
 };
@@ -84,6 +87,15 @@ impl<T: Eq + Hash> From<ValueOrArray<Option<T>>> for FilterSet<T> {
     }
 }
 
+impl<T: Eq + Hash> IntoIterator for FilterSet<T> {
+    type Item = T;
+    type IntoIter = IntoIter<T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
 impl<T: Eq + Hash> FilterSet<T> {
     /// Returns whether the filter is empty
     pub fn is_empty(&self) -> bool {
@@ -94,6 +106,12 @@ impl<T: Eq + Hash> FilterSet<T> {
     /// any value matches. Otherwise, the filter must include the value
     pub fn matches(&self, value: &T) -> bool {
         self.is_empty() || self.0.contains(value)
+    }
+
+    /// Returns an iterator over the underlying HashSet. Values are visited
+    /// in an arbitrary order.
+    pub fn iter(&self) -> Iter<'_, T> {
+        self.0.iter()
     }
 }
 


### PR DESCRIPTION
## Motivation
Facilitate the iteration of `FilterSet` without the need to first convert it to a `ValueOrArray`.

## Solution

Implement `IntoIterator` using the underlying `HashSet`.

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
