### PR TITLE
fix(eips): make SignedAuthorizationList arbitrary less fallible

### DIFF
--- a/crates/eips/Cargo.toml
+++ b/crates/eips/Cargo.toml
@@ -41,6 +41,7 @@ arbitrary = { workspace = true, features = ["derive"], optional = true }
 
 # for signed authorization list arbitrary
 k256 = { workspace = true, optional = true }
+rand = { workspace = true, optional = true }
 
 [dev-dependencies]
 alloy-primitives = { workspace = true, features = [
@@ -80,6 +81,7 @@ arbitrary = [
     "std",
     "kzg-sidecar",
     "dep:arbitrary",
+    "dep:rand",
     "alloy-primitives/arbitrary",
     "alloy-serde?/arbitrary",
 ]

--- a/crates/eips/src/lib.rs
+++ b/crates/eips/src/lib.rs
@@ -11,6 +11,11 @@
 #[macro_use]
 extern crate alloc;
 
+// To ensure no unused imports, since signed auth list requires arbitrary _and_ k256 features, but
+// is only enabled using the `arbitrary` feature.
+#[cfg(all(not(feature = "k256"), feature = "arbitrary"))]
+use rand as _;
+
 pub mod eip1559;
 pub use eip1559::calc_next_block_base_fee;
 


### PR DESCRIPTION
## Motivation

This is an attempt to fix https://github.com/alloy-rs/alloy/pull/1070

## Solution

The key generation can be made infallible by instead seeding a rng, and generating a `NonZeroScalar` with it.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
