### PR TITLE
fix: make test compile

### DIFF
--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -33,6 +33,7 @@ serde = { workspace = true, features = ["derive"], optional = true }
 
 [dev-dependencies]
 alloy-primitives = { workspace = true, features = ["arbitrary", "rand"] }
+alloy-eips = { workspace = true, features = ["arbitrary"] }
 alloy-signer.workspace = true
 
 arbitrary = { workspace = true, features = ["derive"] }

--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -305,7 +305,9 @@ mod tests {
     use super::*;
     use crate::transaction::SignableTransaction;
     use alloy_eips::eip2930::{AccessList, AccessListItem};
-    use alloy_primitives::{hex, Address, Bytes, Signature, TxKind, U256};
+    use alloy_primitives::{hex, Address, Signature, U256};
+    #[allow(unused_imports)]
+    use alloy_primitives::{Bytes, TxKind};
     use std::{fs, path::PathBuf, vec};
 
     #[cfg(not(feature = "std"))]


### PR DESCRIPTION
cargo t requires eips arbitrary