### PR TITLE
feat: add helper to set both input and data fields

### DIFF
--- a/crates/rpc-types-eth/src/transaction/request.rs
+++ b/crates/rpc-types-eth/src/transaction/request.rs
@@ -503,9 +503,21 @@ impl TransactionInput {
         Self::maybe_input(Some(data))
     }
 
+    /// Creates a new instance with the given input data and sets both `input` and `data` fields to
+    /// the same value.
+    pub fn both(data: Bytes) -> Self {
+        Self::maybe_both(Some(data))
+    }
+
     /// Creates a new instance with the given input data.
     pub const fn maybe_input(input: Option<Bytes>) -> Self {
         Self { input, data: None }
+    }
+
+    /// Creates a new instance with the given input data and sets both `input` and `data` fields to
+    /// the same value.
+    pub fn maybe_both(input: Option<Bytes>) -> Self {
+        Self { data: input.clone(), input }
     }
 
     /// Consumes the type and returns the optional input data.


### PR DESCRIPTION
https://github.com/foundry-rs/foundry/issues/7764

some node impls still only accept the legacy data field...

this makes it easy to set both