### PR TITLE
Impl Eq, PartialEq for WithOtherFields<T: PartialEq | Eq>

### DIFF
--- a/crates/rpc-types/src/with_other.rs
+++ b/crates/rpc-types/src/with_other.rs
@@ -55,6 +55,14 @@ impl<T: Default> Default for WithOtherFields<T> {
     }
 }
 
+impl<T: PartialEq> PartialEq for WithOtherFields<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.inner == other.inner && self.other == other.other
+    }
+}
+
+impl<T: Eq> Eq for WithOtherFields<T> {}
+
 impl<'de, T> Deserialize<'de> for WithOtherFields<T>
 where
     T: Deserialize<'de> + Serialize,


### PR DESCRIPTION
## Motivation

It's not possible to compare `WithOtherFields<T>` even if T: PartialEq.


## Solution

1. Implement PartialEq for `WithOtherFields<T: PartialEq>`
2. Implement Eq for `WithOtherFields<T: Eq>`

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
