### PR TITLE
feat(alloy): forward `rustls` & `native` reqwest TLS configuration to Alloy's metacrate

### DIFF
--- a/crates/alloy/Cargo.toml
+++ b/crates/alloy/Cargo.toml
@@ -65,7 +65,7 @@ hyper = { workspace = true, optional = true }
 # ----------------------------------------- Configuration ---------------------------------------- #
 
 [features]
-default = ["std", "reqwest", "reqwest-default-tls"]
+default = ["std", "reqwest-default-tls"]
 
 # std
 std = [

--- a/crates/alloy/Cargo.toml
+++ b/crates/alloy/Cargo.toml
@@ -65,7 +65,7 @@ hyper = { workspace = true, optional = true }
 # ----------------------------------------- Configuration ---------------------------------------- #
 
 [features]
-default = ["std", "reqwest-default-tls"]
+default = ["std", "reqwest"]
 
 # std
 std = [
@@ -97,10 +97,22 @@ reqwest = [
     "alloy-rpc-client?/reqwest",
     "alloy-provider?/reqwest",
     "alloy-transport-http?/reqwest",
+    "alloy-transport-http?/reqwest-default-tls",
 ]
-reqwest-default-tls = ["reqwest", "alloy-transport-http?/reqwest-default-tls"]
-reqwest-rustls-tls = ["reqwest", "alloy-transport-http?/reqwest-rustls-tls"]
-reqwest-native-tls = ["reqwest", "alloy-transport-http?/reqwest-native-tls"]
+reqwest-rustls-tls = [
+    "dep:reqwest",
+    "alloy-rpc-client?/reqwest",
+    "alloy-provider?/reqwest",
+    "alloy-transport-http?/reqwest",
+    "alloy-transport-http?/reqwest-rustls-tls",
+]
+reqwest-native-tls = [
+    "dep:reqwest",
+    "alloy-rpc-client?/reqwest",
+    "alloy-provider?/reqwest",
+    "alloy-transport-http?/reqwest",
+    "alloy-transport-http?/reqwest-native-tls",
+]
 hyper = [
     "dep:hyper",
     "alloy-rpc-client?/hyper",

--- a/crates/alloy/Cargo.toml
+++ b/crates/alloy/Cargo.toml
@@ -98,9 +98,9 @@ reqwest = [
     "alloy-provider?/reqwest",
     "alloy-transport-http?/reqwest",
 ]
-reqwest-default-tls = ["alloy-transport-http?/reqwest-default-tls"]
-reqwest-rustls-tls = ["alloy-transport-http?/reqwest-rustls-tls"]
-reqwest-native-tls = ["alloy-transport-http?/reqwest-native-tls"]
+reqwest-default-tls = ["reqwest", "alloy-transport-http?/reqwest-default-tls"]
+reqwest-rustls-tls = ["reqwest", "alloy-transport-http?/reqwest-rustls-tls"]
+reqwest-native-tls = ["reqwest", "alloy-transport-http?/reqwest-native-tls"]
 hyper = [
     "dep:hyper",
     "alloy-rpc-client?/hyper",
@@ -131,7 +131,6 @@ providers = ["dep:alloy-provider", "rpc-client", "eips"]
 provider-http = ["providers", "transport-http"]
 provider-ws = ["providers", "alloy-provider?/ws", "transport-ws"]
 provider-ipc = ["providers", "alloy-provider?/ipc", "transport-ipc"]
-
 provider-admin-api = [
     "providers",
     "alloy-provider?/admin-api",
@@ -162,7 +161,6 @@ provider-txpool-api = [
     "alloy-provider?/txpool-api",
     "rpc-types-txpool",
 ]
-
 provider-anvil-node = [
     "providers",
     "provider-anvil-api",

--- a/crates/alloy/Cargo.toml
+++ b/crates/alloy/Cargo.toml
@@ -65,7 +65,7 @@ hyper = { workspace = true, optional = true }
 # ----------------------------------------- Configuration ---------------------------------------- #
 
 [features]
-default = ["std", "reqwest"]
+default = ["std", "reqwest", "reqwest-default-tls"]
 
 # std
 std = [
@@ -97,8 +97,10 @@ reqwest = [
     "alloy-rpc-client?/reqwest",
     "alloy-provider?/reqwest",
     "alloy-transport-http?/reqwest",
-    "alloy-transport-http?/reqwest-default-tls",
 ]
+reqwest-default-tls = ["alloy-transport-http?/reqwest-default-tls"]
+reqwest-rustls-tls = ["alloy-transport-http?/reqwest-rustls-tls"]
+reqwest-native-tls = ["alloy-transport-http?/reqwest-native-tls"]
 hyper = [
     "dep:hyper",
     "alloy-rpc-client?/hyper",


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Closes #965 

In support of the suggested feature as people often express their preference for one over the other

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Avoids introducing breaking changes, adds two new flags: `reqwest-rustls-tls` and `reqwest-native-tls`

If a breaking change were permitted I would add the flag like this: 
https://github.com/alloy-rs/alloy/blob/7c1df0fc4a5aafa5d3cceedc58d103ae04047a3a/crates/alloy/Cargo.toml#L67-L103

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
