### PR TITLE
fix(rpc): show data in when cast send result in custom error

### DIFF
--- a/crates/json-rpc/src/response/error.rs
+++ b/crates/json-rpc/src/response/error.rs
@@ -88,10 +88,7 @@ impl<ErrData: fmt::Display> fmt::Display for ErrorPayload<ErrData> {
             "error code {}: {}{}",
             self.code,
             self.message,
-            self.data
-                .as_ref()
-                .map(|data| format!(", data: {}",data.to_string()))
-                .unwrap_or_default()
+            self.data.as_ref().map(|data| format!(", data: {}", data)).unwrap_or_default()
         )
     }
 }

--- a/crates/json-rpc/src/response/error.rs
+++ b/crates/json-rpc/src/response/error.rs
@@ -81,9 +81,12 @@ fn spelunk_revert(value: &Value) -> Option<Bytes> {
     }
 }
 
-impl<ErrData> fmt::Display for ErrorPayload<ErrData> {
+impl<ErrData: Default + fmt::Display+ Clone > fmt::Display for ErrorPayload<ErrData> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "error code {}: {}", self.code, self.message)
+        write!(f, "error code {}: {}, data: {}", self.code, self.message,
+               <Option<ErrData> as Clone>::clone(&self.data).
+                   unwrap_or_else(|| ErrData::default()).to_string().trim_matches('"')
+        )
     }
 }
 

--- a/crates/json-rpc/src/response/error.rs
+++ b/crates/json-rpc/src/response/error.rs
@@ -85,12 +85,12 @@ impl<ErrData: fmt::Display> fmt::Display for ErrorPayload<ErrData> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "error code {}: {}, data: {}",
+            "error code {}: {}{}",
             self.code,
             self.message,
             self.data
                 .as_ref()
-                .map(|data| data.to_string())
+                .map(|data| format!(", data: {}",data.to_string()))
                 .unwrap_or_default()
         )
     }

--- a/crates/json-rpc/src/response/error.rs
+++ b/crates/json-rpc/src/response/error.rs
@@ -81,11 +81,17 @@ fn spelunk_revert(value: &Value) -> Option<Bytes> {
     }
 }
 
-impl<ErrData: Default + fmt::Display+ Clone > fmt::Display for ErrorPayload<ErrData> {
+impl<ErrData: fmt::Display> fmt::Display for ErrorPayload<ErrData> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "error code {}: {}, data: {}", self.code, self.message,
-               <Option<ErrData> as Clone>::clone(&self.data).
-                   unwrap_or_else(|| ErrData::default()).to_string().trim_matches('"')
+        write!(
+            f,
+            "error code {}: {}, data: {}",
+            self.code,
+            self.message,
+            self.data
+                .as_ref()
+                .map(|data| data.to_string())
+                .unwrap_or_default()
         )
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
```
➜  foundry_test git:(master) ✗ cast send 0x5FbDB2315678afecb367f032d93F642f64180aa3  "customError()" --private-key $PK
Error:
server returned an error response: error code 3: execution reverted:
```
cast send result in execution revert with out reason(data) is hard to debug.  

old version of cast send result would be like:  
```
(code: 3, message: execution reverted: CustomError3333, data: Some(String("0x8d6ea8be0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000f437573746f6d4572726f72333333330000000000000000000000000000000000"))) 
```

it's good to make cast send print data like "0x8d6ea8be...".

## Solution

add data to print in fmt
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
