### PR TITLE
feat(network): constrain `TransactionResponse`

### DIFF
--- a/crates/network/src/any/mod.rs
+++ b/crates/network/src/any/mod.rs
@@ -1,6 +1,6 @@
 use core::fmt;
 
-use crate::{Network, ReceiptResponse};
+use crate::{Network, ReceiptResponse, TransactionResponse};
 use alloy_consensus::TxType;
 use alloy_eips::eip2718::Eip2718Error;
 use alloy_rpc_types::{
@@ -79,5 +79,11 @@ impl Network for AnyNetwork {
 impl ReceiptResponse for AnyTransactionReceipt {
     fn contract_address(&self) -> Option<alloy_primitives::Address> {
         self.contract_address
+    }
+}
+
+impl TransactionResponse for WithOtherFields<Transaction> {
+    fn hash(&self) -> alloy_primitives::B256 {
+        self.hash
     }
 }

--- a/crates/network/src/ethereum/mod.rs
+++ b/crates/network/src/ethereum/mod.rs
@@ -1,4 +1,4 @@
-use crate::{Network, ReceiptResponse};
+use crate::{Network, ReceiptResponse, TransactionResponse};
 
 mod builder;
 
@@ -34,5 +34,11 @@ impl Network for Ethereum {
 impl ReceiptResponse for alloy_rpc_types::TransactionReceipt {
     fn contract_address(&self) -> Option<alloy_primitives::Address> {
         self.contract_address
+    }
+}
+
+impl TransactionResponse for alloy_rpc_types::Transaction {
+    fn hash(&self) -> alloy_primitives::B256 {
+        self.hash
     }
 }

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -9,7 +9,7 @@
 use alloy_consensus::TxReceipt;
 use alloy_eips::eip2718::{Eip2718Envelope, Eip2718Error};
 use alloy_json_rpc::RpcObject;
-use alloy_primitives::Address;
+use alloy_primitives::{Address, B256};
 use core::fmt::{Debug, Display};
 
 mod transaction;
@@ -34,6 +34,12 @@ pub use alloy_eips::eip2718;
 pub trait ReceiptResponse {
     /// Address of the created contract, or `None` if the transaction was not a deployment.
     fn contract_address(&self) -> Option<Address>;
+}
+
+/// Transaction Response
+pub trait TransactionResponse {
+    /// Hash of the transaction
+    fn hash(&self) -> B256;
 }
 
 /// Captures type info for network-specific RPC requests/responses.
@@ -82,7 +88,7 @@ pub trait Network: Debug + Clone + Copy + Sized + Send + Sync + 'static {
         + From<Self::UnsignedTx>;
 
     /// The JSON body of a transaction response.
-    type TransactionResponse: RpcObject;
+    type TransactionResponse: RpcObject + TransactionResponse;
 
     /// The JSON body of a transaction receipt.
     type ReceiptResponse: RpcObject + ReceiptResponse;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

#667 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Add `TransactionResponse` trait. 

Exposes `hash(&self) -> B256` method. 

@prestwich @mattsse I believe we can add more fields that to this that we know will remain consistent across networks such as `from`, `to`, `value`??

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
