### PR TITLE
feature(rpc): use `BlockTransactionsKind` enum instead of bool for full arguments

### DIFF
--- a/crates/rpc-types/src/eth/block.rs
+++ b/crates/rpc-types/src/eth/block.rs
@@ -456,6 +456,15 @@ impl From<bool> for BlockTransactionsKind {
     }
 }
 
+impl From<BlockTransactionsKind> for bool {
+    fn from(kind: BlockTransactionsKind) -> Self {
+        match kind {
+            BlockTransactionsKind::Full => true,
+            BlockTransactionsKind::Hashes => false,
+        }
+    }
+}
+
 /// Error that can occur when converting other types to blocks
 #[derive(Clone, Copy, Debug, thiserror::Error)]
 pub enum BlockError {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Closes #834 

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Implements change as suggested, including the inverse `From` impl

Changes `full` to `kind` and uses the enum

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [x] Breaking changes
