### PR TITLE
feat(serde): deprecate individual num::* for a generic `quantity` module

### DIFF
--- a/crates/consensus/src/account.rs
+++ b/crates/consensus/src/account.rs
@@ -10,7 +10,7 @@ use alloc::{vec, vec::Vec};
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct Account {
     /// The account's nonce.
-    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::u64_via_ruint"))]
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
     pub nonce: u64,
     /// The account's balance.
     pub balance: U256,

--- a/crates/consensus/src/receipt/any.rs
+++ b/crates/consensus/src/receipt/any.rs
@@ -21,7 +21,7 @@ pub struct AnyReceiptEnvelope<T = Log> {
     #[cfg_attr(feature = "serde", serde(flatten))]
     pub inner: ReceiptWithBloom<T>,
     /// The transaction type.
-    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::num::u8_via_ruint"))]
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
     pub r#type: u8,
 }
 

--- a/crates/consensus/src/receipt/receipts.rs
+++ b/crates/consensus/src/receipt/receipts.rs
@@ -19,7 +19,7 @@ pub struct Receipt<T = Log> {
     #[cfg_attr(feature = "serde", serde(alias = "root"))]
     pub status: Eip658Value,
     /// Gas used
-    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::u128_via_ruint"))]
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
     pub cumulative_gas_used: u128,
     /// Log send from contracts.
     pub logs: Vec<T>,

--- a/crates/consensus/src/receipt/status.rs
+++ b/crates/consensus/src/receipt/status.rs
@@ -80,7 +80,7 @@ impl Default for Eip658Value {
 impl serde::Serialize for Eip658Value {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         match self {
-            Self::Eip658(status) => alloy_serde::quantity_bool::serialize(status, serializer),
+            Self::Eip658(status) => alloy_serde::quantity::serialize(status, serializer),
             Self::PostState(state) => state.serialize(serializer),
         }
     }

--- a/crates/consensus/src/transaction/eip1559.rs
+++ b/crates/consensus/src/transaction/eip1559.rs
@@ -14,17 +14,17 @@ use alloc::vec::Vec;
 #[doc(alias = "Eip1559Transaction", alias = "TransactionEip1559", alias = "Eip1559Tx")]
 pub struct TxEip1559 {
     /// EIP-155: Simple replay attack protection
-    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::u64_via_ruint"))]
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
     pub chain_id: ChainId,
     /// A scalar value equal to the number of transactions sent by the sender; formally Tn.
-    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::u64_via_ruint"))]
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
     pub nonce: u64,
     /// A scalar value equal to the maximum
     /// amount of gas that should be used in executing
     /// this transaction. This is paid up-front, before any
     /// computation is done and may not be increased
     /// later; formally Tg.
-    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::u128_via_ruint"))]
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
     pub gas_limit: u128,
     /// A scalar value equal to the maximum
     /// amount of gas that should be used in executing
@@ -37,7 +37,7 @@ pub struct TxEip1559 {
     /// 340282366920938463463374607431768211455
     ///
     /// This is also known as `GasFeeCap`
-    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::u128_via_ruint"))]
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
     pub max_fee_per_gas: u128,
     /// Max Priority fee that transaction is paying
     ///
@@ -46,7 +46,7 @@ pub struct TxEip1559 {
     /// 340282366920938463463374607431768211455
     ///
     /// This is also known as `GasTipCap`
-    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::u128_via_ruint"))]
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
     pub max_priority_fee_per_gas: u128,
     /// The 160-bit address of the message call’s recipient or, for a contract creation
     /// transaction, ∅, used here to denote the only member of B0 ; formally Tt.

--- a/crates/consensus/src/transaction/eip2930.rs
+++ b/crates/consensus/src/transaction/eip2930.rs
@@ -14,10 +14,10 @@ use alloc::vec::Vec;
 #[doc(alias = "Eip2930Transaction", alias = "TransactionEip2930", alias = "Eip2930Tx")]
 pub struct TxEip2930 {
     /// Added as EIP-pub 155: Simple replay attack protection
-    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::u64_via_ruint"))]
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
     pub chain_id: ChainId,
     /// A scalar value equal to the number of transactions sent by the sender; formally Tn.
-    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::u64_via_ruint"))]
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
     pub nonce: u64,
     /// A scalar value equal to the number of
     /// Wei to be paid per unit of gas for all computation
@@ -26,14 +26,14 @@ pub struct TxEip2930 {
     /// As ethereum circulation is around 120mil eth as of 2022 that is around
     /// 120000000000000000000000000 wei we are safe to use u128 as its max number is:
     /// 340282366920938463463374607431768211455
-    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::u128_via_ruint"))]
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
     pub gas_price: u128,
     /// A scalar value equal to the maximum
     /// amount of gas that should be used in executing
     /// this transaction. This is paid up-front, before any
     /// computation is done and may not be increased
     /// later; formally Tg.
-    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::u128_via_ruint"))]
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
     pub gas_limit: u128,
     /// The 160-bit address of the message call’s recipient or, for a contract creation
     /// transaction, ∅, used here to denote the only member of B0 ; formally Tt.

--- a/crates/consensus/src/transaction/eip4844.rs
+++ b/crates/consensus/src/transaction/eip4844.rs
@@ -290,17 +290,17 @@ impl SignableTransaction<Signature> for TxEip4844Variant {
 #[doc(alias = "Eip4844Transaction", alias = "TransactionEip4844", alias = "Eip4844Tx")]
 pub struct TxEip4844 {
     /// Added as EIP-pub 155: Simple replay attack protection
-    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::u64_via_ruint"))]
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
     pub chain_id: ChainId,
     /// A scalar value equal to the number of transactions sent by the sender; formally Tn.
-    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::u64_via_ruint"))]
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
     pub nonce: u64,
     /// A scalar value equal to the maximum
     /// amount of gas that should be used in executing
     /// this transaction. This is paid up-front, before any
     /// computation is done and may not be increased
     /// later; formally Tg.
-    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::u128_via_ruint"))]
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
     pub gas_limit: u128,
     /// A scalar value equal to the maximum
     /// amount of gas that should be used in executing
@@ -313,7 +313,7 @@ pub struct TxEip4844 {
     /// 340282366920938463463374607431768211455
     ///
     /// This is also known as `GasFeeCap`
-    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::u128_via_ruint"))]
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
     pub max_fee_per_gas: u128,
     /// Max Priority fee that transaction is paying
     ///
@@ -322,7 +322,7 @@ pub struct TxEip4844 {
     /// 340282366920938463463374607431768211455
     ///
     /// This is also known as `GasTipCap`
-    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::u128_via_ruint"))]
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
     pub max_priority_fee_per_gas: u128,
     /// The 160-bit address of the message call’s recipient.
     pub to: Address,
@@ -344,7 +344,7 @@ pub struct TxEip4844 {
     /// Max fee per data gas
     ///
     /// aka BlobFeeCap or blobGasFeeCap
-    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::u128_via_ruint"))]
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
     pub max_fee_per_blob_gas: u128,
 
     /// Input has two uses depending if transaction is Create or Call (if `to` field is None or

--- a/crates/consensus/src/transaction/legacy.rs
+++ b/crates/consensus/src/transaction/legacy.rs
@@ -17,13 +17,13 @@ pub struct TxLegacy {
         feature = "serde",
         serde(
             default,
-            with = "alloy_serde::u64_opt_via_ruint",
+            with = "alloy_serde::quantity::opt",
             skip_serializing_if = "Option::is_none",
         )
     )]
     pub chain_id: Option<ChainId>,
     /// A scalar value equal to the number of transactions sent by the sender; formally Tn.
-    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::u64_via_ruint"))]
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
     pub nonce: u64,
     /// A scalar value equal to the number of
     /// Wei to be paid per unit of gas for all computation
@@ -32,14 +32,14 @@ pub struct TxLegacy {
     /// As ethereum circulation is around 120mil eth as of 2022 that is around
     /// 120000000000000000000000000 wei we are safe to use u128 as its max number is:
     /// 340282366920938463463374607431768211455
-    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::u128_via_ruint"))]
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
     pub gas_price: u128,
     /// A scalar value equal to the maximum
     /// amount of gas that should be used in executing
     /// this transaction. This is paid up-front, before any
     /// computation is done and may not be increased
     /// later; formally Tg.
-    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::u128_via_ruint"))]
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
     pub gas_limit: u128,
     /// The 160-bit address of the message call’s recipient or, for a contract creation
     /// transaction, ∅, used here to denote the only member of B0 ; formally Tt.

--- a/crates/eip7547/src/summary.rs
+++ b/crates/eip7547/src/summary.rs
@@ -3,7 +3,6 @@
 
 use alloy_primitives::{Address, B256};
 use alloy_rpc_types_engine::PayloadStatusEnum;
-use alloy_serde::u64_via_ruint;
 use serde::{ser::SerializeMap, Deserialize, Serialize, Serializer};
 use std::fmt;
 
@@ -83,7 +82,7 @@ pub struct InclusionListSummaryEntryV1 {
     /// The address of the inclusion list entry.
     pub address: Address,
     /// The nonce of the inclusion list entry.
-    #[serde(with = "u64_via_ruint")]
+    #[serde(with = "alloy_serde::quantity")]
     pub nonce: u64,
 }
 
@@ -108,10 +107,10 @@ impl fmt::Display for InclusionListSummaryEntryV1 {
 #[serde(rename_all = "camelCase")]
 pub struct InclusionListSummaryV1 {
     /// The slot of the inclusion list summary.
-    #[serde(with = "u64_via_ruint")]
+    #[serde(with = "alloy_serde::quantity")]
     pub slot: u64,
     /// The proposer index of the inclusion list summary.
-    #[serde(with = "u64_via_ruint")]
+    #[serde(with = "alloy_serde::quantity")]
     pub proposer_index: u64,
     /// The parent hash of the inclusion list summary.
     pub parent_hash: B256,

--- a/crates/eips/src/eip1559/basefee.rs
+++ b/crates/eips/src/eip1559/basefee.rs
@@ -8,10 +8,10 @@ use crate::{
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BaseFeeParams {
     /// The base_fee_max_change_denominator from EIP-1559
-    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::num::u128_via_ruint"))]
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
     pub max_change_denominator: u128,
     /// The elasticity multiplier from EIP-1559
-    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::num::u128_via_ruint"))]
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
     pub elasticity_multiplier: u128,
 }
 

--- a/crates/eips/src/eip4895.rs
+++ b/crates/eips/src/eip4895.rs
@@ -20,18 +20,18 @@ pub const GWEI_TO_WEI: u64 = 1_000_000_000;
 #[cfg_attr(feature = "ssz", derive(ssz_derive::Encode, ssz_derive::Decode))]
 pub struct Withdrawal {
     /// Monotonically increasing identifier issued by consensus layer.
-    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::u64_via_ruint"))]
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
     pub index: u64,
     /// Index of validator associated with withdrawal.
     #[cfg_attr(
         feature = "serde",
-        serde(with = "alloy_serde::u64_via_ruint", rename = "validatorIndex")
+        serde(with = "alloy_serde::quantity", rename = "validatorIndex")
     )]
     pub validator_index: u64,
     /// Target address for withdrawn ether.
     pub address: Address,
     /// Value of the withdrawal in gwei.
-    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::u64_via_ruint"))]
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
     pub amount: u64,
 }
 

--- a/crates/eips/src/eip6110.rs
+++ b/crates/eips/src/eip6110.rs
@@ -28,11 +28,11 @@ pub struct DepositRequest {
     /// Withdrawal credentials
     pub withdrawal_credentials: B256,
     /// Amount of ether deposited in gwei
-    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::u64_via_ruint"))]
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
     pub amount: u64,
     /// Deposit signature
     pub signature: FixedBytes<96>,
     /// Deposit index
-    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::u64_via_ruint"))]
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
     pub index: u64,
 }

--- a/crates/eips/src/eip7002.rs
+++ b/crates/eips/src/eip7002.rs
@@ -37,6 +37,6 @@ pub struct WithdrawalRequest {
     /// Validator public key.
     pub validator_public_key: FixedBytes<48>,
     /// Amount of withdrawn ether in gwei.
-    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::u64_via_ruint"))]
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
     pub amount: u64,
 }

--- a/crates/genesis/src/lib.rs
+++ b/crates/genesis/src/lib.rs
@@ -12,13 +12,8 @@
 extern crate alloc;
 
 use alloc::{collections::BTreeMap, string::String};
-
 use alloy_primitives::{Address, Bytes, B256, U256};
-use alloy_serde::{
-    num::{u128_opt_via_ruint, u128_via_ruint, u64_opt_via_ruint, u64_via_ruint},
-    storage::deserialize_storage_map,
-    ttd::deserialize_json_ttd_opt,
-};
+use alloy_serde::{storage::deserialize_storage_map, ttd::deserialize_json_ttd_opt};
 use serde::{Deserialize, Serialize};
 
 /// The genesis block specification.
@@ -29,15 +24,15 @@ pub struct Genesis {
     #[serde(default)]
     pub config: ChainConfig,
     /// The genesis header nonce.
-    #[serde(with = "u64_via_ruint")]
+    #[serde(with = "alloy_serde::quantity")]
     pub nonce: u64,
     /// The genesis header timestamp.
-    #[serde(with = "u64_via_ruint")]
+    #[serde(with = "alloy_serde::quantity")]
     pub timestamp: u64,
     /// The genesis header extra data.
     pub extra_data: Bytes,
     /// The genesis header gas limit.
-    #[serde(with = "u128_via_ruint")]
+    #[serde(with = "alloy_serde::quantity")]
     pub gas_limit: u128,
     /// The genesis header difficulty.
     pub difficulty: U256,
@@ -55,16 +50,16 @@ pub struct Genesis {
     // should NOT be set in a real genesis file, but are included here for compatibility with
     // consensus tests, which have genesis files with these fields populated.
     /// The genesis header base fee
-    #[serde(default, skip_serializing_if = "Option::is_none", with = "u128_opt_via_ruint")]
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
     pub base_fee_per_gas: Option<u128>,
     /// The genesis header excess blob gas
-    #[serde(default, skip_serializing_if = "Option::is_none", with = "u128_opt_via_ruint")]
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
     pub excess_blob_gas: Option<u128>,
     /// The genesis header blob gas used
-    #[serde(default, skip_serializing_if = "Option::is_none", with = "u128_opt_via_ruint")]
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
     pub blob_gas_used: Option<u128>,
     /// The genesis block number
-    #[serde(default, skip_serializing_if = "Option::is_none", with = "u64_opt_via_ruint")]
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
     pub number: Option<u64>,
 }
 
@@ -206,7 +201,7 @@ impl Genesis {
 #[serde(deny_unknown_fields)]
 pub struct GenesisAccount {
     /// The nonce of the account at genesis.
-    #[serde(skip_serializing_if = "Option::is_none", with = "u64_opt_via_ruint", default)]
+    #[serde(skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt", default)]
     pub nonce: Option<u64>,
     /// The balance of the account at genesis.
     pub balance: U256,
@@ -272,14 +267,14 @@ pub struct ChainConfig {
     /// The homestead switch block (None = no fork, 0 = already homestead).
     #[serde(
         skip_serializing_if = "Option::is_none",
-        deserialize_with = "u64_opt_via_ruint::deserialize"
+        deserialize_with = "alloy_serde::quantity::opt::deserialize"
     )]
     pub homestead_block: Option<u64>,
 
     /// The DAO fork switch block (None = no fork).
     #[serde(
         skip_serializing_if = "Option::is_none",
-        deserialize_with = "u64_opt_via_ruint::deserialize"
+        deserialize_with = "alloy_serde::quantity::opt::deserialize"
     )]
     pub dao_fork_block: Option<u64>,
 
@@ -289,7 +284,7 @@ pub struct ChainConfig {
     /// The [EIP-150](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-150.md) hard fork block (None = no fork).
     #[serde(
         skip_serializing_if = "Option::is_none",
-        deserialize_with = "u64_opt_via_ruint::deserialize"
+        deserialize_with = "alloy_serde::quantity::opt::deserialize"
     )]
     pub eip150_block: Option<u64>,
 
@@ -300,105 +295,105 @@ pub struct ChainConfig {
     /// The [EIP-155](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md) hard fork block.
     #[serde(
         skip_serializing_if = "Option::is_none",
-        deserialize_with = "u64_opt_via_ruint::deserialize"
+        deserialize_with = "alloy_serde::quantity::opt::deserialize"
     )]
     pub eip155_block: Option<u64>,
 
     /// The [EIP-158](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-158.md) hard fork block.
     #[serde(
         skip_serializing_if = "Option::is_none",
-        deserialize_with = "u64_opt_via_ruint::deserialize"
+        deserialize_with = "alloy_serde::quantity::opt::deserialize"
     )]
     pub eip158_block: Option<u64>,
 
     /// The Byzantium hard fork block (None = no fork, 0 = already on byzantium).
     #[serde(
         skip_serializing_if = "Option::is_none",
-        deserialize_with = "u64_opt_via_ruint::deserialize"
+        deserialize_with = "alloy_serde::quantity::opt::deserialize"
     )]
     pub byzantium_block: Option<u64>,
 
     /// The Constantinople hard fork block (None = no fork, 0 = already on constantinople).
     #[serde(
         skip_serializing_if = "Option::is_none",
-        deserialize_with = "u64_opt_via_ruint::deserialize"
+        deserialize_with = "alloy_serde::quantity::opt::deserialize"
     )]
     pub constantinople_block: Option<u64>,
 
     /// The Petersburg hard fork block (None = no fork, 0 = already on petersburg).
     #[serde(
         skip_serializing_if = "Option::is_none",
-        deserialize_with = "u64_opt_via_ruint::deserialize"
+        deserialize_with = "alloy_serde::quantity::opt::deserialize"
     )]
     pub petersburg_block: Option<u64>,
 
     /// The Istanbul hard fork block (None = no fork, 0 = already on istanbul).
     #[serde(
         skip_serializing_if = "Option::is_none",
-        deserialize_with = "u64_opt_via_ruint::deserialize"
+        deserialize_with = "alloy_serde::quantity::opt::deserialize"
     )]
     pub istanbul_block: Option<u64>,
 
     /// The Muir Glacier hard fork block (None = no fork, 0 = already on muir glacier).
     #[serde(
         skip_serializing_if = "Option::is_none",
-        deserialize_with = "u64_opt_via_ruint::deserialize"
+        deserialize_with = "alloy_serde::quantity::opt::deserialize"
     )]
     pub muir_glacier_block: Option<u64>,
 
     /// The Berlin hard fork block (None = no fork, 0 = already on berlin).
     #[serde(
         skip_serializing_if = "Option::is_none",
