### PR TITLE
feat: generate valid signed auth signatures

### DIFF
--- a/crates/eips/Cargo.toml
+++ b/crates/eips/Cargo.toml
@@ -41,6 +41,9 @@ arbitrary = { workspace = true, features = ["derive"], optional = true }
 proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
 
+# for signed authorization list arbitrary
+k256 = { workspace = true, optional = true }
+
 [dev-dependencies]
 alloy-primitives = { workspace = true, features = [
     "rand",
@@ -70,7 +73,7 @@ serde = [
 kzg = ["kzg-sidecar", "sha2", "dep:derive_more", "dep:c-kzg", "dep:once_cell"]
 kzg-sidecar = ["sha2"]
 sha2 = ["dep:sha2"]
-k256 = ["alloy-primitives/k256"]
+k256 = ["alloy-primitives/k256", "dep:k256"]
 ssz = [
     "std",
     "dep:ethereum_ssz",

--- a/crates/eips/src/eip7702/auth_list.rs
+++ b/crates/eips/src/eip7702/auth_list.rs
@@ -358,6 +358,7 @@ mod tests {
         assert_eq!(decoded, auth);
     }
 
+    #[cfg(feature = "k256")]
     #[test]
     fn test_arbitrary_auth() {
         let mut unstructured = arbitrary::Unstructured::new(b"unstructured auth");


### PR DESCRIPTION
## Motivation

This makes it so the auth list signature is not hard coded, although this gates the arbitrary implementation behind the k256 feature

## Solution

Just generate a hash, based on the auth, and sign it

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
