### PR TITLE
feat: Add trace_get

### DIFF
--- a/crates/provider/src/ext/trace.rs
+++ b/crates/provider/src/ext/trace.rs
@@ -52,10 +52,10 @@ where
     ) -> TransportResult<Vec<LocalizedTransactionTrace>>;
 
     /// Traces of the transaction on the given positions
-    /// 
+    ///
     /// # Note
-    /// 
-    /// This function accepts single index and build list with it under the hood because 
+    ///
+    /// This function accepts single index and build list with it under the hood because
     /// trace_get method accepts list of indices but limits this list to len == 1.
     async fn trace_get(
         &self,

--- a/crates/provider/src/ext/trace.rs
+++ b/crates/provider/src/ext/trace.rs
@@ -50,6 +50,13 @@ where
         hash: TxHash,
     ) -> TransportResult<Vec<LocalizedTransactionTrace>>;
 
+    /// Traces of the transaction on the given positions
+    async fn trace_get(
+        &self,
+        hash: TxHash,
+        index: u64,
+    ) -> TransportResult<LocalizedTransactionTrace>;
+
     /// Trace the given raw transaction.
     async fn trace_raw_transaction(
         &self,
@@ -117,6 +124,15 @@ where
         hash: TxHash,
     ) -> TransportResult<Vec<LocalizedTransactionTrace>> {
         self.client().request("trace_transaction", (hash,)).await
+    }
+
+    async fn trace_get(
+        &self,
+        hash: TxHash,
+        index: u64,
+    ) -> TransportResult<LocalizedTransactionTrace> {
+        // We are using vec![indices] because API accepts a list, but in fact works only if list.len == 1
+        self.client().request("trace_get", (hash, vec![index])).await
     }
 
     async fn trace_raw_transaction(

--- a/crates/provider/src/ext/trace.rs
+++ b/crates/provider/src/ext/trace.rs
@@ -137,7 +137,7 @@ where
         hash: TxHash,
         index: usize,
     ) -> TransportResult<LocalizedTransactionTrace> {
-        // We are using vec![indices] because API accepts a list, but in fact works only if list.len == 1
+        // We are using `[index]` because API accepts a list, but only supports a single index
         self.client().request("trace_get", (hash, (Index::from(index),))).await
     }
 

--- a/crates/provider/src/ext/trace.rs
+++ b/crates/provider/src/ext/trace.rs
@@ -3,6 +3,7 @@ use crate::{Provider, RpcWithBlock};
 use alloy_eips::BlockNumberOrTag;
 use alloy_network::Network;
 use alloy_primitives::TxHash;
+use alloy_rpc_types_eth::Index;
 use alloy_rpc_types_trace::{
     filter::TraceFilter,
     parity::{LocalizedTransactionTrace, TraceResults, TraceResultsWithTransactionHash, TraceType},
@@ -51,10 +52,15 @@ where
     ) -> TransportResult<Vec<LocalizedTransactionTrace>>;
 
     /// Traces of the transaction on the given positions
+    /// 
+    /// # Note
+    /// 
+    /// This function accepts single index and build list with it under the hood because 
+    /// trace_get method accepts list of indices but limits this list to len == 1.
     async fn trace_get(
         &self,
         hash: TxHash,
-        index: u64,
+        index: usize,
     ) -> TransportResult<LocalizedTransactionTrace>;
 
     /// Trace the given raw transaction.
@@ -129,10 +135,10 @@ where
     async fn trace_get(
         &self,
         hash: TxHash,
-        index: u64,
+        index: usize,
     ) -> TransportResult<LocalizedTransactionTrace> {
         // We are using vec![indices] because API accepts a list, but in fact works only if list.len == 1
-        self.client().request("trace_get", (hash, vec![index])).await
+        self.client().request("trace_get", (hash, (Index::from(index),))).await
     }
 
     async fn trace_raw_transaction(


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
Adds the missing trace_get method in https://github.com/alloy-rs/alloy/issues/926

## Problems
Currently trace_get returns null if queries with multiple indices (params example: "params":["0x346b152d421c095a2eab383d9c5d0309bb28c31e8c5b84fdc6a4f38e2194558d", ["0x0", "0x1"]]) https://github.com/paradigmxyz/reth/pull/3852

Because of this, i choose to use param `index` with type u64, to remove footgun.

## Solution
Usage example. Replace RETH_ENDPOINT with endpoint
```
use alloy_primitives::{b256};
use alloy_provider::{ext::TraceApi, ProviderBuilder};

#[tokio::main]
async fn main() {
    let url = String::from("RETH_ENDPOINT");
    let node_url = url::Url::parse(url.as_str()).unwrap();
    let provider = ProviderBuilder::new().on_http(node_url);


    let result = provider
        .trace_get(
            b256!("346b152d421c095a2eab383d9c5d0309bb28c31e8c5b84fdc6a4f38e2194558d"),
            1,
        )
        .await
        .unwrap();
    println!("{:#?}", result);
}
```
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
