### PR TITLE
Bug(upstream): pin `gcloud-sdk` to `0.24.6`

### DIFF
--- a/crates/signer-gcp/Cargo.toml
+++ b/crates/signer-gcp/Cargo.toml
@@ -21,7 +21,7 @@ alloy-primitives.workspace = true
 alloy-signer.workspace = true
 
 async-trait.workspace = true
-gcloud-sdk = { version = "0.24", features = ["google-cloud-kms-v1"] }
+gcloud-sdk = { version = "=0.24.6", features = ["google-cloud-kms-v1"] }
 k256 = { workspace = true, features = ["pem"] }
 spki.workspace = true
 thiserror.workspace = true


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

`0.24.7` [released](https://github.com/abdolence/gcloud-sdk-rs/releases/tag/v0.24.7) in the last hour throws a deep build issue that is breaking the CI

```
error[E0412]: cannot find type `Operation` in module `super::super::super::super::longrunning`
    --> /home/zerosnacks/.cargo/registry/src/index.crates.io-6f17d22bba15001f/gcloud-sdk-0.24.7/src/../genproto/google.cloud.kms.v1.rs:1432:70
     |
1432 |             tonic::Response<super::super::super::super::longrunning::Operation>,
     |                                                                      ^^^^^^^^^ not found in `super::super::super::super::longrunning`

For more information about this error, try `rustc --explain E0412`.
```

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Pin to `=0.24.6`

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
