### PR TITLE
feat: add EIP-7702 support

### DIFF
--- a/crates/eips/src/eip7702.rs
+++ b/crates/eips/src/eip7702.rs
@@ -1,0 +1,158 @@
+//! [EIP-7702] types.
+//!
+//! [EIP-7702]: https://eips.ethereum.org/EIPS/eip-7702
+
+use alloy_primitives::{Address, ChainId, U256};
+use alloy_rlp::{Decodable, Encodable};
+use core::mem;
+
+/// A list of [`Authorization`] the current transaction will use
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
+#[cfg_attr(
+    any(test, feature = "arbitrary"),
+    derive(proptest_derive::Arbitrary, arbitrary::Arbitrary)
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct AuthorizationList(pub Vec<Authorization>);
+
+impl AuthorizationList {
+    /// Calculates a heuristic for the in-memory size of the [`AuthorizationList`]
+    #[inline]
+    pub fn size(&self) -> usize {
+        // take into account capacity
+        self.0.iter().map(Authorization::size).sum::<usize>()
+            + self.0.capacity() * mem::size_of::<AuthorizationList>()
+    }
+}
+
+impl Encodable for AuthorizationList {
+    fn encode(&self, out: &mut dyn alloy_rlp::BufMut) {
+        let payload = self.0.iter().fold(vec![], |mut a, b| {
+            let mut buf = vec![];
+            b.encode(&mut buf);
+            a.extend_from_slice(&buf);
+            a
+        });
+        let list_header = alloy_rlp::Header { list: true, payload_length: payload.len() };
+        list_header.encode(out);
+        out.put_slice(&payload);
+    }
+}
+
+impl Decodable for AuthorizationList {
+    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        let rlp_head = alloy_rlp::Header::decode(buf)?;
+        if !rlp_head.list {
+            return Err(alloy_rlp::Error::UnexpectedString);
+        }
+        let started_len = buf.len();
+        let list_len = rlp_head.payload_length;
+        let mut consumed = 0;
+
+        let mut authorizations = Vec::new();
+        while consumed < list_len {
+            let authorization: Authorization = Decodable::decode(buf)?;
+            consumed = started_len - buf.len();
+            authorizations.push(authorization);
+        }
+
+        if consumed != rlp_head.payload_length {
+            return Err(alloy_rlp::Error::ListLengthMismatch {
+                expected: rlp_head.payload_length,
+                got: consumed,
+            });
+        }
+        Ok(AuthorizationList(authorizations))
+    }
+}
+
+/// Authorizations are used to temporarily set the code of its signer to
+/// the code referenced by `address`. These also include a `chain_id` (which
+/// can be set to zero and not evaluated) as well as an optional `nonce`.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
+#[cfg_attr(
+    any(test, feature = "arbitrary"),
+    derive(proptest_derive::Arbitrary, arbitrary::Arbitrary)
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct Authorization {
+    /// Chain ID
+    pub chain_id: ChainId,
+    /// The address of the code that will get set to the signer's address
+    pub address: Address,
+    /// Optional nonce
+    pub nonce: Option<u64>,
+    /// yParity: Signature Y parity
+    pub y_parity: bool,
+    /// The R field of the signature
+    pub r: U256,
+    /// The S field of the signature
+    pub s: U256,
+}
+
+impl Authorization {
+    fn fields_length(&self) -> usize {
+        let mut length = 0;
+        length += self.chain_id.length();
+        length += self.address.length();
+        length += self.nonce.map(|n| vec![n]).unwrap_or(vec![]).length();
+        length += self.y_parity.length();
+        length += self.r.length();
+        length += self.s.length();
+        length
+    }
+
+    /// Calculates a heuristic for the in-memory size of the [`Authorization`]
+    #[inline]
+    pub fn size(&self) -> usize {
+        mem::size_of::<ChainId>()
+            + mem::size_of::<Address>()
+            + mem::size_of::<Option<u64>>()
+            + mem::size_of::<bool>()
+            + mem::size_of::<U256>()
+            + mem::size_of::<U256>()
+    }
+}
+
+impl Encodable for Authorization {
+    fn encode(&self, out: &mut dyn alloy_rlp::BufMut) {
+        let list_header = alloy_rlp::Header { list: true, payload_length: self.fields_length() };
+        list_header.encode(out);
+        self.chain_id.encode(out);
+        self.address.encode(out);
+        self.nonce.map(|n| vec![n]).unwrap_or(vec![]).encode(out);
+        self.y_parity.encode(out);
+        self.r.encode(out);
+        self.s.encode(out);
+    }
+}
+
+impl Decodable for Authorization {
+    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        let rlp_head = alloy_rlp::Header::decode(buf)?;
+        if !rlp_head.list {
+            return Err(alloy_rlp::Error::UnexpectedString);
+        }
+
+        let started_len = buf.len();
+        let chain_id: ChainId = Decodable::decode(buf)?;
+        let address: Address = Decodable::decode(buf)?;
+        let nonce_list: Vec<u64> = Decodable::decode(buf)?;
+        let nonce = nonce_list.first().copied();
+        let y_parity = Decodable::decode(buf)?;
+        let r = Decodable::decode(buf)?;
+        let s = Decodable::decode(buf)?;
+
+        let consumed = started_len - buf.len();
+        if consumed != rlp_head.payload_length {
+            return Err(alloy_rlp::Error::ListLengthMismatch {
+                expected: rlp_head.payload_length,
+                got: consumed,
+            });
+        }
+        Ok(Self { chain_id, address, nonce, y_parity, r, s })
+    }
+}
+
+// TODO(eip7702): add tests

