### PR TITLE
feat: Add overrides to eth_estimateGas

### DIFF
--- a/crates/contract/src/call.rs
+++ b/crates/contract/src/call.rs
@@ -406,7 +406,7 @@ impl<T: Transport + Clone, P: Provider<T, N>, D: CallDecoder, N: Network> CallBu
 
     /// Returns the estimated gas cost for the underlying transaction to be executed
     pub async fn estimate_gas(&self) -> Result<u128> {
-        self.provider.estimate_gas(&self.request).block_id(self.block).await.map_err(Into::into)
+        self.provider.estimate_gas(&self.request).block(self.block).await.map_err(Into::into)
     }
 
     /// Queries the blockchain via an `eth_call` without submitting a transaction to the network.

--- a/crates/contract/src/eth_call.rs
+++ b/crates/contract/src/eth_call.rs
@@ -29,7 +29,7 @@ where
     N: Network,
     D: CallDecoder,
 {
-    inner: alloy_provider::EthCall<'req, 'state, T, N>,
+    inner: alloy_provider::EthCall<'req, 'state, T, N, Bytes>,
 
     decoder: &'coder D,
 }
@@ -42,7 +42,7 @@ where
 {
     /// Create a new [`EthCall`].
     pub const fn new(
-        inner: alloy_provider::EthCall<'req, 'state, T, N>,
+        inner: alloy_provider::EthCall<'req, 'state, T, N, Bytes>,
         decoder: &'coder D,
     ) -> Self {
         Self { inner, decoder }
@@ -55,7 +55,7 @@ where
     N: Network,
 {
     /// Create a new [`EthCall`].
-    pub const fn new_raw(inner: alloy_provider::EthCall<'req, 'state, T, N>) -> Self {
+    pub const fn new_raw(inner: alloy_provider::EthCall<'req, 'state, T, N, Bytes>) -> Self {
         Self::new(inner, &RAW_CODER)
     }
 }
@@ -90,13 +90,13 @@ where
     }
 }
 
-impl<'req, 'state, T, N> From<alloy_provider::EthCall<'req, 'state, T, N>>
+impl<'req, 'state, T, N> From<alloy_provider::EthCall<'req, 'state, T, N, Bytes>>
     for EthCall<'req, 'state, 'static, (), T, N>
 where
     T: Transport + Clone,
     N: Network,
 {
-    fn from(inner: alloy_provider::EthCall<'req, 'state, T, N>) -> Self {
+    fn from(inner: alloy_provider::EthCall<'req, 'state, T, N, Bytes>) -> Self {
         Self { inner, decoder: &RAW_CODER }
     }
 }
@@ -127,7 +127,7 @@ where
     N: Network,
     D: CallDecoder,
 {
-    inner: <alloy_provider::EthCall<'req, 'state, T, N> as IntoFuture>::IntoFuture,
+    inner: <alloy_provider::EthCall<'req, 'state, T, N, Bytes> as IntoFuture>::IntoFuture,
     decoder: &'coder D,
 }
 

--- a/crates/provider/src/provider/call.rs
+++ b/crates/provider/src/provider/call.rs
@@ -6,10 +6,10 @@ use alloy_rpc_types::state::StateOverride;
 use alloy_transport::{Transport, TransportErrorKind, TransportResult};
 use futures::FutureExt;
 use serde::ser::SerializeSeq;
-use std::{future::Future, task::Poll};
-use std::marker::PhantomData;
+use std::{future::Future, marker::PhantomData, task::Poll};
 
-type RunningFut<'req, 'state, T, N, Resp, Output, Map> = RpcCall<T, EthCallParams<'req, 'state, N>, Resp, Output, Map, >;
+type RunningFut<'req, 'state, T, N, Resp, Output, Map> =
+    RpcCall<T, EthCallParams<'req, 'state, N>, Resp, Output, Map>;
 
 #[derive(Clone, Debug)]
 struct EthCallParams<'req, 'state, N: Network> {
@@ -34,13 +34,15 @@ impl<N: Network> serde::Serialize for EthCallParams<'_, '_, N> {
 /// The [`EthCallFut`] future is the future type for an `eth_call` RPC request.
 #[derive(Clone, Debug)]
 #[doc(hidden)] // Not public API.
-pub struct EthCallFut<'req, 'state, T, N, Resp, Output, Map>(EthCallFutInner<'req, 'state, T, N, Resp, Output, Map>)
+#[pin_project::pin_project]
+pub struct EthCallFut<'req, 'state, T, N, Resp, Output, Map>(
+    EthCallFutInner<'req, 'state, T, N, Resp, Output, Map>,
+)
 where
     T: Transport + Clone,
     N: Network,
     Resp: RpcReturn,
     Map: Fn(Resp) -> Output;
-
 
 #[derive(Clone, Debug)]
 enum EthCallFutInner<'req, 'state, T, N, Resp, Output, Map>
@@ -108,7 +110,7 @@ where
 }
 
 impl<'req, 'state, T, N, Resp, Output, Map> Future
-for EthCallFut<'req, 'state, T, N, Resp, Output, Map>
+    for EthCallFut<'req, 'state, T, N, Resp, Output, Map>
 where
     T: Transport + Clone,
     N: Network,
@@ -226,7 +228,7 @@ where
 }
 
 impl<'req, 'state, T, N, Resp, Output, Map> std::future::IntoFuture
-for EthCall<'req, 'state, T, N, Resp, Output, Map>
+    for EthCall<'req, 'state, T, N, Resp, Output, Map>
 where
     T: Transport + Clone,
     N: Network,

--- a/crates/provider/src/provider/call.rs
+++ b/crates/provider/src/provider/call.rs
@@ -199,10 +199,13 @@ where
     Map: Fn(Resp) -> Output,
 {
     /// Map the response to a different type.
-    pub fn map_resp<NewOutput, NewMap: Fn(Resp) -> NewOutput>(
+    pub fn map_resp<NewOutput, NewMap>(
         self,
         map: NewMap,
-    ) -> EthCall<'req, 'state, T, N, Resp, NewOutput, NewMap> {
+    ) -> EthCall<'req, 'state, T, N, Resp, NewOutput, NewMap>
+        where
+            NewMap: Fn(Resp) -> NewOutput,
+    {
         EthCall {
             client: self.client,
             data: self.data,

--- a/crates/provider/src/provider/call.rs
+++ b/crates/provider/src/provider/call.rs
@@ -1,14 +1,15 @@
 use alloy_eips::BlockId;
+use alloy_json_rpc::RpcReturn;
 use alloy_network::Network;
-use alloy_primitives::Bytes;
 use alloy_rpc_client::{RpcCall, WeakClient};
 use alloy_rpc_types::state::StateOverride;
 use alloy_transport::{Transport, TransportErrorKind, TransportResult};
 use futures::FutureExt;
 use serde::ser::SerializeSeq;
 use std::{future::Future, task::Poll};
+use std::marker::PhantomData;
 
-type RunningFut<'req, 'state, T, N> = RpcCall<T, EthCallParams<'req, 'state, N>, Bytes>;
+type RunningFut<'req, 'state, T, N, Resp, Output, Map> = RpcCall<T, EthCallParams<'req, 'state, N>, Resp, Output, Map, >;
 
 #[derive(Clone, Debug)]
 struct EthCallParams<'req, 'state, N: Network> {
@@ -33,31 +34,41 @@ impl<N: Network> serde::Serialize for EthCallParams<'_, '_, N> {
 /// The [`EthCallFut`] future is the future type for an `eth_call` RPC request.
 #[derive(Clone, Debug)]
 #[doc(hidden)] // Not public API.
-pub struct EthCallFut<'req, 'state, T, N>(EthCallFutInner<'req, 'state, T, N>)
-where
-    T: Transport + Clone,
-    N: Network;
-
-#[derive(Clone, Debug)]
-enum EthCallFutInner<'req, 'state, T, N: Network>
+pub struct EthCallFut<'req, 'state, T, N, Resp, Output, Map>(EthCallFutInner<'req, 'state, T, N, Resp, Output, Map>)
 where
     T: Transport + Clone,
     N: Network,
+    Resp: RpcReturn,
+    Map: Fn(Resp) -> Output;
+
+
+#[derive(Clone, Debug)]
+enum EthCallFutInner<'req, 'state, T, N, Resp, Output, Map>
+where
+    T: Transport + Clone,
+    N: Network,
+    Resp: RpcReturn,
+    Map: Fn(Resp) -> Output,
 {
     Preparing {
         client: WeakClient<T>,
         data: &'req N::TransactionRequest,
         overrides: Option<&'state StateOverride>,
         block: Option<BlockId>,
+        method: &'static str,
+        map: Map,
     },
-    Running(RunningFut<'req, 'state, T, N>),
+    Running(RunningFut<'req, 'state, T, N, Resp, Output, Map>),
     Polling,
 }
 
-impl<'req, 'state, T, N> EthCallFutInner<'req, 'state, T, N>
+impl<'req, 'state, T, N, Resp, Output, Map> EthCallFutInner<'req, 'state, T, N, Resp, Output, Map>
 where
     T: Transport + Clone,
     N: Network,
+    Resp: RpcReturn,
+    Output: 'static,
+    Map: Fn(Resp) -> Output,
 {
     /// Returns `true` if the future is in the preparing state.
     const fn is_preparing(&self) -> bool {
@@ -69,8 +80,8 @@ where
         matches!(self, Self::Running(..))
     }
 
-    fn poll_preparing(&mut self, cx: &mut std::task::Context<'_>) -> Poll<TransportResult<Bytes>> {
-        let Self::Preparing { client, data, overrides, block } =
+    fn poll_preparing(&mut self, cx: &mut std::task::Context<'_>) -> Poll<TransportResult<Output>> {
+        let Self::Preparing { client, data, overrides, block, method, map } =
             std::mem::replace(self, Self::Polling)
         else {
             unreachable!("bad state")
@@ -83,25 +94,29 @@ where
 
         let params = EthCallParams { data, block: block.unwrap_or_default(), overrides };
 
-        let fut = client.request("eth_call", params);
+        let fut = client.request(method, params).map_resp(map);
 
         *self = Self::Running(fut);
         self.poll_running(cx)
     }
 
-    fn poll_running(&mut self, cx: &mut std::task::Context<'_>) -> Poll<TransportResult<Bytes>> {
+    fn poll_running(&mut self, cx: &mut std::task::Context<'_>) -> Poll<TransportResult<Output>> {
         let Self::Running(ref mut call) = self else { unreachable!("bad state") };
 
         call.poll_unpin(cx)
     }
 }
 
-impl<'req, 'state, T, N> Future for EthCallFut<'req, 'state, T, N>
+impl<'req, 'state, T, N, Resp, Output, Map> Future
+for EthCallFut<'req, 'state, T, N, Resp, Output, Map>
 where
     T: Transport + Clone,
     N: Network,
+    Resp: RpcReturn,
+    Output: 'static,
+    Map: Fn(Resp) -> Output,
 {
-    type Output = TransportResult<Bytes>;
+    type Output = TransportResult<Output>;
 
     fn poll(
         self: std::pin::Pin<&mut Self>,
@@ -124,34 +139,79 @@ where
 /// [`Provider::call`]: crate::Provider::call
 #[must_use = "EthCall must be awaited to execute the call"]
 #[derive(Debug, Clone)]
-pub struct EthCall<'req, 'state, T, N>
+pub struct EthCall<'req, 'state, T, N, Resp, Output = Resp, Map = fn(Resp) -> Output>
 where
     T: Transport + Clone,
     N: Network,
+    Resp: RpcReturn,
+    Map: Fn(Resp) -> Output,
 {
     client: WeakClient<T>,
 
     data: &'req N::TransactionRequest,
     overrides: Option<&'state StateOverride>,
     block: Option<BlockId>,
+    method: &'static str,
+    map: Map,
+    _pd: PhantomData<fn() -> (Resp, Output)>,
 }
 
-impl<'req, T, N> EthCall<'req, 'static, T, N>
+impl<'req, T, N, Resp> EthCall<'req, 'static, T, N, Resp>
 where
     T: Transport + Clone,
     N: Network,
+    Resp: RpcReturn,
 {
     /// Create a new CallBuilder.
     pub const fn new(client: WeakClient<T>, data: &'req N::TransactionRequest) -> Self {
-        Self { client, data, overrides: None, block: None }
+        Self {
+            client,
+            data,
+            overrides: None,
+            block: None,
+            method: "eth_call",
+            map: std::convert::identity,
+            _pd: PhantomData,
+        }
+    }
+
+    /// Create new EthCall for gas estimates.
+    pub const fn gas_estimate(client: WeakClient<T>, data: &'req N::TransactionRequest) -> Self {
+        Self {
+            client,
+            data,
+            overrides: None,
+            block: None,
+            method: "eth_estimateGas",
+            map: std::convert::identity,
+            _pd: PhantomData,
+        }
     }
 }
 
-impl<'req, 'state, T, N> EthCall<'req, 'state, T, N>
+impl<'req, 'state, T, N, Resp, Output, Map> EthCall<'req, 'state, T, N, Resp, Output, Map>
 where
     T: Transport + Clone,
     N: Network,
+    Resp: RpcReturn,
+    Map: Fn(Resp) -> Output,
 {
+    /// Map the response to a different type.
+    pub fn map_resp<NewOutput, NewMap: Fn(Resp) -> NewOutput>(
+        self,
+        map: NewMap,
+    ) -> EthCall<'req, 'state, T, N, Resp, NewOutput, NewMap> {
+        EthCall {
+            client: self.client,
+            data: self.data,
+            overrides: self.overrides,
+            block: self.block,
+            method: self.method,
+            map,
+            _pd: PhantomData,
+        }
+    }
+
     /// Set the state overrides for this call.
     pub const fn overrides(mut self, overrides: &'state StateOverride) -> Self {
         self.overrides = Some(overrides);
@@ -165,14 +225,18 @@ where
     }
 }
 
-impl<'req, 'state, T, N> std::future::IntoFuture for EthCall<'req, 'state, T, N>
+impl<'req, 'state, T, N, Resp, Output, Map> std::future::IntoFuture
+for EthCall<'req, 'state, T, N, Resp, Output, Map>
 where
     T: Transport + Clone,
     N: Network,
+    Resp: RpcReturn,
+    Output: 'static,
+    Map: Fn(Resp) -> Output,
 {
-    type Output = TransportResult<Bytes>;
+    type Output = TransportResult<Output>;
 
-    type IntoFuture = EthCallFut<'req, 'state, T, N>;
+    type IntoFuture = EthCallFut<'req, 'state, T, N, Resp, Output, Map>;
 
     fn into_future(self) -> Self::IntoFuture {
         EthCallFut(EthCallFutInner::Preparing {
@@ -180,6 +244,8 @@ where
             data: self.data,
             overrides: self.overrides,
             block: self.block,
+            method: self.method,
+            map: self.map,
         })
     }
 }

--- a/crates/provider/src/provider/call.rs
+++ b/crates/provider/src/provider/call.rs
@@ -203,8 +203,8 @@ where
         self,
         map: NewMap,
     ) -> EthCall<'req, 'state, T, N, Resp, NewOutput, NewMap>
-        where
-            NewMap: Fn(Resp) -> NewOutput,
+    where
+        NewMap: Fn(Resp) -> NewOutput,
     {
         EthCall {
             client: self.client,

--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -719,7 +719,7 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
     /// or block ID is provided, the gas estimate will be computed for the latest block
     /// with the current state.
     ///
-    /// [`StateOverride`]: alloy_rpc_types::state::StateOverride\
+    /// [`StateOverride`]: alloy_rpc_types::state::StateOverride
     ///
     /// # Note
     ///


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Close https://github.com/alloy-rs/alloy/issues/785

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Add `Resp`, `Output`,  and `Map` generic type parameters to EthCall to allow it to return `u128`. 

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
