### PR TITLE
chore(alloy): add link to book and alloy

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ To incorporate Alloy into your project, you will need to specify the GitHub repo
 cargo add alloy --git https://github.com/alloy-rs/alloy
 ```
 
-After incorporating Alloy, you may wish to utilize specific features of the crate. These features can be enabled through modifications in your project's `Cargo.toml` file. A comprehensive list of available features can be found at [this GitHub link](https://github.com/alloy-rs/alloy/blob/35cbf35164f31d2de1b84b2a8a9986e5b9b1560f/crates/alloy/Cargo.toml#L89). 
+After incorporating Alloy, you may wish to utilize specific features of the crate. These features can be enabled through modifications in your project's `Cargo.toml` file. A comprehensive list of available features can be found at [this GitHub link](https://github.com/alloy-rs/alloy/blob/main/crates/alloy/Cargo.toml).
 
 ## Overview
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@ Alloy connects applications to blockchains.
 Alloy is a rewrite of [`ethers-rs`] from the ground up, with exciting new
 features, high performance, and excellent [docs](https://alloy-rs.github.io/alloy/).
 
-[`ethers-rs`] will continue to be maintained until we have achieved
-feature-parity in Alloy. No action is currently needed from developers.
+We also have a [book](https://alloy.rs/) on all things Alloy and many [examples](https://github.com/alloy-rs/examples) to help you get started.
 
 [![Telegram chat][telegram-badge]][telegram-url]
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

As requested in https://github.com/alloy-rs/alloy/issues/791#issuecomment-2154482019

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Adds missing links to book and examples in the Alloy's meta-crate so users can more easily find it.

Removes notice about `ethers-rs` maintenance in preparation for the release. 

Once the crates are published (or just before) we can update the `installation` section: https://github.com/alloy-rs/alloy/blob/main/README.md#installation (cc @DaniPopes) 

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
