### PR TITLE
feat(rpc-types-anvil): add `Index`, fix compatibility

### DIFF
--- a/crates/rpc-types-anvil/src/lib.rs
+++ b/crates/rpc-types-anvil/src/lib.rs
@@ -142,7 +142,6 @@ pub struct ForkedNetwork {
 
 /// Additional `evm_mine` options
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 #[serde(untagged)]
 pub enum MineOptions {
     /// The options for mining
@@ -312,5 +311,50 @@ mod tests {
         let index: Index =
             serde_json::from_value(json_data).expect("Failed to deserialize large index");
         assert_eq!(index, Index(u64::MAX as usize));
+    }
+
+    #[test]
+    fn test_deserialize_options_with_values() {
+        let data = r#"{"timestamp": 1620000000, "blocks": 10}"#;
+        let deserialized: MineOptions = serde_json::from_str(data).expect("Deserialization failed");
+        assert_eq!(
+            deserialized,
+            MineOptions::Options { timestamp: Some(1620000000), blocks: Some(10) }
+        );
+
+        let data = r#"{"timestamp": "0x608f3d00", "blocks": "0xa"}"#;
+        let deserialized: MineOptions = serde_json::from_str(data).expect("Deserialization failed");
+        assert_eq!(
+            deserialized,
+            MineOptions::Options { timestamp: Some(1620000000), blocks: Some(10) }
+        );
+    }
+
+    #[test]
+    fn test_deserialize_options_with_timestamp() {
+        let data = r#"{"timestamp":"1620000000"}"#;
+        let deserialized: MineOptions = serde_json::from_str(data).expect("Deserialization failed");
+        assert_eq!(
+            deserialized,
+            MineOptions::Options { timestamp: Some(1620000000), blocks: None }
+        );
+
+        let data = r#"{"timestamp":"0x608f3d00"}"#;
+        let deserialized: MineOptions = serde_json::from_str(data).expect("Deserialization failed");
+        assert_eq!(
+            deserialized,
+            MineOptions::Options { timestamp: Some(1620000000), blocks: None }
+        );
+    }
+
+    #[test]
+    fn test_deserialize_timestamp() {
+        let data = r#""1620000000""#;
+        let deserialized: MineOptions = serde_json::from_str(data).expect("Deserialization failed");
+        assert_eq!(deserialized, MineOptions::Timestamp(Some(1620000000)));
+
+        let data = r#""0x608f3d00""#;
+        let deserialized: MineOptions = serde_json::from_str(data).expect("Deserialization failed");
+        assert_eq!(deserialized, MineOptions::Timestamp(Some(1620000000)));
     }
 }

--- a/crates/rpc-types-anvil/src/lib.rs
+++ b/crates/rpc-types-anvil/src/lib.rs
@@ -7,7 +7,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 use alloy_primitives::{BlockHash, ChainId, TxHash, B256, U256};
-use serde::{de::Error, Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::BTreeMap;
 
 /// Represents the params to set forking which can take various forms:
@@ -192,24 +192,26 @@ impl<'a> serde::Deserialize<'a> for Index {
 
             fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
             where
-                E: Error,
+                E: serde::de::Error,
             {
                 Ok(Index(value as usize))
             }
 
             fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
             where
-                E: Error,
+                E: serde::de::Error,
             {
                 value.strip_prefix("0x").map_or_else(
                     || {
                         value.parse::<usize>().map(Index).map_err(|e| {
-                            Error::custom(format!("Failed to parse numeric index: {e}"))
+                            serde::de::Error::custom(format!("Failed to parse numeric index: {e}"))
                         })
                     },
                     |val| {
                         usize::from_str_radix(val, 16).map(Index).map_err(|e| {
-                            Error::custom(format!("Failed to parse hex encoded index value: {e}"))
+                            serde::de::Error::custom(format!(
+                                "Failed to parse hex encoded index value: {e}"
+                            ))
                         })
                     },
                 )
@@ -217,7 +219,7 @@ impl<'a> serde::Deserialize<'a> for Index {
 
             fn visit_string<E>(self, value: String) -> Result<Self::Value, E>
             where
-                E: Error,
+                E: serde::de::Error,
             {
                 self.visit_str(value.as_ref())
             }

--- a/crates/rpc-types-anvil/src/lib.rs
+++ b/crates/rpc-types-anvil/src/lib.rs
@@ -201,16 +201,18 @@ impl<'a> serde::Deserialize<'a> for Index {
             where
                 E: Error,
             {
-                if let Some(val) = value.strip_prefix("0x") {
-                    usize::from_str_radix(val, 16).map(Index).map_err(|e| {
-                        Error::custom(format!("Failed to parse hex encoded index value: {e}"))
-                    })
-                } else {
-                    value
-                        .parse::<usize>()
-                        .map(Index)
-                        .map_err(|e| Error::custom(format!("Failed to parse numeric index: {e}")))
-                }
+                value.strip_prefix("0x").map_or_else(
+                    || {
+                        value.parse::<usize>().map(Index).map_err(|e| {
+                            Error::custom(format!("Failed to parse numeric index: {e}"))
+                        })
+                    },
+                    |val| {
+                        usize::from_str_radix(val, 16).map(Index).map_err(|e| {
+                            Error::custom(format!("Failed to parse hex encoded index value: {e}"))
+                        })
+                    },
+                )
             }
 
             fn visit_string<E>(self, value: String) -> Result<Self::Value, E>

--- a/crates/rpc-types-anvil/src/lib.rs
+++ b/crates/rpc-types-anvil/src/lib.rs
@@ -143,6 +143,7 @@ pub struct ForkedNetwork {
 /// Additional `evm_mine` options
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[serde(untagged)]
 pub enum MineOptions {
     /// The options for mining
     Options {
@@ -151,6 +152,7 @@ pub enum MineOptions {
         timestamp: Option<u64>,
         /// If `blocks` is given, it will mine exactly blocks number of blocks, regardless of any
         /// other blocks mined or reverted during it's operation
+        #[serde(with = "alloy_serde::quantity::opt")]
         blocks: Option<u64>,
     },
     /// The timestamp the block should be mined with

--- a/crates/rpc-types-anvil/src/lib.rs
+++ b/crates/rpc-types-anvil/src/lib.rs
@@ -238,9 +238,9 @@ mod tests {
     fn test_forking_deserialization() {
         // Test full forking object
         let json_data = r#"{"forking": {"jsonRpcUrl": "https://ethereumpublicnode.com","blockNumber": "18441649"}}"#;
-        let deserialized: Forking = serde_json::from_str(json_data).unwrap();
+        let forking: Forking = serde_json::from_str(json_data).unwrap();
         assert_eq!(
-            deserialized,
+            forking,
             Forking {
                 json_rpc_url: Some("https://ethereumpublicnode.com".into()),
                 block_number: Some(18441649)
@@ -249,9 +249,9 @@ mod tests {
 
         // Test forking object with only jsonRpcUrl
         let json_data = r#"{"forking": {"jsonRpcUrl": "https://ethereumpublicnode.com"}}"#;
-        let deserialized: Forking = serde_json::from_str(json_data).unwrap();
+        let forking: Forking = serde_json::from_str(json_data).unwrap();
         assert_eq!(
-            deserialized,
+            forking,
             Forking {
                 json_rpc_url: Some("https://ethereumpublicnode.com".into()),
                 block_number: None
@@ -260,9 +260,9 @@ mod tests {
 
         // Test forking object with only blockNumber
         let json_data = r#"{"forking": {"blockNumber": "18441649"}}"#;
-        let deserialized: Forking =
+        let forking: Forking =
             serde_json::from_str(json_data).expect("Failed to deserialize forking object");
-        assert_eq!(deserialized, Forking { json_rpc_url: None, block_number: Some(18441649) });
+        assert_eq!(forking, Forking { json_rpc_url: None, block_number: Some(18441649) });
     }
 
     #[test]

--- a/crates/rpc-types-anvil/src/lib.rs
+++ b/crates/rpc-types-anvil/src/lib.rs
@@ -234,6 +234,7 @@ mod tests {
 
     #[test]
     fn test_forking_deserialization() {
+        // Test full forking object
         let json_data = r#"{"forking": {"jsonRpcUrl": "https://ethereumpublicnode.com","blockNumber": "18441649"}}"#;
         let deserialized: Forking = serde_json::from_str(json_data).unwrap();
         assert_eq!(
@@ -243,6 +244,23 @@ mod tests {
                 block_number: Some(18441649)
             }
         );
+
+        // Test forking object with only jsonRpcUrl
+        let json_data = r#"{"forking": {"jsonRpcUrl": "https://ethereumpublicnode.com"}}"#;
+        let deserialized: Forking = serde_json::from_str(json_data).unwrap();
+        assert_eq!(
+            deserialized,
+            Forking {
+                json_rpc_url: Some("https://ethereumpublicnode.com".into()),
+                block_number: None
+            }
+        );
+
+        // Test forking object with only blockNumber
+        let json_data = r#"{"forking": {"blockNumber": "18441649"}}"#;
+        let deserialized: Forking =
+            serde_json::from_str(json_data).expect("Failed to deserialize forking object");
+        assert_eq!(deserialized, Forking { json_rpc_url: None, block_number: Some(18441649) });
     }
 
     #[test]

--- a/crates/rpc-types-anvil/src/lib.rs
+++ b/crates/rpc-types-anvil/src/lib.rs
@@ -31,7 +31,7 @@ impl<'de> serde::Deserialize<'de> for Forking {
         #[serde(rename_all = "camelCase")]
         struct ForkOpts {
             json_rpc_url: Option<String>,
-            #[serde(default, with = "alloy_serde::quantity::opt")]
+            #[serde(default, with = "alloy_serde::num::u64_opt_via_ruint")]
             block_number: Option<u64>,
         }
 
@@ -148,15 +148,15 @@ pub enum MineOptions {
     /// The options for mining
     Options {
         /// The timestamp the block should be mined with
-        #[serde(with = "alloy_serde::quantity::opt")]
+        #[serde(with = "alloy_serde::num::u64_opt_via_ruint")]
         timestamp: Option<u64>,
         /// If `blocks` is given, it will mine exactly blocks number of blocks, regardless of any
         /// other blocks mined or reverted during it's operation
-        #[serde(with = "alloy_serde::quantity::opt")]
+        #[serde(with = "alloy_serde::num::u64_opt_via_ruint")]
         blocks: Option<u64>,
     },
     /// The timestamp the block should be mined with
-    #[serde(with = "alloy_serde::quantity::opt")]
+    #[serde(with = "alloy_serde::num::u64_opt_via_ruint")]
     Timestamp(Option<u64>),
 }
 

--- a/crates/rpc-types-anvil/src/lib.rs
+++ b/crates/rpc-types-anvil/src/lib.rs
@@ -31,7 +31,7 @@ impl<'de> serde::Deserialize<'de> for Forking {
         #[serde(rename_all = "camelCase")]
         struct ForkOpts {
             json_rpc_url: Option<String>,
-            #[serde(default, with = "alloy_serde::num::u64_opt_via_ruint")]
+            #[serde(default, with = "alloy_serde::quantity::opt")]
             block_number: Option<u64>,
         }
 
@@ -147,15 +147,14 @@ pub enum MineOptions {
     /// The options for mining
     Options {
         /// The timestamp the block should be mined with
-        #[serde(with = "alloy_serde::num::u64_opt_via_ruint")]
+        #[serde(with = "alloy_serde::quantity::opt")]
         timestamp: Option<u64>,
         /// If `blocks` is given, it will mine exactly blocks number of blocks, regardless of any
         /// other blocks mined or reverted during it's operation
-        #[serde(with = "alloy_serde::num::u64_opt_via_ruint")]
         blocks: Option<u64>,
     },
     /// The timestamp the block should be mined with
-    #[serde(with = "alloy_serde::num::u64_opt_via_ruint")]
+    #[serde(with = "alloy_serde::quantity::opt")]
     Timestamp(Option<u64>),
 }
 
@@ -322,7 +321,7 @@ mod tests {
             MineOptions::Options { timestamp: Some(1620000000), blocks: Some(10) }
         );
 
-        let data = r#"{"timestamp": "0x608f3d00", "blocks": "0xa"}"#;
+        let data = r#"{"timestamp": "0x608f3d00", "blocks": 10}"#;
         let deserialized: MineOptions = serde_json::from_str(data).expect("Deserialization failed");
         assert_eq!(
             deserialized,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Closes: https://github.com/alloy-rs/alloy/issues/838

Required for: https://github.com/foundry-rs/foundry/issues/8084

Related PR in Foundry: https://github.com/foundry-rs/foundry/pull/8186

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Adds `Index`, previously missing from the `rpc-types-anvil`

Fixes deserialization issue in `MineOptions`

Also added some tests for `Forking`, `Index` and `MineOptions` serialization as this was giving trouble in Foundry 

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
