### PR TITLE
fix: deserialized with bincode

### DIFF
--- a/crates/serde/src/optional.rs
+++ b/crates/serde/src/optional.rs
@@ -8,6 +8,6 @@ where
     T: Deserialize<'de> + Default,
     D: Deserializer<'de>,
 {
-    let s: Option<T> = Deserialize::deserialize(deserializer)?;
+    let s: Option<T> = Deserialize::deserialize(deserializer).ok();
     Ok(s.unwrap_or_default())
 }


### PR DESCRIPTION
Encounter error when deserializing TxEip2930 which contains AccessList: https://github.com/paradigmxyz/reth/blob/c3347f323c0a6d7784772624d91edebf4a76d36d/crates/primitives/src/transaction/eip2930.rs#L54 In my version the deserialization was overridden with:
```
pub struct AccessListItem {
    /// Account addresses that would be loaded at the start of execution
    pub address: Address,
    /// Keys of storage that would be loaded at the start of execution
    #[cfg_attr(
        any(test, feature = "arbitrary"),
        proptest(
            strategy = "proptest::collection::vec(proptest::arbitrary::any::<B256>(), 0..=20)"
        )
    )]
    // In JSON, we have to accept `null` for storage key, which is interpreted as an empty array.
    #[cfg_attr(feature = "serde", serde(deserialize_with = "alloy_serde::null_as_default"))]
    pub storage_keys: Vec<B256>,
}
```
and it returns Error when deserializing with `bincode` because null and None from Option is interpreted differently.
```
called `Result::unwrap()` on an `Err` value: InvalidTagEncoding(2)
```
The solution turn erroneous results into None

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