-        deserialize_with = "u64_opt_via_ruint::deserialize"
+        deserialize_with = "alloy_serde::quantity::opt::deserialize"
     )]
     pub berlin_block: Option<u64>,
 
     /// The London hard fork block (None = no fork, 0 = already on london).
     #[serde(
         skip_serializing_if = "Option::is_none",
-        deserialize_with = "u64_opt_via_ruint::deserialize"
+        deserialize_with = "alloy_serde::quantity::opt::deserialize"
     )]
     pub london_block: Option<u64>,
 
     /// The Arrow Glacier hard fork block (None = no fork, 0 = already on arrow glacier).
     #[serde(
         skip_serializing_if = "Option::is_none",
-        deserialize_with = "u64_opt_via_ruint::deserialize"
+        deserialize_with = "alloy_serde::quantity::opt::deserialize"
     )]
     pub arrow_glacier_block: Option<u64>,
 
     /// The Gray Glacier hard fork block (None = no fork, 0 = already on gray glacier).
     #[serde(
         skip_serializing_if = "Option::is_none",
-        deserialize_with = "u64_opt_via_ruint::deserialize"
+        deserialize_with = "alloy_serde::quantity::opt::deserialize"
     )]
     pub gray_glacier_block: Option<u64>,
 
     /// Virtual fork after the merge to use as a network splitter.
     #[serde(
         skip_serializing_if = "Option::is_none",
