### PR TITLE
feat: Add trace_raw_transaction and trace_replay_block_transactions

### DIFF
--- a/crates/provider/src/ext/trace.rs
+++ b/crates/provider/src/ext/trace.rs
@@ -3,7 +3,9 @@ use crate::{Provider, RpcWithBlock};
 use alloy_eips::BlockNumberOrTag;
 use alloy_network::Network;
 use alloy_primitives::TxHash;
-use alloy_rpc_types_trace::parity::{LocalizedTransactionTrace, TraceResults, TraceType};
+use alloy_rpc_types_trace::parity::{
+    LocalizedTransactionTrace, TraceResults, TraceResultsWithTransactionHash, TraceType,
+};
 use alloy_transport::{Transport, TransportResult};
 
 /// List of trace calls for use with [`TraceApi::trace_call_many`]
@@ -47,6 +49,13 @@ where
         hash: TxHash,
     ) -> TransportResult<Vec<LocalizedTransactionTrace>>;
 
+    /// Trace the given raw transaction.
+    async fn trace_raw_transaction(
+        &self,
+        data: &[u8],
+        trace_type: &[TraceType],
+    ) -> TransportResult<TraceResults>;
+
     /// Trace all transactions in the given block.
     ///
     /// # Note
@@ -63,6 +72,13 @@ where
         hash: TxHash,
         trace_type: &[TraceType],
     ) -> TransportResult<TraceResults>;
+
+    /// Replays all transactions in the given block.
+    async fn trace_replay_block_transactions(
+        &self,
+        block: BlockNumberOrTag,
+        trace_type: &[TraceType],
+    ) -> TransportResult<Vec<TraceResultsWithTransactionHash>>;
 }
 
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
@@ -96,6 +112,14 @@ where
         self.client().request("trace_transaction", (hash,)).await
     }
 
+    async fn trace_raw_transaction(
+        &self,
+        data: &[u8],
+        trace_type: &[TraceType],
+    ) -> TransportResult<TraceResults> {
+        self.client().request("trace_rawTransaction", (data, trace_type)).await
+    }
+
     async fn trace_block(
         &self,
         block: BlockNumberOrTag,
@@ -109,6 +133,14 @@ where
         trace_type: &[TraceType],
     ) -> TransportResult<TraceResults> {
         self.client().request("trace_replayTransaction", (hash, trace_type)).await
+    }
+
+    async fn trace_replay_block_transactions(
+        &self,
+        block: BlockNumberOrTag,
+        trace_type: &[TraceType],
+    ) -> TransportResult<Vec<TraceResultsWithTransactionHash>> {
+        self.client().request("trace_replayBlockTransactions", (block, trace_type)).await
     }
 }
 


### PR DESCRIPTION
Add methods for `trace_raw_transaction` and `trace_replay_block_transactions` to the trace api.

Example:
```rust
use std::str::FromStr;
use alloy_chains::{Chain};

use alloy_network::{EthereumWallet, TransactionBuilder};
use alloy_network::eip2718::Encodable2718;
use alloy_primitives::{Address, U256};
use alloy_provider::{ext::TraceApi, Provider, ProviderBuilder};
use alloy_rpc_types::{BlockNumberOrTag, TransactionRequest};
use alloy_rpc_types_trace::parity::TraceType;
use alloy_signer_local::PrivateKeySigner;

#[tokio::main]
async fn main() {
    let url = std::env::var("ETH_MAINNET_HTTP").expect("$ETH_MAINNET_HTTP must be set.");
    let node_url = url::Url::parse(url.as_str()).unwrap();
    let provider = ProviderBuilder::new().on_http(node_url);

    // trace_replay_block_transactions

    let result = provider
        .trace_replay_block_transactions(
            BlockNumberOrTag::Number(20111220),
            &[TraceType::Trace, TraceType::StateDiff],
        )
        .await
        .unwrap();
    println!("{:#?}", result);

    // trace_raw_transaction

    let pk = std::env::var("PK").expect("$PK must be set.");
    let signer = PrivateKeySigner::from_str(&pk).unwrap();
    let from_address = signer.address().clone();
    let wallet = EthereumWallet::from(signer);


    let tx = TransactionRequest::default()
        .with_to(Address::ZERO)
        .with_nonce(provider.get_transaction_count(from_address).await.unwrap())
        .with_chain_id(Chain::mainnet().id())
        .with_value(U256::from(100))
        .with_gas_limit(21_000)
        .with_max_priority_fee_per_gas(1_000_000_000)
        .with_max_fee_per_gas(100_000_000_000);

    let tx_envelope = tx.build(&wallet).await.unwrap();
    let tx_encoded = tx_envelope.encoded_2718();

    let result = provider
        .trace_raw_transaction(&tx_encoded,
            &[TraceType::Trace, TraceType::StateDiff],
        )
        .await
        .unwrap();

    println!("{:#?}", result);
}
```