### PR TITLE
feat: Add trace_replay_transaction

### DIFF
--- a/crates/provider/src/ext/trace.rs
+++ b/crates/provider/src/ext/trace.rs
@@ -56,6 +56,13 @@ where
         &self,
         block: BlockNumberOrTag,
     ) -> TransportResult<Vec<LocalizedTransactionTrace>>;
+
+    /// Replays a transaction.
+    async fn trace_replay_transaction(
+        &self,
+        hash: TxHash,
+        trace_type: &[TraceType],
+    ) -> TransportResult<TraceResults>;
 }
 
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
@@ -94,6 +101,14 @@ where
         block: BlockNumberOrTag,
     ) -> TransportResult<Vec<LocalizedTransactionTrace>> {
         self.client().request("trace_block", (block,)).await
+    }
+
+    async fn trace_replay_transaction(
+        &self,
+        hash: TxHash,
+        trace_type: &[TraceType],
+    ) -> TransportResult<TraceResults> {
+        self.client().request("trace_replayTransaction", (hash, trace_type)).await
     }
 }
 


### PR DESCRIPTION
Add `trace_replay_transaction` method.

Example usage:
```rust
use alloy_primitives::{b256};
use alloy_provider::{ext::TraceApi, ProviderBuilder};
use alloy_rpc_types_trace::parity::TraceType;

#[tokio::main]
async fn main() {
    let url = std::env::var("ETH_MAINNET_HTTP").expect("$ETH_MAINNET_HTTP must be set.");
    let node_url = url::Url::parse(url.as_str()).unwrap();
    let provider = ProviderBuilder::new().on_http(node_url);

    let result = provider
        .trace_replay_transaction(
            b256!("45162e66a30e64c5a23c5cee2180874b72322d28ee05439d2dff8d1f6a100417"),
            &[TraceType::Trace, TraceType::StateDiff],
        )
        .await
        .unwrap();
    println!("{:#?}", result);
}
```