-        deserialize_with = "u64_opt_via_ruint::deserialize"
+        deserialize_with = "alloy_serde::quantity::opt::deserialize"
     )]
     pub merge_netsplit_block: Option<u64>,
 
     /// Shanghai switch time (None = no fork, 0 = already on shanghai).
     #[serde(
         skip_serializing_if = "Option::is_none",
-        deserialize_with = "u64_opt_via_ruint::deserialize"
+        deserialize_with = "alloy_serde::quantity::opt::deserialize"
     )]
     pub shanghai_time: Option<u64>,
 
     /// Cancun switch time (None = no fork, 0 = already on cancun).
     #[serde(
         skip_serializing_if = "Option::is_none",
-        deserialize_with = "u64_opt_via_ruint::deserialize"
+        deserialize_with = "alloy_serde::quantity::opt::deserialize"
     )]
     pub cancun_time: Option<u64>,
 
     /// Prague switch time (None = no fork, 0 = already on prague).
     #[serde(
         skip_serializing_if = "Option::is_none",
-        deserialize_with = "u64_opt_via_ruint::deserialize"
+        deserialize_with = "alloy_serde::quantity::opt::deserialize"
     )]
     pub prague_time: Option<u64>,
 

--- a/crates/rpc-types-anvil/src/lib.rs
+++ b/crates/rpc-types-anvil/src/lib.rs
@@ -31,7 +31,7 @@ impl<'de> serde::Deserialize<'de> for Forking {
         #[serde(rename_all = "camelCase")]
         struct ForkOpts {
             json_rpc_url: Option<String>,
-            #[serde(default, with = "alloy_serde::u64_opt_via_ruint")]
+            #[serde(default, with = "alloy_serde::quantity::opt")]
             block_number: Option<u64>,
         }
 
@@ -62,7 +62,7 @@ impl<'de> serde::Deserialize<'de> for Forking {
 #[serde(rename_all = "camelCase")]
 pub struct NodeInfo {
     /// The current block number
-    #[serde(with = "alloy_serde::u64_via_ruint")]
+    #[serde(with = "alloy_serde::quantity")]
     pub current_block_number: u64,
     /// The current block timestamp
     pub current_block_timestamp: u64,
@@ -147,14 +147,14 @@ pub enum MineOptions {
     /// The options for mining
     Options {
         /// The timestamp the block should be mined with
-        #[serde(with = "alloy_serde::u64_opt_via_ruint")]
+        #[serde(with = "alloy_serde::quantity::opt")]
         timestamp: Option<u64>,
         /// If `blocks` is given, it will mine exactly blocks number of blocks, regardless of any
         /// other blocks mined or reverted during it's operation
         blocks: Option<u64>,
     },
     /// The timestamp the block should be mined with
-    #[serde(with = "alloy_serde::u64_opt_via_ruint")]
+    #[serde(with = "alloy_serde::quantity::opt")]
     Timestamp(Option<u64>),
 }
 

--- a/crates/rpc-types-engine/src/optimism.rs
+++ b/crates/rpc-types-engine/src/optimism.rs
@@ -17,7 +17,7 @@ pub struct OptimismPayloadAttributes {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_tx_pool: Option<bool>,
     /// If set, this sets the exact gas limit the block produced with.
-    #[serde(skip_serializing_if = "Option::is_none", with = "alloy_serde::u64_opt_via_ruint")]
+    #[serde(skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
     pub gas_limit: Option<u64>,
 }
 

--- a/crates/rpc-types-engine/src/payload.rs
+++ b/crates/rpc-types-engine/src/payload.rs
@@ -155,16 +155,16 @@ pub struct ExecutionPayloadV1 {
     /// The previous randao of the block.
     pub prev_randao: B256,
     /// The block number.
-    #[serde(with = "alloy_serde::u64_via_ruint")]
+    #[serde(with = "alloy_serde::quantity")]
     pub block_number: u64,
     /// The gas limit of the block.
-    #[serde(with = "alloy_serde::u64_via_ruint")]
+    #[serde(with = "alloy_serde::quantity")]
     pub gas_limit: u64,
     /// The gas used of the block.
-    #[serde(with = "alloy_serde::u64_via_ruint")]
+    #[serde(with = "alloy_serde::quantity")]
     pub gas_used: u64,
     /// The timestamp of the block.
-    #[serde(with = "alloy_serde::u64_via_ruint")]
+    #[serde(with = "alloy_serde::quantity")]
     pub timestamp: u64,
     /// The extra data of the block.
     pub extra_data: Bytes,
@@ -301,11 +301,11 @@ pub struct ExecutionPayloadV3 {
 
     /// Array of hex [`u64`] representing blob gas used, enabled with V3
     /// See <https://github.com/ethereum/execution-apis/blob/fe8e13c288c592ec154ce25c534e26cb7ce0530d/src/engine/cancun.md#ExecutionPayloadV3>
-    #[serde(with = "alloy_serde::u64_via_ruint")]
+    #[serde(with = "alloy_serde::quantity")]
     pub blob_gas_used: u64,
     /// Array of hex[`u64`] representing excess blob gas, enabled with V3
     /// See <https://github.com/ethereum/execution-apis/blob/fe8e13c288c592ec154ce25c534e26cb7ce0530d/src/engine/cancun.md#ExecutionPayloadV3>
-    #[serde(with = "alloy_serde::u64_via_ruint")]
+    #[serde(with = "alloy_serde::quantity")]
     pub excess_blob_gas: u64,
 }
 
@@ -854,7 +854,7 @@ pub struct ExecutionPayloadBodyV1 {
 #[serde(rename_all = "camelCase")]
 pub struct PayloadAttributes {
     /// Value for the `timestamp` field of the new payload
-    #[serde(with = "alloy_serde::u64_via_ruint")]
+    #[serde(with = "alloy_serde::quantity")]
     pub timestamp: u64,
     /// Value for the `prevRandao` field of the new payload
     pub prev_randao: B256,

--- a/crates/rpc-types-trace/src/filter.rs
+++ b/crates/rpc-types-trace/src/filter.rs
@@ -1,6 +1,5 @@
 //! `trace_filter` types and support
 use alloy_primitives::Address;
-use alloy_serde::num::u64_opt_via_ruint;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 
@@ -10,10 +9,10 @@ use std::collections::HashSet;
 #[serde(rename_all = "camelCase")]
 pub struct TraceFilter {
     /// From block
-    #[serde(with = "u64_opt_via_ruint")]
+    #[serde(with = "alloy_serde::quantity::opt")]
     pub from_block: Option<u64>,
     /// To block
-    #[serde(with = "u64_opt_via_ruint")]
+    #[serde(with = "alloy_serde::quantity::opt")]
     pub to_block: Option<u64>,
     /// From address
     #[serde(default)]

--- a/crates/rpc-types-trace/src/otterscan.rs
+++ b/crates/rpc-types-trace/src/otterscan.rs
@@ -113,7 +113,7 @@ pub struct OtsTransactionReceipt {
     #[serde(flatten)]
     pub receipt: TransactionReceipt<OtsReceipt>,
     /// The timestamp of the transaction.
-    #[serde(default, with = "alloy_serde::u64_opt_via_ruint")]
+    #[serde(default, with = "alloy_serde::quantity::opt")]
     pub timestamp: Option<u64>,
 }
 
@@ -124,10 +124,10 @@ pub struct OtsReceipt {
     /// If the transaction is executed successfully.
     ///
     /// This is the `statusCode`
-    #[serde(with = "alloy_serde::quantity_bool")]
+    #[serde(with = "alloy_serde::quantity")]
     pub status: bool,
     /// The cumulative gas used.
-    #[serde(with = "alloy_serde::u64_via_ruint")]
+    #[serde(with = "alloy_serde::quantity")]
     pub cumulative_gas_used: u64,
     /// The logs sent from contracts.
     ///
@@ -138,7 +138,7 @@ pub struct OtsReceipt {
     /// Note: this is set to null.
     pub logs_bloom: Option<Bloom>,
     /// The transaction type.
-    #[serde(with = "alloy_serde::num::u8_via_ruint")]
+    #[serde(with = "alloy_serde::quantity")]
     pub r#type: u8,
 }
 
@@ -185,21 +185,21 @@ mod tests {
     #[test]
     fn test_otterscan_receipt() {
         let s = r#"{
-      "blockHash": "0xf05aa8b73b005314684595adcff8e6149917b3239b6316247ce5e88eba9fd3f5",
-      "blockNumber": "0x1106fe7",
-      "contractAddress": null,
-      "cumulativeGasUsed": "0x95fac3",
-      "effectiveGasPrice": "0x2e9f0055d",
-      "from": "0x793abeea78d94c14b884a56788f549836a35db65",
-      "gasUsed": "0x14427",
-      "logs": null,
-      "logsBloom": null,
-      "status": "0x1",
-      "to": "0x06450dee7fd2fb8e39061434babcfc05599a6fb8",
-      "transactionHash": "0xd3cead022cbb5d6d18091f8b375e3a3896ec139e986144b9448290d55837275a",
-      "transactionIndex": "0x90",
-      "type": "0x2"
-    }"#;
+            "blockHash": "0xf05aa8b73b005314684595adcff8e6149917b3239b6316247ce5e88eba9fd3f5",
+            "blockNumber": "0x1106fe7",
+            "contractAddress": null,
+            "cumulativeGasUsed": "0x95fac3",
+            "effectiveGasPrice": "0x2e9f0055d",
+            "from": "0x793abeea78d94c14b884a56788f549836a35db65",
+            "gasUsed": "0x14427",
+            "logs": null,
+            "logsBloom": null,
+            "status": "0x1",
+            "to": "0x06450dee7fd2fb8e39061434babcfc05599a6fb8",
+            "transactionHash": "0xd3cead022cbb5d6d18091f8b375e3a3896ec139e986144b9448290d55837275a",
+            "transactionIndex": "0x90",
+            "type": "0x2"
+        }"#;
 
         let _receipt: OtsTransactionReceipt = serde_json::from_str(s).unwrap();
     }

--- a/crates/rpc-types/src/eth/block.rs
+++ b/crates/rpc-types/src/eth/block.rs
@@ -69,16 +69,16 @@ pub struct Header {
     /// Difficulty
     pub difficulty: U256,
     /// Block number
-    #[serde(default, with = "alloy_serde::num::u64_opt_via_ruint")]
+    #[serde(default, with = "alloy_serde::quantity::opt")]
     pub number: Option<u64>,
     /// Gas Limit
-    #[serde(default, with = "alloy_serde::num::u128_via_ruint")]
+    #[serde(default, with = "alloy_serde::quantity")]
     pub gas_limit: u128,
     /// Gas Used
-    #[serde(default, with = "alloy_serde::num::u128_via_ruint")]
+    #[serde(default, with = "alloy_serde::quantity")]
     pub gas_used: u128,
     /// Timestamp
-    #[serde(default, with = "alloy_serde::num::u64_via_ruint")]
+    #[serde(default, with = "alloy_serde::quantity")]
     pub timestamp: u64,
     /// Total difficulty
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -102,28 +102,16 @@ pub struct Header {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub nonce: Option<B64>,
     /// Base fee per unit of gas (if past London)
-    #[serde(
-        default,
-        skip_serializing_if = "Option::is_none",
-        with = "alloy_serde::num::u128_opt_via_ruint"
-    )]
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
     pub base_fee_per_gas: Option<u128>,
     /// Withdrawals root hash added by EIP-4895 and is ignored in legacy headers.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub withdrawals_root: Option<B256>,
     /// Blob gas used
-    #[serde(
-        default,
-        skip_serializing_if = "Option::is_none",
-        with = "alloy_serde::num::u128_opt_via_ruint"
-    )]
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
     pub blob_gas_used: Option<u128>,
     /// Excess blob gas
-    #[serde(
-        default,
-        skip_serializing_if = "Option::is_none",
-        with = "alloy_serde::num::u128_opt_via_ruint"
-    )]
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
     pub excess_blob_gas: Option<u128>,
     /// EIP-4788 parent beacon block root
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/rpc-types/src/eth/fee.rs
+++ b/crates/rpc-types/src/eth/fee.rs
@@ -37,11 +37,7 @@ pub struct FeeHistory {
     /// # Note
     ///
     /// Empty list is skipped only for compatibility with Erigon and Geth.
-    #[serde(
-        default,
-        skip_serializing_if = "Vec::is_empty",
-        with = "alloy_serde::num::u128_vec_via_ruint"
-    )]
+    #[serde(default, skip_serializing_if = "Vec::is_empty", with = "alloy_serde::quantity::vec")]
     pub base_fee_per_gas: Vec<u128>,
     /// An array of block gas used ratios. These are calculated as the ratio
     /// of `gasUsed` and `gasLimit`.
@@ -49,25 +45,21 @@ pub struct FeeHistory {
     /// An array of block base fees per blob gas. This includes the next block after the newest
     /// of the returned range, because this value can be derived from the newest block. Zeroes
     /// are returned for pre-EIP-4844 blocks.
-    #[serde(
-        default,
-        skip_serializing_if = "Vec::is_empty",
-        with = "alloy_serde::num::u128_vec_via_ruint"
-    )]
+    #[serde(default, skip_serializing_if = "Vec::is_empty", with = "alloy_serde::quantity::vec")]
     pub base_fee_per_blob_gas: Vec<u128>,
     /// An array of block blob gas used ratios. These are calculated as the ratio of gasUsed and
     /// gasLimit.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub blob_gas_used_ratio: Vec<f64>,
     /// Lowest number block of the returned range.
-    #[serde(default, with = "alloy_serde::num::u64_via_ruint")]
+    #[serde(default, with = "alloy_serde::quantity")]
     pub oldest_block: u64,
     /// An (optional) array of effective priority fee per gas data points from a single
     /// block. All zeroes are returned if the block is empty.
     #[serde(
         default,
         skip_serializing_if = "Option::is_none",
-        with = "alloy_serde::num::u128_vec_vec_opt_via_ruint"
+        with = "alloy_serde::u128_vec_vec_opt_via_ruint"
     )]
     pub reward: Option<Vec<Vec<u128>>>,
 }

