### PR TITLE
chore: make auth mandatory in recovered auth

### DIFF
--- a/crates/eips/src/eip7702/auth_list.rs
+++ b/crates/eips/src/eip7702/auth_list.rs
@@ -219,6 +219,7 @@ impl RecoveredAuthorization {
     }
 }
 
+#[cfg(feature = "k256")]
 impl TryFrom<SignedAuthorization> for RecoveredAuthorization {
     type Error = alloy_primitives::SignatureError;
 


### PR DESCRIPTION
optional authority if recovery failed doesn't make sense.

this should always be Address