### PR TITLE
[feat] Synchronous filling

### DIFF
--- a/crates/provider/src/builder.rs
+++ b/crates/provider/src/builder.rs
@@ -37,6 +37,8 @@ where
         FillerControlFlow::Finished
     }
 
+    fn fill_sync(&self, _tx: &mut SendableTx<N>) {}
+
     async fn prepare<P, T>(
         &self,
         _provider: &P,

--- a/crates/provider/src/fillers/chain_id.rs
+++ b/crates/provider/src/fillers/chain_id.rs
@@ -63,6 +63,16 @@ impl<N: Network> TxFiller<N> for ChainIdFiller {
         }
     }
 
+    fn fill_sync(&self, tx: &mut SendableTx<N>) {
+        if let Some(chain_id) = self.0.get() {
+            if let Some(builder) = tx.as_mut_builder() {
+                if builder.chain_id().is_none() {
+                    builder.set_chain_id(*chain_id)
+                }
+            };
+        }
+    }
+
     async fn prepare<P, T>(
         &self,
         provider: &P,
@@ -76,22 +86,17 @@ impl<N: Network> TxFiller<N> for ChainIdFiller {
             Some(chain_id) => Ok(chain_id),
             None => {
                 let chain_id = provider.get_chain_id().await?;
-                let chain_id = *self.0.get_or_init(|| chain_id);
-                Ok(chain_id)
+                Ok(*self.0.get_or_init(|| chain_id))
             }
         }
     }
 
     async fn fill(
         &self,
-        fillable: Self::Fillable,
+        _fillable: Self::Fillable,
         mut tx: SendableTx<N>,
     ) -> TransportResult<SendableTx<N>> {
-        if let Some(builder) = tx.as_mut_builder() {
-            if builder.chain_id().is_none() {
-                builder.set_chain_id(fillable)
-            }
-        };
+        self.fill_sync(&mut tx);
         Ok(tx)
     }
 }

--- a/crates/provider/src/fillers/gas.rs
+++ b/crates/provider/src/fillers/gas.rs
@@ -197,6 +197,8 @@ impl<N: Network> TxFiller<N> for GasFiller {
         FillerControlFlow::Ready
     }
 
+    fn fill_sync(&self, _tx: &mut SendableTx<N>) {}
+
     async fn prepare<P, T>(
         &self,
         provider: &P,

--- a/crates/provider/src/fillers/join_fill.rs
+++ b/crates/provider/src/fillers/join_fill.rs
@@ -106,6 +106,11 @@ where
         try_join!(self.prepare_left(provider, tx), self.prepare_right(provider, tx))
     }
 
+    fn fill_sync(&self, tx: &mut SendableTx<N>) {
+        self.left.fill_sync(tx);
+        self.right.fill_sync(tx);
+    }
+
     async fn fill(
         &self,
         to_fill: Self::Fillable,

--- a/crates/provider/src/fillers/join_fill.rs
+++ b/crates/provider/src/fillers/join_fill.rs
@@ -94,6 +94,11 @@ where
         self.left.status(tx).absorb(self.right.status(tx))
     }
 
+    fn fill_sync(&self, tx: &mut SendableTx<N>) {
+        self.left.fill_sync(tx);
+        self.right.fill_sync(tx);
+    }
+
     async fn prepare<P, T>(
         &self,
         provider: &P,
@@ -104,11 +109,6 @@ where
         T: Transport + Clone,
     {
         try_join!(self.prepare_left(provider, tx), self.prepare_right(provider, tx))
-    }
-
-    fn fill_sync(&self, tx: &mut SendableTx<N>) {
-        self.left.fill_sync(tx);
-        self.right.fill_sync(tx);
     }
 
     async fn fill(

--- a/crates/provider/src/fillers/mod.rs
+++ b/crates/provider/src/fillers/mod.rs
@@ -160,8 +160,9 @@ pub trait TxFiller<N: Network = Ethereum>: Clone + Send + Sync + std::fmt::Debug
         self.status(tx).is_finished()
     }
 
-    /// Performs any synchoronous filling. This will always be called before
-    /// `prepare`.
+    /// Performs any synchoronous filling. This should be called before
+    /// [`TxFiller::prepare`] and [`TxFiller::fill`] to fill in any properties
+    /// that can be filled synchronously.
     fn fill_sync(&self, tx: &mut SendableTx<N>);
 
     /// Prepares fillable properties, potentially by making an RPC request.

--- a/crates/provider/src/fillers/mod.rs
+++ b/crates/provider/src/fillers/mod.rs
@@ -20,6 +20,7 @@ pub use gas::GasFiller;
 
 mod join_fill;
 pub use join_fill::JoinFill;
+use tracing::error;
 
 use crate::{
     provider::SendableTx, Identity, PendingTransactionBuilder, Provider, ProviderLayer,
@@ -258,9 +259,12 @@ where
 
             count += 1;
             if count >= 20 {
-                panic!(
-                    "Tx filler loop detected. This indicates a bug in some filler implementation. Please file an issue containing your tx filler set."
+                const ERROR: &str = "Tx filler loop detected. This indicates a bug in some filler implementation. Please file an issue containing this message.";
+                error!(
+                    ?tx, ?self.filler,
+                    ERROR
                 );
+                panic!("{}, {:?}, {:?}", ERROR, &tx, &self.filler);
             }
         }
         Ok(tx)

--- a/crates/provider/src/fillers/mod.rs
+++ b/crates/provider/src/fillers/mod.rs
@@ -160,6 +160,10 @@ pub trait TxFiller<N: Network = Ethereum>: Clone + Send + Sync + std::fmt::Debug
         self.status(tx).is_finished()
     }
 
+    /// Performs any synchoronous filling. This will always be called before
+    /// `prepare`.
+    fn fill_sync(&self, tx: &mut SendableTx<N>);
+
     /// Prepares fillable properties, potentially by making an RPC request.
     fn prepare<P, T>(
         &self,
@@ -249,7 +253,9 @@ where
     where
         N::TxEnvelope: Clone,
     {
-        self.filler.prepare_and_fill(self, SendableTx::Builder(tx)).await
+        let mut tx = SendableTx::Builder(tx);
+        self.filler.fill_sync(&mut tx);
+        self.filler.prepare_and_fill(self, tx).await
     }
 }
 

--- a/crates/provider/src/fillers/nonce.rs
+++ b/crates/provider/src/fillers/nonce.rs
@@ -58,6 +58,8 @@ impl<N: Network> TxFiller<N> for NonceFiller {
         FillerControlFlow::Ready
     }
 
+    fn fill_sync(&self, _tx: &mut SendableTx<N>) {}
+
     async fn prepare<P, T>(
         &self,
         provider: &P,


### PR DESCRIPTION
Closes #830 

## Motivation

Ensure that `from` is set before gas estimation occurs

## Solution

Ensure that all properties that can be filled entirely locally are filled BEFORE any network requests are made
This will set `from` and `chain_id` synchronously locally

Potential followup:
- change to sync mutex in noncefiller

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
