### PR TITLE
chore(docs): Add the missing crate `rpc-types-mev`

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ This repository contains the following crates:
   - [`alloy-rpc-types-beacon`] - Types for the [Ethereum Beacon Node API][beacon-apis]
   - [`alloy-rpc-types-engine`] - Types for the `engine` Ethereum JSON-RPC namespace
   - [`alloy-rpc-types-eth`] - Types for the `eth` Ethereum JSON-RPC namespace
-  - [`alloy-rpc-types-mev`] - Types for the MEV bundle JSON-RPC namespace.
+  - [`alloy-rpc-types-mev`] - Types for the MEV bundle JSON-RPC namespace
   - [`alloy-rpc-types-trace`] - Types for the `trace` Ethereum JSON-RPC namespace
   - [`alloy-rpc-types-txpool`] - Types for the `txpool` Ethereum JSON-RPC namespace
 - [`alloy-serde`] - [Serde]-related utilities

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ This repository contains the following crates:
   - [`alloy-rpc-types-beacon`] - Types for the [Ethereum Beacon Node API][beacon-apis]
   - [`alloy-rpc-types-engine`] - Types for the `engine` Ethereum JSON-RPC namespace
   - [`alloy-rpc-types-eth`] - Types for the `eth` Ethereum JSON-RPC namespace
+  - [`alloy-rpc-types-mev`] - Types for the MEV bundle JSON-RPC namespace.
   - [`alloy-rpc-types-trace`] - Types for the `trace` Ethereum JSON-RPC namespace
   - [`alloy-rpc-types-txpool`] - Types for the `txpool` Ethereum JSON-RPC namespace
 - [`alloy-serde`] - [Serde]-related utilities
@@ -86,6 +87,7 @@ This repository contains the following crates:
 [`alloy-rpc-types-beacon`]: https://github.com/alloy-rs/alloy/tree/main/crates/rpc-types-beacon
 [`alloy-rpc-types-engine`]: https://github.com/alloy-rs/alloy/tree/main/crates/rpc-types-engine
 [`alloy-rpc-types-eth`]: https://github.com/alloy-rs/alloy/tree/main/crates/rpc-types-eth
+[`alloy-rpc-types-mev`]: https://github.com/alloy-rs/alloy/tree/main/crates/rpc-types-mev
 [`alloy-rpc-types-trace`]: https://github.com/alloy-rs/alloy/tree/main/crates/rpc-types-trace
 [`alloy-rpc-types-txpool`]: https://github.com/alloy-rs/alloy/tree/main/crates/rpc-types-txpool
 [`alloy-serde`]: https://github.com/alloy-rs/alloy/tree/main/crates/serde


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
The `rpc-types-mev` crate is not listed in the crates list on the README

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
