### PR TITLE
Fix: Support pre-658 status codes

### DIFF
--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -19,7 +19,9 @@ mod header;
 pub use header::{Header, EMPTY_OMMER_ROOT_HASH, EMPTY_ROOT_HASH};
 
 mod receipt;
-pub use receipt::{AnyReceiptEnvelope, Receipt, ReceiptEnvelope, ReceiptWithBloom, TxReceipt};
+pub use receipt::{
+    AnyReceiptEnvelope, Eip658Value, Receipt, ReceiptEnvelope, ReceiptWithBloom, TxReceipt,
+};
 
 mod request;
 pub use request::Request;

--- a/crates/consensus/src/receipt/any.rs
+++ b/crates/consensus/src/receipt/any.rs
@@ -1,4 +1,4 @@
-use crate::{ReceiptWithBloom, TxReceipt};
+use crate::{Eip658Value, ReceiptWithBloom, TxReceipt};
 use alloy_eips::eip2718::{Decodable2718, Encodable2718};
 use alloy_primitives::{bytes::BufMut, Bloom, Log};
 use alloy_rlp::{Decodable, Encodable};
@@ -47,13 +47,27 @@ impl<T> AnyReceiptEnvelope<T> {
     }
 
     /// Return true if the transaction was successful.
+    ///
+    /// ## Note
+    ///
+    /// This method may not accurately reflect the status of the transaction
+    /// for transactions before [EIP-658].
+    ///
+    /// [EIP-658]: https://eips.ethereum.org/EIPS/eip-658
     pub const fn is_success(&self) -> bool {
         self.status()
     }
 
     /// Returns the success status of the receipt's transaction.
+    ///
+    /// ## Note
+    ///
+    /// This method may not accurately reflect the status of the transaction
+    /// for transactions before [EIP-658].
+    ///
+    /// [EIP-658]: https://eips.ethereum.org/EIPS/eip-658
     pub const fn status(&self) -> bool {
-        self.inner.receipt.status
+        matches!(self.inner.receipt.status, Eip658Value::Eip658(true) | Eip658Value::PostState(_))
     }
 
     /// Return the receipt's bloom.
