### PR TITLE
chore: move trace methods from `Provider` to `TraceApi`

### DIFF
--- a/crates/provider/src/ext/mod.rs
+++ b/crates/provider/src/ext/mod.rs
@@ -11,5 +11,8 @@ pub use engine::EngineApi;
 mod debug;
 pub use debug::DebugApi;
 
+mod trace;
+pub use trace::{TraceApi, TraceCallList};
+
 mod txpool;
 pub use txpool::TxPoolApi;

--- a/crates/provider/src/ext/trace.rs
+++ b/crates/provider/src/ext/trace.rs
@@ -1,0 +1,117 @@
+//! This module extends the Ethereum JSON-RPC provider with the Trace namespace's RPC methods.
+use crate::{Provider, RpcWithBlock};
+use alloy_eips::BlockNumberOrTag;
+use alloy_network::Network;
+use alloy_primitives::TxHash;
+use alloy_rpc_types_trace::parity::{LocalizedTransactionTrace, TraceResults, TraceType};
+use alloy_transport::{Transport, TransportResult};
+
+/// List of trace calls for use with [`TraceApi::trace_call_many`]
+pub type TraceCallList<'a, N> = &'a [(<N as Network>::TransactionRequest, Vec<TraceType>)];
+
+/// Trace namespace rpc interface that gives access to several non-standard RPC methods.
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+pub trait TraceApi<N, T>: Send + Sync
+where
+    N: Network,
+    T: Transport + Clone,
+{
+    /// Executes the given transaction and returns a number of possible traces.
+    ///
+    /// # Note
+    ///
+    /// Not all nodes support this call.
+    fn trace_call<'a, 'b>(
+        &self,
+        request: &'a N::TransactionRequest,
+        trace_type: &'b [TraceType],
+    ) -> RpcWithBlock<T, (&'a N::TransactionRequest, &'b [TraceType]), TraceResults>;
+
+    /// Traces multiple transactions on top of the same block, i.e. transaction `n` will be executed
+    /// on top of the given block with all `n - 1` transaction applied first.
+    ///
+    /// Allows tracing dependent transactions.
+    ///
+    /// # Note
+    ///
+    /// Not all nodes support this call.
+    fn trace_call_many<'a>(
+        &self,
+        request: TraceCallList<'a, N>,
+    ) -> RpcWithBlock<T, TraceCallList<'a, N>, TraceResults>;
+
+    /// Parity trace transaction.
+    async fn trace_transaction(
+        &self,
+        hash: TxHash,
+    ) -> TransportResult<Vec<LocalizedTransactionTrace>>;
+
+    /// Trace all transactions in the given block.
+    ///
+    /// # Note
+    ///
+    /// Not all nodes support this call.
+    async fn trace_block(
+        &self,
+        block: BlockNumberOrTag,
+    ) -> TransportResult<Vec<LocalizedTransactionTrace>>;
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+impl<N, T, P> TraceApi<N, T> for P
+where
+    N: Network,
+    T: Transport + Clone,
+    P: Provider<T, N>,
+{
+    fn trace_call<'a, 'b>(
+        &self,
+        request: &'a <N as Network>::TransactionRequest,
+        trace_type: &'b [TraceType],
+    ) -> RpcWithBlock<T, (&'a <N as Network>::TransactionRequest, &'b [TraceType]), TraceResults>
+    {
+        RpcWithBlock::new(self.weak_client(), "trace_call", (request, trace_type))
+    }
+
+    fn trace_call_many<'a>(
+        &self,
+        request: TraceCallList<'a, N>,
+    ) -> RpcWithBlock<T, TraceCallList<'a, N>, TraceResults> {
+        RpcWithBlock::new(self.weak_client(), "trace_callMany", request)
+    }
+
+    async fn trace_transaction(
+        &self,
+        hash: TxHash,
+    ) -> TransportResult<Vec<LocalizedTransactionTrace>> {
+        self.client().request("trace_transaction", (hash,)).await
+    }
+
+    async fn trace_block(
+        &self,
+        block: BlockNumberOrTag,
+    ) -> TransportResult<Vec<LocalizedTransactionTrace>> {
+        self.client().request("trace_block", (block,)).await
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::ProviderBuilder;
+
+    use super::*;
+
+    fn init_tracing() {
+        let _ = tracing_subscriber::fmt::try_init();
+    }
+
+    #[tokio::test]
+    async fn test_trace_block() {
+        init_tracing();
+        let provider = ProviderBuilder::new().on_anvil();
+        let traces = provider.trace_block(BlockNumberOrTag::Latest).await.unwrap();
+        assert_eq!(traces.len(), 0);
+    }
+}

