### PR TITLE
Add conversion from BlockHashOrNumber to BlockId

### DIFF
--- a/crates/eips/src/eip1898.rs
+++ b/crates/eips/src/eip1898.rs
@@ -385,6 +385,17 @@ impl From<BlockNumberOrTag> for BlockId {
     }
 }
 
+impl From<BlockHashOrNumber> for BlockId {
+    fn from(block: BlockHashOrNumber) -> Self {
+        match block {
+            BlockHashOrNumber::Hash(hash) => {
+                Self::Hash(RpcBlockHash { block_hash: hash, require_canonical: None })
+            }
+            BlockHashOrNumber::Number(num) => Self::Number(BlockNumberOrTag::Number(num)),
+        }
+    }
+}
+
 impl From<B256> for BlockId {
     fn from(block_hash: B256) -> Self {
         Self::Hash(RpcBlockHash { block_hash, require_canonical: None })


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Implementing `reth_rpc_eth_types::EthApiError` https://github.com/paradigmxyz/reth/pull/7416#discussion_r1703734505

## Solution

Adds conversion from `alloy_eips::BlockHashOrNumber` to `alloy_eips::BlockId`

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