--- a/crates/rpc-types/src/eth/log.rs
+++ b/crates/rpc-types/src/eth/log.rs
@@ -17,26 +17,22 @@ pub struct Log<T = LogData> {
     /// Hash of the block the transaction that emitted this log was mined in
     pub block_hash: Option<B256>,
     /// Number of the block the transaction that emitted this log was mined in
-    #[serde(with = "alloy_serde::u64_opt_via_ruint")]
+    #[serde(with = "alloy_serde::quantity::opt")]
     pub block_number: Option<u64>,
     /// The timestamp of the block as proposed in:
     /// <https://ethereum-magicians.org/t/proposal-for-adding-blocktimestamp-to-logs-object-returned-by-eth-getlogs-and-related-requests>
     /// <https://github.com/ethereum/execution-apis/issues/295>
-    #[serde(
-        skip_serializing_if = "Option::is_none",
-        with = "alloy_serde::u64_opt_via_ruint",
-        default
-    )]
+    #[serde(skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt", default)]
     pub block_timestamp: Option<u64>,
     /// Transaction Hash
     #[doc(alias = "tx_hash")]
     pub transaction_hash: Option<B256>,
     /// Index of the Transaction in the block
-    #[serde(with = "alloy_serde::u64_opt_via_ruint")]
+    #[serde(with = "alloy_serde::quantity::opt")]
     #[doc(alias = "tx_index")]
     pub transaction_index: Option<u64>,
     /// Log Index in Block
