### PR TITLE
Make `alloy_rpc_types_eth::SubscriptionResult` generic over tx

### DIFF
--- a/crates/rpc-types-eth/src/pubsub.rs
+++ b/crates/rpc-types-eth/src/pubsub.rs
@@ -7,7 +7,7 @@ use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
 /// Subscription result.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
 #[serde(untagged)]
-pub enum SubscriptionResult {
+pub enum SubscriptionResult<T = Transaction> {
     /// New block header.
     Header(Box<RichHeader>),
     /// Log
@@ -15,7 +15,7 @@ pub enum SubscriptionResult {
     /// Transaction hash
     TransactionHash(B256),
     /// Full Transaction
-    FullTransaction(Box<Transaction>),
+    FullTransaction(Box<T>),
     /// SyncStatus
     SyncState(PubSubSyncStatus),
 }
@@ -45,7 +45,10 @@ pub struct SyncStatusMetadata {
     pub highest_block: Option<u64>,
 }
 
-impl Serialize for SubscriptionResult {
+impl<T> Serialize for SubscriptionResult<T>
+where
+    T: Serialize,
+{
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

To plug into reth RPC, transaction type needs to be configurable at node builder level and adopted by all types further down, incl `SubscriptionResult`

## Solution

Make `SubscriptionResult` generic over transaction

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
