### PR TITLE
add custom conversion error to handle additional situations (such as optimism deposit tx)

### DIFF
--- a/crates/rpc-types-eth/src/transaction/error.rs
+++ b/crates/rpc-types-eth/src/transaction/error.rs
@@ -58,19 +58,13 @@ pub enum ConversionError {
     /// Missing block number
     #[error("missing block number")]
     MissingBlockNumber,
-    /// Missing source hash (for Optimism deposit tx)
-    #[error("missing source hash")]
-    MissingSourceHash,
-    /// Invalid source hash (for Optimism deposit tx)
-    #[error("invalid source hash")]
-    InvalidSourceHash,
-    /// Invalid mint value (for Optimism deposit tx)
-    #[error("invalid mint value")]
-    InvalidMintValue,
     /// Blob gas used integer conversion error
     #[error("blob gas used integer conversion error: {0}")]
     BlobGasUsedConversion(TryFromIntError),
     /// Excess blob gas integer conversion error
     #[error("excess blob gas integer conversion error: {0}")]
     ExcessBlobGasConversion(TryFromIntError),
+    /// A custom Conversion Error that doesn't fit other categories.
+    #[error("conversion error: {0}")]
+    Custom(String),
 }

--- a/crates/rpc-types-eth/src/transaction/error.rs
+++ b/crates/rpc-types-eth/src/transaction/error.rs
@@ -62,8 +62,8 @@ pub enum ConversionError {
     #[error("missing source hash")]
     MissingSourceHash,
     /// Invalid source hash (for Optimism deposit tx)
-    #[error("invalid block number")]
-    InvalidBlockNumber,
+    #[error("invalid source hash")]
+    InvalidSourceHash,
     /// Invalid mint value (for Optimism deposit tx)
     #[error("invalid mint value")]
     InvalidMintValue,

--- a/crates/rpc-types-eth/src/transaction/error.rs
+++ b/crates/rpc-types-eth/src/transaction/error.rs
@@ -58,6 +58,15 @@ pub enum ConversionError {
     /// Missing block number
     #[error("missing block number")]
     MissingBlockNumber,
+    /// Missing source hash (for Optimism deposit tx)
+    #[error("missing source hash")]
+    MissingSourceHash,
+    /// Invalid source hash (for Optimism deposit tx)
+    #[error("invalid block number")]
+    InvalidBlockNumber,
+    /// Invalid mint value (for Optimism deposit tx)
+    #[error("invalid mint value")]
+    InvalidMintValue,
     /// Blob gas used integer conversion error
     #[error("blob gas used integer conversion error: {0}")]
     BlobGasUsedConversion(TryFromIntError),


### PR DESCRIPTION
## Motivation

https://github.com/paradigmxyz/reth/pull/8763 implements conversion of Alloy transaction to Reth transaction for Optimism deposit transactions. In the conversion process, additional errors are required.

## Solution

[EDIT] Originally, this PR added new errors for the three situations that were not already covered.

After additional discussion, the PR was revised to add a single `Custom(String)` error type that could be used in situations that were not already covered, rather than enumerating all possibilities.

The plan is to remove the whole enum in the future. From @prestwich:

> yeah, let's move this to custom and then plan to delete the whole enum when we embed the tx envelope in the rpc response

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
