### PR TITLE
feat: add TryFrom for GethTrace for all inner variants

### DIFF
--- a/crates/rpc-types-trace/CHANGELOG.md
+++ b/crates/rpc-types-trace/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/alloy-rs/alloy/compare/v0.1.1...HEAD)
 
+- Add `try_from()` and `try_into_{variant}()`for all inner `GethTrace` variants ([#929](https://github.com/alloy-rs/alloy/issues/929))
+
+
 ## [0.1.1](https://github.com/alloy-rs/alloy/tree/v0.1.1)
 
 ### Features

--- a/crates/rpc-types-trace/CHANGELOG.md
+++ b/crates/rpc-types-trace/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/alloy-rs/alloy/compare/v0.1.1...HEAD)
 
-- Add `try_from()` and `try_into_{variant}()` for all inner `GethTrace` variants ([#929](https://github.com/alloy-rs/alloy/issues/929))
+- Add `try_into_{variant}()` for all inner `GethTrace` variants ([#929](https://github.com/alloy-rs/alloy/issues/929))
 
 
 ## [0.1.1](https://github.com/alloy-rs/alloy/tree/v0.1.1)

--- a/crates/rpc-types-trace/CHANGELOG.md
+++ b/crates/rpc-types-trace/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/alloy-rs/alloy/compare/v0.1.1...HEAD)
 
-- Add `try_from()` and `try_into_{variant}()`for all inner `GethTrace` variants ([#929](https://github.com/alloy-rs/alloy/issues/929))
+- Add `try_from()` and `try_into_{variant}()` for all inner `GethTrace` variants ([#929](https://github.com/alloy-rs/alloy/issues/929))
 
 
 ## [0.1.1](https://github.com/alloy-rs/alloy/tree/v0.1.1)

--- a/crates/rpc-types-trace/Cargo.toml
+++ b/crates/rpc-types-trace/Cargo.toml
@@ -25,7 +25,7 @@ alloy-serde.workspace = true
 
 serde.workspace = true
 serde_json.workspace = true
-thiserror = "1.0.61"
+thiserror.workspace = true
 
 [dev-dependencies]
 alloy-primitives = { workspace = true, features = [

--- a/crates/rpc-types-trace/Cargo.toml
+++ b/crates/rpc-types-trace/Cargo.toml
@@ -25,6 +25,7 @@ alloy-serde.workspace = true
 
 serde.workspace = true
 serde_json.workspace = true
+thiserror = "1.0.61"
 
 [dev-dependencies]
 alloy-primitives = { workspace = true, features = [

--- a/crates/rpc-types-trace/src/geth/mod.rs
+++ b/crates/rpc-types-trace/src/geth/mod.rs
@@ -130,7 +130,7 @@ pub enum GethTrace {
 
 impl GethTrace {
     /// Try to convert the inner tracer to [DefaultFrame]
-    pub fn try_into_default(self) -> Result<DefaultFrame, UnexpectedTracerError> {
+    pub fn try_into_default_frame(self) -> Result<DefaultFrame, UnexpectedTracerError> {
         match self {
             Self::Default(inner) => Ok(inner),
             _ => Err(UnexpectedTracerError(self)),
@@ -138,7 +138,7 @@ impl GethTrace {
     }
 
     /// Try to convert the inner tracer to [CallFrame]
-    pub fn try_into_call(self) -> Result<CallFrame, UnexpectedTracerError> {
+    pub fn try_into_call_frame(self) -> Result<CallFrame, UnexpectedTracerError> {
         match self {
             Self::CallTracer(inner) => Ok(inner),
             _ => Err(UnexpectedTracerError(self)),
@@ -146,7 +146,7 @@ impl GethTrace {
     }
 
     /// Try to convert the inner tracer to [FourByteFrame]
-    pub fn try_into_four_byte(self) -> Result<FourByteFrame, UnexpectedTracerError> {
+    pub fn try_into_four_byte_frame(self) -> Result<FourByteFrame, UnexpectedTracerError> {
         match self {
             Self::FourByteTracer(inner) => Ok(inner),
             _ => Err(UnexpectedTracerError(self)),
@@ -154,7 +154,7 @@ impl GethTrace {
     }
 
     /// Try to convert the inner tracer to [PreStateFrame]
-    pub fn try_into_pre_state(self) -> Result<PreStateFrame, UnexpectedTracerError> {
+    pub fn try_into_pre_state_frame(self) -> Result<PreStateFrame, UnexpectedTracerError> {
         match self {
             Self::PreStateTracer(inner) => Ok(inner),
             _ => Err(UnexpectedTracerError(self)),
@@ -162,7 +162,7 @@ impl GethTrace {
     }
 
     /// Try to convert the inner tracer to [NoopFrame]
-    pub fn try_into_noop(self) -> Result<NoopFrame, UnexpectedTracerError> {
+    pub fn try_into_noop_frame(self) -> Result<NoopFrame, UnexpectedTracerError> {
         match self {
             Self::NoopTracer(inner) => Ok(inner),
             _ => Err(UnexpectedTracerError(self)),
@@ -170,7 +170,7 @@ impl GethTrace {
     }
 
     /// Try to convert the inner tracer to [MuxFrame]
-    pub fn try_into_mux(self) -> Result<MuxFrame, UnexpectedTracerError> {
+    pub fn try_into_mux_frame(self) -> Result<MuxFrame, UnexpectedTracerError> {
         match self {
             Self::MuxTracer(inner) => Ok(inner),
             _ => Err(UnexpectedTracerError(self)),
@@ -178,7 +178,7 @@ impl GethTrace {
     }
 
     /// Try to convert the inner tracer to [serde_json::Value]
-    pub fn try_into_js(self) -> Result<serde_json::Value, UnexpectedTracerError> {
+    pub fn try_into_json_value(self) -> Result<serde_json::Value, UnexpectedTracerError> {
         match self {
             Self::JS(inner) => Ok(inner),
             _ => Err(UnexpectedTracerError(self)),
@@ -225,83 +225,6 @@ impl From<NoopFrame> for GethTrace {
 impl From<MuxFrame> for GethTrace {
     fn from(value: MuxFrame) -> Self {
         Self::MuxTracer(value)
-    }
-}
-
-impl TryFrom<GethTrace> for DefaultFrame {
-    type Error = UnexpectedTracerError;
-
-    fn try_from(value: GethTrace) -> Result<Self, UnexpectedTracerError> {
-        match value {
-            GethTrace::Default(inner) => Ok(inner),
-            _ => Err(UnexpectedTracerError(value)),
-        }
-    }
-}
-
-impl TryFrom<GethTrace> for CallFrame {
-    type Error = UnexpectedTracerError;
-
-    fn try_from(value: GethTrace) -> Result<Self, UnexpectedTracerError> {
-        match value {
-            GethTrace::CallTracer(inner) => Ok(inner),
-            _ => Err(UnexpectedTracerError(value)),
-        }
-    }
-}
-
-impl TryFrom<GethTrace> for FourByteFrame {
-    type Error = UnexpectedTracerError;
-
-    fn try_from(value: GethTrace) -> Result<Self, UnexpectedTracerError> {
-        match value {
-            GethTrace::FourByteTracer(inner) => Ok(inner),
-            _ => Err(UnexpectedTracerError(value)),
-        }
-    }
-}
-
-impl TryFrom<GethTrace> for PreStateFrame {
-    type Error = UnexpectedTracerError;
-
-    fn try_from(value: GethTrace) -> Result<Self, UnexpectedTracerError> {
-        match value {
-            GethTrace::PreStateTracer(inner) => Ok(inner),
-            _ => Err(UnexpectedTracerError(value)),
-        }
-    }
-}
-
-impl TryFrom<GethTrace> for NoopFrame {
-    type Error = UnexpectedTracerError;
-
-    fn try_from(value: GethTrace) -> Result<Self, UnexpectedTracerError> {
-        match value {
-            GethTrace::NoopTracer(inner) => Ok(inner),
-            _ => Err(UnexpectedTracerError(value)),
-        }
-    }
-}
-
-impl TryFrom<GethTrace> for MuxFrame {
-    type Error = UnexpectedTracerError;
-
-    fn try_from(value: GethTrace) -> Result<Self, UnexpectedTracerError> {
-        match value {
-            GethTrace::MuxTracer(inner) => Ok(inner),
-            _ => Err(UnexpectedTracerError(value)),
-        }
-    }
-}
-
-impl TryFrom<GethTrace> for serde_json::Value {
-    type Error = UnexpectedTracerError;
-
-    fn try_from(value: GethTrace) -> Result<Self, UnexpectedTracerError> {
-        match value {
-            GethTrace::JS(inner) => Ok(inner),
-            _ => Err(UnexpectedTracerError(value)),
-        }
     }
 }
 
@@ -801,79 +724,40 @@ mod tests {
     }
 
     #[test]
-    fn test_inner_try_from_geth_trace() {
-        let geth_trace = GethTrace::Default(DefaultFrame::default());
-        let inner = DefaultFrame::try_from(geth_trace);
-        assert!(inner.is_ok());
-
-        let geth_trace = GethTrace::CallTracer(CallFrame::default());
-        let inner = CallFrame::try_from(geth_trace);
-        assert!(inner.is_ok());
-
-        let geth_trace = GethTrace::FourByteTracer(FourByteFrame::default());
-        let inner = FourByteFrame::try_from(geth_trace);
-        assert!(inner.is_ok());
-
-        let geth_trace = GethTrace::PreStateTracer(PreStateFrame::Default(PreStateMode::default()));
-        let inner = PreStateFrame::try_from(geth_trace);
-        assert!(inner.is_ok());
-
-        let geth_trace = GethTrace::NoopTracer(NoopFrame::default());
-        let inner = NoopFrame::try_from(geth_trace);
-        assert!(inner.is_ok());
-
-        let geth_trace = GethTrace::MuxTracer(MuxFrame::default());
-        let inner = MuxFrame::try_from(geth_trace);
-        assert!(inner.is_ok());
-
-        let geth_trace = GethTrace::JS(serde_json::Value::Null);
-        let inner = serde_json::Value::try_from(geth_trace);
-        assert!(inner.is_ok());
-    }
-
-    #[test]
-    fn test_inner_try_from_geth_trace_wrong_tracer() {
-        let geth_trace = GethTrace::Default(DefaultFrame::default());
-        let inner = CallFrame::try_from(geth_trace);
-        assert!(inner.is_err());
-        assert!(matches!(inner, Err(UnexpectedTracerError(_))));
-    }
-
-    #[test]
     fn test_geth_trace_into_tracer() {
         let geth_trace = GethTrace::Default(DefaultFrame::default());
-        let inner = geth_trace.try_into_default();
+        let inner = geth_trace.try_into_default_frame();
         assert!(inner.is_ok());
 
         let geth_trace = GethTrace::CallTracer(CallFrame::default());
-        let inner = geth_trace.try_into_call();
+        let inner = geth_trace.try_into_call_frame();
         assert!(inner.is_ok());
 
         let geth_trace = GethTrace::FourByteTracer(FourByteFrame::default());
-        let inner = geth_trace.try_into_four_byte();
+        let inner = geth_trace.try_into_four_byte_frame();
         assert!(inner.is_ok());
 
         let geth_trace = GethTrace::PreStateTracer(PreStateFrame::Default(PreStateMode::default()));
-        let inner = geth_trace.try_into_pre_state();
+        let inner = geth_trace.try_into_pre_state_frame();
         assert!(inner.is_ok());
 
         let geth_trace = GethTrace::NoopTracer(NoopFrame::default());
-        let inner = geth_trace.try_into_noop();
+        let inner = geth_trace.try_into_noop_frame();
         assert!(inner.is_ok());
 
         let geth_trace = GethTrace::MuxTracer(MuxFrame::default());
-        let inner = geth_trace.try_into_mux();
+        let inner = geth_trace.try_into_mux_frame();
         assert!(inner.is_ok());
 
         let geth_trace = GethTrace::JS(serde_json::Value::Null);
-        let inner = geth_trace.try_into_js();
+        let inner = geth_trace.try_into_json_value();
         assert!(inner.is_ok());
     }
 
     #[test]
     fn test_geth_trace_into_tracer_wrong_tracer() {
         let geth_trace = GethTrace::Default(DefaultFrame::default());
-        let inner = geth_trace.try_into_call();
+        let inner = geth_trace.try_into_call_frame();
         assert!(inner.is_err());
         assert!(matches!(inner, Err(UnexpectedTracerError(_))));
     }

--- a/crates/rpc-types-trace/src/geth/mod.rs
+++ b/crates/rpc-types-trace/src/geth/mod.rs
@@ -835,7 +835,7 @@ mod tests {
     fn test_inner_try_from_geth_trace_wrong_tracer() {
         let geth_trace = GethTrace::Default(DefaultFrame::default());
         let inner = CallFrame::try_from(geth_trace);
-        assert!(!inner.is_ok());
+        assert!(inner.is_err());
         assert!(matches!(inner, Err(UnexpectedTracerError(_))));
     }
 
@@ -874,7 +874,7 @@ mod tests {
     fn test_geth_trace_into_tracer_wrong_tracer() {
         let geth_trace = GethTrace::Default(DefaultFrame::default());
         let inner = geth_trace.try_into_call();
-        assert!(!inner.is_ok());
+        assert!(inner.is_err());
         assert!(matches!(inner, Err(UnexpectedTracerError(_))));
     }
 }

--- a/crates/rpc-types-trace/src/geth/mod.rs
+++ b/crates/rpc-types-trace/src/geth/mod.rs
@@ -132,7 +132,7 @@ impl GethTrace {
     /// Try to convert the inner tracer to [DefaultFrame]
     pub fn try_into_default(self) -> Result<DefaultFrame, UnexpectedTracerError> {
         match self {
-            GethTrace::Default(inner) => Ok(inner),
+            Self::Default(inner) => Ok(inner),
             _ => Err(UnexpectedTracerError(self)),
         }
     }
@@ -140,7 +140,7 @@ impl GethTrace {
     /// Try to convert the inner tracer to [CallFrame]
     pub fn try_into_call(self) -> Result<CallFrame, UnexpectedTracerError> {
         match self {
-            GethTrace::CallTracer(inner) => Ok(inner),
+            Self::CallTracer(inner) => Ok(inner),
             _ => Err(UnexpectedTracerError(self)),
         }
     }
@@ -148,7 +148,7 @@ impl GethTrace {
     /// Try to convert the inner tracer to [FourByteFrame]
     pub fn try_into_four_byte(self) -> Result<FourByteFrame, UnexpectedTracerError> {
         match self {
-            GethTrace::FourByteTracer(inner) => Ok(inner),
+            Self::FourByteTracer(inner) => Ok(inner),
             _ => Err(UnexpectedTracerError(self)),
         }
     }
@@ -156,7 +156,7 @@ impl GethTrace {
     /// Try to convert the inner tracer to [PreStateFrame]
     pub fn try_into_pre_state(self) -> Result<PreStateFrame, UnexpectedTracerError> {
         match self {
-            GethTrace::PreStateTracer(inner) => Ok(inner),
+            Self::PreStateTracer(inner) => Ok(inner),
             _ => Err(UnexpectedTracerError(self)),
         }
     }
@@ -164,7 +164,7 @@ impl GethTrace {
     /// Try to convert the inner tracer to [NoopFrame]
     pub fn try_into_noop(self) -> Result<NoopFrame, UnexpectedTracerError> {
         match self {
-            GethTrace::NoopTracer(inner) => Ok(inner),
+            Self::NoopTracer(inner) => Ok(inner),
             _ => Err(UnexpectedTracerError(self)),
         }
     }
@@ -172,7 +172,7 @@ impl GethTrace {
     /// Try to convert the inner tracer to [MuxFrame]
     pub fn try_into_mux(self) -> Result<MuxFrame, UnexpectedTracerError> {
         match self {
-            GethTrace::MuxTracer(inner) => Ok(inner),
+            Self::MuxTracer(inner) => Ok(inner),
             _ => Err(UnexpectedTracerError(self)),
         }
     }
@@ -180,7 +180,7 @@ impl GethTrace {
     /// Try to convert the inner tracer to [serde_json::Value]
     pub fn try_into_js(self) -> Result<serde_json::Value, UnexpectedTracerError> {
         match self {
-            GethTrace::JS(inner) => Ok(inner),
+            Self::JS(inner) => Ok(inner),
             _ => Err(UnexpectedTracerError(self)),
         }
     }

--- a/crates/rpc-types-trace/src/geth/mod.rs
+++ b/crates/rpc-types-trace/src/geth/mod.rs
@@ -176,7 +176,7 @@ impl From<MuxFrame> for GethTrace {
 impl TryFrom<GethTrace> for DefaultFrame {
     type Error = ConversionError;
 
-    fn try_from(value: GethTrace) -> Result<DefaultFrame, ConversionError> {
+    fn try_from(value: GethTrace) -> Result<Self, ConversionError> {
         match value {
             GethTrace::Default(inner) => Ok(inner),
             _ => Err(ConversionError::UnexpectedTracer(value)),
@@ -187,7 +187,7 @@ impl TryFrom<GethTrace> for DefaultFrame {
 impl TryFrom<GethTrace> for CallFrame {
     type Error = ConversionError;
 
-    fn try_from(value: GethTrace) -> Result<CallFrame, ConversionError> {
+    fn try_from(value: GethTrace) -> Result<Self, ConversionError> {
         match value {
             GethTrace::CallTracer(inner) => Ok(inner),
             _ => Err(ConversionError::UnexpectedTracer(value)),
@@ -198,7 +198,7 @@ impl TryFrom<GethTrace> for CallFrame {
 impl TryFrom<GethTrace> for FourByteFrame {
     type Error = ConversionError;
 
-    fn try_from(value: GethTrace) -> Result<FourByteFrame, ConversionError> {
+    fn try_from(value: GethTrace) -> Result<Self, ConversionError> {
         match value {
             GethTrace::FourByteTracer(inner) => Ok(inner),
             _ => Err(ConversionError::UnexpectedTracer(value)),
@@ -209,7 +209,7 @@ impl TryFrom<GethTrace> for FourByteFrame {
 impl TryFrom<GethTrace> for PreStateFrame {
     type Error = ConversionError;
 
-    fn try_from(value: GethTrace) -> Result<PreStateFrame, ConversionError> {
+    fn try_from(value: GethTrace) -> Result<Self, ConversionError> {
         match value {
             GethTrace::PreStateTracer(inner) => Ok(inner),
             _ => Err(ConversionError::UnexpectedTracer(value)),
@@ -220,7 +220,7 @@ impl TryFrom<GethTrace> for PreStateFrame {
 impl TryFrom<GethTrace> for NoopFrame {
     type Error = ConversionError;
 
-    fn try_from(value: GethTrace) -> Result<NoopFrame, ConversionError> {
+    fn try_from(value: GethTrace) -> Result<Self, ConversionError> {
         match value {
             GethTrace::NoopTracer(inner) => Ok(inner),
             _ => Err(ConversionError::UnexpectedTracer(value)),
@@ -231,7 +231,7 @@ impl TryFrom<GethTrace> for NoopFrame {
 impl TryFrom<GethTrace> for MuxFrame {
     type Error = ConversionError;
 
-    fn try_from(value: GethTrace) -> Result<MuxFrame, ConversionError> {
+    fn try_from(value: GethTrace) -> Result<Self, ConversionError> {
         match value {
             GethTrace::MuxTracer(inner) => Ok(inner),
             _ => Err(ConversionError::UnexpectedTracer(value)),
@@ -242,7 +242,7 @@ impl TryFrom<GethTrace> for MuxFrame {
 impl TryFrom<GethTrace> for serde_json::Value {
     type Error = ConversionError;
 
-    fn try_from(value: GethTrace) -> Result<serde_json::Value, ConversionError> {
+    fn try_from(value: GethTrace) -> Result<Self, ConversionError> {
         match value {
             GethTrace::JS(inner) => Ok(inner),
             _ => Err(ConversionError::UnexpectedTracer(value)),

--- a/crates/rpc-types-trace/src/geth/mod.rs
+++ b/crates/rpc-types-trace/src/geth/mod.rs
@@ -128,6 +128,64 @@ pub enum GethTrace {
     JS(serde_json::Value),
 }
 
+impl GethTrace {
+    /// Try to convert the inner tracer to [DefaultFrame]
+    pub fn try_into_default(self) -> Result<DefaultFrame, UnexpectedTracerError> {
+        match self {
+            GethTrace::Default(inner) => Ok(inner),
+            _ => Err(UnexpectedTracerError(self)),
+        }
+    }
+
+    /// Try to convert the inner tracer to [CallFrame]
+    pub fn try_into_call(self) -> Result<CallFrame, UnexpectedTracerError> {
+        match self {
+            GethTrace::CallTracer(inner) => Ok(inner),
+            _ => Err(UnexpectedTracerError(self)),
+        }
+    }
+
+    /// Try to convert the inner tracer to [FourByteFrame]
+    pub fn try_into_four_byte(self) -> Result<FourByteFrame, UnexpectedTracerError> {
+        match self {
+            GethTrace::FourByteTracer(inner) => Ok(inner),
+            _ => Err(UnexpectedTracerError(self)),
+        }
+    }
+
+    /// Try to convert the inner tracer to [PreStateFrame]
+    pub fn try_into_pre_state(self) -> Result<PreStateFrame, UnexpectedTracerError> {
+        match self {
+            GethTrace::PreStateTracer(inner) => Ok(inner),
+            _ => Err(UnexpectedTracerError(self)),
+        }
+    }
+
+    /// Try to convert the inner tracer to [NoopFrame]
+    pub fn try_into_noop(self) -> Result<NoopFrame, UnexpectedTracerError> {
+        match self {
+            GethTrace::NoopTracer(inner) => Ok(inner),
+            _ => Err(UnexpectedTracerError(self)),
+        }
+    }
+
+    /// Try to convert the inner tracer to [MuxFrame]
+    pub fn try_into_mux(self) -> Result<MuxFrame, UnexpectedTracerError> {
+        match self {
+            GethTrace::MuxTracer(inner) => Ok(inner),
+            _ => Err(UnexpectedTracerError(self)),
+        }
+    }
+
+    /// Try to convert the inner tracer to [serde_json::Value]
+    pub fn try_into_js(self) -> Result<serde_json::Value, UnexpectedTracerError> {
+        match self {
+            GethTrace::JS(inner) => Ok(inner),
+            _ => Err(UnexpectedTracerError(self)),
+        }
+    }
+}
+
 impl Default for GethTrace {
     fn default() -> Self {
         Self::Default(DefaultFrame::default())
@@ -777,6 +835,45 @@ mod tests {
     fn test_inner_try_from_geth_trace_wrong_tracer() {
         let geth_trace = GethTrace::Default(DefaultFrame::default());
         let inner = CallFrame::try_from(geth_trace);
+        assert!(!inner.is_ok());
+        assert!(matches!(inner, Err(UnexpectedTracerError(_))));
+    }
+
+    #[test]
+    fn test_geth_trace_into_tracer() {
+        let geth_trace = GethTrace::Default(DefaultFrame::default());
+        let inner = geth_trace.try_into_default();
+        assert!(inner.is_ok());
+
+        let geth_trace = GethTrace::CallTracer(CallFrame::default());
+        let inner = geth_trace.try_into_call();
+        assert!(inner.is_ok());
+
+        let geth_trace = GethTrace::FourByteTracer(FourByteFrame::default());
+        let inner = geth_trace.try_into_four_byte();
+        assert!(inner.is_ok());
+
+        let geth_trace = GethTrace::PreStateTracer(PreStateFrame::Default(PreStateMode::default()));
+        let inner = geth_trace.try_into_pre_state();
+        assert!(inner.is_ok());
+
+        let geth_trace = GethTrace::NoopTracer(NoopFrame::default());
+        let inner = geth_trace.try_into_noop();
+        assert!(inner.is_ok());
+
+        let geth_trace = GethTrace::MuxTracer(MuxFrame::default());
+        let inner = geth_trace.try_into_mux();
+        assert!(inner.is_ok());
+
+        let geth_trace = GethTrace::JS(serde_json::Value::Null);
+        let inner = geth_trace.try_into_js();
+        assert!(inner.is_ok());
+    }
+
+    #[test]
+    fn test_geth_trace_into_tracer_wrong_tracer() {
+        let geth_trace = GethTrace::Default(DefaultFrame::default());
+        let inner = geth_trace.try_into_call();
         assert!(!inner.is_ok());
         assert!(matches!(inner, Err(UnexpectedTracerError(_))));
     }

--- a/crates/rpc-types-trace/src/geth/mod.rs
+++ b/crates/rpc-types-trace/src/geth/mod.rs
@@ -23,13 +23,10 @@ pub mod mux;
 pub mod noop;
 pub mod pre_state;
 
-/// Error variant when converting from [GethTrace] to one of the specific tracer types.
+/// Error when the inner tracer from [GethTrace] is mismatching to the target tracer.
 #[derive(Debug, thiserror::Error)]
-pub enum ConversionError {
-    /// Unexpected tracer
-    #[error("unexpected tracer")]
-    UnexpectedTracer(GethTrace),
-}
+#[error("unexpected tracer")]
+pub struct UnexpectedTracerError(pub GethTrace);
 
 /// Result type for geth style transaction trace
 pub type TraceResult = crate::common::TraceResult<GethTrace, String>;
@@ -174,78 +171,78 @@ impl From<MuxFrame> for GethTrace {
 }
 
 impl TryFrom<GethTrace> for DefaultFrame {
-    type Error = ConversionError;
+    type Error = UnexpectedTracerError;
 
-    fn try_from(value: GethTrace) -> Result<Self, ConversionError> {
+    fn try_from(value: GethTrace) -> Result<Self, UnexpectedTracerError> {
         match value {
             GethTrace::Default(inner) => Ok(inner),
-            _ => Err(ConversionError::UnexpectedTracer(value)),
+            _ => Err(UnexpectedTracerError(value)),
         }
     }
 }
 
 impl TryFrom<GethTrace> for CallFrame {
-    type Error = ConversionError;
+    type Error = UnexpectedTracerError;
 
-    fn try_from(value: GethTrace) -> Result<Self, ConversionError> {
+    fn try_from(value: GethTrace) -> Result<Self, UnexpectedTracerError> {
         match value {
             GethTrace::CallTracer(inner) => Ok(inner),
-            _ => Err(ConversionError::UnexpectedTracer(value)),
+            _ => Err(UnexpectedTracerError(value)),
         }
     }
 }
 
 impl TryFrom<GethTrace> for FourByteFrame {
-    type Error = ConversionError;
+    type Error = UnexpectedTracerError;
 
-    fn try_from(value: GethTrace) -> Result<Self, ConversionError> {
+    fn try_from(value: GethTrace) -> Result<Self, UnexpectedTracerError> {
         match value {
             GethTrace::FourByteTracer(inner) => Ok(inner),
-            _ => Err(ConversionError::UnexpectedTracer(value)),
+            _ => Err(UnexpectedTracerError(value)),
         }
     }
 }
 
 impl TryFrom<GethTrace> for PreStateFrame {
-    type Error = ConversionError;
+    type Error = UnexpectedTracerError;
 
-    fn try_from(value: GethTrace) -> Result<Self, ConversionError> {
+    fn try_from(value: GethTrace) -> Result<Self, UnexpectedTracerError> {
         match value {
             GethTrace::PreStateTracer(inner) => Ok(inner),
-            _ => Err(ConversionError::UnexpectedTracer(value)),
+            _ => Err(UnexpectedTracerError(value)),
         }
     }
 }
 
 impl TryFrom<GethTrace> for NoopFrame {
-    type Error = ConversionError;
+    type Error = UnexpectedTracerError;
 
-    fn try_from(value: GethTrace) -> Result<Self, ConversionError> {
+    fn try_from(value: GethTrace) -> Result<Self, UnexpectedTracerError> {
         match value {
             GethTrace::NoopTracer(inner) => Ok(inner),
-            _ => Err(ConversionError::UnexpectedTracer(value)),
+            _ => Err(UnexpectedTracerError(value)),
         }
     }
 }
 
 impl TryFrom<GethTrace> for MuxFrame {
-    type Error = ConversionError;
+    type Error = UnexpectedTracerError;
 
-    fn try_from(value: GethTrace) -> Result<Self, ConversionError> {
+    fn try_from(value: GethTrace) -> Result<Self, UnexpectedTracerError> {
         match value {
             GethTrace::MuxTracer(inner) => Ok(inner),
-            _ => Err(ConversionError::UnexpectedTracer(value)),
+            _ => Err(UnexpectedTracerError(value)),
         }
     }
 }
 
 impl TryFrom<GethTrace> for serde_json::Value {
-    type Error = ConversionError;
+    type Error = UnexpectedTracerError;
 
-    fn try_from(value: GethTrace) -> Result<Self, ConversionError> {
+    fn try_from(value: GethTrace) -> Result<Self, UnexpectedTracerError> {
         match value {
             GethTrace::JS(inner) => Ok(inner),
-            _ => Err(ConversionError::UnexpectedTracer(value)),
+            _ => Err(UnexpectedTracerError(value)),
         }
     }
 }
@@ -781,6 +778,6 @@ mod tests {
         let geth_trace = GethTrace::Default(DefaultFrame::default());
         let inner = CallFrame::try_from(geth_trace);
         assert!(!inner.is_ok());
-        assert!(matches!(inner, Err(ConversionError::UnexpectedTracer(_))));
+        assert!(matches!(inner, Err(UnexpectedTracerError(_))));
     }
 }


### PR DESCRIPTION
Fixes #929 

For me it feels more rust like to use `{variant}::try_from(geth_trace)` instead of `geth_trace.try_into_{variant}()`. How do you feel about that @mattsse?

Example:
```rust
use alloy_primitives::b256;
use alloy_provider::{ext::DebugApi, ProviderBuilder};
use alloy_rpc_types_trace::geth::{
    GethDebugBuiltInTracerType, GethDebugTracerConfig, GethDebugTracerType, GethDebugTracingOptions, GethDefaultTracingOptions,
    PreStateConfig, PreStateFrame, TraceResult,
};
use std::convert::{TryFrom, TryInto};

#[tokio::main]
async fn main() {
    let url = std::env::var("ETH_MAINNET_HTTP").expect("$ETH_MAINNET_HTTP must be set.");
    let node_url = url::Url::parse(url.as_str()).unwrap();
    let provider = ProviderBuilder::new().on_http(node_url);

    let tracer_opts = GethDebugTracingOptions {
        tracer: Some(GethDebugTracerType::BuiltInTracer(GethDebugBuiltInTracerType::PreStateTracer)),
        config: GethDefaultTracingOptions::default().disable_storage().disable_stack().disable_memory().disable_return_data(),
        timeout: None,
        tracer_config: GethDebugTracerConfig::default(),
    }
    .with_prestate_config(PreStateConfig { diff_mode: Some(true) });

    let call_result =
        provider.debug_trace_block_by_hash(b256!("1b9f245b55515d17fd5b3467bfe595670c9599b3d54837cd32cfde5e2e667830"), tracer_opts).await;

    let trace_results = match call_result {
        Ok(trace_results) => trace_results,
        Err(e) => {
            println!("Error: {:?}", e);
            return;
        }
    };

    for trace_result in trace_results {
        match trace_result {
            TraceResult::Success { result, tx_hash } => {
                let pre_state_frame = PreStateFrame::try_from(result);
                assert!(pre_state_frame.is_ok());
            }
            TraceResult::Error { .. } => {}
        }
    }
}

```