### PR TITLE
chore: clean up 7702 encoding

### DIFF
--- a/crates/eips/src/eip7702/auth_list.rs
+++ b/crates/eips/src/eip7702/auth_list.rs
@@ -51,17 +51,9 @@ impl Authorization {
     pub fn signature_hash(&self) -> B256 {
         use super::constants::MAGIC;
 
-        #[derive(RlpEncodable)]
-        struct Auth {
-            chain_id: ChainId,
-            nonce: OptionalNonce,
-            address: Address,
-        }
-
         let mut buf = Vec::new();
         buf.put_u8(MAGIC);
-
-        Auth { chain_id: self.chain_id, nonce: self.nonce, address: self.address }.encode(&mut buf);
+        self.encode(&mut buf);
 
         keccak256(buf)
     }


### PR DESCRIPTION
We've updated EIP-7702 to use the same RLP encoding order throughout the EIP, so the helper struct we have now is no longer necessary.

Ref https://github.com/ethereum/EIPs/pull/8679

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
