### PR TITLE
chore: expose Claims is_within_time_window as pub

### DIFF
--- a/crates/rpc-types-engine/src/jwt.rs
+++ b/crates/rpc-types-engine/src/jwt.rs
@@ -114,7 +114,7 @@ impl Claims {
     }
 
     /// Checks if the `iat` claim is within the allowed range from the current time.
-    fn is_within_time_window(&self) -> bool {
+    pub fn is_within_time_window(&self) -> bool {
         let now_secs = get_current_timestamp();
         now_secs.abs_diff(self.iat) <= JWT_MAX_IAT_DIFF.as_secs()
     }

--- a/crates/rpc-types-engine/src/jwt.rs
+++ b/crates/rpc-types-engine/src/jwt.rs
@@ -109,7 +109,7 @@ pub struct Claims {
 
 impl Claims {
     /// Creates a new instance of [`Claims`] with the current timestamp as the `iat` claim.
-    fn with_current_timestamp() -> Self {
+    pub fn with_current_timestamp() -> Self {
         Self { iat: get_current_timestamp(), exp: None }
     }
 


### PR DESCRIPTION
## Motivation

Re-creating a `Client` when the claims are out of date is necessary if a custom transport using jwt will be used for more than 60 seconds. To do this, the transport could re-create only if the current claims are within the time window. However, this method is private, so no such custom transport can be created without pasting the existing methods and constants.

## Solution

Expose `is_within_time_window`

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