-    #[serde(with = "alloy_serde::u64_opt_via_ruint")]
+    #[serde(with = "alloy_serde::quantity::opt")]
     pub log_index: Option<u64>,
     /// Geth Compatibility Field: whether this log was removed
     #[serde(default)]

--- a/crates/rpc-types/src/eth/transaction/mod.rs
+++ b/crates/rpc-types/src/eth/transaction/mod.rs
@@ -40,16 +40,16 @@ pub struct Transaction {
     /// Hash
     pub hash: B256,
     /// Nonce
-    #[serde(with = "alloy_serde::num::u64_via_ruint")]
+    #[serde(with = "alloy_serde::quantity")]
     pub nonce: u64,
     /// Block hash
     #[serde(default)]
     pub block_hash: Option<B256>,
     /// Block number
-    #[serde(default, with = "alloy_serde::num::u64_opt_via_ruint")]
+    #[serde(default, with = "alloy_serde::quantity::opt")]
     pub block_number: Option<u64>,
     /// Transaction Index
-    #[serde(default, with = "alloy_serde::num::u64_opt_via_ruint")]
+    #[serde(default, with = "alloy_serde::quantity::opt")]
     pub transaction_index: Option<u64>,
     /// Sender
     pub from: Address,
@@ -58,35 +58,19 @@ pub struct Transaction {
     /// Transferred value
     pub value: U256,
     /// Gas Price
-    #[serde(
-        default,
-        skip_serializing_if = "Option::is_none",
-        with = "alloy_serde::num::u128_opt_via_ruint"
-    )]
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
     pub gas_price: Option<u128>,
     /// Gas amount
