### PR TITLE
chore: update changelogs for v0.1.1

### DIFF
--- a/crates/alloy/CHANGELOG.md
+++ b/crates/alloy/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/alloy-rs/alloy/compare/...HEAD)
+## [Unreleased](https://github.com/alloy-rs/alloy/compare/v0.1.1...HEAD)
+
+## [0.1.1](https://github.com/alloy-rs/alloy/tree/v0.1.1)
 
 ### Bug Fixes
 

--- a/crates/consensus/CHANGELOG.md
+++ b/crates/consensus/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/alloy-rs/alloy/compare/...HEAD)
+## [Unreleased](https://github.com/alloy-rs/alloy/compare/v0.1.1...HEAD)
+
+### Features
+
+- Add EIP-7251 request types ([#919](https://github.com/alloy-rs/alloy/issues/919))
+
+## [0.1.1](https://github.com/alloy-rs/alloy/tree/v0.1.1)
 
 ### Bug Fixes
 
@@ -38,7 +44,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Features
 
-- Add EIP-7251 request types ([#919](https://github.com/alloy-rs/alloy/issues/919))
 - Derive serde for header ([#902](https://github.com/alloy-rs/alloy/issues/902))
 - Move `{,With}OtherFields` to serde crate ([#892](https://github.com/alloy-rs/alloy/issues/892))
 - Add as_ is_ functions to envelope ([#872](https://github.com/alloy-rs/alloy/issues/872))

--- a/crates/contract/CHANGELOG.md
+++ b/crates/contract/CHANGELOG.md
@@ -5,7 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/alloy-rs/alloy/compare/...HEAD)
+## [Unreleased](https://github.com/alloy-rs/alloy/compare/v0.1.1...HEAD)
+
+## [0.1.1](https://github.com/alloy-rs/alloy/tree/v0.1.1)
+
 
 ### Bug Fixes
 

--- a/crates/eip7547/CHANGELOG.md
+++ b/crates/eip7547/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/alloy-rs/alloy/compare/...HEAD)
+## [Unreleased](https://github.com/alloy-rs/alloy/compare/v0.1.1...HEAD)
+
+## [0.1.1](https://github.com/alloy-rs/alloy/tree/v0.1.1)
 
 ### Features
 

--- a/crates/eips/CHANGELOG.md
+++ b/crates/eips/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/alloy-rs/alloy/compare/...HEAD)
+## [Unreleased](https://github.com/alloy-rs/alloy/compare/v0.1.1...HEAD)
+
+## [0.1.1](https://github.com/alloy-rs/alloy/tree/v0.1.1)
 
 ### Bug Fixes
 

--- a/crates/genesis/CHANGELOG.md
+++ b/crates/genesis/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/alloy-rs/alloy/compare/...HEAD)
+## [Unreleased](https://github.com/alloy-rs/alloy/compare/v0.1.1...HEAD)
+
+## [0.1.1](https://github.com/alloy-rs/alloy/tree/v0.1.1)
 
 ### Bug Fixes
 

--- a/crates/json-rpc/CHANGELOG.md
+++ b/crates/json-rpc/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/alloy-rs/alloy/compare/...HEAD)
+## [Unreleased](https://github.com/alloy-rs/alloy/compare/v0.1.1...HEAD)
+
+## [0.1.1](https://github.com/alloy-rs/alloy/tree/v0.1.1)
 
 ### Bug Fixes
 

--- a/crates/network/CHANGELOG.md
+++ b/crates/network/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/alloy-rs/alloy/compare/...HEAD)
+## [Unreleased](https://github.com/alloy-rs/alloy/compare/v0.1.1...HEAD)
+
+## [0.1.1](https://github.com/alloy-rs/alloy/tree/v0.1.1)
 
 ### Bug Fixes
 

--- a/crates/node-bindings/CHANGELOG.md
+++ b/crates/node-bindings/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/alloy-rs/alloy/compare/...HEAD)
+## [Unreleased](https://github.com/alloy-rs/alloy/compare/v0.1.1...HEAD)
+
+## [0.1.1](https://github.com/alloy-rs/alloy/tree/v0.1.1)
 
 ### Bug Fixes
 

--- a/crates/provider/CHANGELOG.md
+++ b/crates/provider/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/alloy-rs/alloy/compare/...HEAD)
+## [Unreleased](https://github.com/alloy-rs/alloy/compare/v0.1.1...HEAD)
+
+## [0.1.1](https://github.com/alloy-rs/alloy/tree/v0.1.1)
 
 ### Bug Fixes
 

--- a/crates/pubsub/CHANGELOG.md
+++ b/crates/pubsub/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/alloy-rs/alloy/compare/...HEAD)
+## [Unreleased](https://github.com/alloy-rs/alloy/compare/v0.1.1...HEAD)
+
+## [0.1.1](https://github.com/alloy-rs/alloy/tree/v0.1.1)
 
 ### Bug Fixes
 

--- a/crates/rpc-client/CHANGELOG.md
+++ b/crates/rpc-client/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/alloy-rs/alloy/compare/...HEAD)
+## [Unreleased](https://github.com/alloy-rs/alloy/compare/v0.1.1...HEAD)
+
+## [0.1.1](https://github.com/alloy-rs/alloy/tree/v0.1.1)
 
 ### Bug Fixes
 

