### PR TITLE
TxRequest into EIP-4844 without sidecar

### DIFF
--- a/crates/rpc-types-eth/Cargo.toml
+++ b/crates/rpc-types-eth/Cargo.toml
@@ -51,6 +51,7 @@ alloy-eips = { workspace = true, features = ["arbitrary", "k256"] }
 arbitrary = { workspace = true, features = ["derive"] }
 rand.workspace = true
 similar-asserts.workspace = true
+assert_matches.workspace = true
 
 [features]
 arbitrary = [

--- a/crates/rpc-types-eth/src/transaction/request.rs
+++ b/crates/rpc-types-eth/src/transaction/request.rs
@@ -269,22 +269,20 @@ impl TransactionRequest {
         };
 
         TxEip4844 {
-                chain_id: self.chain_id.unwrap_or(1),
-                nonce: self.nonce.expect("checked in complete_4844"),
-                gas_limit: self.gas.expect("checked in complete_4844"),
-                max_fee_per_gas: self.max_fee_per_gas.expect("checked in complete_4844"),
-                max_priority_fee_per_gas: self
-                    .max_priority_fee_per_gas
-                    .expect("checked in complete_4844"),
-                to: to_address,
-                value: self.value.unwrap_or_default(),
-                access_list: self.access_list.unwrap_or_default(),
-                blob_versioned_hashes: self
-                    .blob_versioned_hashes
-                    .expect("populated at top of block"),
-                max_fee_per_blob_gas: self.max_fee_per_blob_gas.expect("checked in complete_4844"),
-                input: self.input.into_input().unwrap_or_default(),
-            }
+            chain_id: self.chain_id.unwrap_or(1),
+            nonce: self.nonce.expect("checked in complete_4844"),
+            gas_limit: self.gas.expect("checked in complete_4844"),
+            max_fee_per_gas: self.max_fee_per_gas.expect("checked in complete_4844"),
+            max_priority_fee_per_gas: self
+                .max_priority_fee_per_gas
+                .expect("checked in complete_4844"),
+            to: to_address,
+            value: self.value.unwrap_or_default(),
+            access_list: self.access_list.unwrap_or_default(),
+            blob_versioned_hashes: self.blob_versioned_hashes.expect("populated at top of block"),
+            max_fee_per_blob_gas: self.max_fee_per_blob_gas.expect("checked in complete_4844"),
+            input: self.input.into_input().unwrap_or_default(),
+        }
     }
 
     /// Build an EIP-4844 transaction with sidecar.

--- a/crates/rpc-types-eth/src/transaction/request.rs
+++ b/crates/rpc-types-eth/src/transaction/request.rs
@@ -413,7 +413,6 @@ impl TransactionRequest {
             missing.push("to");
         }
 
-        // Either `sidecar` or `blob_versioned_hashes` must be set.
         if self.sidecar.is_none() {
             missing.push("sidecar");
         }

--- a/crates/rpc-types-eth/src/transaction/request.rs
+++ b/crates/rpc-types-eth/src/transaction/request.rs
@@ -255,7 +255,7 @@ impl TransactionRequest {
         }
     }
 
-    /// Build an EIP-4844 transaction with sidecar.
+    /// Build an EIP-4844 transaction without sidecar.
     ///
     /// # Panics
     ///
@@ -279,7 +279,7 @@ impl TransactionRequest {
             to: to_address,
             value: self.value.unwrap_or_default(),
             access_list: self.access_list.unwrap_or_default(),
-            blob_versioned_hashes: self.blob_versioned_hashes.expect("populated at top of block"),
+            blob_versioned_hashes: self.blob_versioned_hashes.expect("checked in complete_4844"),
             max_fee_per_blob_gas: self.max_fee_per_blob_gas.expect("checked in complete_4844"),
             input: self.input.into_input().unwrap_or_default(),
         }

--- a/crates/rpc-types-eth/src/transaction/request.rs
+++ b/crates/rpc-types-eth/src/transaction/request.rs
@@ -241,17 +241,17 @@ impl TransactionRequest {
         }
     }
 
-    /// Build an EIP-4844 transaction.
+    /// Build an EIP-4844 transaction variant - either with or without sidecar.
     ///
     /// # Panics
     ///
     /// If required fields are missing. Use `complete_4844` to check if the
     /// request can be built.
-    fn build_4844(self) -> TxEip4844Variant {
+    fn build_4844_variant(self) -> TxEip4844Variant {
         if self.sidecar.is_none() {
             self.build_4844_without_sidecar().into()
         } else {
-            self.build_4844_with_sidecar().into()
+            self.build_4844().into()
         }
     }
 
@@ -291,7 +291,7 @@ impl TransactionRequest {
     ///
     /// If required fields are missing. Use `complete_4844` to check if the
     /// request can be built.
-    fn build_4844_with_sidecar(mut self) -> TxEip4844WithSidecar {
+    fn build_4844(mut self) -> TxEip4844WithSidecar {
         self.populate_blob_hashes();
 
         let checked_to = self.to.expect("checked in complete_4844.");
@@ -518,7 +518,7 @@ impl TransactionRequest {
             TxType::Legacy => self.build_legacy().into(),
             TxType::Eip2930 => self.build_2930().into(),
             TxType::Eip1559 => self.build_1559().into(),
-            TxType::Eip4844 => self.build_4844().into(),
+            TxType::Eip4844 => self.build_4844_variant().into(),
         })
     }
 }


### PR DESCRIPTION
## Motivation

The `TransactionArguments` struct's `build_typed_tx` method will, in case of **EIP-4844** transaction, always try to build  a `TypedTransaction` using `sidecar`.

This isn't necessarily correct if `sidecar` is `None` but `blob_versioned_hashes` are set to `Some(...)`.
In this case, it should be fine to build a transaction _without sidecar_.

This PR allows that to happen.

## Solution

* implement `build_consensus_tx` for `TransactionRequest` for conversion into `TypedTransaction`
* modifies some _private_ legacy functions to return `Result<...>` instead of panicking
* leaves the other legacy function(s) functionally the same

## PR Checklist

- [x] Added Tests