--- a/crates/eips/src/lib.rs
+++ b/crates/eips/src/lib.rs
@@ -44,3 +44,5 @@ pub mod merge;
 pub mod eip7002;
 
 pub mod eip7685;
+
+pub mod eip7702;

--- a/crates/rpc-types/src/eth/transaction/mod.rs
+++ b/crates/rpc-types/src/eth/transaction/mod.rs
@@ -9,7 +9,10 @@ use alloy_primitives::{Address, Bytes, TxKind, B256, U256};
 use serde::{Deserialize, Serialize};
 
 pub use alloy_consensus::BlobTransactionSidecar;
-pub use alloy_eips::eip2930::{AccessList, AccessListItem, AccessListWithGasUsed};
+pub use alloy_eips::{
+    eip2930::{AccessList, AccessListItem, AccessListWithGasUsed},
+    eip7702::{Authorization, AuthorizationList},
+};
 
 mod common;
 pub use common::TransactionInfo;
@@ -108,6 +111,13 @@ pub struct Transaction {
     /// Pre-pay to warm storage access.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub access_list: Option<AccessList>,
+    /// EIP7702
+    ///
+    /// The code of the signer of each authorization list item will be
+    /// set to the code referenced by the address included for the
+    /// duration of the transaction
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub authorization_list: Option<AuthorizationList>,
     /// EIP2718
     ///
     /// Transaction type,
@@ -165,6 +175,7 @@ impl Transaction {
             max_fee_per_gas: self.max_fee_per_gas,
             max_priority_fee_per_gas: self.max_priority_fee_per_gas,
             max_fee_per_blob_gas: self.max_fee_per_blob_gas,
+            authorization_list: self.authorization_list,
             blob_versioned_hashes: self.blob_versioned_hashes,
             sidecar: None,
         }
@@ -323,6 +334,7 @@ mod tests {
             chain_id: Some(17),
             blob_versioned_hashes: None,
             access_list: None,
+            authorization_list: None,
             transaction_type: Some(20),
             max_fee_per_gas: Some(21),
             max_priority_fee_per_gas: Some(22),
@@ -361,6 +373,7 @@ mod tests {
             chain_id: Some(17),
             blob_versioned_hashes: None,
             access_list: None,
+            authorization_list: None,
             transaction_type: Some(20),
             max_fee_per_gas: Some(21),
             max_priority_fee_per_gas: Some(22),

--- a/crates/rpc-types/src/eth/transaction/request.rs
+++ b/crates/rpc-types/src/eth/transaction/request.rs
@@ -5,6 +5,7 @@ use alloy_consensus::{
     TxEip1559, TxEip2930, TxEip4844, TxEip4844Variant, TxEip4844WithSidecar, TxEnvelope, TxLegacy,
     TxType, TypedTransaction,
 };
+use alloy_eips::eip7702::AuthorizationList;
 use alloy_primitives::{Address, Bytes, ChainId, TxKind, B256, U256};
 use serde::{Deserialize, Serialize};
 use std::hash::Hash;
@@ -77,6 +78,10 @@ pub struct TransactionRequest {
     /// An EIP-2930 access list, which lowers cost for accessing accounts and storages in the list. See [EIP-2930](https://eips.ethereum.org/EIPS/eip-2930) for more information.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub access_list: Option<AccessList>,
+    /// An EIP-7702 authorization list. See [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702)
+    /// for more information.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub authorization_list: Option<AuthorizationList>,
     /// The EIP-2718 transaction type. See [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718) for more information.
     #[serde(
         default,


### PR DESCRIPTION
Sharing our work for adding EIP-7702 transaction support to reth / revm / alloy

Current state:

- 7702 transaction support has been added to reth and alloy
- EOA code loading has been added to revm but full 7702 execution has not been tested yet
- The teardown of 7702 transactions in revm has not been added yet
- Gas calculations have not been updated and are not correct
- Compact encoding of added types in reth is currently byte-for-byte
- Overall correctness needs to be checked
- Not all tests have been added or updated

Incomplete items and points of discussion are marked with `TODO(eip7702)` 

If you have any questions about any of this work let us know

The three related PRs:

https://github.com/paradigmxyz/reth/pull/8895
https://github.com/bluealloy/revm/pull/1541
https://github.com/alloy-rs/alloy/pull/928

