### PR TITLE
feat(network): Add `input` method to `TransactionResponse`

### DIFF
--- a/crates/network/src/any/mod.rs
+++ b/crates/network/src/any/mod.rs
@@ -1,6 +1,7 @@
 use crate::{Network, ReceiptResponse, TransactionResponse};
 use alloy_consensus::TxType;
 use alloy_eips::eip2718::Eip2718Error;
+use alloy_primitives::Bytes;
 use alloy_rpc_types_eth::{AnyTransactionReceipt, Header, Transaction, TransactionRequest};
 use alloy_serde::WithOtherFields;
 use core::fmt;
@@ -105,5 +106,9 @@ impl TransactionResponse for WithOtherFields<Transaction> {
 
     fn gas(&self) -> u128 {
         self.gas
+    }
+
+    fn input(&self) -> Bytes {
+        self.input.clone()
     }
 }

--- a/crates/network/src/any/mod.rs
+++ b/crates/network/src/any/mod.rs
@@ -108,7 +108,7 @@ impl TransactionResponse for WithOtherFields<Transaction> {
         self.gas
     }
 
-    fn input(&self) -> Bytes {
-        self.input.clone()
+    fn input(&self) -> &Bytes {
+        &self.input
     }
 }

--- a/crates/network/src/ethereum/mod.rs
+++ b/crates/network/src/ethereum/mod.rs
@@ -1,4 +1,5 @@
 use crate::{Network, ReceiptResponse, TransactionResponse};
+use alloy_primitives::Bytes;
 
 mod builder;
 
@@ -61,5 +62,9 @@ impl TransactionResponse for alloy_rpc_types_eth::Transaction {
 
     fn gas(&self) -> u128 {
         self.gas
+    }
+
+    fn input(&self) -> Bytes {
+        self.input.clone()
     }
 }

--- a/crates/network/src/ethereum/mod.rs
+++ b/crates/network/src/ethereum/mod.rs
@@ -64,7 +64,7 @@ impl TransactionResponse for alloy_rpc_types_eth::Transaction {
         self.gas
     }
 
-    fn input(&self) -> Bytes {
-        self.input.clone()
+    fn input(&self) -> &Bytes {
+        &self.input
     }
 }

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -74,6 +74,7 @@ pub trait TransactionResponse {
     fn gas(&self) -> u128;
 
     /// Input data
+    #[doc(alias = "calldata")]
     fn input(&self) -> Bytes;
 }
 

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -75,7 +75,7 @@ pub trait TransactionResponse {
 
     /// Input data
     #[doc(alias = "calldata")]
-    fn input(&self) -> Bytes;
+    fn input(&self) -> &Bytes;
 }
 
 /// Captures type info for network-specific RPC requests/responses.

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -9,7 +9,7 @@
 use alloy_consensus::TxReceipt;
 use alloy_eips::eip2718::{Eip2718Envelope, Eip2718Error};
 use alloy_json_rpc::RpcObject;
-use alloy_primitives::{Address, TxHash, U256};
+use alloy_primitives::{Address, Bytes, TxHash, U256};
 use core::fmt::{Debug, Display};
 
 mod transaction;
@@ -72,6 +72,9 @@ pub trait TransactionResponse {
 
     /// Gas limit
     fn gas(&self) -> u128;
+
+    /// Input data
+    fn input(&self) -> Bytes;
 }
 
 /// Captures type info for network-specific RPC requests/responses.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
It would be nice to have a method to get input data from `TransactionResponse`.
During my development, there was a situation in which I wanted to know what method was being called and with what arguments from `TransactionResponse`.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Adds `input` method to `TransactionResponse` and implements it to `TransactionResponse` type for each `Network`

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
