### PR TITLE
rpc-types-anvil: Implement `Default` to `NodeForkConfig`

### DIFF
--- a/crates/rpc-types-anvil/src/lib.rs
+++ b/crates/rpc-types-anvil/src/lib.rs
@@ -94,7 +94,7 @@ pub struct NodeEnvironment {
 }
 
 /// The node's fork configuration.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NodeForkConfig {
     /// URL of the forked network


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Foundry needs the default value of `NodeForkConfig`. 
ref: https://github.com/foundry-rs/foundry/blob/7e6ebaf09dcb1ca6f7087d87d20d8ef9435a3ec6/crates/anvil/src/eth/api.rs#L1766-L1776

Also, the original `NodeForkConfig` on the foundry side implements `Default`.
ref: https://github.com/foundry-rs/foundry/blob/7e6ebaf09dcb1ca6f7087d87d20d8ef9435a3ec6/crates/anvil/core/src/types.rs#L185-L192

related to: https://github.com/foundry-rs/foundry/issues/8084, https://github.com/alloy-rs/alloy/issues/838, and https://github.com/foundry-rs/foundry/pull/8098

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Adds `Default` derive to `NodeForkConfig` struct

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
