### PR TITLE
Convenience method for conversion from `BlockId` to `u64`

### DIFF
--- a/crates/eips/src/eip1898.rs
+++ b/crates/eips/src/eip1898.rs
@@ -280,6 +280,14 @@ impl BlockId {
         }
     }
 
+    /// Returns the block number if it is [BlockId::Number] and not a tag
+    pub const fn as_block_number(&self) -> Option<u64> {
+        match self {
+            Self::Number(x) => x.as_number(),
+            _ => None,
+        }
+    }
+
     /// Returns true if this is [BlockNumberOrTag::Latest]
     pub const fn is_latest(&self) -> bool {
         matches!(self, Self::Number(BlockNumberOrTag::Latest))

--- a/crates/eips/src/eip1898.rs
+++ b/crates/eips/src/eip1898.rs
@@ -281,7 +281,7 @@ impl BlockId {
     }
 
     /// Returns the block number if it is [BlockId::Number] and not a tag
-    pub const fn as_block_number(&self) -> Option<u64> {
+    pub const fn as_u64(&self) -> Option<u64> {
         match self {
             Self::Number(x) => x.as_number(),
             _ => None,

--- a/crates/eips/src/eip1898.rs
+++ b/crates/eips/src/eip1898.rs
@@ -759,6 +759,18 @@ mod tests {
     }
 
     #[test]
+    fn block_id_as_u64() {
+        assert_eq!(BlockId::number(123).as_u64(), Some(123));
+        assert_eq!(BlockId::number(0).as_u64(), Some(0));
+        assert_eq!(BlockId::earliest().as_u64(), None);
+        assert_eq!(BlockId::latest().as_u64(), None);
+        assert_eq!(BlockId::pending().as_u64(), None);
+        assert_eq!(BlockId::safe().as_u64(), None);
+        assert_eq!(BlockId::hash(BlockHash::ZERO).as_u64(), None);
+        assert_eq!(BlockId::hash_canonical(BlockHash::ZERO).as_u64(), None);
+    }
+
+    #[test]
     fn can_parse_eip1898_block_ids() {
         let num = serde_json::json!(
             { "blockNumber": "0x0" }

--- a/crates/eips/src/eip1898.rs
+++ b/crates/eips/src/eip1898.rs
@@ -280,7 +280,7 @@ impl BlockId {
         }
     }
 
-    /// Returns the block number if it is [BlockId::Number] and not a tag
+    /// Returns the block number if it is [`BlockId::Number`] and not a tag
     pub const fn as_u64(&self) -> Option<u64> {
         match self {
             Self::Number(x) => x.as_number(),


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Consider the case where we need to convert a `BlockId` into a `u64`. Currently, this is achievable by the following:

```rust
fn block_id_to_u64(block_id: BlockId) -> Option<u64> {
    if let BlockId::Number(number_or_tag) = block_id {
        number_or_tag.as_number()
    } else {
        None
    }
}
```

This works but given that the `BlockId::as_block_hash` method already exists, this seems like a logical inclusion into Alloy itself.

https://github.com/alloy-rs/alloy/blob/060de7871a76e99863917e62717c97423c37cadf/crates/eips/src/eip1898.rs#L275-L281

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [x] ~~Added Documentation~~
- [x] ~~Breaking changes~~
