### PR TITLE
chore: update EIP7002 withdrawal requests based on spec

### DIFF
--- a/crates/eips/src/eip7002.rs
+++ b/crates/eips/src/eip7002.rs
@@ -35,7 +35,7 @@ pub struct WithdrawalRequest {
     /// Address of the source of the exit.
     pub source_address: Address,
     /// Validator public key.
-    pub validator_public_key: FixedBytes<48>,
+    pub validator_pubkey: FixedBytes<48>,
     /// Amount of withdrawn ether in gwei.
     #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
     pub amount: u64,


### PR DESCRIPTION
## Motivation

There was an update on the naming of the `validatorPublickey` field for EIP-7002:
https://github.com/ethereum/execution-apis/pull/549/files

## Solution

`s/validator_public_key/validator_pubkey`

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
