### PR TITLE
docs: readme fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ cargo add alloy --features full
 Alternatively, you can add the following to your `Cargo.toml` file:
 
 ```toml
-alloy = { version = "0.1", features = ["full"] }
+alloy = { version = "0.2", features = ["full"] }
 ```
 
 For a more fine-grained control over the features you wish to include, you can add the individual crates to your `Cargo.toml` file, or use the `alloy` crate with the features you need.


### PR DESCRIPTION
It looks to me that the version in the README should also be bumped to 0.2, as that is the version added when running `cargo add alloy --features full`.