### PR TITLE
Refactor: align naming of `transaction_hash` / `transaction_type`

### DIFF
--- a/crates/consensus/src/receipt/envelope.rs
+++ b/crates/consensus/src/receipt/envelope.rs
@@ -40,7 +40,7 @@ pub enum ReceiptEnvelope<T = Log> {
 
 impl<T> ReceiptEnvelope<T> {
     /// Return the [`TxType`] of the inner receipt.
-    pub const fn tx_type(&self) -> TxType {
+    pub const fn transaction_type(&self) -> TxType {
         match self {
             Self::Legacy(_) => TxType::Legacy,
             Self::Eip2930(_) => TxType::Eip2930,

--- a/crates/consensus/src/transaction/eip1559.rs
+++ b/crates/consensus/src/transaction/eip1559.rs
@@ -192,7 +192,7 @@ impl TxEip1559 {
             }
             .encode(out);
         }
-        out.put_u8(self.tx_type() as u8);
+        out.put_u8(self.transaction_type() as u8);
         self.encode_with_signature_fields(signature, out);
     }
 
@@ -239,7 +239,7 @@ impl TxEip1559 {
     }
 
     /// Get transaction type
-    pub(crate) const fn tx_type(&self) -> TxType {
+    pub(crate) const fn transaction_type(&self) -> TxType {
         TxType::Eip1559
     }
 
@@ -294,7 +294,7 @@ impl SignableTransaction<Signature> for TxEip1559 {
     }
 
     fn encode_for_signing(&self, out: &mut dyn alloy_rlp::BufMut) {
-        out.put_u8(self.tx_type() as u8);
+        out.put_u8(self.transaction_type() as u8);
         self.encode(out)
     }
 

--- a/crates/consensus/src/transaction/eip2930.rs
+++ b/crates/consensus/src/transaction/eip2930.rs
@@ -170,7 +170,7 @@ impl TxEip2930 {
             }
             .encode(out);
         }
-        out.put_u8(self.tx_type() as u8);
+        out.put_u8(self.transaction_type() as u8);
         self.encode_with_signature_fields(signature, out);
     }
 
@@ -217,7 +217,7 @@ impl TxEip2930 {
     }
 
     /// Get transaction type.
-    pub const fn tx_type(&self) -> TxType {
+    pub const fn transaction_type(&self) -> TxType {
         TxType::Eip2930
     }
 }
@@ -258,7 +258,7 @@ impl SignableTransaction<Signature> for TxEip2930 {
     }
 
     fn encode_for_signing(&self, out: &mut dyn BufMut) {
-        out.put_u8(self.tx_type() as u8);
+        out.put_u8(self.transaction_type() as u8);
         Header { list: true, payload_length: self.fields_len() }.encode(out);
         self.encode_fields(out);
     }

--- a/crates/consensus/src/transaction/eip4844.rs
+++ b/crates/consensus/src/transaction/eip4844.rs
@@ -89,7 +89,7 @@ impl TxEip4844Variant {
     }
 
     /// Get the transaction type.
-    pub const fn tx_type(&self) -> TxType {
+    pub const fn transaction_type(&self) -> TxType {
         TxType::Eip4844
     }
 
@@ -112,10 +112,11 @@ impl TxEip4844Variant {
 
     /// Encodes the [TxEip4844Variant] fields as RLP, with a tx type. If `with_header` is `false`,
     /// the following will be encoded:
-    /// `tx_type (0x03) || rlp([transaction_payload_body, blobs, commitments, proofs])`
+    /// `transaction_type (0x03) || rlp([transaction_payload_body, blobs, commitments, proofs])`
     ///
     /// If `with_header` is `true`, the following will be encoded:
-    /// `rlp(tx_type (0x03) || rlp([transaction_payload_body, blobs, commitments, proofs]))`
+    /// `rlp(transaction_type (0x03) || rlp([transaction_payload_body, blobs, commitments,
+    /// proofs]))`
     #[doc(hidden)]
     pub fn encode_with_signature(
         &self,
@@ -141,7 +142,7 @@ impl TxEip4844Variant {
             }
             .encode(out);
         }
-        out.put_u8(self.tx_type() as u8);
+        out.put_u8(self.transaction_type() as u8);
 
         match self {
             Self::TxEip4844(tx) => {
@@ -525,7 +526,7 @@ impl TxEip4844 {
             }
             .encode(out);
         }
-        out.put_u8(self.tx_type() as u8);
+        out.put_u8(self.transaction_type() as u8);
         self.encode_with_signature_fields(signature, out);
     }
 
@@ -572,19 +573,19 @@ impl TxEip4844 {
     }
 
     /// Get transaction type
-    pub const fn tx_type(&self) -> TxType {
+    pub const fn transaction_type(&self) -> TxType {
         TxType::Eip4844
     }
 
     /// Encodes the EIP-4844 transaction in RLP for signing.
     ///
     /// This encodes the transaction as:
-    /// `tx_type || rlp(chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas, gas_limit, to,
-    /// value, input, access_list, max_fee_per_blob_gas, blob_versioned_hashes)`
+    /// `transaction_type || rlp(chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas,
+    /// gas_limit, to, value, input, access_list, max_fee_per_blob_gas, blob_versioned_hashes)`
     ///
     /// Note that there is no rlp header before the transaction type byte.
     pub fn encode_for_signing(&self, out: &mut dyn BufMut) {
-        out.put_u8(self.tx_type() as u8);
+        out.put_u8(self.transaction_type() as u8);
         Header { list: true, payload_length: self.fields_len() }.encode(out);
         self.encode_fields(out);
     }
@@ -723,8 +724,8 @@ impl TxEip4844WithSidecar {
     }
 
     /// Get the transaction type.
-    pub const fn tx_type(&self) -> TxType {
-        self.tx.tx_type()
+    pub const fn transaction_type(&self) -> TxType {
+        self.tx.transaction_type()
     }
 
     /// Get access to the inner tx [TxEip4844].

--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -164,7 +164,7 @@ impl TxEnvelope {
     }
 
     /// Return the hash of the inner Signed
-    pub const fn tx_hash(&self) -> &B256 {
+    pub const fn transaction_hash(&self) -> &B256 {
         match self {
             Self::Legacy(tx) => tx.hash(),
             Self::Eip2930(tx) => tx.hash(),

--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -174,7 +174,7 @@ impl TxEnvelope {
     }
 
     /// Return the [`TxType`] of the inner txn.
-    pub const fn tx_type(&self) -> TxType {
+    pub const fn transaction_type(&self) -> TxType {
         match self {
             Self::Legacy(_) => TxType::Legacy,
             Self::Eip2930(_) => TxType::Eip2930,
@@ -316,7 +316,7 @@ mod tests {
         let raw_tx = alloy_primitives::hex::decode("02f86f0102843b9aca0085029e7822d68298f094d9e1459a7a482635700cbc20bbaf52d495ab9c9680841b55ba3ac080a0c199674fcb29f353693dd779c017823b954b3c69dffa3cd6b2a6ff7888798039a028ca912de909e7e6cdef9cdcaf24c54dd8c1032946dfa1d85c206b32a9064fe8").unwrap();
         let res = TxEnvelope::decode(&mut raw_tx.as_slice()).unwrap();
 
-        assert_eq!(res.tx_type(), TxType::Eip1559);
+        assert_eq!(res.transaction_type(), TxType::Eip1559);
 
         let tx = match res {
             TxEnvelope::Eip1559(tx) => tx,
@@ -336,7 +336,7 @@ mod tests {
 
         let raw_tx = alloy_primitives::hex::decode("f9015482078b8505d21dba0083022ef1947a250d5630b4cf539739df2c5dacb4c659f2488d880c46549a521b13d8b8e47ff36ab50000000000000000000000000000000000000000000066ab5a608bd00a23f2fe000000000000000000000000000000000000000000000000000000000000008000000000000000000000000048c04ed5691981c42154c6167398f95e8f38a7ff00000000000000000000000000000000000000000000000000000000632ceac70000000000000000000000000000000000000000000000000000000000000002000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc20000000000000000000000006c6ee5e31d828de241282b9606c8e98ea48526e225a0c9077369501641a92ef7399ff81c21639ed4fd8fc69cb793cfa1dbfab342e10aa0615facb2f1bcf3274a354cfe384a38d0cc008a11c2dd23a69111bc6930ba27a8").unwrap();
         let res = TxEnvelope::decode(&mut raw_tx.as_slice()).unwrap();
-        assert_eq!(res.tx_type(), TxType::Legacy);
+        assert_eq!(res.transaction_type(), TxType::Legacy);
 
         let tx = match res {
             TxEnvelope::Legacy(tx) => tx,
@@ -363,7 +363,7 @@ mod tests {
         // https://sepolia.etherscan.io/getRawTx?tx=0x9a22ccb0029bc8b0ddd073be1a1d923b7ae2b2ea52100bae0db4424f9107e9c0
         let raw_tx = alloy_primitives::hex::decode("0x03f9011d83aa36a7820fa28477359400852e90edd0008252089411e9ca82a3a762b4b5bd264d4173a242e7a770648080c08504a817c800f8a5a0012ec3d6f66766bedb002a190126b3549fce0047de0d4c25cffce0dc1c57921aa00152d8e24762ff22b1cfd9f8c0683786a7ca63ba49973818b3d1e9512cd2cec4a0013b98c6c83e066d5b14af2b85199e3d4fc7d1e778dd53130d180f5077e2d1c7a001148b495d6e859114e670ca54fb6e2657f0cbae5b08063605093a4b3dc9f8f1a0011ac212f13c5dff2b2c6b600a79635103d6f580a4221079951181b25c7e654901a0c8de4cced43169f9aa3d36506363b2d2c44f6c49fc1fd91ea114c86f3757077ea01e11fdd0d1934eda0492606ee0bb80a7bf8f35cc5f86ec60fe5031ba48bfd544").unwrap();
         let res = TxEnvelope::decode(&mut raw_tx.as_slice()).unwrap();
-        assert_eq!(res.tx_type(), TxType::Eip4844);
+        assert_eq!(res.transaction_type(), TxType::Eip4844);
 
         let tx = match res {
             TxEnvelope::Eip4844(tx) => tx,

--- a/crates/consensus/src/transaction/typed.rs
+++ b/crates/consensus/src/transaction/typed.rs
@@ -78,7 +78,7 @@ impl From<TxEnvelope> for TypedTransaction {
 
 impl TypedTransaction {
     /// Return the [`TxType`] of the inner txn.
-    pub const fn tx_type(&self) -> TxType {
+    pub const fn transaction_type(&self) -> TxType {
         match self {
             Self::Legacy(_) => TxType::Legacy,
             Self::Eip2930(_) => TxType::Eip2930,

--- a/crates/network/src/any/builder.rs
+++ b/crates/network/src/any/builder.rs
@@ -129,12 +129,12 @@ impl TransactionBuilder<AnyNetwork> for WithOtherFields<TransactionRequest> {
         self.deref().can_submit()
     }
 
-    fn output_tx_type(&self) -> <AnyNetwork as Network>::TxType {
-        self.deref().output_tx_type().into()
+    fn output_transaction_type(&self) -> <AnyNetwork as Network>::TxType {
+        self.deref().output_transaction_type().into()
     }
 
-    fn output_tx_type_checked(&self) -> Option<<AnyNetwork as Network>::TxType> {
-        self.deref().output_tx_type_checked().map(Into::into)
+    fn output_transaction_type_checked(&self) -> Option<<AnyNetwork as Network>::TxType> {
+        self.deref().output_transaction_type_checked().map(Into::into)
     }
 
     fn prep_for_submission(&mut self) {

--- a/crates/network/src/any/builder.rs
+++ b/crates/network/src/any/builder.rs
@@ -142,10 +142,13 @@ impl TransactionBuilder<AnyNetwork> for WithOtherFields<TransactionRequest> {
     }
 
     fn build_unsigned(self) -> BuildResult<<AnyNetwork as Network>::UnsignedTx, AnyNetwork> {
-        if let Err((tx_type, missing)) = self.missing_keys() {
+        if let Err((transaction_type, missing)) = self.missing_keys() {
             return Err((
                 self,
-                TransactionBuilderError::InvalidTransactionRequest(tx_type.into(), missing),
+                TransactionBuilderError::InvalidTransactionRequest(
+                    transaction_type.into(),
+                    missing,
+                ),
             ));
         }
         Ok(self.inner.build_typed_tx().expect("checked by missing_keys"))

--- a/crates/network/src/ethereum/builder.rs
+++ b/crates/network/src/ethereum/builder.rs
@@ -147,11 +147,11 @@ impl TransactionBuilder<Ethereum> for TransactionRequest {
         common && (legacy || eip2930 || eip1559 || eip4844)
     }
 
-    fn output_tx_type(&self) -> TxType {
+    fn output_transaction_type(&self) -> TxType {
         self.preferred_type()
     }
 
-    fn output_tx_type_checked(&self) -> Option<TxType> {
+    fn output_transaction_type_checked(&self) -> Option<TxType> {
         self.buildable_type()
     }
 

--- a/crates/network/src/ethereum/builder.rs
+++ b/crates/network/src/ethereum/builder.rs
@@ -162,10 +162,10 @@ impl TransactionBuilder<Ethereum> for TransactionRequest {
     }
 
     fn build_unsigned(self) -> BuildResult<TypedTransaction, Ethereum> {
-        if let Err((tx_type, missing)) = self.missing_keys() {
+        if let Err((transaction_type, missing)) = self.missing_keys() {
             return Err((
                 self,
-                TransactionBuilderError::InvalidTransactionRequest(tx_type, missing),
+                TransactionBuilderError::InvalidTransactionRequest(transaction_type, missing),
             ));
         }
         Ok(self.build_typed_tx().expect("checked by missing_keys"))
@@ -272,11 +272,13 @@ mod tests {
 
         let error = request.build_unsigned().unwrap_err();
 
-        let (_, TransactionBuilderError::InvalidTransactionRequest(tx_type, errors)) = error else {
+        let (_, TransactionBuilderError::InvalidTransactionRequest(transaction_type, errors)) =
+            error
+        else {
             panic!("wrong variant")
         };
 
-        assert_eq!(tx_type, TxType::Legacy);
+        assert_eq!(transaction_type, TxType::Legacy);
         assert_eq!(errors.len(), 3);
         assert!(errors.contains(&"to"));
         assert!(errors.contains(&"nonce"));
@@ -289,11 +291,13 @@ mod tests {
 
         let error = request.build_unsigned().unwrap_err();
 
-        let (_, TransactionBuilderError::InvalidTransactionRequest(tx_type, errors)) = error else {
+        let (_, TransactionBuilderError::InvalidTransactionRequest(transaction_type, errors)) =
+            error
+        else {
             panic!("wrong variant")
         };
 
-        assert_eq!(tx_type, TxType::Eip1559);
+        assert_eq!(transaction_type, TxType::Eip1559);
         assert_eq!(errors.len(), 5);
         assert!(errors.contains(&"to"));
         assert!(errors.contains(&"nonce"));
@@ -310,11 +314,13 @@ mod tests {
 
         let error = request.build_unsigned().unwrap_err();
 
-        let (_, TransactionBuilderError::InvalidTransactionRequest(tx_type, errors)) = error else {
+        let (_, TransactionBuilderError::InvalidTransactionRequest(transaction_type, errors)) =
+            error
+        else {
             panic!("wrong variant")
         };
 
-        assert_eq!(tx_type, TxType::Eip2930);
+        assert_eq!(transaction_type, TxType::Eip2930);
         assert_eq!(errors.len(), 3);
         assert!(errors.contains(&"to"));
         assert!(errors.contains(&"nonce"));
@@ -328,11 +334,13 @@ mod tests {
 
         let error = request.build_unsigned().unwrap_err();
 
-        let (_, TransactionBuilderError::InvalidTransactionRequest(tx_type, errors)) = error else {
+        let (_, TransactionBuilderError::InvalidTransactionRequest(transaction_type, errors)) =
+            error
+        else {
             panic!("wrong variant")
         };
 
-        assert_eq!(tx_type, TxType::Eip4844);
+        assert_eq!(transaction_type, TxType::Eip4844);
         assert_eq!(errors.len(), 7);
         assert!(errors.contains(&"to"));
         assert!(errors.contains(&"nonce"));

--- a/crates/network/src/transaction/builder.rs
+++ b/crates/network/src/transaction/builder.rs
@@ -292,7 +292,7 @@ pub trait TransactionBuilder<N: Network>: Default + Sized + Send + Sync + 'stati
     /// Check if all necessary keys are present to build the currently-preferred
     /// transaction type, returning a list of missing keys.
     fn complete_preferred(&self) -> Result<(), Vec<&'static str>> {
-        self.complete_type(self.output_tx_type())
+        self.complete_type(self.output_transaction_type())
     }
 
     /// Assert that the builder prefers a certain transaction type. This does
@@ -300,7 +300,7 @@ pub trait TransactionBuilder<N: Network>: Default + Sized + Send + Sync + 'stati
     /// `dbg_assert_eq!` to check the builder status, and will have no affect
     /// in release builds.
     fn assert_preferred(&self, ty: N::TxType) {
-        debug_assert_eq!(self.output_tx_type(), ty);
+        debug_assert_eq!(self.output_transaction_type(), ty);
     }
 
     /// Assert that the builder prefers a certain transaction type. This does
@@ -322,11 +322,11 @@ pub trait TransactionBuilder<N: Network>: Default + Sized + Send + Sync + 'stati
 
     /// Returns the transaction type that this builder will attempt to build.
     /// This does not imply that the builder is ready to build.
-    fn output_tx_type(&self) -> N::TxType;
+    fn output_transaction_type(&self) -> N::TxType;
 
     /// Returns the transaction type that this builder will build. `None` if
     /// the builder is not ready to build.
-    fn output_tx_type_checked(&self) -> Option<N::TxType>;
+    fn output_transaction_type_checked(&self) -> Option<N::TxType>;
 
     /// Trim any conflicting keys and populate any computed fields (like blob
     /// hashes).

--- a/crates/provider/src/fillers/nonce.rs
+++ b/crates/provider/src/fillers/nonce.rs
@@ -149,18 +149,18 @@ mod tests {
         };
 
         let pending = provider.send_transaction(tx.clone()).await.unwrap();
-        let tx_hash = pending.watch().await.unwrap();
+        let transaction_hash = pending.watch().await.unwrap();
         let mined_tx = provider
-            .get_transaction_by_hash(tx_hash)
+            .get_transaction_by_hash(transaction_hash)
             .await
             .expect("failed to fetch tx")
             .expect("tx not included");
         assert_eq!(mined_tx.nonce, 0);
 
         let pending = provider.send_transaction(tx).await.unwrap();
-        let tx_hash = pending.watch().await.unwrap();
+        let transaction_hash = pending.watch().await.unwrap();
         let mined_tx = provider
-            .get_transaction_by_hash(tx_hash)
+            .get_transaction_by_hash(transaction_hash)
             .await
             .expect("fail to fetch tx")
             .expect("tx didn't finalize");

--- a/crates/provider/src/fillers/signer.rs
+++ b/crates/provider/src/fillers/signer.rs
@@ -124,14 +124,14 @@ mod tests {
         };
 
         let builder = provider.send_transaction(tx).await.unwrap();
-        let node_hash = *builder.tx_hash();
+        let node_hash = *builder.transaction_hash();
         assert_eq!(
             node_hash,
             b256!("eb56033eab0279c6e9b685a5ec55ea0ff8d06056b62b7f36974898d4fbb57e64")
         );
 
         let pending = builder.register().await.unwrap();
-        let local_hash = *pending.tx_hash();
+        let local_hash = *pending.transaction_hash();
         assert_eq!(local_hash, node_hash);
 
         let local_hash2 = pending.await.unwrap();

--- a/crates/provider/src/heart.rs
+++ b/crates/provider/src/heart.rs
@@ -34,7 +34,7 @@ use tokio::{
 /// // Register the pending transaction with the provider.
 /// let pending_tx = builder.register().await?;
 /// // Wait for the transaction to be confirmed 2 times.
-/// let tx_hash = pending_tx.await?;
+/// let transaction_hash = pending_tx.await?;
 /// # Ok(())
 /// # }
 /// ```
@@ -42,7 +42,7 @@ use tokio::{
 /// This can also be more concisely written using `watch`:
 /// ```no_run
 /// # async fn example<N: alloy_network::Network>(provider: impl alloy_provider::Provider, tx: alloy_rpc_types::transaction::TransactionRequest) -> Result<(), Box<dyn std::error::Error>> {
-/// let tx_hash = provider.send_transaction(tx)
+/// let transaction_hash = provider.send_transaction(tx)
 ///     .await?
 ///     .with_required_confirmations(2)
 ///     .with_timeout(Some(std::time::Duration::from_secs(60)))
@@ -60,8 +60,8 @@ pub struct PendingTransactionBuilder<'a, T, N> {
 
 impl<'a, T: Transport + Clone, N: Network> PendingTransactionBuilder<'a, T, N> {
     /// Creates a new pending transaction builder.
-    pub const fn new(provider: &'a RootProvider<T, N>, tx_hash: B256) -> Self {
-        Self::from_config(provider, PendingTransactionConfig::new(tx_hash))
+    pub const fn new(provider: &'a RootProvider<T, N>, transaction_hash: B256) -> Self {
+        Self::from_config(provider, PendingTransactionConfig::new(transaction_hash))
     }
 
     /// Creates a new pending transaction builder from the given configuration.
@@ -429,9 +429,9 @@ impl<S> Heartbeat<S> {
         let to_keep = self.reap_at.split_off(&now);
         let to_reap = std::mem::replace(&mut self.reap_at, to_keep);
 
-        for tx_hash in to_reap.values() {
-            if self.unconfirmed.remove(tx_hash).is_some() {
-                debug!(tx=%tx_hash, "reaped");
+        for transaction_hash in to_reap.values() {
+            if self.unconfirmed.remove(transaction_hash).is_some() {
+                debug!(tx=%transaction_hash, "reaped");
             }
         }
     }
@@ -456,8 +456,10 @@ impl<S> Heartbeat<S> {
         let Some(block_height) = &block.header.number else { return };
 
         // Check if we are watching for any of the transactions in this block.
-        let to_check =
-            block.transactions.hashes().filter_map(|tx_hash| self.unconfirmed.remove(tx_hash));
+        let to_check = block
+            .transactions
+            .hashes()
+            .filter_map(|transaction_hash| self.unconfirmed.remove(transaction_hash));
         for watcher in to_check {
             // If `confirmations` is not more than 1 we can notify the watcher immediately.
             let confirmations = watcher.config.required_confirmations;

--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -130,8 +130,8 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
     ///
     /// let sub = provider.subscribe_pending_transactions().await?;
     /// let mut stream = sub.into_stream().take(5);
-    /// while let Some(tx_hash) = stream.next().await {
-    ///    println!("new pending transaction hash: {tx_hash}");
+    /// while let Some(transaction_hash) = stream.next().await {
+    ///    println!("new pending transaction hash: {transaction_hash}");
     /// }
     /// # Ok(())
     /// # }
@@ -287,8 +287,8 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
     ///
     /// let poller = provider.watch_pending_transactions().await?;
     /// let mut stream = poller.into_stream().flat_map(futures::stream::iter).take(5);
-    /// while let Some(tx_hash) = stream.next().await {
-    ///    println!("new pending transaction hash: {tx_hash}");
+    /// while let Some(transaction_hash) = stream.next().await {
+    ///    println!("new pending transaction hash: {transaction_hash}");
     /// }
     /// # Ok(())
     /// # }
@@ -451,7 +451,7 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
     ///
     /// ```no_run
     /// # async fn example<N: alloy_network::Network>(provider: impl alloy_provider::Provider, tx: alloy_rpc_types::transaction::TransactionRequest) -> Result<(), Box<dyn std::error::Error>> {
-    /// let tx_hash = provider.send_transaction(tx)
+    /// let transaction_hash = provider.send_transaction(tx)
     ///     .await?
     ///     .with_required_confirmations(2)
     ///     .with_timeout(Some(std::time::Duration::from_secs(60)))
@@ -483,8 +483,8 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
         match tx {
             SendableTx::Builder(mut tx) => {
                 alloy_network::TransactionBuilder::prep_for_submission(&mut tx);
-                let tx_hash = self.client().request("eth_sendTransaction", (tx,)).await?;
-                Ok(PendingTransactionBuilder::new(self.root(), tx_hash))
+                let transaction_hash = self.client().request("eth_sendTransaction", (tx,)).await?;
+                Ok(PendingTransactionBuilder::new(self.root(), transaction_hash))
             }
             SendableTx::Envelope(tx) => {
                 let mut encoded_tx = vec![];
@@ -502,8 +502,8 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
         encoded_tx: &[u8],
     ) -> TransportResult<PendingTransactionBuilder<'_, T, N>> {
         let rlp_hex = hex::encode_prefixed(encoded_tx);
-        let tx_hash = self.client().request("eth_sendRawTransaction", (rlp_hex,)).await?;
-        Ok(PendingTransactionBuilder::new(self.root(), tx_hash))
+        let transaction_hash = self.client().request("eth_sendRawTransaction", (rlp_hex,)).await?;
+        Ok(PendingTransactionBuilder::new(self.root(), transaction_hash))
     }
 
     /// Gets the balance of the account at the specified tag, which defaults to latest.
@@ -1158,8 +1158,10 @@ mod tests {
         init_tracing();
 
         let provider = ProviderBuilder::new().on_anvil();
-        let tx_hash = b256!("5c03fab9114ceb98994b43892ade87ddfd9ae7e8f293935c3bd29d435dc9fd95");
-        let tx = provider.get_transaction_by_hash(tx_hash).await.expect("failed to fetch tx");
+        let transaction_hash =
+            b256!("5c03fab9114ceb98994b43892ade87ddfd9ae7e8f293935c3bd29d435dc9fd95");
+        let tx =
+            provider.get_transaction_by_hash(transaction_hash).await.expect("failed to fetch tx");
 
         assert!(tx.is_none());
     }
@@ -1175,11 +1177,11 @@ mod tests {
             .value(U256::ZERO)
             .input(bytes!("deadbeef").into());
 
-        let tx_hash =
+        let transaction_hash =
             *provider.send_transaction(req).await.expect("failed to send tx").transaction_hash();
 
         let tx = provider
-            .get_transaction_by_hash(tx_hash)
+            .get_transaction_by_hash(transaction_hash)
             .await
             .expect("failed to fetch tx")
             .expect("tx not included");

--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -1021,12 +1021,12 @@ mod tests {
         };
 
         let builder = provider.send_transaction(tx.clone()).await.expect("failed to send tx");
-        let hash1 = *builder.tx_hash();
+        let hash1 = *builder.transaction_hash();
         let hash2 = builder.watch().await.expect("failed to await pending tx");
         assert_eq!(hash1, hash2);
 
         let builder = provider.send_transaction(tx).await.expect("failed to send tx");
-        let hash1 = *builder.tx_hash();
+        let hash1 = *builder.transaction_hash();
         let hash2 =
             builder.get_receipt().await.expect("failed to await pending tx").transaction_hash;
         assert_eq!(hash1, hash2);
@@ -1175,7 +1175,8 @@ mod tests {
             .value(U256::ZERO)
             .input(bytes!("deadbeef").into());
 
-        let tx_hash = *provider.send_transaction(req).await.expect("failed to send tx").tx_hash();
+        let tx_hash =
+            *provider.send_transaction(req).await.expect("failed to send tx").transaction_hash();
 
         let tx = provider
             .get_transaction_by_hash(tx_hash)
@@ -1262,7 +1263,7 @@ mod tests {
             )
             .await.unwrap();
         assert_eq!(
-            pending.tx_hash().to_string(),
+            pending.transaction_hash().to_string(),
             "0x9dae5cf33694a02e8a7d5de3fe31e9d05ca0ba6e9180efac4ab20a06c9e598a3"
         );
     }

--- a/crates/rpc-types-trace/src/common.rs
+++ b/crates/rpc-types-trace/src/common.rs
@@ -11,26 +11,26 @@ pub enum TraceResult<Ok, Err> {
     Success {
         /// Trace results produced by the tracer
         result: Ok,
-        /// transaction hash
+        /// Transaction hash
         #[serde(skip_serializing_if = "Option::is_none", rename = "txHash")]
-        tx_hash: Option<TxHash>,
+        transaction_hash: Option<TxHash>,
     },
     /// Untagged error variant
     Error {
         /// Trace failure produced by the tracer
         error: Err,
-        /// transaction hash
+        /// Transaction hash
         #[serde(skip_serializing_if = "Option::is_none", rename = "txHash")]
-        tx_hash: Option<TxHash>,
+        transaction_hash: Option<TxHash>,
     },
 }
 
 impl<Ok, Err> TraceResult<Ok, Err> {
     /// Returns the hash of the transaction that was traced.
-    pub const fn tx_hash(&self) -> Option<TxHash> {
+    pub const fn transaction_hash(&self) -> Option<TxHash> {
         *match self {
-            Self::Success { tx_hash, .. } => tx_hash,
-            Self::Error { tx_hash, .. } => tx_hash,
+            Self::Success { transaction_hash, .. } => transaction_hash,
+            Self::Error { transaction_hash, .. } => transaction_hash,
         }
     }
 
@@ -61,13 +61,13 @@ impl<Ok, Err> TraceResult<Ok, Err> {
     }
 
     /// Creates a new success trace result.
-    pub const fn new_success(result: Ok, tx_hash: Option<TxHash>) -> Self {
-        Self::Success { result, tx_hash }
+    pub const fn new_success(result: Ok, transaction_hash: Option<TxHash>) -> Self {
+        Self::Success { result, transaction_hash }
     }
 
     /// Creates a new error trace result.
-    pub const fn new_error(error: Err, tx_hash: Option<TxHash>) -> Self {
-        Self::Error { error, tx_hash }
+    pub const fn new_error(error: Err, transaction_hash: Option<TxHash>) -> Self {
+        Self::Error { error, transaction_hash }
     }
 }
 
@@ -94,7 +94,7 @@ mod tests {
 
         assert!(success_result.is_success());
         assert!(!success_result.is_error());
-        assert_eq!(success_result.tx_hash(), tx_hash);
+        assert_eq!(success_result.transaction_hash(), tx_hash);
         assert_eq!(success_result.success(), Some(&OkResult { message: "Success".to_string() }));
         assert_eq!(success_result.error(), None);
 
@@ -103,7 +103,7 @@ mod tests {
 
         assert!(!error_result.is_success());
         assert!(error_result.is_error());
-        assert_eq!(error_result.tx_hash(), tx_hash);
+        assert_eq!(error_result.transaction_hash(), tx_hash);
         assert_eq!(error_result.success(), None);
         assert_eq!(error_result.error(), Some(&ErrResult { code: 404 }));
     }

--- a/crates/rpc-types-trace/src/common.rs
+++ b/crates/rpc-types-trace/src/common.rs
@@ -87,23 +87,23 @@ mod tests {
 
     #[test]
     fn test_trace_result_getters() {
-        let tx_hash = Some(TxHash::ZERO);
+        let transaction_hash = Some(TxHash::ZERO);
 
         let success_result: TraceResult<OkResult, ErrResult> =
-            TraceResult::new_success(OkResult { message: "Success".to_string() }, tx_hash);
+            TraceResult::new_success(OkResult { message: "Success".to_string() }, transaction_hash);
 
         assert!(success_result.is_success());
         assert!(!success_result.is_error());
-        assert_eq!(success_result.transaction_hash(), tx_hash);
+        assert_eq!(success_result.transaction_hash(), transaction_hash);
         assert_eq!(success_result.success(), Some(&OkResult { message: "Success".to_string() }));
         assert_eq!(success_result.error(), None);
 
         let error_result: TraceResult<OkResult, ErrResult> =
-            TraceResult::new_error(ErrResult { code: 404 }, tx_hash);
+            TraceResult::new_error(ErrResult { code: 404 }, transaction_hash);
 
         assert!(!error_result.is_success());
         assert!(error_result.is_error());
-        assert_eq!(error_result.transaction_hash(), tx_hash);
+        assert_eq!(error_result.transaction_hash(), transaction_hash);
         assert_eq!(error_result.success(), None);
         assert_eq!(error_result.error(), Some(&ErrResult { code: 404 }));
     }

--- a/crates/rpc-types-trace/src/geth/mod.rs
+++ b/crates/rpc-types-trace/src/geth/mod.rs
@@ -647,7 +647,7 @@ mod tests {
             "txHash": "0x7cc741c553d4098f319c894d9db208999ca49ee1b5c53f6a9992e687cbffb69e"
         }"#;
         let result: TraceResult = serde_json::from_str(s).unwrap();
-        let hash = result.tx_hash().unwrap();
+        let hash = result.transaction_hash().unwrap();
         assert_eq!(
             hash,
             "0x7cc741c553d4098f319c894d9db208999ca49ee1b5c53f6a9992e687cbffb69e"

--- a/crates/rpc-types/src/eth/transaction/receipt.rs
+++ b/crates/rpc-types/src/eth/transaction/receipt.rs
@@ -87,7 +87,7 @@ impl TransactionReceipt {
 
     /// Returns the transaction type.
     pub const fn transaction_type(&self) -> TxType {
-        self.inner.tx_type()
+        self.inner.transaction_type()
     }
 
     /// Calculates the address that will be created by the transaction, if any.

--- a/crates/rpc-types/src/eth/transaction/request.rs
+++ b/crates/rpc-types/src/eth/transaction/request.rs
@@ -489,13 +489,13 @@ impl TransactionRequest {
 
     /// Build an [`TypedTransaction`]
     pub fn build_typed_tx(self) -> Result<TypedTransaction, Self> {
-        let tx_type = self.buildable_type();
+        let transaction_type = self.buildable_type();
 
-        if tx_type.is_none() {
+        if transaction_type.is_none() {
             return Err(self);
         }
 
-        Ok(match tx_type.expect("checked") {
+        Ok(match transaction_type.expect("checked") {
             TxType::Legacy => self.build_legacy().into(),
             TxType::Eip2930 => self.build_2930().into(),
             TxType::Eip1559 => self.build_1559().into(),


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Closes #814 

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Renaming, no behavioral changes

Consistently apply:

- `tx_hash` -> `transaction_hash`
- `tx_type` -> `transaction_type`

Originally planned a much larger PR (see https://github.com/alloy-rs/alloy/compare/main...zerosnacks/refactor-align-naming-tx) but I feel that it is better to break (possibly contentious) proposed changes into different PRs with accompanying tickets.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [x] Breaking changes