--- a/crates/rpc-types-admin/CHANGELOG.md
+++ b/crates/rpc-types-admin/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/alloy-rs/alloy/compare/...HEAD)
+## [Unreleased](https://github.com/alloy-rs/alloy/compare/v0.1.1...HEAD)
+
+## [0.1.1](https://github.com/alloy-rs/alloy/tree/v0.1.1)
 
 ### Refactor
 

--- a/crates/rpc-types-anvil/CHANGELOG.md
+++ b/crates/rpc-types-anvil/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/alloy-rs/alloy/compare/...HEAD)
+## [Unreleased](https://github.com/alloy-rs/alloy/compare/v0.1.1...HEAD)
+
+## [0.1.1](https://github.com/alloy-rs/alloy/tree/v0.1.1)
 
 ### Features
 

--- a/crates/rpc-types-beacon/CHANGELOG.md
+++ b/crates/rpc-types-beacon/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/alloy-rs/alloy/compare/...HEAD)
+## [Unreleased](https://github.com/alloy-rs/alloy/compare/v0.1.1...HEAD)
+
+## [0.1.1](https://github.com/alloy-rs/alloy/tree/v0.1.1)
 
 ### Features
 

--- a/crates/rpc-types-engine/CHANGELOG.md
+++ b/crates/rpc-types-engine/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/alloy-rs/alloy/compare/...HEAD)
+## [Unreleased](https://github.com/alloy-rs/alloy/compare/v0.1.1...HEAD)
+
+## [0.1.1](https://github.com/alloy-rs/alloy/tree/v0.1.1)
 
 ### Bug Fixes
 

--- a/crates/rpc-types-eth/CHANGELOG.md
+++ b/crates/rpc-types-eth/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/alloy-rs/alloy/compare/...HEAD)
+## [Unreleased](https://github.com/alloy-rs/alloy/compare/v0.1.1...HEAD)
+
+## [0.1.1](https://github.com/alloy-rs/alloy/tree/v0.1.1)
 
 ### Dependencies
 

--- a/crates/rpc-types-trace/CHANGELOG.md
+++ b/crates/rpc-types-trace/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/alloy-rs/alloy/compare/...HEAD)
+## [Unreleased](https://github.com/alloy-rs/alloy/compare/v0.1.1...HEAD)
+
+## [0.1.1](https://github.com/alloy-rs/alloy/tree/v0.1.1)
 
 ### Features
 

--- a/crates/rpc-types-txpool/CHANGELOG.md
+++ b/crates/rpc-types-txpool/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/alloy-rs/alloy/compare/...HEAD)
+## [Unreleased](https://github.com/alloy-rs/alloy/compare/v0.1.1...HEAD)
+
+## [0.1.1](https://github.com/alloy-rs/alloy/tree/v0.1.1)
 
 ### Refactor
 

--- a/crates/rpc-types/CHANGELOG.md
+++ b/crates/rpc-types/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/alloy-rs/alloy/compare/...HEAD)
+## [Unreleased](https://github.com/alloy-rs/alloy/compare/v0.1.1...HEAD)
+
+## [0.1.1](https://github.com/alloy-rs/alloy/tree/v0.1.1)
 
 ### Bug Fixes
 

