### PR TITLE
fix: deserialization of null storage keys in AccessListItem

### DIFF
--- a/crates/eips/src/eip2930.rs
+++ b/crates/eips/src/eip2930.rs
@@ -31,7 +31,7 @@ pub struct AccessListItem {
         )
     )]
     // In JSON, we have to accept `null` for storage key, which is interpreted as an empty array.
-    #[cfg_attr(feature = "serde", serde(deserialize_with = "alloy_serde::optional::null_as_default"))]
+    #[cfg_attr(feature = "serde", serde(deserialize_with = "alloy_serde::null_as_default"))]
     pub storage_keys: Vec<B256>,
 }
 

--- a/crates/eips/src/eip2930.rs
+++ b/crates/eips/src/eip2930.rs
@@ -30,6 +30,7 @@ pub struct AccessListItem {
             strategy = "proptest::collection::vec(proptest::arbitrary::any::<B256>(), 0..=20)"
         )
     )]
+    #[cfg_attr(feature = "serde", serde(deserialize_with = "alloy_serde::optional::or_default"))]
     pub storage_keys: Vec<B256>,
 }
 

--- a/crates/eips/src/eip2930.rs
+++ b/crates/eips/src/eip2930.rs
@@ -31,7 +31,7 @@ pub struct AccessListItem {
         )
     )]
     // In JSON, we have to accept `null` for storage key, which is interpreted as an empty array.
-    #[cfg_attr(feature = "serde", serde(deserialize_with = "alloy_serde::optional::or_default"))]
+    #[cfg_attr(feature = "serde", serde(deserialize_with = "alloy_serde::optional::null_as_default"))]
     pub storage_keys: Vec<B256>,
 }
 

--- a/crates/eips/src/eip2930.rs
+++ b/crates/eips/src/eip2930.rs
@@ -30,6 +30,7 @@ pub struct AccessListItem {
             strategy = "proptest::collection::vec(proptest::arbitrary::any::<B256>(), 0..=20)"
         )
     )]
+    // In JSON, we have to accept `null` for storage key, which is interpreted as an empty array.
     #[cfg_attr(feature = "serde", serde(deserialize_with = "alloy_serde::optional::or_default"))]
     pub storage_keys: Vec<B256>,
 }
@@ -167,7 +168,23 @@ pub struct AccessListWithGasUsed {
 
 #[cfg(all(test, feature = "serde"))]
 mod tests {
+    use serde_json::json;
+
     use super::*;
+
+    #[test]
+    fn access_list_null_storage_keys() {
+        let json = json!([
+            {
+                "address": "0x81b7bdd5b89c90b63f604fc7cdd17035cb939707",
+                "storageKeys": null,
+            }
+        ]);
+
+        let access_list = serde_json::from_value::<AccessList>(json).unwrap();
+        assert_eq!(access_list.len(), 1);
+        assert_eq!(access_list[0].storage_keys, Vec::<B256>::default());
+    }
 
     #[test]
     fn access_list_serde() {

--- a/crates/serde/src/lib.rs
+++ b/crates/serde/src/lib.rs
@@ -18,6 +18,8 @@ use serde::Serializer;
 mod bool;
 pub use self::bool::*;
 
+pub mod optional;
+
 #[cfg_attr(not(test), deprecated = "use `quantity::{self, opt, vec}` instead")]
 pub mod num;
 #[allow(deprecated)]

--- a/crates/serde/src/lib.rs
+++ b/crates/serde/src/lib.rs
@@ -18,7 +18,8 @@ use serde::Serializer;
 mod bool;
 pub use self::bool::*;
 
-pub mod optional;
+mod optional;
+pub use self::optional::*;
 
 #[cfg_attr(not(test), deprecated = "use `quantity::{self, opt, vec}` instead")]
 pub mod num;

--- a/crates/serde/src/optional.rs
+++ b/crates/serde/src/optional.rs
@@ -1,17 +1,9 @@
 //! Serde functions for encoding optional values.
-//!
-//! This is defined as a "hex encoded unsigned integer", with a special case of 0 being `0x0`.
-//!
-//! A regex for this format is: `^0x([1-9a-f]+[0-9a-f]*|0)$`.
-//!
-//! This is only valid for human-readable [`serde`] implementations.
-//! For non-human-readable implementations, the format is unspecified.
-//! Currently, it uses a fixed-width big-endian byte-array.
 use serde::{Deserialize, Deserializer};
 
 /// For use with serde's `deserialize_with` on a sequence that must be
 /// deserialized as a single but optional (i.e. possibly `null`) value.
-pub fn or_default<'de, T, D>(deserializer: D) -> Result<T, D::Error>
+pub fn null_as_default<'de, T, D>(deserializer: D) -> Result<T, D::Error>
 where
     T: Deserialize<'de> + Default,
     D: Deserializer<'de>,

--- a/crates/serde/src/optional.rs
+++ b/crates/serde/src/optional.rs
@@ -1,0 +1,21 @@
+//! Serde functions for encoding optional values.
+//!
+//! This is defined as a "hex encoded unsigned integer", with a special case of 0 being `0x0`.
+//!
+//! A regex for this format is: `^0x([1-9a-f]+[0-9a-f]*|0)$`.
+//!
+//! This is only valid for human-readable [`serde`] implementations.
+//! For non-human-readable implementations, the format is unspecified.
+//! Currently, it uses a fixed-width big-endian byte-array.
+use serde::{Deserialize, Deserializer};
+
+/// For use with serde's `deserialize_with` on a sequence that must be
+/// deserialized as a single but optional (i.e. possibly `null`) value.
+pub fn or_default<'de, T, D>(deserializer: D) -> Result<T, D::Error>
+where
+    T: Deserialize<'de> + Default,
+    D: Deserializer<'de>,
+{
+    let s: Option<T> = Deserialize::deserialize(deserializer)?;
+    Ok(s.unwrap_or_default())
+}


### PR DESCRIPTION
## Motivation

We recently adopted the `AccessList` and `AccessListItem` types for EDR/Hardhat. This fixes an issue when deserializing an `AccessListItem` where the `null` value for storage keys was not accepted.

## Solution

Added a custom serde deserialization handler.

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
