### PR TITLE
fix(eip7702): Add correct rlp decode/encode

### DIFF
--- a/crates/consensus/src/transaction/eip2930.rs
+++ b/crates/consensus/src/transaction/eip2930.rs
@@ -206,7 +206,7 @@ impl TxEip2930 {
         let tx = Self::decode_fields(buf)?;
         let signature = Signature::decode_rlp_vrs(buf)?;
 
-        let signed = tx.into_signed(signature);
+        let signed: Signed<TxEip2930> = tx.into_signed(signature);
         if buf.len() + header.payload_length != original_len {
             return Err(alloy_rlp::Error::ListLengthMismatch {
                 expected: header.payload_length,

--- a/crates/consensus/src/transaction/eip2930.rs
+++ b/crates/consensus/src/transaction/eip2930.rs
@@ -206,7 +206,7 @@ impl TxEip2930 {
         let tx = Self::decode_fields(buf)?;
         let signature = Signature::decode_rlp_vrs(buf)?;
 
-        let signed: Signed<TxEip2930> = tx.into_signed(signature);
+        let signed = tx.into_signed(signature);
         if buf.len() + header.payload_length != original_len {
             return Err(alloy_rlp::Error::ListLengthMismatch {
                 expected: header.payload_length,

--- a/crates/eips/src/eip7702/auth_list.rs
+++ b/crates/eips/src/eip7702/auth_list.rs
@@ -2,8 +2,11 @@ use core::ops::Deref;
 
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
-use alloy_primitives::{keccak256, Address, ChainId, B256};
-use alloy_rlp::{BufMut, Decodable, Encodable, Header, RlpDecodable, RlpEncodable};
+use alloy_primitives::{keccak256, Address, ChainId, Signature, B256};
+use alloy_rlp::{
+    length_of_length, BufMut, Decodable, Encodable, Header, Result as RlpResult, RlpDecodable,
+    RlpEncodable,
+};
 
 /// An unsigned EIP-7702 authorization.
 #[derive(Debug, Clone, RlpEncodable, RlpDecodable, Eq, PartialEq)]
@@ -59,34 +62,79 @@ impl Authorization {
     }
 
     /// Convert to a signed authorization by adding a signature.
-    pub const fn into_signed<S>(self, signature: S) -> SignedAuthorization<S> {
+    pub const fn into_signed(self, signature: Signature) -> SignedAuthorization {
         SignedAuthorization { inner: self, signature }
     }
 }
 
 /// A signed EIP-7702 authorization.
-#[derive(Debug, Clone, RlpEncodable, RlpDecodable, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct SignedAuthorization<S> {
+pub struct SignedAuthorization {
     #[cfg_attr(feature = "serde", serde(flatten))]
     inner: Authorization,
-    signature: S,
+    signature: Signature,
 }
 
-impl<S> SignedAuthorization<S> {
+impl SignedAuthorization {
     /// Get the `signature` for the authorization.
-    pub const fn signature(&self) -> &S {
+    pub const fn signature(&self) -> &Signature {
         &self.signature
     }
 
     /// Splits the authorization into parts.
-    pub fn into_parts(self) -> (Authorization, S) {
+    pub fn into_parts(self) -> (Authorization, Signature) {
         (self.inner, self.signature)
+    }
+
+    /// Decodes the transaction from RLP bytes, including the signature.
+    fn decode_fields(buf: &mut &[u8]) -> RlpResult<SignedAuthorization> {
+        Ok(Self {
+            inner: Authorization {
+                chain_id: Decodable::decode(buf)?,
+                address: Decodable::decode(buf)?,
+                nonce: Decodable::decode(buf)?,
+            },
+            signature: Signature::decode_rlp_vrs(buf)?,
+        })
+    }
+
+    /// Outputs the length of the transaction's fields, without a RLP header.
+    fn fields_len(&self) -> usize {
+        self.inner.chain_id.length()
+            + self.inner.address.length()
+            + self.inner.nonce.length()
+            + self.signature.rlp_vrs_len()
+    }
+}
+
+impl Decodable for SignedAuthorization {
+    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        let header = Header::decode(buf)?;
+        if !header.list {
+            return Err(alloy_rlp::Error::UnexpectedString);
+        }
+        SignedAuthorization::decode_fields(buf)
+    }
+}
+
+impl Encodable for SignedAuthorization {
+    fn encode(&self, buf: &mut dyn BufMut) {
+        Header { list: true, payload_length: self.fields_len() }.encode(buf);
+        self.inner.chain_id.encode(buf);
+        self.inner.address.encode(buf);
+        self.inner.nonce.encode(buf);
+        self.signature.write_rlp_vrs(buf)
+    }
+
+    fn length(&self) -> usize {
+        let len = self.fields_len();
+        len + length_of_length(len)
     }
 }
 
 #[cfg(feature = "k256")]
-impl SignedAuthorization<alloy_primitives::Signature> {
+impl SignedAuthorization {
     /// Recover the authority for the authorization.
     ///
     /// # Note
@@ -104,7 +152,7 @@ impl SignedAuthorization<alloy_primitives::Signature> {
     }
 }
 
-impl<S> Deref for SignedAuthorization<S> {
+impl Deref for SignedAuthorization {
     type Target = Authorization;
 
     fn deref(&self) -> &Self::Target {
@@ -174,6 +222,13 @@ impl Encodable for OptionalNonce {
                 nonce.encode(out);
             }
             None => Header { list: true, payload_length: 0 }.encode(out),
+        }
+    }
+
+    fn length(&self) -> usize {
+        match self.0 {
+            Some(nonce) => nonce.length() + length_of_length(nonce.length()),
+            None => 1,
         }
     }
 }
@@ -262,7 +317,7 @@ mod tests {
         let mut buf = Vec::new();
         auth.encode(&mut buf);
         assert_eq!(hex::encode(&buf), expected);
-        let decoded = SignedAuthorization::<Signature>::decode(&mut buf.as_ref()).unwrap();
+        let decoded = SignedAuthorization::decode(&mut buf.as_ref()).unwrap();
         assert_eq!(buf.len(), auth.length());
         assert_eq!(decoded, auth);
     }

--- a/crates/eips/src/eip7702/auth_list.rs
+++ b/crates/eips/src/eip7702/auth_list.rs
@@ -88,7 +88,7 @@ impl SignedAuthorization {
     }
 
     /// Decodes the transaction from RLP bytes, including the signature.
-    fn decode_fields(buf: &mut &[u8]) -> RlpResult<SignedAuthorization> {
+    fn decode_fields(buf: &mut &[u8]) -> RlpResult<Self> {
         Ok(Self {
             inner: Authorization {
                 chain_id: Decodable::decode(buf)?,
@@ -114,7 +114,7 @@ impl Decodable for SignedAuthorization {
         if !header.list {
             return Err(alloy_rlp::Error::UnexpectedString);
         }
-        SignedAuthorization::decode_fields(buf)
+        Self::decode_fields(buf)
     }
 }
 
@@ -226,10 +226,7 @@ impl Encodable for OptionalNonce {
     }
 
     fn length(&self) -> usize {
-        match self.0 {
-            Some(nonce) => nonce.length() + length_of_length(nonce.length()),
-            None => 1,
-        }
+        self.map(|nonce| nonce.length() + length_of_length(nonce.length())).unwrap_or(1)
     }
 }
 
@@ -261,8 +258,7 @@ impl Deref for OptionalNonce {
 
 #[cfg(test)]
 mod tests {
-    use alloy_primitives::hex;
-    use alloy_primitives::Signature;
+    use alloy_primitives::{hex, Signature};
     use core::str::FromStr;
 
     use super::*;

--- a/crates/eips/src/eip7702/auth_list.rs
+++ b/crates/eips/src/eip7702/auth_list.rs
@@ -83,7 +83,7 @@ impl SignedAuthorization {
     }
 
     /// Splits the authorization into parts.
-    pub fn into_parts(self) -> (Authorization, Signature) {
+    pub const fn into_parts(self) -> (Authorization, Signature) {
         (self.inner, self.signature)
     }
 

--- a/crates/eips/src/eip7702/auth_list.rs
+++ b/crates/eips/src/eip7702/auth_list.rs
@@ -301,7 +301,6 @@ mod tests {
 
     #[test]
     fn test_encode_decode_signed_auth() {
-        let expected = "f85b01940000000000000000000000000000000000000006c1011ba048b55bfa915ac795c431978d8a6a992b628d557da5ff759b307d495a36649353a0efffd310ac743f371de3b9f7f9cb56c0b28ad43601b4ab949f53faa07bd2c804";
         let auth = SignedAuthorization {
             inner: Authorization {
                 chain_id: 1u64,
@@ -312,7 +311,10 @@ mod tests {
         };
         let mut buf = Vec::new();
         auth.encode(&mut buf);
+
+        let expected = "f85b01940000000000000000000000000000000000000006c1011ba048b55bfa915ac795c431978d8a6a992b628d557da5ff759b307d495a36649353a0efffd310ac743f371de3b9f7f9cb56c0b28ad43601b4ab949f53faa07bd2c804";
         assert_eq!(hex::encode(&buf), expected);
+
         let decoded = SignedAuthorization::decode(&mut buf.as_ref()).unwrap();
         assert_eq!(buf.len(), auth.length());
         assert_eq!(decoded, auth);


### PR DESCRIPTION
eip7702 AuthorizationList rlp format is not correct.

The format that gets encoded is: `0xf85ed801940000000000000000000000000000000000000006c101f8431ba048b55bfa915ac795c431978d8a6a992b628d557da5ff759b307d495a36649353a0efffd310ac743f371de3b9f7f9cb56c0b28ad43601b4ab949f53faa07bd2c804`
That decoded is:
`[["0x01","0x0000000000000000000000000000000000000006",["0x01"]],["0x1b","0x48b55bfa915ac795c431978d8a6a992b628d557da5ff759b307d495a36649353","0xefffd310ac743f371de3b9f7f9cb56c0b28ad43601b4ab949f53faa07bd2c804"]]`
https://toolkit.abdk.consulting/ethereum#rlp

There are two inner lists that should not be there.

Removed Generic over `SignedAuthorization` as it seems it is not needed. We default to Signature (can revert back if this is not the case)

