### PR TITLE
feat(alloy): add `"full"` feature flag

### DIFF
--- a/crates/alloy/Cargo.toml
+++ b/crates/alloy/Cargo.toml
@@ -194,11 +194,14 @@ eip712 = [
 
 # full
 full = [
-    "providers",
-    "rpc-client",
-    "rpc-types",
-    "network",
-    "signer-wallet",
     "consensus",
+    "contract",
     "k256",
+    "network",
+    "provider-http", # includes `providers`
+    "provider-ws",   # includes `providers`
+    "provider-ipc",  # includes `providers`
+    "rpc-client",
+    "rpc-types",     # includes `rpc-types-eth`
+    "signer-wallet", # includes `signers`
 ]

--- a/crates/alloy/Cargo.toml
+++ b/crates/alloy/Cargo.toml
@@ -72,6 +72,21 @@ std = [
     "alloy-consensus?/std",
 ]
 
+# full
+full = [
+    "consensus",
+    "contract",
+    "eips",
+    "k256",
+    "kzg",
+    "network",
+    "provider-http", # includes `providers`
+    "provider-ws",   # includes `providers`
+    "provider-ipc",  # includes `providers`
+    "rpc-types",     # includes `rpc-types-eth`
+    "signer-wallet", # includes `signers`
+]
+
 # configuration
 reqwest = [
     "dep:reqwest",
@@ -188,22 +203,4 @@ eip712 = [
     "alloy-signer-ledger?/eip712",
     # TODO: https://github.com/alloy-rs/alloy/issues/201
     # "alloy-signer-trezor?/eip712",
-]
-
-# ---------------------------------------- Full re-exports --------------------------------------- #
-
-# full
-full = [
-    "consensus",
-    "contract",
-    "eips",
-    "k256",
-    "kzg",
-    "network",
-    "provider-http", # includes `providers`
-    "provider-ws",   # includes `providers`
-    "provider-ipc",  # includes `providers`
-    "rpc-client",
-    "rpc-types",     # includes `rpc-types-eth`
-    "signer-wallet", # includes `signers`
 ]

--- a/crates/alloy/Cargo.toml
+++ b/crates/alloy/Cargo.toml
@@ -88,6 +88,17 @@ hyper = [
 ]
 wasm-bindgen = ["alloy-transport?/wasm-bindgen"]
 
+# full
+full = [
+    "providers",
+    "rpc-client",
+    "rpc-types",
+    "network",
+    "signer-wallet",
+    "consensus",
+    "k256",
+]
+
 # ---------------------------------------- Main re-exports --------------------------------------- #
 
 # general
@@ -116,8 +127,8 @@ pubsub = [
 rpc = []
 json-rpc = ["rpc", "dep:alloy-json-rpc"]
 rpc-client = ["rpc", "dep:alloy-rpc-client"]
-rpc-client-ws = ["rpc", "alloy-rpc-client?/ws"]
-rpc-client-ipc = ["rpc", "alloy-rpc-client?/ipc"]
+rpc-client-ws = ["rpc-client", "alloy-rpc-client?/ws"]
+rpc-client-ipc = ["rpc-client", "alloy-rpc-client?/ipc"]
 rpc-types = ["rpc", "dep:alloy-rpc-types", "alloy-rpc-types?/eth"]
 rpc-types-anvil = ["rpc-types", "alloy-rpc-types?/anvil"]
 rpc-types-beacon = ["rpc-types", "alloy-rpc-types?/beacon"]

--- a/crates/alloy/Cargo.toml
+++ b/crates/alloy/Cargo.toml
@@ -196,7 +196,9 @@ eip712 = [
 full = [
     "consensus",
     "contract",
+    "eips",
     "k256",
+    "kzg",
     "network",
     "provider-http", # includes `providers`
     "provider-ws",   # includes `providers`

--- a/crates/alloy/Cargo.toml
+++ b/crates/alloy/Cargo.toml
@@ -88,17 +88,6 @@ hyper = [
 ]
 wasm-bindgen = ["alloy-transport?/wasm-bindgen"]
 
-# full
-full = [
-    "providers",
-    "rpc-client",
-    "rpc-types",
-    "network",
-    "signer-wallet",
-    "consensus",
-    "k256",
-]
-
 # ---------------------------------------- Main re-exports --------------------------------------- #
 
 # general
@@ -176,7 +165,7 @@ postgres = ["alloy-core/postgres"]
 getrandom = ["alloy-core/getrandom"]
 rand = ["alloy-core/rand"]
 rlp = ["alloy-core/rlp"]
-serde = ["alloy-core/serde", "alloy-eips?/serde", "alloy-serde"]
+serde = ["alloy-core/serde", "alloy-eips?/serde", "dep:alloy-serde"]
 ssz = ["alloy-core/ssz", "alloy-rpc-types?/ssz"]
 arbitrary = [
     "alloy-core/arbitrary",
@@ -199,4 +188,17 @@ eip712 = [
     "alloy-signer-ledger?/eip712",
     # TODO: https://github.com/alloy-rs/alloy/issues/201
     # "alloy-signer-trezor?/eip712",
+]
+
+# ---------------------------------------- Full re-exports --------------------------------------- #
+
+# full
+full = [
+    "providers",
+    "rpc-client",
+    "rpc-types",
+    "network",
+    "signer-wallet",
+    "consensus",
+    "k256",
 ]

--- a/crates/provider/src/lib.rs
+++ b/crates/provider/src/lib.rs
@@ -48,3 +48,5 @@ pub mod utils;
 
 #[doc(no_inline)]
 pub use alloy_network::{self as network, Network};
+
+pub use alloy_rpc_client as client;

--- a/crates/provider/src/lib.rs
+++ b/crates/provider/src/lib.rs
@@ -49,4 +49,8 @@ pub mod utils;
 #[doc(no_inline)]
 pub use alloy_network::{self as network, Network};
 
-pub use alloy_rpc_client as client;
+#[cfg(feature = "ws")]
+pub use alloy_rpc_client::WsConnect;
+
+#[cfg(feature = "ipc")]
+pub use alloy_rpc_client::IpcConnect;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Closes #876 

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

- Makes sure to enable `rpc-client` when enabling `rpc-client-ws` so that you do not also need to add the `rpc-client` flag if you if `rpc-client-ws`. This behavior is in line with the other feature flags.
- For easy of access make select `rpc-client` features (`WsConnect`) and (`IpcConnect`) directly available (if defined as flag) on the provider. Previously this required separately defining the `rpc-client` flag and importing it from the `rpc::client` namespace.

Related PR (see impact of proposed changes): https://github.com/alloy-rs/examples/pull/106

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
