### PR TITLE
chore: remove proptest in all crates and Arbitrary derives

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,8 +140,6 @@ serde_with = "3.3.0"
 ## misc-testing
 arbitrary = "1.3"
 assert_matches = "1.5"
-proptest = { version = "1.4", default-features = false, features = ["alloc"] }
-proptest-derive = { version = "0.4", default-features = false }
 serial_test = "3.0"
 similar-asserts = "1.5"
 tempfile = "3.10"

--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -29,8 +29,6 @@ c-kzg = { workspace = true, features = ["serde"], optional = true }
 
 # arbitrary
 arbitrary = { workspace = true, features = ["derive"], optional = true }
-proptest = { workspace = true, optional = true }
-proptest-derive = { workspace = true, optional = true }
 
 # serde
 serde = { workspace = true, features = ["derive"], optional = true }
@@ -41,8 +39,6 @@ alloy-eips = { workspace = true, features = ["arbitrary"] }
 alloy-signer.workspace = true
 
 arbitrary = { workspace = true, features = ["derive"] }
-proptest = { workspace = true }
-proptest-derive = { workspace = true }
 k256.workspace = true
 tokio = { workspace = true, features = ["macros"] }
 serde_json.workspace = true
@@ -55,8 +51,6 @@ kzg = ["dep:c-kzg", "alloy-eips/kzg", "std"]
 arbitrary = [
     "std",
     "dep:arbitrary",
-    "dep:proptest-derive",
-    "dep:proptest",
     "alloy-eips/arbitrary",
 ]
 serde = [

--- a/crates/consensus/src/request.rs
+++ b/crates/consensus/src/request.rs
@@ -1,5 +1,3 @@
-#![allow(unknown_lints, non_local_definitions)] // TODO: remove when proptest-derive updates
-
 use alloy_eips::{
     eip6110::DepositRequest,
     eip7002::WithdrawalRequest,
@@ -15,7 +13,7 @@ use alloy_rlp::{Decodable, Encodable};
 #[non_exhaustive]
 #[cfg_attr(
     any(test, feature = "arbitrary"),
-    derive(proptest_derive::Arbitrary, arbitrary::Arbitrary)
+    derive(arbitrary::Arbitrary)
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(untagged))]