--- a/crates/serde/CHANGELOG.md
+++ b/crates/serde/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/alloy-rs/alloy/compare/...HEAD)
+## [Unreleased](https://github.com/alloy-rs/alloy/compare/v0.1.1...HEAD)
+
+## [0.1.1](https://github.com/alloy-rs/alloy/tree/v0.1.1)
 
 ### Features
 

--- a/crates/signer-aws/CHANGELOG.md
+++ b/crates/signer-aws/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/alloy-rs/alloy/compare/...HEAD)
+## [Unreleased](https://github.com/alloy-rs/alloy/compare/v0.1.1...HEAD)
+
+## [0.1.1](https://github.com/alloy-rs/alloy/tree/v0.1.1)
 
 ### Dependencies
 

--- a/crates/signer-gcp/CHANGELOG.md
+++ b/crates/signer-gcp/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/alloy-rs/alloy/compare/...HEAD)
+## [Unreleased](https://github.com/alloy-rs/alloy/compare/v0.1.1...HEAD)
+
+## [0.1.1](https://github.com/alloy-rs/alloy/tree/v0.1.1)
 
 ### Bug Fixes
 

--- a/crates/signer-ledger/CHANGELOG.md
+++ b/crates/signer-ledger/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/alloy-rs/alloy/compare/...HEAD)
+## [Unreleased](https://github.com/alloy-rs/alloy/compare/v0.1.1...HEAD)
+
+## [0.1.1](https://github.com/alloy-rs/alloy/tree/v0.1.1)
 
 ### Bug Fixes
 

--- a/crates/signer-local/CHANGELOG.md
+++ b/crates/signer-local/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/alloy-rs/alloy/compare/...HEAD)
+## [Unreleased](https://github.com/alloy-rs/alloy/compare/v0.1.1...HEAD)
+
+## [0.1.1](https://github.com/alloy-rs/alloy/tree/v0.1.1)
 
 ### Refactor
 

--- a/crates/signer-trezor/CHANGELOG.md
+++ b/crates/signer-trezor/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/alloy-rs/alloy/compare/...HEAD)
+## [Unreleased](https://github.com/alloy-rs/alloy/compare/v0.1.1...HEAD)
+
+## [0.1.1](https://github.com/alloy-rs/alloy/tree/v0.1.1)
 
 ### Dependencies
 

--- a/crates/signer/CHANGELOG.md
+++ b/crates/signer/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/alloy-rs/alloy/compare/...HEAD)
+## [Unreleased](https://github.com/alloy-rs/alloy/compare/v0.1.1...HEAD)
+
+## [0.1.1](https://github.com/alloy-rs/alloy/tree/v0.1.1)
 
 ### Bug Fixes
 

--- a/crates/transport-http/CHANGELOG.md
+++ b/crates/transport-http/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/alloy-rs/alloy/compare/...HEAD)
+## [Unreleased](https://github.com/alloy-rs/alloy/compare/v0.1.1...HEAD)
+
+## [0.1.1](https://github.com/alloy-rs/alloy/tree/v0.1.1)
 
 ### Bug Fixes
 

--- a/crates/transport-ipc/CHANGELOG.md
+++ b/crates/transport-ipc/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/alloy-rs/alloy/compare/...HEAD)
+## [Unreleased](https://github.com/alloy-rs/alloy/compare/v0.1.1...HEAD)
+
+## [0.1.1](https://github.com/alloy-rs/alloy/tree/v0.1.1)
 
 ### Bug Fixes
 

--- a/crates/transport-ws/CHANGELOG.md
+++ b/crates/transport-ws/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/alloy-rs/alloy/compare/...HEAD)
+## [Unreleased](https://github.com/alloy-rs/alloy/compare/v0.1.1...HEAD)
+
+## [0.1.1](https://github.com/alloy-rs/alloy/tree/v0.1.1)
 
 ### Bug Fixes
 

--- a/crates/transport/CHANGELOG.md
+++ b/crates/transport/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/alloy-rs/alloy/compare/...HEAD)
+## [Unreleased](https://github.com/alloy-rs/alloy/compare/v0.1.1...HEAD)
+
+## [0.1.1](https://github.com/alloy-rs/alloy/tree/v0.1.1)
 
 ### Bug Fixes
 


### PR DESCRIPTION

## Motivation

we released v0.1.1 yesterday, so the changelogs from the changelog PR are outdated (everything is marked as unreleased)

## Solution

mark things as released
