### PR TITLE
feat: add eip-7702 helpers

### DIFF
--- a/crates/alloy/Cargo.toml
+++ b/crates/alloy/Cargo.toml
@@ -85,10 +85,10 @@ full = [
     "kzg",
     "network",
     "provider-http", # includes `providers`
-    "provider-ws", # includes `providers`
-    "provider-ipc", # includes `providers`
-    "rpc-types", # includes `rpc-types-eth`
-    "signer-local", # includes `signers`
+    "provider-ws",   # includes `providers`
+    "provider-ipc",  # includes `providers`
+    "rpc-types",     # includes `rpc-types-eth`
+    "signer-local",  # includes `signers`
 ]
 
 # configuration
@@ -218,6 +218,7 @@ arbitrary = [
 k256 = [
     "alloy-core/k256",
     "alloy-consensus?/k256",
+    "alloy-eips?/k256",
     "alloy-network?/k256",
     "alloy-rpc-types?/k256",
 ]

--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -50,7 +50,7 @@ serde_json.workspace = true
 [features]
 default = ["std"]
 std = ["alloy-eips/std", "c-kzg?/std"]
-k256 = ["alloy-primitives/k256"]
+k256 = ["alloy-primitives/k256", "alloy-eips/k256"]
 kzg = ["dep:c-kzg", "alloy-eips/kzg", "std"]
 arbitrary = [
     "std",

--- a/crates/eips/Cargo.toml
+++ b/crates/eips/Cargo.toml
@@ -70,6 +70,7 @@ serde = [
 kzg = ["kzg-sidecar", "sha2", "dep:derive_more", "dep:c-kzg", "dep:once_cell"]
 kzg-sidecar = ["sha2"]
 sha2 = ["dep:sha2"]
+k256 = ["alloy-primitives/k256"]
 ssz = [
     "std",
     "dep:ethereum_ssz",

--- a/crates/eips/README.md
+++ b/crates/eips/README.md
@@ -18,3 +18,4 @@ Contains constants, helpers, and basic data structures for consensus EIPs.
 - [EIP-7002](https://eips.ethereum.org/EIPS/eip-7002)
 - [EIP-7251](https://eips.ethereum.org/EIPS/eip-7251)
 - [EIP-7685](https://eips.ethereum.org/EIPS/eip-7685)
+- [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702)

--- a/crates/eips/src/eip6110.rs
+++ b/crates/eips/src/eip6110.rs
@@ -1,4 +1,4 @@
-//! Contains Deposit types, first introduced in the Prague hardfork: <https://github.com/ethereum/execution-apis/blob/main/src/engine/prague.md>
+//! Contains Deposit types, first introduced in the [Prague hardfork](https://github.com/ethereum/execution-apis/blob/main/src/engine/prague.md).
 //!
 //! See also [EIP-6110](https://eips.ethereum.org/EIPS/eip-6110): Supply validator deposits on chain
 //!

--- a/crates/eips/src/eip7251.rs
+++ b/crates/eips/src/eip7251.rs
@@ -1,4 +1,4 @@
-//! Contains consolidtion types, first introduced in the Prague hardfork: <https://github.com/ethereum/execution-apis/blob/main/src/engine/prague.md>
+//! Contains consolidtion types, first introduced in the [Prague hardfork](https://github.com/ethereum/execution-apis/blob/main/src/engine/prague.md).
 //!
 //! See also [EIP-7251](https://eips.ethereum.org/EIPS/eip-7251): Increase the MAX_EFFECTIVE_BALANCE
 

--- a/crates/eips/src/eip7702/auth_list.rs
+++ b/crates/eips/src/eip7702/auth_list.rs
@@ -64,7 +64,7 @@ impl Authorization {
     }
 
     /// Convert to a signed authorization by adding a signature.
-    pub fn into_signed<S>(self, signature: S) -> SignedAuthorization<S> {
+    pub const fn into_signed<S>(self, signature: S) -> SignedAuthorization<S> {
         SignedAuthorization { inner: self, signature }
     }
 }

--- a/crates/eips/src/eip7702/auth_list.rs
+++ b/crates/eips/src/eip7702/auth_list.rs
@@ -110,7 +110,7 @@ impl<S> Deref for SignedAuthorization<S> {
 /// nonce was specified (i.e. `None`). If there is 1 item, this is the same as `Some`.
 ///
 /// The wrapper type is used for RLP encoding and decoding.
-#[derive(Debug, Copy, Clone)]
+#[derive(Default, Debug, Copy, Clone)]
 pub struct OptionalNonce(Option<u64>);
 
 impl OptionalNonce {

--- a/crates/eips/src/eip7702/auth_list.rs
+++ b/crates/eips/src/eip7702/auth_list.rs
@@ -91,7 +91,7 @@ impl SignedAuthorization<Signature> {
     ///
     /// Implementers should check that the authority has no code.
     pub fn recover_authority(&self) -> Result<Address, SignatureError> {
-        self.signature.recover_address_from_prehash(&self.inner.authority_prehash())
+        self.signature.recover_address_from_prehash(&self.inner.signature_hash())
     }
 }
 

--- a/crates/eips/src/eip7702/auth_list.rs
+++ b/crates/eips/src/eip7702/auth_list.rs
@@ -34,7 +34,8 @@ impl Authorization {
     ///
     /// # Note
     ///
-    /// If this is `Some`, implementers should check that the nonce of the authority is equal to this nonce.
+    /// If this is `Some`, implementers should check that the nonce of the authority is equal to
+    /// this nonce.
     pub fn nonce(&self) -> Option<u64> {
         *self.nonce
     }

--- a/crates/eips/src/eip7702/auth_list.rs
+++ b/crates/eips/src/eip7702/auth_list.rs
@@ -115,7 +115,7 @@ pub struct OptionalNonce(Option<u64>);
 
 impl OptionalNonce {
     /// Create a new [`OptionalNonce`]
-    pub fn new(nonce: Option<u64>) -> Self {
+    pub const fn new(nonce: Option<u64>) -> Self {
         Self(nonce)
     }
 }

--- a/crates/eips/src/eip7702/auth_list.rs
+++ b/crates/eips/src/eip7702/auth_list.rs
@@ -40,8 +40,8 @@ impl Authorization {
         *self.nonce
     }
 
-    /// Computes the signature hash used to sign the authorization, or recover the authority from a signed authorization list
-    /// item.
+    /// Computes the signature hash used to sign the authorization, or recover the authority from a
+    /// signed authorization list item.
     ///
     /// The signature hash is `keccak(MAGIC || rlp([chain_id, [nonce], address]))`
     #[inline]

--- a/crates/eips/src/eip7702/auth_list.rs
+++ b/crates/eips/src/eip7702/auth_list.rs
@@ -36,7 +36,8 @@ impl Authorization {
     ///
     /// # Note
     ///
-    /// If this is `Some`, implementers should check that the nonce of the authority (see [`Self::recover_authority`]) is equal to this nonce.
+    /// If this is `Some`, implementers should check that the nonce of the authority (see
+    /// [`Self::recover_authority`]) is equal to this nonce.
     pub fn nonce(&self) -> Option<u64> {
         *self.nonce
     }
@@ -46,7 +47,8 @@ impl Authorization {
         &self.signature
     }
 
-    /// Computes the authority prehash used to recover the authority from an authorization list item.
+    /// Computes the authority prehash used to recover the authority from an authorization list
+    /// item.
     ///
     /// The authority prehash is `keccak(MAGIC || rlp([chain_id, [nonce], address]))`
     #[inline]
@@ -78,7 +80,8 @@ impl Authorization {
 
 /// An internal wrapper around an `Option<u64>` for optional nonces.
 ///
-/// In EIP-7702 the nonce is encoded as a list of either 0 or 1 items, where 0 items means that no nonce was specified (i.e. `None`). If there is 1 item, this is the same as `Some`.
+/// In EIP-7702 the nonce is encoded as a list of either 0 or 1 items, where 0 items means that no
+/// nonce was specified (i.e. `None`). If there is 1 item, this is the same as `Some`.
 ///
 /// The wrapper type is used for RLP encoding and decoding.
 #[derive(Debug, Copy, Clone)]

--- a/crates/eips/src/eip7702/auth_list.rs
+++ b/crates/eips/src/eip7702/auth_list.rs
@@ -3,15 +3,16 @@ use core::ops::Deref;
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 use alloy_primitives::{keccak256, Address, ChainId, B256};
-#[cfg(feature = "k256")]
-use alloy_primitives::{Signature, SignatureError};
 use alloy_rlp::{BufMut, Decodable, Encodable, Header, RlpDecodable, RlpEncodable};
 
 /// An unsigned EIP-7702 authorization.
 #[derive(Debug, Clone, RlpEncodable, RlpDecodable)]
 pub struct Authorization {
+    /// The chain ID of the authorization.
     pub chain_id: ChainId,
+    /// The address of the authorization.
     pub address: Address,
+    /// The nonce for the authorization.
     pub nonce: OptionalNonce,
 }
 
@@ -84,13 +85,13 @@ impl<S> SignedAuthorization<S> {
 }
 
 #[cfg(feature = "k256")]
-impl SignedAuthorization<Signature> {
+impl SignedAuthorization<alloy_primitives::Signature> {
     /// Recover the authority for the authorization.
     ///
     /// # Note
     ///
     /// Implementers should check that the authority has no code.
-    pub fn recover_authority(&self) -> Result<Address, SignatureError> {
+    pub fn recover_authority(&self) -> Result<Address, alloy_primitives::SignatureError> {
         self.signature.recover_address_from_prehash(&self.inner.signature_hash())
     }
 }

--- a/crates/eips/src/eip7702/auth_list.rs
+++ b/crates/eips/src/eip7702/auth_list.rs
@@ -34,8 +34,7 @@ impl Authorization {
     ///
     /// # Note
     ///
-    /// If this is `Some`, implementers should check that the nonce of the authority (see
-    /// [`Self::recover_authority`]) is equal to this nonce.
+    /// If this is `Some`, implementers should check that the nonce of the authority is equal to this nonce.
     pub fn nonce(&self) -> Option<u64> {
         *self.nonce
     }

--- a/crates/eips/src/eip7702/auth_list.rs
+++ b/crates/eips/src/eip7702/auth_list.rs
@@ -94,9 +94,39 @@ impl SignedAuthorization<alloy_primitives::Signature> {
     pub fn recover_authority(&self) -> Result<Address, alloy_primitives::SignatureError> {
         self.signature.recover_address_from_prehash(&self.inner.signature_hash())
     }
+
+    /// Recover the authority and transform the signed authorization into a
+    /// [`RecoveredAuthorization`].
+    pub fn into_recovered(self) -> RecoveredAuthorization {
+        RecoveredAuthorization { inner: self.inner, authority: self.recover_authority().ok() }
+    }
 }
 
 impl<S> Deref for SignedAuthorization<S> {
+    type Target = Authorization;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+/// A recovered authorization.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct RecoveredAuthorization {
+    inner: Authorization,
+    authority: Option<Address>,
+}
+
+impl RecoveredAuthorization {
+    /// Get the `authority` for the authorization.
+    ///
+    /// If this is `None`, then the authority could not be recovered.
+    pub const fn authority(&self) -> Option<Address> {
+        self.authority
+    }
+}
+
+impl Deref for RecoveredAuthorization {
     type Target = Authorization;
 
     fn deref(&self) -> &Self::Target {

--- a/crates/eips/src/eip7702/auth_list.rs
+++ b/crates/eips/src/eip7702/auth_list.rs
@@ -25,12 +25,12 @@ impl Authorization {
     /// # Note
     ///
     /// Implementers should check that this matches the current `chain_id` *or* is 0.
-    pub fn chain_id(&self) -> ChainId {
+    pub const fn chain_id(&self) -> ChainId {
         self.chain_id
     }
 
     /// Get the `address` for the authorization.
-    pub fn address(&self) -> &Address {
+    pub const fn address(&self) -> &Address {
         &self.address
     }
 
@@ -45,7 +45,7 @@ impl Authorization {
     }
 
     /// Get the `signature` for the authorization.
-    pub fn signature(&self) -> &Signature {
+    pub const fn signature(&self) -> &Signature {
         &self.signature
     }
 

--- a/crates/eips/src/eip7702/auth_list.rs
+++ b/crates/eips/src/eip7702/auth_list.rs
@@ -1,0 +1,112 @@
+use core::ops::Deref;
+
+use alloy_primitives::{keccak256, Address, ChainId, Signature, SignatureError, B256};
+use alloy_rlp::{BufMut, Decodable, Encodable, Header, RlpEncodable};
+
+use super::constants::MAGIC;
+
+/// An EIP-7702 authorization list.
+pub type AuthorizationList = Vec<Authorization>;
+
+/// An EIP-7702 authorization.
+#[derive(Debug, Clone, RlpEncodable)]
+pub struct Authorization {
+    chain_id: ChainId,
+    address: Address,
+    nonce: OptionalNonce,
+    signature: Signature,
+}
+
+impl Authorization {
+    /// Get the `chain_id` for the authorization.
+    ///
+    /// # Note
+    ///
+    /// Implementers should check that this matches the current `chain_id` *or* is 0.
+    pub fn chain_id(&self) -> ChainId {
+        self.chain_id
+    }
+
+    /// Get the `address` for the authorization.
+    pub fn address(&self) -> &Address {
+        &self.address
+    }
+
+    /// Get the `nonce` for the authorization.
+    ///
+    /// # Note
+    ///
+    /// If this is `Some`, implementers should check that the nonce of the authority (see [`Self::recover_authority`]) is equal to this nonce.
+    pub fn nonce(&self) -> Option<u64> {
+        *self.nonce
+    }
+
+    /// Get the `signature` for the authorization.
+    pub fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    /// Computes the authority prehash used to recover the authority from an authorization list item.
+    ///
+    /// The authority prehash is `keccak(MAGIC || rlp([chain_id, [nonce], address]))`
+    #[inline]
+    fn authority_prehash(&self) -> B256 {
+        #[derive(RlpEncodable)]
+        struct Auth {
+            chain_id: ChainId,
+            nonce: OptionalNonce,
+            address: Address,
+        }
+
+        let mut buf = Vec::new();
+        buf.put_u8(MAGIC);
+
+        Auth { chain_id: self.chain_id, nonce: self.nonce, address: self.address }.encode(&mut buf);
+
+        keccak256(buf)
+    }
+
+    /// Recover the authority for the authorization.
+    ///
+    /// # Note
+    ///
+    /// Implementers should check that the authority has no code.
+    pub fn recover_authority(&self) -> Result<Address, SignatureError> {
+        self.signature.recover_address_from_prehash(&self.authority_prehash())
+    }
+}
+
+/// An internal wrapper around an `Option<u64>` for optional nonces.
+///
+/// In EIP-7702 the nonce is encoded as a list of either 0 or 1 items, where 0 items means that no nonce was specified (i.e. `None`). If there is 1 item, this is the same as `Some`.
+///
+/// The wrapper type is used for RLP encoding and decoding.
+#[derive(Debug, Copy, Clone)]
+struct OptionalNonce(Option<u64>);
+
+impl Encodable for OptionalNonce {
+    fn encode(&self, out: &mut dyn BufMut) {
+        match self.0 {
+            Some(nonce) => {
+                Header { list: true, payload_length: nonce.length() }.encode(out);
+                nonce.encode(out);
+            }
+            None => Header { list: true, payload_length: 0 }.encode(out),
+        }
+    }
+}
+
+impl Decodable for OptionalNonce {
+    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        let list: Vec<u64> = Vec::decode(buf)?;
+        Ok(Self(list.first().copied()))
+    }
+}
+
+impl Deref for OptionalNonce {
+    type Target = Option<u64>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}

--- a/crates/eips/src/eip7702/auth_list.rs
+++ b/crates/eips/src/eip7702/auth_list.rs
@@ -7,9 +7,6 @@ use alloy_primitives::{keccak256, SignatureError, B256};
 use alloy_primitives::{Address, ChainId, Signature};
 use alloy_rlp::{BufMut, Decodable, Encodable, Header, RlpEncodable};
 
-/// An EIP-7702 authorization list.
-pub type AuthorizationList = Vec<Authorization>;
-
 /// An EIP-7702 authorization.
 #[derive(Debug, Clone, RlpEncodable)]
 pub struct Authorization {

--- a/crates/eips/src/eip7702/auth_list.rs
+++ b/crates/eips/src/eip7702/auth_list.rs
@@ -98,7 +98,8 @@ impl SignedAuthorization<alloy_primitives::Signature> {
     /// Recover the authority and transform the signed authorization into a
     /// [`RecoveredAuthorization`].
     pub fn into_recovered(self) -> RecoveredAuthorization {
-        RecoveredAuthorization { inner: self.inner, authority: self.recover_authority().ok() }
+        let authority = self.recover_authority().ok();
+        RecoveredAuthorization { inner: self.inner, authority }
     }
 }
 

--- a/crates/eips/src/eip7702/auth_list.rs
+++ b/crates/eips/src/eip7702/auth_list.rs
@@ -54,6 +54,7 @@ impl Authorization {
     ///
     /// The authority prehash is `keccak(MAGIC || rlp([chain_id, [nonce], address]))`
     #[inline]
+    #[cfg(feature = "k256")]
     fn authority_prehash(&self) -> B256 {
         #[derive(RlpEncodable)]
         struct Auth {
@@ -75,6 +76,7 @@ impl Authorization {
     /// # Note
     ///
     /// Implementers should check that the authority has no code.
+    #[cfg(feature = "k256")]
     pub fn recover_authority(&self) -> Result<Address, SignatureError> {
         self.signature.recover_address_from_prehash(&self.authority_prehash())
     }

--- a/crates/eips/src/eip7702/auth_list.rs
+++ b/crates/eips/src/eip7702/auth_list.rs
@@ -140,11 +140,18 @@ impl Encodable for OptionalNonce {
 
 impl Decodable for OptionalNonce {
     fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
-        let list: Vec<u64> = Vec::decode(buf)?;
-        if list.len() > 1 {
+        let mut bytes = Header::decode_bytes(buf, true)?;
+        if bytes.is_empty() {
+            return Ok(Self(None));
+        }
+
+        let payload_view = &mut bytes;
+        let nonce = u64::decode(payload_view)?;
+        if !payload_view.is_empty() {
+            // if there's more than 1 item in the nonce list we error
             Err(alloy_rlp::Error::UnexpectedLength)
         } else {
-            Ok(Self(list.first().copied()))
+            Ok(Self(Some(nonce)))
         }
     }
 }

--- a/crates/eips/src/eip7702/auth_list.rs
+++ b/crates/eips/src/eip7702/auth_list.rs
@@ -141,7 +141,11 @@ impl Encodable for OptionalNonce {
 impl Decodable for OptionalNonce {
     fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
         let list: Vec<u64> = Vec::decode(buf)?;
-        Ok(Self(list.first().copied()))
+        if list.len() > 1 {
+            Err(alloy_rlp::Error::UnexpectedLength)
+        } else {
+            Ok(Self(list.first().copied()))
+        }
     }
 }
 

--- a/crates/eips/src/eip7702/auth_list.rs
+++ b/crates/eips/src/eip7702/auth_list.rs
@@ -1,5 +1,7 @@
 use core::ops::Deref;
 
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 use alloy_primitives::{keccak256, Address, ChainId, Signature, SignatureError, B256};
 use alloy_rlp::{BufMut, Decodable, Encodable, Header, RlpEncodable};
 

--- a/crates/eips/src/eip7702/auth_list.rs
+++ b/crates/eips/src/eip7702/auth_list.rs
@@ -10,9 +10,9 @@ use alloy_rlp::{BufMut, Decodable, Encodable, Header, RlpDecodable, RlpEncodable
 /// An unsigned EIP-7702 authorization.
 #[derive(Debug, Clone, RlpEncodable, RlpDecodable)]
 pub struct Authorization {
-    chain_id: ChainId,
-    address: Address,
-    nonce: OptionalNonce,
+    pub chain_id: ChainId,
+    pub address: Address,
+    pub nonce: OptionalNonce,
 }
 
 impl Authorization {
@@ -110,7 +110,20 @@ impl<S> Deref for SignedAuthorization<S> {
 ///
 /// The wrapper type is used for RLP encoding and decoding.
 #[derive(Debug, Copy, Clone)]
-struct OptionalNonce(Option<u64>);
+pub struct OptionalNonce(Option<u64>);
+
+impl OptionalNonce {
+    /// Create a new [`OptionalNonce`]
+    pub fn new(nonce: Option<u64>) -> Self {
+        Self(nonce)
+    }
+}
+
+impl From<Option<u64>> for OptionalNonce {
+    fn from(value: Option<u64>) -> Self {
+        Self::new(value)
+    }
+}
 
 impl Encodable for OptionalNonce {
     fn encode(&self, out: &mut dyn BufMut) {

--- a/crates/eips/src/eip7702/auth_list.rs
+++ b/crates/eips/src/eip7702/auth_list.rs
@@ -2,10 +2,10 @@ use core::ops::Deref;
 
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
-use alloy_primitives::{keccak256, Address, ChainId, Signature, SignatureError, B256};
+#[cfg(feature = "k256")]
+use alloy_primitives::{keccak256, SignatureError, B256};
+use alloy_primitives::{Address, ChainId, Signature};
 use alloy_rlp::{BufMut, Decodable, Encodable, Header, RlpEncodable};
-
-use super::constants::MAGIC;
 
 /// An EIP-7702 authorization list.
 pub type AuthorizationList = Vec<Authorization>;
@@ -56,6 +56,8 @@ impl Authorization {
     #[inline]
     #[cfg(feature = "k256")]
     fn authority_prehash(&self) -> B256 {
+        use super::constants::MAGIC;
+
         #[derive(RlpEncodable)]
         struct Auth {
             chain_id: ChainId,

--- a/crates/eips/src/eip7702/constants.rs
+++ b/crates/eips/src/eip7702/constants.rs
@@ -1,0 +1,18 @@
+//! [EIP-7702] constants.
+//!
+//! [EIP-7702]: https://eips.ethereum.org/EIPS/eip-7702
+
+/// Identifier for EIP7702's set code transaction.
+///
+/// See also [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702).
+pub const EIP7702_TX_TYPE_ID: u8 = 4;
+
+/// Magic number used to calculate an EIP7702 authority.
+///
+/// See also [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702).
+pub const MAGIC: u8 = 0x05;
+
+/// An additional gas cost per EIP7702 authorization list item.
+///
+/// See also [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702).
+pub const PER_AUTH_BASE_COST: u64 = 2500;

--- a/crates/eips/src/eip7702/mod.rs
+++ b/crates/eips/src/eip7702/mod.rs
@@ -1,0 +1,8 @@
+//! [EIP-7702] constants, helpers, and types.
+//!
+//! [EIP-7702]: https://eips.ethereum.org/EIPS/eip-7702
+
+mod auth_list;
+pub use auth_list::*;
+
+pub mod constants;

--- a/crates/eips/src/lib.rs
+++ b/crates/eips/src/lib.rs
@@ -27,10 +27,10 @@ pub mod eip2935;
 
 pub mod eip4788;
 
-pub mod eip4895;
-
 pub mod eip4844;
 pub use eip4844::{calc_blob_gasprice, calc_excess_blob_gas};
+
+pub mod eip4895;
 
 pub mod eip6110;
 pub mod merge;
@@ -40,3 +40,5 @@ pub mod eip7002;
 pub mod eip7251;
 
 pub mod eip7685;
+
+pub mod eip7702;

--- a/crates/rpc-types-eth/Cargo.toml
+++ b/crates/rpc-types-eth/Cargo.toml
@@ -66,4 +66,4 @@ arbitrary = [
 ]
 jsonrpsee-types = ["dep:jsonrpsee-types"]
 ssz = ["alloy-primitives/ssz", "alloy-eips/ssz"]
-k256 = ["alloy-consensus/k256"]
+k256 = ["alloy-consensus/k256", "alloy-eips/k256"]


### PR DESCRIPTION
## Motivation

EIP-7702 is up for inclusion in Prague.

## Solution

Adds helpers and some types specified in [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702).

The transaction type itself will be added in another PR as it is not relevant right now (for example, the RPC spec has not been updated yet).

This also adds a `k256` feature to `alloy_eips` since authority recovery requires signature recovery which is only possible with `k256` enabled in `alloy_primitives`

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
