### PR TITLE
feat: full block ambiguity

### DIFF
--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -437,7 +437,19 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
         number: BlockNumberOrTag,
         hydrate: bool,
     ) -> TransportResult<Option<Block>> {
-        self.client().request("eth_getBlockByNumber", (number, hydrate)).await
+        let block = self
+            .client()
+            .request::<_, Option<Block>>("eth_getBlockByNumber", (number, hydrate))
+            .await?
+            .map(|mut block| {
+                if !hydrate {
+                    // this ensures an empty response for `Hashes` has the expected form
+                    // this is required because deserializing [] is ambiguous
+                    block.transactions.convert_to_hashes();
+                }
+                block
+            });
+        Ok(block)
     }
 
     /// Broadcasts a transaction to the network.
@@ -525,7 +537,20 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
         hash: BlockHash,
         full: bool,
     ) -> TransportResult<Option<Block>> {
-        self.client().request("eth_getBlockByHash", (hash, full)).await
+        let block = self
+            .client()
+            .request::<_, Option<Block>>("eth_getBlockByHash", (hash, full))
+            .await?
+            .map(|mut block| {
+                if !full {
+                    // this ensures an empty response for `Hashes` has the expected form
+                    // this is required because deserializing [] is ambiguous
+                    block.transactions.convert_to_hashes();
+                }
+                block
+            });
+
+        Ok(block)
     }
 
     /// Gets the client version of the chain client().
@@ -1317,5 +1342,14 @@ mod tests {
             .with_input(bytes!("06fdde03")); // `name()`
         let result = provider.call(&req).await.unwrap();
         assert_eq!(String::abi_decode(&result, true).unwrap(), "Wrapped Ether");
+    }
+
+    #[tokio::test]
+    async fn test_empty_transactions() {
+        init_tracing();
+        let provider = ProviderBuilder::new().on_anvil();
+
+        let block = provider.get_block_by_number(0.into(), false).await.unwrap().unwrap();
+        assert!(block.transactions.is_hashes());
     }
 }

--- a/crates/rpc-types/src/eth/block.rs
+++ b/crates/rpc-types/src/eth/block.rs
@@ -164,10 +164,10 @@ impl Header {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum BlockTransactions<T = Transaction> {
-    /// Only hashes
-    Hashes(Vec<B256>),
     /// Full transactions
     Full(Vec<T>),
+    /// Only hashes
+    Hashes(Vec<B256>),
     /// Special case for uncle response.
     Uncle,
 }
@@ -216,8 +216,8 @@ impl<T> BlockTransactions<T> {
     /// Returns an iterator over the transactions (if any). This will be empty
     /// if the block is an uncle or if the transaction list contains only
     /// hashes.
-    pub fn txns(&self) -> Option<impl Iterator<Item = &T>> {
-        self.as_transactions().map(|txs| txs.iter())
+    pub fn txns(&self) -> impl Iterator<Item = &T> {
+        self.as_transactions().map(|txs| txs.iter()).unwrap_or_else(|| [].iter())
     }
 
     /// Returns an instance of BlockTransactions with the Uncle special case.
@@ -846,5 +846,35 @@ mod tests {
         let serialized = serde_json::to_string(&block).unwrap();
         let block2 = serde_json::from_str::<Block>(&serialized).unwrap();
         assert_eq!(block, block2);
+    }
+
+    #[test]
+    fn serde_empty_block() {
+        let s = r#"{
+    "hash": "0xb25d0e54ca0104e3ebfb5a1dcdf9528140854d609886a300946fd6750dcb19f4",
+    "parentHash": "0x9400ec9ef59689c157ac89eeed906f15ddd768f94e1575e0e27d37c241439a5d",
+    "sha3Uncles": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+    "miner": "0x829bd824b016326a401d083b33d092293333a830",
+    "stateRoot": "0x546e330050c66d02923e7f1f3e925efaf64e4384eeecf2288f40088714a77a84",
+    "transactionsRoot": "0xd5eb3ad6d7c7a4798cc5fb14a6820073f44a941107c5d79dac60bd16325631fe",
+    "receiptsRoot": "0xb21c41cbb3439c5af25304e1405524c885e733b16203221900cb7f4b387b62f0",
+    "logsBloom": "0x1f304e641097eafae088627298685d20202004a4a59e4d8900914724e2402b028c9d596660581f361240816e82d00fa14250c9ca89840887a381efa600288283d170010ab0b2a0694c81842c2482457e0eb77c2c02554614007f42aaf3b4dc15d006a83522c86a240c06d241013258d90540c3008888d576a02c10120808520a2221110f4805200302624d22092b2c0e94e849b1e1aa80bc4cc3206f00b249d0a603ee4310216850e47c8997a20aa81fe95040a49ca5a420464600e008351d161dc00d620970b6a801535c218d0b4116099292000c08001943a225d6485528828110645b8244625a182c1a88a41087e6d039b000a180d04300d0680700a15794",
+    "difficulty": "0xc40faff9c737d",
+    "number": "0xa9a230",
+    "gasLimit": "0xbe5a66",
+    "gasUsed": "0xbe0fcc",
+    "timestamp": "0x5f93b749",
+    "totalDifficulty": "0x3dc957fd8167fb2684a",
+    "extraData": "0x7070796520e4b883e5bda9e7a59ee4bb99e9b1bc0103",
+    "mixHash": "0xd5e2b7b71fbe4ddfe552fb2377bf7cddb16bbb7e185806036cee86994c6e97fc",
+    "nonce": "0x4722f2acd35abe0f",
+    "uncles": [],
+    "transactions": [],
+    "size": "0xaeb6"
+}"#;
+
+        let block = serde_json::from_str::<Block>(s).unwrap();
+        assert!(block.transactions.is_empty());
+        assert!(block.transactions.as_transactions().is_some());
     }
 }


### PR DESCRIPTION
closes #805

this changes the deserialization order, so empty response is deserialized as `Full`

this adds an additional check to get_block_by calls to enforce hashes