--- a/crates/provider/src/lib.rs
+++ b/crates/provider/src/lib.rs
@@ -40,8 +40,7 @@ pub use heart::{PendingTransaction, PendingTransactionBuilder, PendingTransactio
 
 mod provider;
 pub use provider::{
-    EthCall, FilterPollerBuilder, Provider, RootProvider, RpcWithBlock, SendableTx, TraceCallList,
-    WalletProvider,
+    EthCall, FilterPollerBuilder, Provider, RootProvider, RpcWithBlock, SendableTx, WalletProvider,
 };
 
 pub mod utils;

--- a/crates/provider/src/provider/mod.rs
+++ b/crates/provider/src/provider/mod.rs
@@ -8,7 +8,7 @@ mod sendable;
 pub use sendable::SendableTx;
 
 mod r#trait;
-pub use r#trait::{FilterPollerBuilder, Provider, TraceCallList};
+pub use r#trait::{FilterPollerBuilder, Provider};
 
 mod wallet;
 pub use wallet::WalletProvider;

--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -17,7 +17,6 @@ use alloy_rpc_types::{
     AccessListWithGasUsed, Block, BlockId, BlockNumberOrTag, EIP1186AccountProofResponse,
     FeeHistory, Filter, FilterChanges, Log, SyncStatus,
 };
-use alloy_rpc_types_trace::parity::{LocalizedTransactionTrace, TraceResults, TraceType};
 use alloy_transport::{BoxTransport, Transport, TransportErrorKind, TransportResult};
 use serde_json::value::RawValue;
 use std::borrow::Cow;
@@ -26,9 +25,6 @@ use std::borrow::Cow;
 ///
 /// See [`PollerBuilder`] for more details.
 pub type FilterPollerBuilder<T, R> = PollerBuilder<T, (U256,), Vec<R>>;
-
-/// List of trace calls for use with [`Provider::trace_call_many`]
-pub type TraceCallList<'a, N> = &'a [(<N as Network>::TransactionRequest, Vec<TraceType>)];
 
 // todo: adjust docs
 // todo: reorder
@@ -789,56 +785,6 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
         RpcWithBlock::new(self.weak_client(), "eth_createAccessList", request)
     }
 
-    /// Executes the given transaction and returns a number of possible traces.
-    ///
-    /// # Note
-    ///
-    /// Not all nodes support this call.
-    fn trace_call<'a, 'b>(
-        &self,
-        request: &'a N::TransactionRequest,
-        trace_type: &'b [TraceType],
-    ) -> RpcWithBlock<T, (&'a N::TransactionRequest, &'b [TraceType]), TraceResults> {
-        RpcWithBlock::new(self.weak_client(), "trace_call", (request, trace_type))
-    }
-
-    /// Traces multiple transactions on top of the same block, i.e. transaction `n` will be executed
-    /// on top of the given block with all `n - 1` transaction applied first.
-    ///
-    /// Allows tracing dependent transactions.
-    ///
-    /// # Note
-    ///
-    /// Not all nodes support this call.
-    fn trace_call_many<'a>(
-        &self,
-        request: TraceCallList<'a, N>,
-    ) -> RpcWithBlock<T, TraceCallList<'a, N>, TraceResults> {
-        RpcWithBlock::new(self.weak_client(), "trace_callMany", request)
-    }
-
-    // todo: move to extension trait
-    /// Parity trace transaction.
-    async fn trace_transaction(
-        &self,
-        hash: TxHash,
-    ) -> TransportResult<Vec<LocalizedTransactionTrace>> {
-        self.client().request("trace_transaction", (hash,)).await
-    }
-
-    // todo: move to extension trait
-    /// Trace all transactions in the given block.
-    ///
-    /// # Note
-    ///
-    /// Not all nodes support this call.
-    async fn trace_block(
-        &self,
-        block: BlockNumberOrTag,
-    ) -> TransportResult<Vec<LocalizedTransactionTrace>> {
-        self.client().request("trace_block", (block,)).await
-    }
-
     /* ------------------------------------------ anvil ----------------------------------------- */
 
     /// Set the bytecode of a given account.
@@ -1305,14 +1251,6 @@ mod tests {
         let provider = ProviderBuilder::new().on_anvil();
         let receipts = provider.get_block_receipts(BlockNumberOrTag::Latest).await.unwrap();
         assert!(receipts.is_some());
-    }
-
-    #[tokio::test]
-    async fn gets_block_traces() {
-        init_tracing();
-        let provider = ProviderBuilder::new().on_anvil();
-        let traces = provider.trace_block(BlockNumberOrTag::Latest).await.unwrap();
-        assert_eq!(traces.len(), 0);
     }
 
     #[tokio::test]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

This comment above some trace methods
`// todo: move to extension trait`

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Moved trace related methods, types and tests from `provider/trait.rs` to `ext/trace.rs`

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
