### PR TITLE
fix: downgrade tokio-tungstenite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,7 @@ tokio = "1"
 tokio-util = "0.7"
 tokio-stream = "0.1"
 tokio-test = "0.4"
+tokio-tungstenite = { version = "0.22" }
 tower = { version = "0.4", features = ["util"] }
 
 # tracing

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,9 +96,9 @@ http-body-util = "0.1"
 tokio = "1"
 tokio-util = "0.7"
 tokio-stream = "0.1"
+rustls = { version = "0.23", default-features = false, features = ["std"] }
 tokio-test = "0.4"
-# enforce default crypto backend https://github.com/alloy-rs/alloy/issues/874
-tokio-tungstenite = { version = "=0.22" }
+tokio-tungstenite = { version = "0.23" }
 tower = { version = "0.4", features = ["util"] }
 
 # tracing

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,8 @@ tokio = "1"
 tokio-util = "0.7"
 tokio-stream = "0.1"
 tokio-test = "0.4"
-tokio-tungstenite = { version = "0.22" }
+# enforce default crypto backend https://github.com/alloy-rs/alloy/issues/874
+tokio-tungstenite = { version = "=0.22" }
 tower = { version = "0.4", features = ["util"] }
 
 # tracing

--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -1044,6 +1044,17 @@ mod tests {
 
     #[cfg(feature = "ws")]
     #[tokio::test]
+    async fn websocket_tls_setup() {
+        let url = "wss://eth-mainnet.ws.alchemyapi.io/v2/MdZcimFJ2yz2z6pw21UYL-KNA0zmgX-F";
+        // we don't care about the response, only that it doesn't panic on the TLS setup
+        let _provider = ProviderBuilder::<_, _, Ethereum>::default()
+            .with_recommended_fillers()
+            .on_builtin(url)
+            .await;
+    }
+
+    #[cfg(feature = "ws")]
+    #[tokio::test]
     async fn subscribe_blocks_ws() {
         use futures::stream::StreamExt;
 

--- a/crates/transport-ws/Cargo.toml
+++ b/crates/transport-ws/Cargo.toml
@@ -28,6 +28,8 @@ tracing.workspace = true
 http = "1.1"
 tokio = { workspace = true, features = ["sync", "rt", "time"] }
 tokio-tungstenite = { workspace = true, features = ["rustls-tls-webpki-roots"] }
+# choose ring as the default TLS backend
+rustls = { workspace = true, features = ["ring"] }
 
 # WASM only
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/crates/transport-ws/Cargo.toml
+++ b/crates/transport-ws/Cargo.toml
@@ -27,7 +27,7 @@ tracing.workspace = true
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 http = "1.1"
 tokio = { workspace = true, features = ["sync", "rt", "time"] }
-tokio-tungstenite = { version = "0.23", features = ["rustls-tls-webpki-roots"] }
+tokio-tungstenite = { workspace = true, features = ["rustls-tls-webpki-roots"] }
 
 # WASM only
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/crates/transport-ws/src/lib.rs
+++ b/crates/transport-ws/src/lib.rs
@@ -16,6 +16,9 @@ mod native;
 #[cfg(not(target_arch = "wasm32"))]
 pub use native::WsConnect;
 
+#[cfg(not(target_arch = "wasm32"))]
+use rustls as _;
+
 #[cfg(target_arch = "wasm32")]
 mod wasm;
 #[cfg(target_arch = "wasm32")]


### PR DESCRIPTION
closes #874

~~tmp rolls back tungstenite before tls backend is disabled.

Update:

enable rustls/ring as the default backend instead