-    #[serde(with = "alloy_serde::num::u128_via_ruint")]
+    #[serde(with = "alloy_serde::quantity")]
     pub gas: u128,
     /// Max BaseFeePerGas the user is willing to pay.
-    #[serde(
-        default,
-        skip_serializing_if = "Option::is_none",
-        with = "alloy_serde::num::u128_opt_via_ruint"
-    )]
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
     pub max_fee_per_gas: Option<u128>,
     /// The miner's tip.
-    #[serde(
-        default,
-        skip_serializing_if = "Option::is_none",
-        with = "alloy_serde::num::u128_opt_via_ruint"
-    )]
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
     pub max_priority_fee_per_gas: Option<u128>,
     /// Configured max fee per blob gas for eip-4844 transactions
-    #[serde(
-        default,
-        skip_serializing_if = "Option::is_none",
-        with = "alloy_serde::num::u128_opt_via_ruint"
-    )]
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
     pub max_fee_per_blob_gas: Option<u128>,
     /// Data
     pub input: Bytes,
@@ -96,11 +80,7 @@ pub struct Transaction {
     #[serde(flatten, skip_serializing_if = "Option::is_none")]
     pub signature: Option<Signature>,
     /// The chain id of the transaction, if any.
-    #[serde(
-        default,
-        skip_serializing_if = "Option::is_none",
-        with = "alloy_serde::u64_opt_via_ruint"
-    )]
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
     pub chain_id: Option<u64>,
     /// Contains the blob hashes for eip-4844 transactions.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -119,7 +99,7 @@ pub struct Transaction {
         default,
         rename = "type",
         skip_serializing_if = "Option::is_none",
-        with = "alloy_serde::num::u8_opt_via_ruint"
+        with = "alloy_serde::quantity::opt"
     )]
     #[doc(alias = "tx_type")]
     pub transaction_type: Option<u8>,

--- a/crates/rpc-types/src/eth/transaction/optimism.rs
+++ b/crates/rpc-types/src/eth/transaction/optimism.rs
@@ -33,28 +33,16 @@ pub struct OptimismTransactionReceiptFields {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub deposit_receipt_version: Option<U64>,
     /// L1 fee for the transaction
-    #[serde(
-        default,
-        skip_serializing_if = "Option::is_none",
-        with = "alloy_serde::num::u128_opt_via_ruint"
-    )]
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
     pub l1_fee: Option<u128>,
     /// L1 fee scalar for the transaction
     #[serde(default, skip_serializing_if = "Option::is_none", with = "l1_fee_scalar_serde")]
     pub l1_fee_scalar: Option<f64>,
     /// L1 gas price for the transaction
-    #[serde(
-        default,
-        skip_serializing_if = "Option::is_none",
-        with = "alloy_serde::num::u128_opt_via_ruint"
-    )]
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
     pub l1_gas_price: Option<u128>,
     /// L1 gas used for the transaction
-    #[serde(
-        default,
-        skip_serializing_if = "Option::is_none",
-        with = "alloy_serde::num::u128_opt_via_ruint"
-    )]
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
     pub l1_gas_used: Option<u128>,
 }
 

--- a/crates/rpc-types/src/eth/transaction/receipt.rs
+++ b/crates/rpc-types/src/eth/transaction/receipt.rs
@@ -24,38 +24,30 @@ pub struct TransactionReceipt<T = ReceiptEnvelope<Log>> {
     #[doc(alias = "tx_hash")]
     pub transaction_hash: B256,
     /// Index within the block.
-    #[serde(default, with = "alloy_serde::u64_opt_via_ruint")]
+    #[serde(default, with = "alloy_serde::quantity::opt")]
     #[doc(alias = "tx_index")]
     pub transaction_index: Option<u64>,
     /// Hash of the block this transaction was included within.
     #[serde(default)]
     pub block_hash: Option<B256>,
     /// Number of the block this transaction was included within.
-    #[serde(default, with = "alloy_serde::u64_opt_via_ruint")]
+    #[serde(default, with = "alloy_serde::quantity::opt")]
     pub block_number: Option<u64>,
     /// Gas used by this transaction alone.
-    #[serde(with = "alloy_serde::u128_via_ruint")]
+    #[serde(with = "alloy_serde::quantity")]
     pub gas_used: u128,
     /// The price paid post-execution by the transaction (i.e. base fee + priority fee). Both
     /// fields in 1559-style transactions are maximums (max fee + max priority fee), the amount
     /// that's actually paid by users can only be determined post-execution
-    #[serde(with = "alloy_serde::u128_via_ruint")]
+    #[serde(with = "alloy_serde::quantity")]
     pub effective_gas_price: u128,
     /// Blob gas used by the eip-4844 transaction
     ///
     /// This is None for non eip-4844 transactions
-    #[serde(
-        skip_serializing_if = "Option::is_none",
-        with = "alloy_serde::u128_opt_via_ruint",
-        default
-    )]
+    #[serde(skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt", default)]
     pub blob_gas_used: Option<u128>,
     /// The price paid by the eip-4844 transaction per blob gas.
-    #[serde(
-        skip_serializing_if = "Option::is_none",
-        with = "alloy_serde::u128_opt_via_ruint",
-        default
-    )]
+    #[serde(skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt", default)]
     pub blob_gas_price: Option<u128>,
     /// Address of the sender
     pub from: Address,

--- a/crates/rpc-types/src/eth/transaction/request.rs
+++ b/crates/rpc-types/src/eth/transaction/request.rs
@@ -21,39 +21,19 @@ pub struct TransactionRequest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub to: Option<TxKind>,
     /// The legacy gas price.
-    #[serde(
-        default,
-        skip_serializing_if = "Option::is_none",
-        with = "alloy_serde::num::u128_opt_via_ruint"
-    )]
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
     pub gas_price: Option<u128>,
     /// The max base fee per gas the sender is willing to pay.
-    #[serde(
-        default,
-        skip_serializing_if = "Option::is_none",
-        with = "alloy_serde::num::u128_opt_via_ruint"
-    )]
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
     pub max_fee_per_gas: Option<u128>,
     /// The max priority fee per gas the sender is willing to pay, also called the miner tip.
-    #[serde(
-        default,
-        skip_serializing_if = "Option::is_none",
-        with = "alloy_serde::num::u128_opt_via_ruint"
-    )]
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
     pub max_priority_fee_per_gas: Option<u128>,
     /// The max fee per blob gas for EIP-4844 blob transactions.
