### PR TITLE
chore: update eip-2935 bytecode and address

### DIFF
--- a/crates/eips/CHANGELOG.md
+++ b/crates/eips/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/alloy-rs/alloy/compare/v0.1.1...HEAD)
 
+### Changes
+
+- Updated EIP-2935 address and bytecode in line with latest EIP changes ([#934](https://github.com/alloy-rs/alloy/issues/934))
+
 ## [0.1.1](https://github.com/alloy-rs/alloy/tree/v0.1.1)
 
 ### Bug Fixes

--- a/crates/eips/src/eip2935.rs
+++ b/crates/eips/src/eip2935.rs
@@ -8,4 +8,4 @@ use alloy_primitives::{address, bytes, Address, Bytes};
 pub const HISTORY_STORAGE_ADDRESS: Address = address!("25a219378dad9b3503c8268c9ca836a52427a4fb");
 
 /// The code for the EIP-2935 history storage contract.
-pub static HISTORY_STORAGE_CODE: Bytes = bytes!("60203611603157600143035f35116029575f356120000143116029576120005f3506545f5260205ff35b5f5f5260205ff35b5f5ffd00");
+pub static HISTORY_STORAGE_CODE: Bytes = bytes!("3373fffffffffffffffffffffffffffffffffffffffe1460575767ffffffffffffffff5f3511605357600143035f3511604b575f35612000014311604b57611fff5f3516545f5260205ff35b5f5f5260205ff35b5f5ffd5b5f35611fff60014303165500");

--- a/crates/eips/src/eip2935.rs
+++ b/crates/eips/src/eip2935.rs
@@ -5,7 +5,7 @@
 use alloy_primitives::{address, bytes, Address, Bytes};
 
 /// The address for the EIP-2935 history storage contract.
-pub const HISTORY_STORAGE_ADDRESS: Address = address!("25a219378dad9b3503c8268c9ca836a52427a4fb");
+pub const HISTORY_STORAGE_ADDRESS: Address = address!("0aae40965e6800cd9b1f4b05ff21581047e3f91e");
 
 /// The code for the EIP-2935 history storage contract.
 pub static HISTORY_STORAGE_CODE: Bytes = bytes!("3373fffffffffffffffffffffffffffffffffffffffe1460575767ffffffffffffffff5f3511605357600143035f3511604b575f35612000014311604b57611fff5f3516545f5260205ff35b5f5f5260205ff35b5f5ffd5b5f35611fff60014303165500");


### PR DESCRIPTION
## Motivation

See https://github.com/ethereum/EIPs/blob/45587bd019487b0bd59bec941bc0e2d708811cc8/EIPS/eip-2935.md

Ref https://github.com/paradigmxyz/reth/issues/8379

## Solution

- Update the history storage address
- Update the history storage system contract bytecode

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