--- a/crates/consensus/src/request.rs
+++ b/crates/consensus/src/request.rs
@@ -11,10 +11,7 @@ use alloy_rlp::{Decodable, Encodable};
 /// See also [EIP-7685](https://eips.ethereum.org/EIPS/eip-7685).
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[non_exhaustive]
-#[cfg_attr(
-    any(test, feature = "arbitrary"),
-    derive(arbitrary::Arbitrary)
-)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(untagged))]
 pub enum Request {

--- a/crates/eips/Cargo.toml
+++ b/crates/eips/Cargo.toml
@@ -38,8 +38,6 @@ ethereum_ssz = { workspace = true, optional = true }
 
 # arbitrary
 arbitrary = { workspace = true, features = ["derive"], optional = true }
-proptest = { workspace = true, optional = true }
-proptest-derive = { workspace = true, optional = true }
 
 [dev-dependencies]
 alloy-primitives = { workspace = true, features = [
@@ -48,8 +46,6 @@ alloy-primitives = { workspace = true, features = [
     "arbitrary",
 ] }
 arbitrary = { workspace = true, features = ["derive"] }
-proptest.workspace = true
-proptest-derive.workspace = true
 serde_json.workspace = true
 
 [features]
@@ -81,8 +77,6 @@ arbitrary = [
     "std",
     "kzg-sidecar",
     "dep:arbitrary",
-    "dep:proptest-derive",
-    "dep:proptest",
     "alloy-primitives/arbitrary",
     "alloy-serde?/arbitrary",
 ]

--- a/crates/eips/src/eip1898.rs
+++ b/crates/eips/src/eip1898.rs
@@ -1,7 +1,5 @@
 //! [EIP-1898]: https://eips.ethereum.org/EIPS/eip-1898
 
-#![allow(unknown_lints, non_local_definitions)] // TODO: remove when proptest-derive updates
-
 use alloy_primitives::{hex::FromHexError, ruint::ParseError, BlockHash, BlockNumber, B256, U64};
 use alloy_rlp::{bytes, Decodable, Encodable, Error as RlpError};
 use core::{
@@ -618,7 +616,7 @@ impl From<(BlockHash, BlockNumber)> for BlockNumHash {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     any(test, feature = "arbitrary"),
-    derive(proptest_derive::Arbitrary, arbitrary::Arbitrary)
+    derive(arbitrary::Arbitrary)
 )]
 pub enum BlockHashOrNumber {
     /// A block hash

--- a/crates/eips/src/eip1898.rs
+++ b/crates/eips/src/eip1898.rs
@@ -614,10 +614,7 @@ impl From<(BlockHash, BlockNumber)> for BlockNumHash {
 /// Either a block hash _or_ a block number
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(
-    any(test, feature = "arbitrary"),
-    derive(arbitrary::Arbitrary)
-)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
 pub enum BlockHashOrNumber {
     /// A block hash
     Hash(B256),

--- a/crates/eips/src/eip2930.rs
+++ b/crates/eips/src/eip2930.rs
@@ -12,10 +12,7 @@ use core::{mem, ops::Deref};
 /// A list of addresses and storage keys that the transaction plans to access.
 /// Accesses outside the list are possible, but become more expensive.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash, RlpDecodable, RlpEncodable)]
-#[cfg_attr(
-    any(test, feature = "arbitrary"),
-    derive(arbitrary::Arbitrary)
-)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct AccessListItem {
@@ -37,14 +34,9 @@ impl AccessListItem {
 
 /// AccessList as defined in EIP-2930
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash, RlpDecodableWrapper, RlpEncodableWrapper)]
-#[cfg_attr(
-    any(test, feature = "arbitrary"),
-    derive(arbitrary::Arbitrary)
-)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct AccessList(
-    pub Vec<AccessListItem>,
-);
+pub struct AccessList(pub Vec<AccessListItem>);
 
 impl From<Vec<AccessListItem>> for AccessList {
     fn from(list: Vec<AccessListItem>) -> Self {

--- a/crates/eips/src/eip2930.rs
+++ b/crates/eips/src/eip2930.rs
@@ -2,8 +2,6 @@
 //!
 //! [EIP-2930]: https://eips.ethereum.org/EIPS/eip-2930
 
-#![allow(unknown_lints, non_local_definitions)] // TODO: remove when proptest-derive updates
-
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
@@ -16,7 +14,7 @@ use core::{mem, ops::Deref};
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash, RlpDecodable, RlpEncodable)]
 #[cfg_attr(
     any(test, feature = "arbitrary"),
-    derive(proptest_derive::Arbitrary, arbitrary::Arbitrary)
+    derive(arbitrary::Arbitrary)
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
@@ -24,12 +22,6 @@ pub struct AccessListItem {
     /// Account addresses that would be loaded at the start of execution
     pub address: Address,
     /// Keys of storage that would be loaded at the start of execution
-    #[cfg_attr(
-        any(test, feature = "arbitrary"),
-        proptest(
-            strategy = "proptest::collection::vec(proptest::arbitrary::any::<B256>(), 0..=20)"
-        )
-    )]
     // In JSON, we have to accept `null` for storage key, which is interpreted as an empty array.
     #[cfg_attr(feature = "serde", serde(deserialize_with = "alloy_serde::null_as_default"))]
     pub storage_keys: Vec<B256>,
@@ -47,16 +39,10 @@ impl AccessListItem {
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash, RlpDecodableWrapper, RlpEncodableWrapper)]
 #[cfg_attr(
     any(test, feature = "arbitrary"),
-    derive(proptest_derive::Arbitrary, arbitrary::Arbitrary)
+    derive(arbitrary::Arbitrary)
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AccessList(
-    #[cfg_attr(
-        any(test, feature = "arbitrary"),
-        proptest(
-            strategy = "proptest::collection::vec(proptest::arbitrary::any::<AccessListItem>(), 0..=20)"
-        )
-    )]
     pub Vec<AccessListItem>,
 );
 

--- a/crates/eips/src/eip4844/sidecar.rs
+++ b/crates/eips/src/eip4844/sidecar.rs
@@ -1,7 +1,5 @@
 //! EIP-4844 sidecar type
 
-#![allow(unknown_lints, non_local_definitions)] // TODO: remove when proptest-derive updates
-
 use crate::eip4844::{
     kzg_to_versioned_hash, Blob, Bytes48, BYTES_PER_BLOB, BYTES_PER_COMMITMENT, BYTES_PER_PROOF,
 };
