### PR TITLE
feat(rpc-types): add topic0 (alias `event_signature`) getter to `Log`

### DIFF
--- a/crates/rpc-types/src/eth/log.rs
+++ b/crates/rpc-types/src/eth/log.rs
@@ -57,6 +57,11 @@ impl Log<LogData> {
         self.inner.topics()
     }
 
+    /// Getter for the topic0 field, the event signature.
+    pub fn event_signature(&self) -> B256 {
+        self.inner.topics()[0]
+    }
+
     /// Get the topic list, mutably. This gives access to the internal
     /// array, without allowing extension of that array. Shortcut for
     /// [`LogData::topics_mut`]

--- a/crates/rpc-types/src/eth/log.rs
+++ b/crates/rpc-types/src/eth/log.rs
@@ -58,6 +58,7 @@ impl Log<LogData> {
     }
 
     /// Getter for the topic0 field.
+    #[doc(alias = "event_signature")]
     pub fn topic0(&self) -> Option<&B256> {
         self.inner.topics().first()
     }

--- a/crates/rpc-types/src/eth/log.rs
+++ b/crates/rpc-types/src/eth/log.rs
@@ -57,9 +57,9 @@ impl Log<LogData> {
         self.inner.topics()
     }
 
-    /// Getter for the topic0 field, the event signature.
-    pub fn event_signature(&self) -> B256 {
-        self.inner.topics()[0]
+    /// Getter for the topic0 field.
+    pub fn topic0(&self) -> Option<&B256> {
+        self.inner.topics().get(0)
     }
 
     /// Get the topic list, mutably. This gives access to the internal

--- a/crates/rpc-types/src/eth/log.rs
+++ b/crates/rpc-types/src/eth/log.rs
@@ -59,7 +59,7 @@ impl Log<LogData> {
 
     /// Getter for the topic0 field.
     pub fn topic0(&self) -> Option<&B256> {
-        self.inner.topics().get(0)
+        self.inner.topics().first()
     }
 
     /// Get the topic list, mutably. This gives access to the internal


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Currently there is not an elegant way of accessing the event signature in the `Log` as returned by the `SubscriptionStream`, which is useful for matching against when one subscribes to all (or multiple) contract events.

For context: https://github.com/alloy-rs/examples/blob/dbe65d8ca96348ffa64720ea566079e7c1e87fbf/examples/subscriptions/examples/subscribe_all_logs.rs#L45-L62

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

~~Adds simple getter for 0-indexing into `topics`, mirrors the `event_signature` syntax used for setting `topic0` on the `Filter` instance. I don't see a good reason to add getters for the other topics.~~

Adds simple getter for `topic0`, checking for existence.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
