### PR TITLE
network: Add `status` method to `ReceiptResponse` trait

### DIFF
--- a/crates/network/src/any/mod.rs
+++ b/crates/network/src/any/mod.rs
@@ -92,6 +92,7 @@ impl ReceiptResponse for AnyTransactionReceipt {
     /// This can be handled using [`TxReceipt::status_or_post_state`].
     ///
     /// [EIP-658]: https://eips.ethereum.org/EIPS/eip-658
+    /// [`TxReceipt`]: alloy_consensus::TxReceipt
     fn status(&self) -> bool {
         self.inner.inner.status()
     }

--- a/crates/network/src/any/mod.rs
+++ b/crates/network/src/any/mod.rs
@@ -82,17 +82,6 @@ impl ReceiptResponse for AnyTransactionReceipt {
         self.contract_address
     }
 
-    /// ## Note
-    ///
-    /// Caution must be taken when using this method for deep-historical
-    /// receipts, as it may not accurately reflect the status of the
-    /// transaction. The transaction status is not knowable from the receipt
-    /// for transactions before [EIP-658].
-    ///
-    /// This can be handled using [`TxReceipt::status_or_post_state`].
-    ///
-    /// [EIP-658]: https://eips.ethereum.org/EIPS/eip-658
-    /// [`TxReceipt::status_or_post_state`]: alloy_consensus::TxReceipt::status_or_post_state
     fn status(&self) -> bool {
         self.inner.inner.status()
     }

--- a/crates/network/src/any/mod.rs
+++ b/crates/network/src/any/mod.rs
@@ -92,7 +92,7 @@ impl ReceiptResponse for AnyTransactionReceipt {
     /// This can be handled using [`TxReceipt::status_or_post_state`].
     ///
     /// [EIP-658]: https://eips.ethereum.org/EIPS/eip-658
-    /// [`TxReceipt`]: alloy_consensus::TxReceipt
+    /// [`TxReceipt::status_or_post_state`]: alloy_consensus::TxReceipt::status_or_post_state
     fn status(&self) -> bool {
         self.inner.inner.status()
     }

--- a/crates/network/src/any/mod.rs
+++ b/crates/network/src/any/mod.rs
@@ -81,6 +81,10 @@ impl ReceiptResponse for AnyTransactionReceipt {
     fn contract_address(&self) -> Option<alloy_primitives::Address> {
         self.contract_address
     }
+
+    fn status(&self) -> bool {
+        self.inner.inner.status()
+    }
 }
 
 impl TransactionResponse for WithOtherFields<Transaction> {

--- a/crates/network/src/any/mod.rs
+++ b/crates/network/src/any/mod.rs
@@ -82,6 +82,16 @@ impl ReceiptResponse for AnyTransactionReceipt {
         self.contract_address
     }
 
+    /// ## Note
+    ///
+    /// Caution must be taken when using this method for deep-historical
+    /// receipts, as it may not accurately reflect the status of the
+    /// transaction. The transaction status is not knowable from the receipt
+    /// for transactions before [EIP-658].
+    ///
+    /// This can be handled using [`TxReceipt::status_or_post_state`].
+    ///
+    /// [EIP-658]: https://eips.ethereum.org/EIPS/eip-658
     fn status(&self) -> bool {
         self.inner.inner.status()
     }

--- a/crates/network/src/ethereum/mod.rs
+++ b/crates/network/src/ethereum/mod.rs
@@ -36,17 +36,6 @@ impl ReceiptResponse for alloy_rpc_types_eth::TransactionReceipt {
         self.contract_address
     }
 
-    /// ## Note
-    ///
-    /// Caution must be taken when using this method for deep-historical
-    /// receipts, as it may not accurately reflect the status of the
-    /// transaction. The transaction status is not knowable from the receipt
-    /// for transactions before [EIP-658].
-    ///
-    /// This can be handled using [`TxReceipt::status_or_post_state`].
-    ///
-    /// [EIP-658]: https://eips.ethereum.org/EIPS/eip-658
-    /// [`TxReceipt::status_or_post_state`]: alloy_consensus::TxReceipt::status_or_post_state
     fn status(&self) -> bool {
         self.inner.status()
     }

--- a/crates/network/src/ethereum/mod.rs
+++ b/crates/network/src/ethereum/mod.rs
@@ -46,6 +46,7 @@ impl ReceiptResponse for alloy_rpc_types_eth::TransactionReceipt {
     /// This can be handled using [`TxReceipt::status_or_post_state`].
     ///
     /// [EIP-658]: https://eips.ethereum.org/EIPS/eip-658
+    /// [`TxReceipt`]: alloy_consensus::TxReceipt
     fn status(&self) -> bool {
         self.inner.status()
     }

--- a/crates/network/src/ethereum/mod.rs
+++ b/crates/network/src/ethereum/mod.rs
@@ -36,6 +36,16 @@ impl ReceiptResponse for alloy_rpc_types_eth::TransactionReceipt {
         self.contract_address
     }
 
+    /// ## Note
+    ///
+    /// Caution must be taken when using this method for deep-historical
+    /// receipts, as it may not accurately reflect the status of the
+    /// transaction. The transaction status is not knowable from the receipt
+    /// for transactions before [EIP-658].
+    ///
+    /// This can be handled using [`TxReceipt::status_or_post_state`].
+    ///
+    /// [EIP-658]: https://eips.ethereum.org/EIPS/eip-658
     fn status(&self) -> bool {
         self.inner.status()
     }

--- a/crates/network/src/ethereum/mod.rs
+++ b/crates/network/src/ethereum/mod.rs
@@ -35,6 +35,10 @@ impl ReceiptResponse for alloy_rpc_types_eth::TransactionReceipt {
     fn contract_address(&self) -> Option<alloy_primitives::Address> {
         self.contract_address
     }
+
+    fn status(&self) -> bool {
+        self.inner.status()
+    }
 }
 
 impl TransactionResponse for alloy_rpc_types_eth::Transaction {

--- a/crates/network/src/ethereum/mod.rs
+++ b/crates/network/src/ethereum/mod.rs
@@ -46,7 +46,7 @@ impl ReceiptResponse for alloy_rpc_types_eth::TransactionReceipt {
     /// This can be handled using [`TxReceipt::status_or_post_state`].
     ///
     /// [EIP-658]: https://eips.ethereum.org/EIPS/eip-658
-    /// [`TxReceipt`]: alloy_consensus::TxReceipt
+    /// [`TxReceipt::status_or_post_state`]: alloy_consensus::TxReceipt::status_or_post_state
     fn status(&self) -> bool {
         self.inner.status()
     }

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -47,7 +47,7 @@ pub trait ReceiptResponse {
     /// This can be handled using [`TxReceipt::status_or_post_state`].
     ///
     /// [EIP-658]: https://eips.ethereum.org/EIPS/eip-658
-    /// [`TxReceipt`]: alloy_consensus::TxReceipt
+    /// [`TxReceipt::status_or_post_state`]: alloy_consensus::TxReceipt::status_or_post_state
     fn status(&self) -> bool;
 }
 

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -36,6 +36,17 @@ pub trait ReceiptResponse {
     fn contract_address(&self) -> Option<Address>;
 
     /// Status of the transaction.
+    ///
+    /// ## Note
+    ///
+    /// Caution must be taken when using this method for deep-historical
+    /// receipts, as it may not accurately reflect the status of the
+    /// transaction. The transaction status is not knowable from the receipt
+    /// for transactions before [EIP-658].
+    ///
+    /// This can be handled using [`TxReceipt::status_or_post_state`].
+    ///
+    /// [EIP-658]: https://eips.ethereum.org/EIPS/eip-658
     fn status(&self) -> bool;
 }
 

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -34,6 +34,9 @@ pub use alloy_eips::eip2718;
 pub trait ReceiptResponse {
     /// Address of the created contract, or `None` if the transaction was not a deployment.
     fn contract_address(&self) -> Option<Address>;
+
+    /// Status of the transaction.
+    fn status(&self) -> bool;
 }
 
 /// Transaction Response

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -47,6 +47,7 @@ pub trait ReceiptResponse {
     /// This can be handled using [`TxReceipt::status_or_post_state`].
     ///
     /// [EIP-658]: https://eips.ethereum.org/EIPS/eip-658
+    /// [`TxReceipt`]: alloy_consensus::TxReceipt
     fn status(&self) -> bool;
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

from: https://github.com/alloy-rs/alloy/issues/845

It would be helpful to know the tx status from the receipt gotten by `get_receipt` method in `PendingTransactionBuilder` or by `get_transaction_receipt` in `Provider`.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Define `status` method in `ReceiptResponse` trait and implement it in `TransactionReceipt` for each network

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
