### PR TITLE
chore(rpc-types): remove duplicate `Index` definition in `rpc-types-anvil` in favor of the one in `rpc-types-eth`

### DIFF
--- a/crates/rpc-types-eth/src/index.rs
+++ b/crates/rpc-types-eth/src/index.rs
@@ -92,6 +92,7 @@ impl<'a> Deserialize<'a> for Index {
 mod tests {
     use super::*;
     use rand::{thread_rng, Rng};
+    use serde_json::json;
 
     #[test]
     fn test_serde_index_rand() {
@@ -102,5 +103,52 @@ mod tests {
             let de: Index = serde_json::from_str(&val).unwrap();
             assert_eq!(index, de);
         }
+    }
+
+    #[test]
+    fn test_serde_index_deserialization() {
+        // Test decimal index
+        let json_data = json!(42);
+        let index: Index =
+            serde_json::from_value(json_data).expect("Failed to deserialize decimal index");
+        assert_eq!(index, Index::from(42));
+
+        // Test hex index
+        let json_data = json!("0x2A");
+        let index: Index =
+            serde_json::from_value(json_data).expect("Failed to deserialize hex index");
+        assert_eq!(index, Index::from(42));
+
+        // Test invalid hex index
+        let json_data = json!("0xGHI");
+        let result: Result<Index, _> = serde_json::from_value(json_data);
+        assert!(result.is_err());
+
+        // Test invalid decimal index
+        let json_data = json!("abc");
+        let result: Result<Index, _> = serde_json::from_value(json_data);
+        assert!(result.is_err());
+
+        // Test string decimal index
+        let json_data = json!("123");
+        let index: Index =
+            serde_json::from_value(json_data).expect("Failed to deserialize string decimal index");
+        assert_eq!(index, Index::from(123));
+
+        // Test invalid numeric string
+        let json_data = json!("123abc");
+        let result: Result<Index, _> = serde_json::from_value(json_data);
+        assert!(result.is_err());
+
+        // Test negative index
+        let json_data = json!(-1);
+        let result: Result<Index, _> = serde_json::from_value(json_data);
+        assert!(result.is_err());
+
+        // Test large index
+        let json_data = json!(u64::MAX);
+        let index: Index =
+            serde_json::from_value(json_data).expect("Failed to deserialize large index");
+        assert_eq!(index, Index::from(u64::MAX as usize));
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Noticed that `Index` was already defined in `rpc-types-eth`, removing the need to define it again in `rpc-types-anvil`.

See: https://github.com/alloy-rs/alloy/blob/main/crates/rpc-types-eth/src/index.rs

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [x] Breaking changes
