### PR TITLE
Added stages to the sync info rpc type

### DIFF
--- a/crates/rpc-types-eth/src/syncing.rs
+++ b/crates/rpc-types-eth/src/syncing.rs
@@ -1,6 +1,6 @@
 use alloy_primitives::{B512, U256, U64};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 
 /// Syncing info
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -18,7 +18,16 @@ pub struct SyncInfo {
     pub warp_chunks_processed: Option<U256>,
     /// The details of the sync stages as an hashmap
     /// where the key is the name of the stage and the value is the block number.
-    pub stages: Option<HashMap<String, U256>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stages: Option<Vec<Stage>>,
+}
+
+/// The detail of the sync stages.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Stage {
+    name: String,
+    block: U64,
 }
 
 /// Peers info

--- a/crates/rpc-types-eth/src/syncing.rs
+++ b/crates/rpc-types-eth/src/syncing.rs
@@ -1,9 +1,9 @@
 use alloy_primitives::{B512, U256, U64};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 
 /// Syncing info
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SyncInfo {
     /// Starting block
@@ -16,6 +16,9 @@ pub struct SyncInfo {
     pub warp_chunks_amount: Option<U256>,
     /// Warp sync snapshot chunks processed.
     pub warp_chunks_processed: Option<U256>,
+    /// The details of the sync stages as an hashmap
+    /// where the key is the name of the stage and the value is the block number.
+    pub stages: Option<HashMap<String, U256>>,
 }
 
 /// Peers info
@@ -99,7 +102,7 @@ pub struct PipProtocolInfo {
 }
 
 /// Sync status
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum SyncStatus {
     /// Info when syncing
     Info(SyncInfo),

--- a/crates/rpc-types-eth/src/syncing.rs
+++ b/crates/rpc-types-eth/src/syncing.rs
@@ -27,7 +27,7 @@ pub struct SyncInfo {
 #[serde(rename_all = "camelCase")]
 pub struct Stage {
     /// The name of the sync stage.
-    #[serde(rename = "stage_name", alias = "stage_name")]
+    #[serde(alias = "stage_name")]
     name: String,
     /// Indicates the progress of the sync stage.
     #[serde(alias = "block_number", with = "alloy_serde::quantity")]

--- a/crates/rpc-types-eth/src/syncing.rs
+++ b/crates/rpc-types-eth/src/syncing.rs
@@ -26,8 +26,12 @@ pub struct SyncInfo {
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Stage {
+    /// The name of the sync stage.
+    #[serde(rename = "stage_name", alias = "stage_name")]
     name: String,
-    block: U64,
+    /// Indicates the progress of the sync stage.
+    #[serde(rename = "block_number", alias = "block_number", with = "alloy_serde::quantity")]
+    block: u64,
 }
 
 /// Peers info

--- a/crates/rpc-types-eth/src/syncing.rs
+++ b/crates/rpc-types-eth/src/syncing.rs
@@ -105,7 +105,7 @@ pub struct PipProtocolInfo {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum SyncStatus {
     /// Info when syncing
-    Info(SyncInfo),
+    Info(Box<SyncInfo>),
     /// Not syncing
     None,
 }
@@ -120,7 +120,7 @@ impl<'de> Deserialize<'de> for SyncStatus {
         enum Syncing {
             /// When client is synced to the highest block, eth_syncing with return "false"
             None(bool),
-            IsSyncing(SyncInfo),
+            IsSyncing(Box<SyncInfo>),
         }
 
         match Syncing::deserialize(deserializer)? {

--- a/crates/rpc-types-eth/src/syncing.rs
+++ b/crates/rpc-types-eth/src/syncing.rs
@@ -30,7 +30,7 @@ pub struct Stage {
     #[serde(rename = "stage_name", alias = "stage_name")]
     name: String,
     /// Indicates the progress of the sync stage.
-    #[serde(rename = "block_number", alias = "block_number", with = "alloy_serde::quantity")]
+    #[serde(alias = "block_number", with = "alloy_serde::quantity")]
     block: u64,
 }
 

--- a/crates/rpc-types-eth/src/syncing.rs
+++ b/crates/rpc-types-eth/src/syncing.rs
@@ -28,10 +28,10 @@ pub struct SyncInfo {
 pub struct Stage {
     /// The name of the sync stage.
     #[serde(alias = "stage_name")]
-    name: String,
+    pub name: String,
     /// Indicates the progress of the sync stage.
     #[serde(alias = "block_number", with = "alloy_serde::quantity")]
-    block: u64,
+    pub block: u64,
 }
 
 /// Peers info


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
Ref: https://github.com/paradigmxyz/reth/issues/7838

CC: @mattsse 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Adding a new optional field to sync info to show stages sync detail on eth_syncing rpc method.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