-    #[serde(
-        default,
-        skip_serializing_if = "Option::is_none",
-        with = "alloy_serde::num::u128_opt_via_ruint"
-    )]
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
     pub max_fee_per_blob_gas: Option<u128>,
     /// The gas limit for the transaction.
-    #[serde(
-        default,
-        skip_serializing_if = "Option::is_none",
-        with = "alloy_serde::num::u128_opt_via_ruint"
-    )]
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
     pub gas: Option<u128>,
     /// The value transferred in the transaction, in wei.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -62,18 +42,10 @@ pub struct TransactionRequest {
     #[serde(default, flatten)]
     pub input: TransactionInput,
     /// The nonce of the transaction.
-    #[serde(
-        default,
-        skip_serializing_if = "Option::is_none",
-        with = "alloy_serde::num::u64_opt_via_ruint"
-    )]
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
     pub nonce: Option<u64>,
     /// The chain ID for the transaction.
-    #[serde(
-        default,
-        skip_serializing_if = "Option::is_none",
-        with = "alloy_serde::num::u64_opt_via_ruint"
-    )]
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
     pub chain_id: Option<ChainId>,
     /// An EIP-2930 access list, which lowers cost for accessing accounts and storages in the list. See [EIP-2930](https://eips.ethereum.org/EIPS/eip-2930) for more information.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -83,7 +55,7 @@ pub struct TransactionRequest {
         default,
         rename = "type",
         skip_serializing_if = "Option::is_none",
-        with = "alloy_serde::num::u8_opt_via_ruint"
+        with = "alloy_serde::quantity::opt"
     )]
     #[doc(alias = "tx_type")]
     pub transaction_type: Option<u8>,