@@ -20,7 +18,6 @@ use alloc::vec::Vec;
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
 #[repr(C)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(any(test, feature = "arbitrary"), derive(proptest_derive::Arbitrary))]
 #[doc(alias = "BlobTxSidecar")]
 pub struct BlobTransactionSidecar {
     /// The blob data.

--- a/crates/eips/src/eip4895.rs
+++ b/crates/eips/src/eip4895.rs
@@ -2,8 +2,6 @@
 //!
 //! [EIP-4895]: https://eips.ethereum.org/EIPS/eip-4895
 
-#![allow(unknown_lints, non_local_definitions)] // TODO: remove when proptest-derive updates
-
 use alloy_primitives::{Address, U256};
 use alloy_rlp::{RlpDecodable, RlpEncodable};
 
@@ -14,7 +12,7 @@ pub const GWEI_TO_WEI: u64 = 1_000_000_000;
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, RlpEncodable, RlpDecodable)]
 #[cfg_attr(
     any(test, feature = "arbitrary"),
-    derive(proptest_derive::Arbitrary, arbitrary::Arbitrary)
+    derive(arbitrary::Arbitrary)
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "ssz", derive(ssz_derive::Encode, ssz_derive::Decode))]

--- a/crates/eips/src/eip4895.rs
+++ b/crates/eips/src/eip4895.rs
@@ -10,10 +10,7 @@ pub const GWEI_TO_WEI: u64 = 1_000_000_000;
 
 /// Withdrawal represents a validator withdrawal from the consensus layer.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, RlpEncodable, RlpDecodable)]
-#[cfg_attr(
-    any(test, feature = "arbitrary"),
-    derive(arbitrary::Arbitrary)
-)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "ssz", derive(ssz_derive::Encode, ssz_derive::Decode))]
 pub struct Withdrawal {

--- a/crates/eips/src/eip6110.rs
+++ b/crates/eips/src/eip6110.rs
@@ -4,8 +4,6 @@
 //!
 //! Provides validator deposits as a list of deposit operations added to the Execution Layer block.
 
-#![allow(unknown_lints, non_local_definitions)] // TODO: remove when proptest-derive updates
-
 use alloy_primitives::{address, Address, FixedBytes, B256};
 use alloy_rlp::{RlpDecodable, RlpEncodable};
 
@@ -20,7 +18,7 @@ pub const MAINNET_DEPOSIT_CONTRACT_ADDRESS: Address =
 #[cfg_attr(feature = "ssz", derive(ssz_derive::Encode, ssz_derive::Decode))]
 #[cfg_attr(
     any(test, feature = "arbitrary"),
-    derive(proptest_derive::Arbitrary, arbitrary::Arbitrary)
+    derive(arbitrary::Arbitrary)
 )]
 pub struct DepositRequest {
     /// Validator public key

--- a/crates/eips/src/eip6110.rs
+++ b/crates/eips/src/eip6110.rs
@@ -16,10 +16,7 @@ pub const MAINNET_DEPOSIT_CONTRACT_ADDRESS: Address =
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ssz", derive(ssz_derive::Encode, ssz_derive::Decode))]
-#[cfg_attr(
-    any(test, feature = "arbitrary"),
-    derive(arbitrary::Arbitrary)
-)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
 pub struct DepositRequest {
     /// Validator public key
     pub pubkey: FixedBytes<48>,

--- a/crates/eips/src/eip7002.rs
+++ b/crates/eips/src/eip7002.rs
@@ -2,8 +2,6 @@
 //!
 //! See also [EIP-7002](https://eips.ethereum.org/EIPS/eip-7002): Execution layer triggerable withdrawals
 
-#![allow(unknown_lints, non_local_definitions)] // TODO: remove when proptest-derive updates
-
 use alloy_primitives::{address, bytes, Address, Bytes, FixedBytes};
 use alloy_rlp::{RlpDecodable, RlpEncodable};
 
@@ -29,7 +27,7 @@ pub const WITHDRAWAL_REQUEST_TYPE: u8 = 0x01;
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(
     any(test, feature = "arbitrary"),
-    derive(proptest_derive::Arbitrary, arbitrary::Arbitrary)
+    derive(arbitrary::Arbitrary)
 )]
 pub struct WithdrawalRequest {
     /// Address of the source of the exit.

--- a/crates/eips/src/eip7002.rs
+++ b/crates/eips/src/eip7002.rs
@@ -25,10 +25,7 @@ pub const WITHDRAWAL_REQUEST_TYPE: u8 = 0x01;
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, RlpEncodable, RlpDecodable, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
-#[cfg_attr(
-    any(test, feature = "arbitrary"),
-    derive(arbitrary::Arbitrary)
-)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
 pub struct WithdrawalRequest {
     /// Address of the source of the exit.
     pub source_address: Address,

--- a/crates/eips/src/eip7251.rs
+++ b/crates/eips/src/eip7251.rs
@@ -2,8 +2,6 @@
 //!
 //! See also [EIP-7251](https://eips.ethereum.org/EIPS/eip-7251): Increase the MAX_EFFECTIVE_BALANCE
 
-#![allow(unknown_lints, non_local_definitions)] // TODO: remove when proptest-derive updates
-
 use alloy_primitives::{address, bytes, Address, Bytes, FixedBytes};
 use alloy_rlp::{RlpDecodable, RlpEncodable};
 
@@ -25,7 +23,7 @@ pub const CONSOLIDATION_REQUEST_TYPE: u8 = 0x02;
 #[cfg_attr(feature = "ssz", derive(ssz_derive::Encode, ssz_derive::Decode))]
 #[cfg_attr(
     any(test, feature = "arbitrary"),
-    derive(proptest_derive::Arbitrary, arbitrary::Arbitrary)
+    derive(arbitrary::Arbitrary)
 )]
 pub struct ConsolidationRequest {
     /// Source address

--- a/crates/eips/src/eip7251.rs
+++ b/crates/eips/src/eip7251.rs
@@ -21,10 +21,7 @@ pub const CONSOLIDATION_REQUEST_TYPE: u8 = 0x02;
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "ssz", derive(ssz_derive::Encode, ssz_derive::Decode))]
-#[cfg_attr(
-    any(test, feature = "arbitrary"),
-    derive(arbitrary::Arbitrary)
-)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
 pub struct ConsolidationRequest {
     /// Source address
     pub source_address: Address,

--- a/crates/eips/src/eip7702/auth_list.rs
+++ b/crates/eips/src/eip7702/auth_list.rs
@@ -15,7 +15,7 @@ use core::hash::{Hash, Hasher};
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(
     any(test, feature = "arbitrary"),
-    derive(proptest_derive::Arbitrary, arbitrary::Arbitrary)
+    derive(arbitrary::Arbitrary)
 )]
 pub struct Authorization {
     /// The chain ID of the authorization.
@@ -235,7 +235,7 @@ impl Deref for RecoveredAuthorization {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     any(test, feature = "arbitrary"),
-    derive(proptest_derive::Arbitrary, arbitrary::Arbitrary)
+    derive(arbitrary::Arbitrary)
 )]
 pub struct OptionalNonce(Option<u64>);
 

