### PR TITLE
feat: integrate `EvmOverrides` to rpc types

### DIFF
--- a/crates/rpc-types-eth/src/state.rs
+++ b/crates/rpc-types-eth/src/state.rs
@@ -167,7 +167,7 @@ mod tests {
     #[test]
     fn test_evm_overrides_new() {
         let state: StateOverride = HashMap::new();
-        let block: Box<BlockOverrides> = Box::new(BlockOverrides::default());
+        let block: Box<BlockOverrides> = Box::default();
 
         let evm_overrides = EvmOverrides::new(Some(state.clone()), Some(block.clone()));
 
@@ -189,7 +189,7 @@ mod tests {
 
     #[test]
     fn test_evm_overrides_block() {
-        let block: Box<BlockOverrides> = Box::new(BlockOverrides::default());
+        let block: Box<BlockOverrides> = Box::default();
         let evm_overrides = EvmOverrides::block(Some(block.clone()));
 
         assert!(!evm_overrides.has_state());
@@ -212,7 +212,7 @@ mod tests {
 
     #[test]
     fn test_evm_overrides_with_block() {
-        let block: Box<BlockOverrides> = Box::new(BlockOverrides::default());
+        let block: Box<BlockOverrides> = Box::default();
         let mut evm_overrides = EvmOverrides::default();
 
         assert!(!evm_overrides.has_block());

--- a/crates/rpc-types-eth/src/state.rs
+++ b/crates/rpc-types-eth/src/state.rs
@@ -83,12 +83,6 @@ impl EvmOverrides {
     }
 }
 
-impl From<Option<StateOverride>> for EvmOverrides {
-    fn from(state: Option<StateOverride>) -> Self {
-        Self::state(state)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -221,14 +215,5 @@ mod tests {
 
         assert!(evm_overrides.has_block());
         assert_eq!(*evm_overrides.block.unwrap(), *block);
-    }
-
-    #[test]
-    fn test_evm_overrides_from_state() {
-        let state: StateOverride = HashMap::new();
-        let evm_overrides: EvmOverrides = Some(state.clone()).into();
-
-        assert!(evm_overrides.has_state());
-        assert_eq!(evm_overrides.state.unwrap(), state);
     }
 }


### PR DESCRIPTION
To replace https://github.com/paradigmxyz/reth/blob/c694433675c3fed05fbe72c50476f4a195acafc6/crates/rpc/rpc/src/eth/revm_utils.rs#L30-L41