### PR TITLE
fix: ots_getContractCreater has field hash instead of tx

### DIFF
--- a/crates/rpc-types-trace/src/otterscan.rs
+++ b/crates/rpc-types-trace/src/otterscan.rs
@@ -169,7 +169,7 @@ pub struct TransactionsWithReceipts {
 }
 
 /// Custom struct for otterscan `getContractCreator` RPC responses
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ContractCreator {
     /// The transaction used to create the contract.
     pub hash: TxHash,

--- a/crates/rpc-types-trace/src/otterscan.rs
+++ b/crates/rpc-types-trace/src/otterscan.rs
@@ -3,7 +3,7 @@
 //! <https://www.quicknode.com/docs/ethereum/ots_getBlockTransactions>
 //! <https://github.com/otterscan/otterscan/blob/develop/docs/custom-jsonrpc.md>
 
-use alloy_primitives::{Address, Bloom, Bytes, U256};
+use alloy_primitives::{Address, Bloom, Bytes, TxHash, U256};
 use alloy_rpc_types_eth::{Block, Rich, Transaction, TransactionReceipt};
 use serde::{Deserialize, Serialize};
 
@@ -172,8 +172,7 @@ pub struct TransactionsWithReceipts {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ContractCreator {
     /// The transaction used to create the contract.
-    #[doc(alias = "transaction")]
-    pub tx: Transaction,
+    pub hash: TxHash,
     /// The address of the contract creator.
     pub creator: Address,
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

the response of `ots_getContractCreator` from https://github.com/otterscan/otterscan/blob/develop/docs/custom-jsonrpc.md#ots_getcontractcreator as below:


> object containing the following attributes, or null if the address does not contain a contract.
hash - The tx hash of the transaction who created the contract.
creator - The address who directly created the contract. Note that for simple transactions that directly deploy a contract this corresponds to the EOA in the from field of the transaction. For deployer contracts, i.e., the contract is created as a result of a method call, this corresponds to the address of the contract who created it.

```json
{
  "jsonrpc": "2.0",
  "id": 1,
  "result": {
    "hash": "0xe881c43cd88063e84a1d0283f41ee5348239b259c0d17a7e2e4552da3f4b2bc7",
    "creator": "0x6c9fc64a53c1b71fb3f9af64d1ae3a4931a5f4e9"
  }
}
```

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [x] Breaking changes