--- a/crates/rpc-types-eth/Cargo.toml
+++ b/crates/rpc-types-eth/Cargo.toml
@@ -33,8 +33,6 @@ thiserror.workspace = true
 
 # arbitrary
 arbitrary = { version = "1.3", features = ["derive"], optional = true }
-proptest = { version = "1.4", optional = true }
-proptest-derive = { version = "0.4", optional = true }
 
 # jsonrpsee
 jsonrpsee-types = { version = "0.23", optional = true }
@@ -50,16 +48,12 @@ alloy-primitives = { workspace = true, features = [
 alloy-consensus = { workspace = true, features = ["std", "arbitrary"] }
 
 arbitrary = { workspace = true, features = ["derive"] }
-proptest.workspace = true
-proptest-derive.workspace = true
 rand.workspace = true
 similar-asserts.workspace = true
 
 [features]
 arbitrary = [
     "dep:arbitrary",
-    "dep:proptest-derive",
-    "dep:proptest",
     "alloy-primitives/arbitrary",
     "alloy-serde/arbitrary",
     "alloy-eips/arbitrary",

--- a/crates/rpc-types-eth/src/log.rs
+++ b/crates/rpc-types-eth/src/log.rs
@@ -1,5 +1,3 @@
-#![allow(unknown_lints, non_local_definitions)] // TODO: remove when proptest-derive updates
-
 use alloy_primitives::{Address, BlockHash, LogData, TxHash, B256};
 use serde::{Deserialize, Serialize};
 
@@ -7,7 +5,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(
     any(test, feature = "arbitrary"),
-    derive(proptest_derive::Arbitrary, arbitrary::Arbitrary)
+    derive(arbitrary::Arbitrary)
 )]
 #[serde(rename_all = "camelCase")]
 pub struct Log<T = LogData> {

--- a/crates/rpc-types-eth/src/log.rs
+++ b/crates/rpc-types-eth/src/log.rs
@@ -3,10 +3,7 @@ use serde::{Deserialize, Serialize};
 
 /// Ethereum Log emitted by a transaction
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[cfg_attr(
-    any(test, feature = "arbitrary"),
-    derive(arbitrary::Arbitrary)
-)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
 #[serde(rename_all = "camelCase")]
 pub struct Log<T = LogData> {
     #[serde(flatten)]

--- a/crates/rpc-types-eth/src/transaction/receipt.rs
+++ b/crates/rpc-types-eth/src/transaction/receipt.rs
@@ -1,5 +1,3 @@
-#![allow(unknown_lints, non_local_definitions)] // TODO: remove when proptest-derive updates
-
 use crate::Log;
 use alloy_consensus::{AnyReceiptEnvelope, ReceiptEnvelope, TxType};
 use alloy_primitives::{Address, BlockHash, TxHash, B256};
@@ -13,7 +11,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(
     any(test, feature = "arbitrary"),
-    derive(proptest_derive::Arbitrary, arbitrary::Arbitrary)
+    derive(arbitrary::Arbitrary)
 )]
 #[serde(rename_all = "camelCase")]
 #[doc(alias = "TxReceipt")]

--- a/crates/rpc-types-eth/src/transaction/receipt.rs
+++ b/crates/rpc-types-eth/src/transaction/receipt.rs
@@ -9,10 +9,7 @@ use serde::{Deserialize, Serialize};
 /// This type is generic over an inner [`ReceiptEnvelope`] which contains
 /// consensus data and metadata.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(
-    any(test, feature = "arbitrary"),
-    derive(arbitrary::Arbitrary)
-)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
 #[serde(rename_all = "camelCase")]
 #[doc(alias = "TxReceipt")]
 pub struct TransactionReceipt<T = ReceiptEnvelope<Log>> {

--- a/crates/rpc-types-trace/Cargo.toml
+++ b/crates/rpc-types-trace/Cargo.toml
@@ -36,7 +36,5 @@ alloy-primitives = { workspace = true, features = [
 ] }
 
 arbitrary = { workspace = true, features = ["derive"] }
-proptest.workspace = true
-proptest-derive.workspace = true
 rand.workspace = true
 similar-asserts.workspace = true

--- a/crates/serde/Cargo.toml
+++ b/crates/serde/Cargo.toml
@@ -25,7 +25,6 @@ serde_json = { workspace = true, features = ["alloc"] }
 
 # arbitrary
 arbitrary = { version = "1.3", features = ["derive"], optional = true }
-proptest = { version = "1.4", optional = true }
 
 [dev-dependencies]
 alloy-primitives = { workspace = true, features = [
@@ -36,7 +35,6 @@ alloy-primitives = { workspace = true, features = [
 ] }
 
 arbitrary = { workspace = true, features = ["derive"] }
-proptest.workspace = true
 rand.workspace = true
 
 [features]
@@ -44,7 +42,6 @@ default = ["std"]
 std = ["alloy-primitives/std", "serde/std", "serde_json/std"]
 arbitrary = [
     "dep:arbitrary",
-    "dep:proptest",
     "alloy-primitives/arbitrary",
     "std",
 ]

--- a/crates/serde/Cargo.toml
+++ b/crates/serde/Cargo.toml
@@ -26,7 +26,6 @@ serde_json = { workspace = true, features = ["alloc"] }
 # arbitrary
 arbitrary = { version = "1.3", features = ["derive"], optional = true }
 proptest = { version = "1.4", optional = true }
-proptest-derive = { version = "0.4", optional = true }
 
 [dev-dependencies]
 alloy-primitives = { workspace = true, features = [
@@ -38,7 +37,6 @@ alloy-primitives = { workspace = true, features = [
 
 arbitrary = { workspace = true, features = ["derive"] }
 proptest.workspace = true
-proptest-derive.workspace = true
 rand.workspace = true
 
 [features]
@@ -46,7 +44,6 @@ default = ["std"]
 std = ["alloy-primitives/std", "serde/std", "serde_json/std"]
 arbitrary = [
     "dep:arbitrary",
-    "dep:proptest-derive",
     "dep:proptest",
     "alloy-primitives/arbitrary",
     "std",

--- a/crates/serde/src/other/arbitrary_.rs
+++ b/crates/serde/src/other/arbitrary_.rs
@@ -17,7 +17,7 @@ impl arbitrary::Arbitrary<'_> for OtherFields {
 /// Redefinition of `serde_json::Value` for the purpose of implementing `Arbitrary`.
 #[derive(Clone, Debug, arbitrary::Arbitrary)]
 #[allow(unnameable_types)]
-pub enum ArbitraryValue {
+enum ArbitraryValue {
     Null,
     Bool(bool),
     Number(u64),

--- a/crates/serde/src/other/arbitrary_.rs
+++ b/crates/serde/src/other/arbitrary_.rs
@@ -1,10 +1,5 @@
 use crate::OtherFields;
 use alloc::collections::BTreeMap;
-use proptest::{
-    arbitrary::any,
-    prop_oneof,
-    strategy::{BoxedStrategy, Just, Strategy},
-};
 
 #[cfg(not(feature = "std"))]
 use alloc::{string::String, vec::Vec};
@@ -19,22 +14,6 @@ impl arbitrary::Arbitrary<'_> for OtherFields {
     }
 }
 
-impl proptest::arbitrary::Arbitrary for OtherFields {
-    type Parameters = ();
-    type Strategy = proptest::strategy::Map<
-        proptest::collection::VecStrategy<(
-            <String as proptest::arbitrary::Arbitrary>::Strategy,
-            <ArbitraryValue as proptest::arbitrary::Arbitrary>::Strategy,
-        )>,
-        fn(Vec<(String, ArbitraryValue)>) -> Self,
-    >;
-
-    fn arbitrary_with((): Self::Parameters) -> Self::Strategy {
-        proptest::collection::vec(any::<(String, ArbitraryValue)>(), 0..16)
-            .prop_map(|map| map.into_iter().map(|(k, v)| (k, v.into_json_value())).collect())
-    }
-}
-
 /// Redefinition of `serde_json::Value` for the purpose of implementing `Arbitrary`.
 #[derive(Clone, Debug, arbitrary::Arbitrary)]
 #[allow(unnameable_types)]
@@ -45,27 +24,6 @@ pub enum ArbitraryValue {
     String(String),
     Array(Vec<ArbitraryValue>),
     Object(BTreeMap<String, ArbitraryValue>),
-}
-
-impl proptest::arbitrary::Arbitrary for ArbitraryValue {
-    type Parameters = ();
-    type Strategy = BoxedStrategy<Self>;
-
-    fn arbitrary_with((): Self::Parameters) -> Self::Strategy {
-        prop_oneof![
-            Just(Self::Null),
-            any::<bool>().prop_map(Self::Bool),
-            any::<u64>().prop_map(Self::Number),
-            any::<String>().prop_map(Self::String),
-        ]
-        .prop_recursive(4, 64, 16, |this| {
-            prop_oneof![
-                1 => proptest::collection::vec(this.clone(), 0..16).prop_map(Self::Array),
-                1 => proptest::collection::btree_map(any::<String>(), this, 0..16).prop_map(Self::Object),
-            ]
-        })
-        .boxed()
-    }
 }
 
 impl ArbitraryValue {
@@ -83,16 +41,4 @@ impl ArbitraryValue {
             ),
         }
     }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    proptest::proptest!(
-        #[test]
-        fn test_arbitrary_value(value in any::<ArbitraryValue>()) {
-            let _json_value = value.into_json_value();
-        }
-    );
 }

--- a/crates/serde/src/other/mod.rs
+++ b/crates/serde/src/other/mod.rs
@@ -1,7 +1,5 @@
 //! Support for capturing other fields.
 
-#![allow(unknown_lints, non_local_definitions)] // TODO: remove when proptest-derive updates
-
 use alloc::collections::BTreeMap;
 use core::{
     fmt,
@@ -170,10 +168,7 @@ impl<'a> IntoIterator for &'a OtherFields {
 ///
 /// See [`OtherFields`] for more information.
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize)]
-#[cfg_attr(
-    any(test, feature = "arbitrary"),
-    derive(proptest_derive::Arbitrary, arbitrary::Arbitrary)
-)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
 pub struct WithOtherFields<T> {
     /// The inner struct.
     #[serde(flatten)]


### PR DESCRIPTION
## Motivation
This was only required because reth required these types to implement `proptest::Arbitrary`. This is no longer the case, and `arbitrary::Arbitrary` is already usable.

## Solution

Remove ~~almost~~ all proptest derives, remove unused proptest dependencies.

~~There is a single `proptest!` left, which is for other fields, would like to know whether that's necessary or not.~~

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