@@ -73,22 +87,22 @@ impl<T> AnyReceiptEnvelope<T> {
 }
 
 impl<T> TxReceipt<T> for AnyReceiptEnvelope<T> {
-    /// Returns the success status of the receipt's transaction.
-    fn status(&self) -> bool {
-        self.inner.receipt.status
+    fn status_or_post_state(&self) -> &Eip658Value {
+        self.inner.status_or_post_state()
     }
 
-    /// Return the receipt's bloom.
+    fn status(&self) -> bool {
+        self.inner.status()
+    }
+
     fn bloom(&self) -> Bloom {
         self.inner.logs_bloom
     }
 
-    /// Returns the cumulative gas used at this receipt.
     fn cumulative_gas_used(&self) -> u128 {
         self.inner.receipt.cumulative_gas_used
     }
 
-    /// Return the receipt logs.
     fn logs(&self) -> &[T] {
         &self.inner.receipt.logs
     }

--- a/crates/consensus/src/receipt/envelope.rs
+++ b/crates/consensus/src/receipt/envelope.rs
@@ -58,7 +58,7 @@ impl<T> ReceiptEnvelope<T> {
 
     /// Returns the success status of the receipt's transaction.
     pub fn status(&self) -> bool {
-        self.as_receipt().unwrap().status
+        self.as_receipt().unwrap().status.coerce_status()
     }
 
     /// Returns the cumulative gas used at this receipt.
@@ -96,8 +96,12 @@ impl<T> ReceiptEnvelope<T> {
 }
 
 impl<T> TxReceipt<T> for ReceiptEnvelope<T> {
+    fn status_or_post_state(&self) -> &crate::Eip658Value {
+        &self.as_receipt().unwrap().status
+    }
+
     fn status(&self) -> bool {
-        self.as_receipt().unwrap().status
+        self.as_receipt().unwrap().status.coerce_status()
     }
 
     /// Return the receipt's bloom.

--- a/crates/consensus/src/receipt/receipts.rs
+++ b/crates/consensus/src/receipt/receipts.rs
@@ -16,7 +16,7 @@ pub struct Receipt<T = Log> {
     /// If transaction is executed successfully.
     ///
     /// This is the `statusCode`
-    #[cfg_attr(feature = "serde", serde(alias = "name"))]
+    #[cfg_attr(feature = "serde", serde(alias = "root"))]
     pub status: Eip658Value,
     /// Gas used
     #[cfg_attr(feature = "serde", serde(with = "alloy_serde::u128_via_ruint"))]

--- a/crates/consensus/src/receipt/receipts.rs
+++ b/crates/consensus/src/receipt/receipts.rs
@@ -248,3 +248,31 @@ where
         Ok(Self { receipt: Receipt::<T>::arbitrary(u)?, logs_bloom: Bloom::arbitrary(u)? })
     }
 }
+
+#[cfg(test)]
+mod test {
+    #[cfg(feature = "serde")]
+    #[test]
+    fn root_vs_status() {
+        let receipt = super::Receipt::<()> {
+            status: super::Eip658Value::Eip658(true),
+            cumulative_gas_used: 0,
+            logs: Vec::new(),
+        };
+
+        let json = serde_json::to_string(&receipt).unwrap();
+        assert_eq!(json, r#"{"status":"0x1","cumulativeGasUsed":"0x0","logs":[]}"#);
+
+        let receipt = super::Receipt::<()> {
+            status: super::Eip658Value::PostState(Default::default()),
+            cumulative_gas_used: 0,
+            logs: Vec::new(),
+        };
+
+        let json = serde_json::to_string(&receipt).unwrap();
+        assert_eq!(
+            json,
+            r#"{"root":"0x0000000000000000000000000000000000000000000000000000000000000000","cumulativeGasUsed":"0x0","logs":[]}"#
+        );
+    }
+}

--- a/crates/consensus/src/receipt/status.rs
+++ b/crates/consensus/src/receipt/status.rs
@@ -80,13 +80,7 @@ impl Default for Eip658Value {
 impl serde::Serialize for Eip658Value {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         match self {
-            Self::Eip658(status) => {
-                if serializer.is_human_readable() {
-                    serializer.serialize_str(if *status { "0x1" } else { "0x" })
-                } else {
-                    serializer.serialize_bool(*status)
-                }
-            }
+            Self::Eip658(status) => alloy_serde::quantity_bool::serialize(status, serializer),
             Self::PostState(state) => state.serialize(serializer),
         }
     }

--- a/crates/consensus/src/receipt/status.rs
+++ b/crates/consensus/src/receipt/status.rs
@@ -1,0 +1,181 @@
+use alloy_primitives::B256;
+use alloy_rlp::{BufMut, Decodable, Encodable, Error, Header};
+
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+/// Captures the result of a transaction execution.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+pub enum Eip658Value {
+    /// A boolean `statusCode` introduced by [EIP-658].
+    ///
+    /// [EIP-658]: https://eips.ethereum.org/EIPS/eip-658
+    Eip658(bool),
+    /// A pre-[EIP-658] hash value.
+    ///
+    /// [EIP-658]: https://eips.ethereum.org/EIPS/eip-658
+    PostState(B256),
+}
+
+impl Eip658Value {
+    /// Returns true if the transaction was successful OR if the transaction
+    /// is pre-[EIP-658].
+    ///
+    /// [EIP-658]: https://eips.ethereum.org/EIPS/eip-658
+    pub const fn coerce_status(&self) -> bool {
+        matches!(self, Self::Eip658(true) | Self::PostState(_))
+    }
+
+    /// Returns true if the transaction was a pre-[EIP-658] transaction.
+    ///
+    /// [EIP-658]: https://eips.ethereum.org/EIPS/eip-658
+    pub const fn is_post_state(&self) -> bool {
+        matches!(self, Self::PostState(_))
+    }
+
+    /// Returns true if the transaction was a post-[EIP-658] transaction.
+    pub const fn is_eip658(&self) -> bool {
+        matches!(self, Self::PostState(_))
+    }
+
+    /// Fallibly convert to the post state.
+    pub const fn as_post_state(&self) -> Option<B256> {
+        match self {
+            Self::PostState(state) => Some(*state),
+            _ => None,
+        }
+    }
+
+    /// Fallibly convert to the [EIP-658] status code.
+    ///
+    /// [EIP-658]: https://eips.ethereum.org/EIPS/eip-658
+    pub const fn as_eip658(&self) -> Option<bool> {
+        match self {
+            Self::Eip658(status) => Some(*status),
+            _ => None,
+        }
+    }
+}
+
+impl From<bool> for Eip658Value {
+    fn from(status: bool) -> Self {
+        Self::Eip658(status)
+    }
+}
+
+impl From<B256> for Eip658Value {
+    fn from(state: B256) -> Self {
+        Self::PostState(state)
+    }
+}
+
+// NB: default to success
+impl Default for Eip658Value {
+    fn default() -> Self {
+        Self::Eip658(true)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for Eip658Value {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            Self::Eip658(status) => {
+                if serializer.is_human_readable() {
+                    serializer.serialize_str(if *status { "0x1" } else { "0x" })
+                } else {
+                    serializer.serialize_bool(*status)
+                }
+            }
+            Self::PostState(state) => state.serialize(serializer),
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+// NB: some visit methods partially or wholly copied from alloy-primitives
+impl<'de> serde::Deserialize<'de> for Eip658Value {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        use serde::de;
+        struct Visitor;
+
+        impl<'de> de::Visitor<'de> for Visitor {
+            type Value = Eip658Value;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                formatter.write_str("a boolean or a 32-byte hash")
+            }
+
+            fn visit_bool<E: de::Error>(self, v: bool) -> Result<Self::Value, E> {
+                Ok(Eip658Value::Eip658(v))
+            }
+
+            fn visit_bytes<E: de::Error>(self, v: &[u8]) -> Result<Self::Value, E> {
+                B256::try_from(v).map(Eip658Value::PostState).map_err(de::Error::custom)
+            }
+
+            fn visit_seq<A: de::SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
+                let len_error = |i| de::Error::invalid_length(i, &"exactly 32 bytes");
+                let mut bytes = [0u8; 32];
+
+                for (i, byte) in bytes.iter_mut().enumerate() {
+                    *byte = seq.next_element()?.ok_or_else(|| len_error(i))?;
+                }
+
+                if let Ok(Some(_)) = seq.next_element::<u8>() {
+                    return Err(len_error(33));
+                }
+
+                Ok(Eip658Value::PostState(bytes.into()))
+            }
+
+            fn visit_str<E: de::Error>(self, v: &str) -> Result<Self::Value, E> {
+                match v {
+                    "0x" | "0x0" | "false" => Ok(Eip658Value::Eip658(false)),
+                    "0x1" | "true" => Ok(Eip658Value::Eip658(true)),
+                    _ => v.parse::<B256>().map(Eip658Value::PostState).map_err(de::Error::custom),
+                }
+            }
+        }
+
+        deserializer.deserialize_any(Visitor)
+    }
+}
+
+impl Encodable for Eip658Value {
+    fn encode(&self, buf: &mut dyn BufMut) {
+        match self {
+            Self::Eip658(status) => {
+                status.encode(buf);
+            }
+            Self::PostState(state) => {
+                state.encode(buf);
+            }
+        }
+    }
+
+    fn length(&self) -> usize {
+        match self {
+            Self::Eip658(_) => 1,
+            Self::PostState(_) => 32,
+        }
+    }
+}
+
+impl Decodable for Eip658Value {
+    fn decode(buf: &mut &[u8]) -> Result<Self, Error> {
+        let h = Header::decode(buf)?;
+
+        match h.payload_length {
+            1 => {
+                let status = bool::decode(buf)?;
+                Ok(Self::Eip658(status))
+            }
+            32 => {
+                let state = B256::decode(buf)?;
+                Ok(Self::PostState(state))
+            }
+            _ => Err(Error::UnexpectedLength),
+        }
+    }
+}

--- a/crates/rpc-types/src/eth/transaction/receipt.rs
+++ b/crates/rpc-types/src/eth/transaction/receipt.rs
@@ -83,7 +83,7 @@ impl TransactionReceipt {
             ReceiptEnvelope::Eip1559(receipt)
             | ReceiptEnvelope::Eip2930(receipt)
             | ReceiptEnvelope::Eip4844(receipt)
-            | ReceiptEnvelope::Legacy(receipt) => receipt.receipt.status,
+            | ReceiptEnvelope::Legacy(receipt) => receipt.receipt.status.coerce_status(),
             _ => false,
         }
     }
@@ -137,7 +137,7 @@ pub type AnyTransactionReceipt = WithOtherFields<TransactionReceipt<AnyReceiptEn
 #[cfg(test)]
 mod test {
     use super::*;
-    use alloy_consensus::{Receipt, ReceiptWithBloom};
+    use alloy_consensus::{Receipt, ReceiptWithBloom, Eip658Value};
     use alloy_primitives::{address, b256, bloom, Bloom};
     use arbitrary::Arbitrary;
     use rand::Rng;
@@ -167,7 +167,11 @@ mod test {
         assert!(matches!(
             receipt.inner,
             ReceiptEnvelope::Eip1559(ReceiptWithBloom {
-                receipt: Receipt { status: true, cumulative_gas_used: EXPECTED_CGU, .. },
+                receipt: Receipt {
+                    status: Eip658Value::Eip658(true),
+                    cumulative_gas_used: EXPECTED_CGU,
+                    ..
+                },
                 logs_bloom: EXPECTED_BLOOM
             })
         ));

--- a/crates/rpc-types/src/eth/transaction/receipt.rs
+++ b/crates/rpc-types/src/eth/transaction/receipt.rs
@@ -137,7 +137,7 @@ pub type AnyTransactionReceipt = WithOtherFields<TransactionReceipt<AnyReceiptEn
 #[cfg(test)]
 mod test {
     use super::*;
-    use alloy_consensus::{Receipt, ReceiptWithBloom, Eip658Value};
+    use alloy_consensus::{Eip658Value, Receipt, ReceiptWithBloom};
     use alloy_primitives::{address, b256, bloom, Bloom};
     use arbitrary::Arbitrary;
     use rand::Rng;


### PR DESCRIPTION
Closes #630 

## Motivation

Support receipts from 2017 and earlier

## Solution

- Add an enum that covers the pre- and post-Eip658 values
- impl serde and rlp for that enum
- change receipt to manual serialize impl to allow for naming `root` or `status`
- add docs warning of incorrect status behavior for old receipts
- 

Open question
- when serializing, should the unused field be set to `null` by serializing a `None`?

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [x] Breaking changes
