### PR TITLE
fix: export stream types part of public api

### DIFF
--- a/crates/pubsub/src/lib.rs
+++ b/crates/pubsub/src/lib.rs
@@ -25,4 +25,7 @@ mod managers;
 mod service;
 
 mod sub;
-pub use sub::{RawSubscription, Subscription, SubscriptionItem};
+pub use sub::{
+    RawSubscription, SubAnyStream, SubResultStream, Subscription, SubscriptionItem,
+    SubscriptionStream,
+};


### PR DESCRIPTION
these types are part of public api but can't be imported.