### PR TITLE
feat: impl `From<RpcBlockHash>` for `BlockHashOrNumber`

### DIFF
--- a/crates/eips/src/eip1898.rs
+++ b/crates/eips/src/eip1898.rs
@@ -658,6 +658,12 @@ impl From<U64> for BlockHashOrNumber {
     }
 }
 
+impl From<RpcBlockHash> for BlockHashOrNumber {
+    fn from(value: RpcBlockHash) -> Self {
+        Self::Hash(value.into())
+    }
+}
+
 /// Allows for RLP encoding of either a block hash or block number
 impl Encodable for BlockHashOrNumber {
     fn encode(&self, out: &mut dyn bytes::BufMut) {


### PR DESCRIPTION
Useful to switch between `BlockHashOrNumber` hash and `BlockId` hash.