### PR TITLE
Fix: unpin `gcloud-sdk` to `0.24`, reverting #836

### DIFF
--- a/crates/signer-gcp/Cargo.toml
+++ b/crates/signer-gcp/Cargo.toml
@@ -21,7 +21,10 @@ alloy-primitives.workspace = true
 alloy-signer.workspace = true
 
 async-trait.workspace = true
-gcloud-sdk = { version = "=0.24.6", features = ["google-cloud-kms-v1"] }
+gcloud-sdk = { version = "0.24", features = [
+    "google-cloud-kms-v1",
+    "google-longrunning",
+] }
 k256 = { workspace = true, features = ["pem"] }
 spki.workspace = true
 thiserror.workspace = true


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Undoes #836, upgrades to `0.24.7`

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Adds the `google-longrunning` feature flag, now required.

See: https://github.com/abdolence/gcloud-sdk-rs/issues/144

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
