### PR TITLE
feature: re-export `RecommendedFiller` in `alloy` meta-crate

### DIFF
--- a/crates/provider/src/builder.rs
+++ b/crates/provider/src/builder.rs
@@ -1,6 +1,7 @@
 use crate::{
     fillers::{
-        ChainIdFiller, FillerControlFlow, GasFiller, JoinFill, NonceFiller, SignerFiller, TxFiller,
+        ChainIdFiller, FillerControlFlow, GasFiller, JoinFill, NonceFiller, RecommendedFiller,
+        SignerFiller, TxFiller,
     },
     provider::SendableTx,
     Provider, RootProvider,
@@ -10,10 +11,6 @@ use alloy_network::{Ethereum, Network};
 use alloy_rpc_client::{BuiltInConnectionString, ClientBuilder, RpcClient};
 use alloy_transport::{BoxTransport, Transport, TransportError, TransportResult};
 use std::marker::PhantomData;
-
-/// The recommended filler.
-type RecommendFiller =
-    JoinFill<JoinFill<JoinFill<Identity, GasFiller>, NonceFiller>, ChainIdFiller>;
 
 /// A layering abstraction in the vein of [`tower::Layer`]
 ///
@@ -130,7 +127,7 @@ impl<N> Default for ProviderBuilder<Identity, Identity, N> {
 impl<L, N> ProviderBuilder<L, Identity, N> {
     /// Add preconfigured set of layers handling gas estimation, nonce
     /// management, and chain-id fetching.
-    pub fn with_recommended_fillers(self) -> ProviderBuilder<L, RecommendFiller, N> {
+    pub fn with_recommended_fillers(self) -> ProviderBuilder<L, RecommendedFiller, N> {
         self.filler(GasFiller).filler(NonceFiller::default()).filler(ChainIdFiller::default())
     }
 

--- a/crates/provider/src/fillers/mod.rs
+++ b/crates/provider/src/fillers/mod.rs
@@ -22,7 +22,8 @@ mod join_fill;
 pub use join_fill::JoinFill;
 
 use crate::{
-    provider::SendableTx, PendingTransactionBuilder, Provider, ProviderLayer, RootProvider,
+    provider::SendableTx, Identity, PendingTransactionBuilder, Provider, ProviderLayer,
+    RootProvider,
 };
 use alloy_json_rpc::RpcError;
 use alloy_network::{Ethereum, Network};
@@ -30,6 +31,11 @@ use alloy_transport::{Transport, TransportResult};
 use async_trait::async_trait;
 use futures_utils_wasm::impl_future;
 use std::marker::PhantomData;
+
+/// The recommended filler, a preconfigured set of layers handling gas estimation, nonce
+/// management, and chain-id fetching.
+pub type RecommendedFiller =
+    JoinFill<JoinFill<JoinFill<Identity, GasFiller>, NonceFiller>, ChainIdFiller>;
 
 /// The control flow for a filler.
 #[derive(Clone, Debug, PartialEq, Eq)]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Closes #821 

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

- Changes `RecommendFiller` -> `RecommendedFiller`
- Groups the export with the other fillers so it is accessible on `fillers::RecommendedFiller` in the `alloy` meta-crate

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
