### PR TITLE
fix: set minimal priority fee to 1 wei

### DIFF
--- a/crates/provider/src/fillers/gas.rs
+++ b/crates/provider/src/fillers/gas.rs
@@ -273,7 +273,7 @@ mod tests {
 
         let tx = tx.get_receipt().await.unwrap();
 
-        assert_eq!(tx.effective_gas_price, 0x3b9aca00);
+        assert_eq!(tx.effective_gas_price, 0x3b9aca01);
         assert_eq!(tx.gas_used, 0x5208);
     }
 

--- a/crates/provider/src/utils.rs
+++ b/crates/provider/src/utils.rs
@@ -86,9 +86,9 @@ mod tests {
 
         let rewards = vec![vec![0_u128], vec![0_u128], vec![0_u128]];
 
-        assert_eq!(super::estimate_priority_fee(&rewards), 0_u128);
+        assert_eq!(super::estimate_priority_fee(&rewards), EIP1559_MIN_PRIORITY_FEE);
 
-        assert_eq!(super::estimate_priority_fee(&[]), 0_u128);
+        assert_eq!(super::estimate_priority_fee(&[]), EIP1559_MIN_PRIORITY_FEE);
     }
 
     #[test]

--- a/crates/provider/src/utils.rs
+++ b/crates/provider/src/utils.rs
@@ -27,7 +27,7 @@ fn estimate_priority_fee(rewards: &[Vec<u128>]) -> u128 {
     let mut rewards =
         rewards.iter().filter_map(|r| r.first()).filter(|r| **r > 0_u128).collect::<Vec<_>>();
     if rewards.is_empty() {
-        return 0_u128;
+        return EIP1559_MIN_PRIORITY_FEE;
     }
 
     rewards.sort_unstable();

--- a/crates/provider/src/utils.rs
+++ b/crates/provider/src/utils.rs
@@ -34,11 +34,8 @@ fn estimate_priority_fee(rewards: &[Vec<u128>]) -> u128 {
 
     let n = rewards.len();
 
-    let median = if n % 2 == 0 {
-        (*rewards[n / 2 - 1] + *rewards[n / 2]) / 2
-    } else {
-        *rewards[n / 2]
-    };
+    let median =
+        if n % 2 == 0 { (*rewards[n / 2 - 1] + *rewards[n / 2]) / 2 } else { *rewards[n / 2] };
 
     std::cmp::max(median, EIP1559_MIN_PRIORITY_FEE)
 }

--- a/crates/provider/src/utils.rs
+++ b/crates/provider/src/utils.rs
@@ -8,6 +8,8 @@ pub const EIP1559_FEE_ESTIMATION_PAST_BLOCKS: u64 = 10;
 pub const EIP1559_BASE_FEE_MULTIPLIER: u128 = 2;
 /// The default percentile of gas premiums that are fetched for fee estimation.
 pub const EIP1559_FEE_ESTIMATION_REWARD_PERCENTILE: f64 = 20.0;
+/// The minimum priority fee to provide.
+pub const EIP1559_MIN_PRIORITY_FEE: u128 = 1;
 
 /// An estimator function for EIP1559 fees.
 pub type EstimatorFunction = fn(u128, &[Vec<u128>]) -> Eip1559Estimation;
@@ -30,14 +32,15 @@ fn estimate_priority_fee(rewards: &[Vec<u128>]) -> u128 {
 
     rewards.sort_unstable();
 
-    // Return the median.
     let n = rewards.len();
 
-    if n % 2 == 0 {
+    let median = if n % 2 == 0 {
         (*rewards[n / 2 - 1] + *rewards[n / 2]) / 2
     } else {
         *rewards[n / 2]
-    }
+    };
+
+    std::cmp::max(median, EIP1559_MIN_PRIORITY_FEE)
 }
 
 /// The default EIP-1559 fee estimator which is based on the work by [MetaMask](https://github.com/MetaMask/core/blob/main/packages/gas-fee-controller/src/fetchGasEstimatesViaEthFeeHistory/calculateGasFeeEstimatesForPriorityLevels.ts#L56)


### PR DESCRIPTION
## Motivation

ref https://github.com/foundry-rs/foundry/issues/7806

It seems that some of the chains always require non-zero priority fee.

## Solution

Enforce minimum 1 wei priority fee in default estimator. In ethers we had similar constant set to 3 gwei so this shouldn't cause any issues.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