--- a/crates/rpc-types/src/eth/txpool.rs
+++ b/crates/rpc-types/src/eth/txpool.rs
@@ -168,10 +168,10 @@ pub struct TxpoolInspect {
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TxpoolStatus {
     /// number of pending tx
-    #[serde(with = "alloy_serde::num::u64_via_ruint")]
+    #[serde(with = "alloy_serde::quantity")]
     pub pending: u64,
     /// number of queued tx
-    #[serde(with = "alloy_serde::num::u64_via_ruint")]
+    #[serde(with = "alloy_serde::quantity")]
     pub queued: u64,
 }
 

--- a/crates/serde/src/bool.rs
+++ b/crates/serde/src/bool.rs
@@ -1,4 +1,5 @@
 /// Serde serialization and deserialization for [`bool`] as `0x0` or `0x1`.
+#[deprecated = "use `quantity::bool` instead"]
 pub mod quantity_bool {
     use alloy_primitives::aliases::U1;
     use serde::{Deserialize, Deserializer, Serialize, Serializer};

--- a/crates/serde/src/lib.rs
+++ b/crates/serde/src/lib.rs
@@ -16,15 +16,19 @@ mod bool;
 pub use self::bool::*;
 
 /// Helpers for dealing with numbers.
+#[cfg_attr(not(test), deprecated = "use `quantity::{self, opt, vec}` instead")]
 pub mod num;
-pub use self::num::*;
+#[allow(deprecated)]
+pub use num::*;
+
+pub mod quantity;
 
 /// Storage related helpers.
 pub mod storage;
-pub use self::storage::JsonStorageKey;
+pub use storage::JsonStorageKey;
 
 pub mod ttd;
-pub use self::ttd::*;
+pub use ttd::*;
 
 use alloc::format;
 use serde::Serializer;

--- a/crates/serde/src/quantity.rs
+++ b/crates/serde/src/quantity.rs
@@ -6,7 +6,7 @@
 //!
 //! This is only valid for human-readable [`serde`] implementations.
 //! For non-human-readable implementations, the format is unspecified.
-//! Currently, it is uses a fixed-width big-endian byte-array.
+//! Currently, it uses a fixed-width big-endian byte-array.
 
 use private::ConvertRuint;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};

--- a/crates/serde/src/quantity.rs
+++ b/crates/serde/src/quantity.rs
@@ -1,0 +1,286 @@
+//! Serde functions for encoding primitive numbers using the Ethereum JSON-RPC "quantity" format.
+//!
+//! This is defined as a "hex encoded unsigned integer", with a special case of 0 being `0x0`.
+//!
+//! A regex for this format is: `^0x([1-9a-f]+[0-9a-f]*|0)$`.
+
+use private::ConvertRuint;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+#[allow(deprecated)]
+pub use crate::num::u128_vec_vec_opt_via_ruint;
+
+/// Serializes a primitive number as a "quantity" hex string.
+pub fn serialize<T, S>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
+where
+    T: ConvertRuint,
+    S: Serializer,
+{
+    value.into_ruint().serialize(serializer)
+}
+
+/// Deserializes a primitive number from a "quantity" hex string.
+pub fn deserialize<'de, T, D>(deserializer: D) -> Result<T, D::Error>
+where
+    T: ConvertRuint,
+    D: Deserializer<'de>,
+{
+    T::Ruint::deserialize(deserializer).map(T::from_ruint)
+}
+
+/// Serde functions for encoding optional primitive numbers using the Ethereum "quantity" format.
+///
+/// See [`quantity`](self) for more information.
+pub mod opt {
+    use super::private::ConvertRuint;
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    /// Serializes an optional primitive number as a "quantity" hex string.
+    pub fn serialize<T, S>(value: &Option<T>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        T: ConvertRuint,
+        S: Serializer,
+    {
+        match value {
+            Some(value) => super::serialize(value, serializer),
+            None => serializer.serialize_none(),
+        }
+    }
+
+    /// Deserializes an optional primitive number from a "quantity" hex string.
+    pub fn deserialize<'de, T, D>(deserializer: D) -> Result<Option<T>, D::Error>
+    where
+        T: ConvertRuint,
+        D: Deserializer<'de>,
+    {
+        Ok(Option::<T::Ruint>::deserialize(deserializer)?.map(T::from_ruint))
+    }
+}
+
+/// Serde functions for encoding a list of primitive numbers using the Ethereum "quantity" format.
+///
+/// See [`quantity`](self) for more information.
+pub mod vec {
+    use super::private::ConvertRuint;
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    #[cfg(not(feature = "std"))]
+    use alloc::vec::Vec;
+
+    /// Serializes a vector of primitive numbers as a "quantity" hex string.
+    pub fn serialize<T, S>(value: &[T], serializer: S) -> Result<S::Ok, S::Error>
+    where
+        T: ConvertRuint,
+        S: Serializer,
+    {
+        let vec = value.iter().copied().map(T::into_ruint).collect::<Vec<_>>();
+        vec.serialize(serializer)
+    }
+
+    /// Deserializes a vector of primitive numbers from a "quantity" hex string.
+    pub fn deserialize<'de, T, D>(deserializer: D) -> Result<Vec<T>, D::Error>
+    where
+        T: ConvertRuint,
+        D: Deserializer<'de>,
+    {
+        let vec = Vec::<T::Ruint>::deserialize(deserializer)?;
+        Ok(vec.into_iter().map(T::from_ruint).collect())
+    }
+}
+
+/// Private implementation details of the [`quantity`] module.
+mod private {
+    #[doc(hidden)]
+    pub trait ConvertRuint: Copy + Sized {
+        // We have to use `Try*` traits because `From` is not implemented by ruint types.
+        // They shouldn't ever error.
+        type Ruint: Copy
+            + serde::Serialize
+            + serde::de::DeserializeOwned
+            + TryFrom<Self>
+            + TryInto<Self>;
+
+        #[inline]
+        fn into_ruint(self) -> Self::Ruint {
+            self.try_into().ok().unwrap()
+        }
+
+        #[inline]
+        fn from_ruint(ruint: Self::Ruint) -> Self {
+            ruint.try_into().ok().unwrap()
+        }
+    }
+
+    macro_rules! impl_from_ruint {
+        ($($primitive:ty = $ruint:ty),* $(,)?) => {
+            $(
+                impl ConvertRuint for $primitive {
+                    type Ruint = $ruint;
+                }
+            )*
+        };
+    }
+
+    impl_from_ruint! {
+        bool = alloy_primitives::ruint::aliases::U1,
+        u8   = alloy_primitives::U8,
+        u16  = alloy_primitives::U16,
+        u32  = alloy_primitives::U32,
+        u64  = alloy_primitives::U64,
+        u128 = alloy_primitives::U128,
+    }
+}
+
+/// serde functions for handling `Vec<Vec<u128>>` via [U128](alloy_primitives::U128)
+pub mod u128_vec_vec_opt {
+    use alloy_primitives::U128;
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    #[cfg(not(feature = "std"))]
+    use alloc::vec::Vec;
+
+    /// Deserializes an `u128` accepting a hex quantity string with optional 0x prefix or
+    /// a number
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<Vec<Vec<u128>>>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        (Option::<Vec<Vec<U128>>>::deserialize(deserializer)?).map_or_else(
+            || Ok(None),
+            |vec| {
+                Ok(Some(
+                    vec.into_iter().map(|v| v.into_iter().map(|val| val.to()).collect()).collect(),
+                ))
+            },
+        )
+    }
+
+    /// Serializes u128 as hex string
+    pub fn serialize<S: Serializer>(
+        value: &Option<Vec<Vec<u128>>>,
+        s: S,
+    ) -> Result<S::Ok, S::Error> {
+        match value {
+            Some(vec) => {
+                let vec = vec
+                    .iter()
+                    .map(|v| v.iter().map(|val| U128::from(*val)).collect::<Vec<_>>())
+                    .collect::<Vec<_>>();
+                vec.serialize(s)
+            }
+            None => s.serialize_none(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde::{Deserialize, Serialize};
+
+    #[cfg(not(feature = "std"))]
+    use alloc::{string::ToString, vec, vec::Vec};
+
+    #[test]
+    fn test_hex_u64() {
+        #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+        struct Value {
+            #[serde(with = "super")]
+            inner: u64,
+        }
+
+        let val = Value { inner: 1000 };
+        let s = serde_json::to_string(&val).unwrap();
+        assert_eq!(s, "{\"inner\":\"0x3e8\"}");
+
+        let deserialized: Value = serde_json::from_str(&s).unwrap();
+        assert_eq!(val, deserialized);
+    }
+
+    #[test]
+    fn test_u128_via_ruint() {
+        #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+        struct Value {
+            #[serde(with = "super")]
+            inner: u128,
+        }
+
+        let val = Value { inner: 1000 };
+        let s = serde_json::to_string(&val).unwrap();
+        assert_eq!(s, "{\"inner\":\"0x3e8\"}");
+
+        let deserialized: Value = serde_json::from_str(&s).unwrap();
+        assert_eq!(val, deserialized);
+
+        let s = "{\"inner\":\"1000\"}".to_string();
+        let deserialized: Value = serde_json::from_str(&s).unwrap();
+
+        assert_eq!(val, deserialized);
+    }
+
+    #[test]
+    fn test_u128_opt_via_ruint() {
+        #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+        struct Value {
+            #[serde(with = "super::opt")]
+            inner: Option<u128>,
+        }
+
+        let val = Value { inner: Some(1000) };
+        let s = serde_json::to_string(&val).unwrap();
+        assert_eq!(s, "{\"inner\":\"0x3e8\"}");
+
+        let deserialized: Value = serde_json::from_str(&s).unwrap();
+        assert_eq!(val, deserialized);
+
+        let s = "{\"inner\":\"1000\"}".to_string();
+        let deserialized: Value = serde_json::from_str(&s).unwrap();
+
+        assert_eq!(val, deserialized);
+
+        let val = Value { inner: None };
+        let s = serde_json::to_string(&val).unwrap();
+        assert_eq!(s, "{\"inner\":null}");
+
+        let deserialized: Value = serde_json::from_str(&s).unwrap();
+        assert_eq!(val, deserialized);
+    }
+
+    #[test]
+    fn test_u128_vec_via_ruint() {
+        #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+        struct Value {
+            #[serde(with = "super::vec")]
+            inner: Vec<u128>,
+        }
+
+        let val = Value { inner: vec![1000, 2000] };
+        let s = serde_json::to_string(&val).unwrap();
+        assert_eq!(s, "{\"inner\":[\"0x3e8\",\"0x7d0\"]}");
+
+        let deserialized: Value = serde_json::from_str(&s).unwrap();
+        assert_eq!(val, deserialized);
+    }
+
+    #[test]
+    fn test_u128_vec_vec_opt_via_ruint() {
+        #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+        struct Value {
+            #[serde(with = "super::u128_vec_vec_opt")]
+            inner: Option<Vec<Vec<u128>>>,
+        }
+
+        let val = Value { inner: Some(vec![vec![1000, 2000], vec![3000, 4000]]) };
+        let s = serde_json::to_string(&val).unwrap();
+        assert_eq!(s, "{\"inner\":[[\"0x3e8\",\"0x7d0\"],[\"0xbb8\",\"0xfa0\"]]}");
+
+        let deserialized: Value = serde_json::from_str(&s).unwrap();
+        assert_eq!(val, deserialized);
+
+        let val = Value { inner: None };
+        let s = serde_json::to_string(&val).unwrap();
+        assert_eq!(s, "{\"inner\":null}");
+
+        let deserialized: Value = serde_json::from_str(&s).unwrap();
+        assert_eq!(val, deserialized);
+    }
+}

--- a/crates/serde/src/quantity.rs
+++ b/crates/serde/src/quantity.rs
@@ -3,12 +3,13 @@
 //! This is defined as a "hex encoded unsigned integer", with a special case of 0 being `0x0`.
 //!
 //! A regex for this format is: `^0x([1-9a-f]+[0-9a-f]*|0)$`.
+//!
+//! This is only valid for human-readable [`serde`] implementations.
+//! For non-human-readable implementations, the format is unspecified.
+//! Currently, it is uses a fixed-width big-endian byte-array.
 
 use private::ConvertRuint;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-
-#[allow(deprecated)]
-pub use crate::num::u128_vec_vec_opt_via_ruint;
 
 /// Serializes a primitive number as a "quantity" hex string.
 pub fn serialize<T, S>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
@@ -88,7 +89,7 @@ pub mod vec {
     }
 }
 
-/// Private implementation details of the [`quantity`] module.
+/// Private implementation details of the [`quantity`](self) module.
 mod private {
     #[doc(hidden)]
     pub trait ConvertRuint: Copy + Sized {


### PR DESCRIPTION
Highlights that this is Ethereum JSON-RPC `quantity` encoding, removes `ruint` from the name, and makes it generic

Unfortunately `#[deprecated]` does not emit any warnings for `serde(with = "...")` invocations