### PR TITLE
Allow to convert CallBuilderTo TransactionRequest

### DIFF
--- a/crates/contract/src/call.rs
+++ b/crates/contract/src/call.rs
@@ -131,6 +131,13 @@ pub struct CallBuilder<T, P, D, N: Network = Ethereum> {
     transport: PhantomData<T>,
 }
 
+impl<T, P, D, N: Network> CallBuilder<T, P, D, N> {
+    /// Converts the call builder to the inner transaction request
+    pub fn into_transaction_request(self) -> N::TransactionRequest {
+        self.request
+    }
+}
+
 impl<T, P, D, N: Network> AsRef<N::TransactionRequest> for CallBuilder<T, P, D, N> {
     fn as_ref(&self) -> &N::TransactionRequest {
         &self.request


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Sometimes we don't want to `send()` a transaction created with `CallBuilder`, but instead convert it to `TransactionRequest`, in order to later include it in a bundle.

`CallBuilder::as_ref()` could be used, but it would require to clone the resulting `&TransactionRequest` to call `FillProvider::fill()`.

## Solution

Adding `into_transaction_request()` to `CallBuilder`.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes

Cc @igorline