### PR TITLE
feat(network): block context in ReceiptResponse

### DIFF
--- a/crates/network/src/any/mod.rs
+++ b/crates/network/src/any/mod.rs
@@ -84,6 +84,14 @@ impl ReceiptResponse for AnyTransactionReceipt {
     fn status(&self) -> bool {
         self.inner.inner.status()
     }
+
+    fn block_hash(&self) -> Option<alloy_primitives::BlockHash> {
+        self.inner.block_hash
+    }
+
+    fn block_number(&self) -> Option<u64> {
+        self.inner.block_number
+    }
 }
 
 impl TransactionResponse for WithOtherFields<Transaction> {

--- a/crates/network/src/ethereum/mod.rs
+++ b/crates/network/src/ethereum/mod.rs
@@ -40,6 +40,14 @@ impl ReceiptResponse for alloy_rpc_types_eth::TransactionReceipt {
     fn status(&self) -> bool {
         self.inner.status()
     }
+
+    fn block_hash(&self) -> Option<alloy_primitives::BlockHash> {
+        self.block_hash
+    }
+
+    fn block_number(&self) -> Option<u64> {
+        self.block_number
+    }
 }
 
 impl TransactionResponse for alloy_rpc_types_eth::Transaction {

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -9,7 +9,7 @@
 use alloy_consensus::TxReceipt;
 use alloy_eips::eip2718::{Eip2718Envelope, Eip2718Error};
 use alloy_json_rpc::RpcObject;
-use alloy_primitives::{Address, Bytes, TxHash, U256};
+use alloy_primitives::{Address, BlockHash, Bytes, TxHash, U256};
 use core::fmt::{Debug, Display};
 
 mod transaction;
@@ -49,6 +49,12 @@ pub trait ReceiptResponse {
     /// [EIP-658]: https://eips.ethereum.org/EIPS/eip-658
     /// [`TxReceipt::status_or_post_state`]: alloy_consensus::TxReceipt::status_or_post_state
     fn status(&self) -> bool;
+
+    /// Hash of the block this transaction was included within.
+    fn block_hash(&self) -> Option<BlockHash>;
+
+    /// Number of the block this transaction was included within.
+    fn block_number(&self) -> Option<u64>;
 }
 
 /// Transaction Response


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Ref #1002 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Add `block_hash` and `block_number` to `ReceiptResponse`

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
