### PR TITLE
feat: add missing debug_* rpc methods

### DIFF
--- a/crates/provider/src/ext/debug.rs
+++ b/crates/provider/src/ext/debug.rs
@@ -1,7 +1,7 @@
 //! This module extends the Ethereum JSON-RPC provider with the Debug namespace's RPC methods.
 use crate::Provider;
 use alloy_network::Network;
-use alloy_primitives::{Bytes, TxHash, B256};
+use alloy_primitives::{hex, Bytes, TxHash, B256};
 use alloy_rpc_types_eth::{Block, BlockNumberOrTag, TransactionRequest};
 use alloy_rpc_types_trace::geth::{
     BlockTraceResult, GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace, TraceResult,
@@ -169,6 +169,7 @@ where
         rlp_block: &[u8],
         trace_options: GethDebugTracingOptions,
     ) -> TransportResult<Vec<TraceResult>> {
+        let rlp_block = hex::encode_prefixed(rlp_block);
         self.client().request("debug_traceBlock", (rlp_block, trace_options)).await
     }
 

--- a/crates/provider/src/ext/debug.rs
+++ b/crates/provider/src/ext/debug.rs
@@ -18,6 +18,9 @@ pub trait DebugApi<N, T>: Send + Sync {
     /// Retrieves and returns the RLP encoded block by number, hash or tag.
     async fn debug_get_raw_block(&self, block: BlockNumberOrTag) -> TransportResult<Bytes>;
 
+    /// Returns an EIP-2718 binary-encoded transaction..
+    async fn debug_get_raw_transaction(&self, hash: TxHash) -> TransportResult<Bytes>;
+
     /// Reruns the transaction specified by the hash and returns the trace.
     ///
     /// It will replay any prior transactions to achieve the same state the transaction was executed
@@ -111,6 +114,10 @@ where
 
     async fn debug_get_raw_block(&self, block: BlockNumberOrTag) -> TransportResult<Bytes> {
         self.client().request("debug_getRawBlock", (block,)).await
+    }
+
+    async fn debug_get_raw_transaction(&self, hash: TxHash) -> TransportResult<Bytes> {
+        self.client().request("debug_getRawTransaction", (hash,)).await
     }
 
     async fn debug_trace_transaction(
@@ -240,7 +247,7 @@ mod test {
 
         let block = BlockNumberOrTag::Latest;
         let rlp_block = provider
-            .debug_get_raw_header(block)
+            .debug_get_raw_block(block)
             .await
             .expect("debug_getRawBlock call should succeed");
 

--- a/crates/provider/src/ext/debug.rs
+++ b/crates/provider/src/ext/debug.rs
@@ -4,7 +4,7 @@ use alloy_network::Network;
 use alloy_primitives::{Bytes, TxHash, B256};
 use alloy_rpc_types_eth::{Block, BlockNumberOrTag, TransactionRequest};
 use alloy_rpc_types_trace::geth::{
-    GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace, TraceResult,
+    BlockTraceResult, GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace, TraceResult,
 };
 use alloy_transport::{Transport, TransportResult};
 
@@ -26,6 +26,13 @@ pub trait DebugApi<N, T>: Send + Sync {
 
     /// Returns an array of recent bad blocks that the client has seen on the network.
     async fn debug_get_bad_blocks(&self) -> TransportResult<Vec<Block>>;
+
+    /// Returns the structured logs created during the execution of EVM between two blocks (excluding start) as a JSON object.
+    async fn debug_trace_chain(
+        &self,
+        start_exclusive: BlockNumberOrTag,
+        end_inclusive: BlockNumberOrTag,
+    ) -> TransportResult<Vec<BlockTraceResult>>;
 
     /// Reruns the transaction specified by the hash and returns the trace.
     ///
@@ -132,6 +139,14 @@ where
 
     async fn debug_get_bad_blocks(&self) -> TransportResult<Vec<Block>> {
         self.client().request("debug_getBadBlocks", ()).await
+    }
+
+    async fn debug_trace_chain(
+        &self,
+        start_exclusive: BlockNumberOrTag,
+        end_inclusive: BlockNumberOrTag,
+    ) -> TransportResult<Vec<BlockTraceResult>> {
+        self.client().request("debug_traceChain", (start_exclusive, end_inclusive)).await
     }
 
     async fn debug_trace_transaction(

--- a/crates/provider/src/ext/debug.rs
+++ b/crates/provider/src/ext/debug.rs
@@ -27,14 +27,16 @@ pub trait DebugApi<N, T>: Send + Sync {
     /// Returns an array of recent bad blocks that the client has seen on the network.
     async fn debug_get_bad_blocks(&self) -> TransportResult<Vec<Block>>;
 
-    /// Returns the structured logs created during the execution of EVM between two blocks (excluding start) as a JSON object.
+    /// Returns the structured logs created during the execution of EVM between two blocks
+    /// (excluding start) as a JSON object.
     async fn debug_trace_chain(
         &self,
         start_exclusive: BlockNumberOrTag,
         end_inclusive: BlockNumberOrTag,
     ) -> TransportResult<Vec<BlockTraceResult>>;
 
-    /// The debug_traceBlock method will return a full stack trace of all invoked opcodes of all transaction that were included in this block.
+    /// The debug_traceBlock method will return a full stack trace of all invoked opcodes of all
+    /// transaction that were included in this block.
     ///
     /// This expects an RLP-encoded block.
     ///

--- a/crates/provider/src/ext/debug.rs
+++ b/crates/provider/src/ext/debug.rs
@@ -34,6 +34,19 @@ pub trait DebugApi<N, T>: Send + Sync {
         end_inclusive: BlockNumberOrTag,
     ) -> TransportResult<Vec<BlockTraceResult>>;
 
+    /// The debug_traceBlock method will return a full stack trace of all invoked opcodes of all transaction that were included in this block.
+    ///
+    /// This expects an RLP-encoded block.
+    ///
+    /// # Note
+    ///
+    /// The parent of this block must be present, or it will fail.
+    async fn debug_trace_block(
+        &self,
+        rlp_block: &[u8],
+        trace_options: GethDebugTracingOptions,
+    ) -> TransportResult<Vec<TraceResult>>;
+
     /// Reruns the transaction specified by the hash and returns the trace.
     ///
     /// It will replay any prior transactions to achieve the same state the transaction was executed
@@ -147,6 +160,14 @@ where
         end_inclusive: BlockNumberOrTag,
     ) -> TransportResult<Vec<BlockTraceResult>> {
         self.client().request("debug_traceChain", (start_exclusive, end_inclusive)).await
+    }
+
+    async fn debug_trace_block(
+        &self,
+        rlp_block: &[u8],
+        trace_options: GethDebugTracingOptions,
+    ) -> TransportResult<Vec<TraceResult>> {
+        self.client().request("debug_traceBlock", (rlp_block, trace_options)).await
     }
 
     async fn debug_trace_transaction(

--- a/crates/provider/src/ext/debug.rs
+++ b/crates/provider/src/ext/debug.rs
@@ -18,8 +18,11 @@ pub trait DebugApi<N, T>: Send + Sync {
     /// Retrieves and returns the RLP encoded block by number, hash or tag.
     async fn debug_get_raw_block(&self, block: BlockNumberOrTag) -> TransportResult<Bytes>;
 
-    /// Returns an EIP-2718 binary-encoded transaction..
+    /// Returns an EIP-2718 binary-encoded transaction.
     async fn debug_get_raw_transaction(&self, hash: TxHash) -> TransportResult<Bytes>;
+
+    /// Returns an array of EIP-2718 binary-encoded receipts.
+    async fn debug_get_raw_receipts(&self, block: BlockNumberOrTag) -> TransportResult<Vec<Bytes>>;
 
     /// Reruns the transaction specified by the hash and returns the trace.
     ///
@@ -118,6 +121,10 @@ where
 
     async fn debug_get_raw_transaction(&self, hash: TxHash) -> TransportResult<Bytes> {
         self.client().request("debug_getRawTransaction", (hash,)).await
+    }
+
+    async fn debug_get_raw_receipts(&self, block: BlockNumberOrTag) -> TransportResult<Vec<Bytes>> {
+        self.client().request("debug_getRawReceipts", (block,)).await
     }
 
     async fn debug_trace_transaction(


### PR DESCRIPTION
## Motivation

Adds the missing `debug_*` methods in https://github.com/alloy-rs/alloy/issues/926

Note that even though the issue says that we want to achieve full compatibility with reth, some of these methods are not implemented, like [`debug_getBadBlocks`](https://github.com/paradigmxyz/reth/blob/5416adf97b8e333c9a04ed9f3a18cdffd1a4f5f2/crates/rpc/rpc/src/debug.rs#L713).

Also note that the tests are dummies because:

- Proper tests should probably live in the node implementations. 
- These methods are not supported by anvil.

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
