### PR TITLE
fix: use `BlockId` superset over `BlockNumberOrTag` where applicable 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,8 @@ jobs:
           - "--no-default-features"
           # Default features
           - ""
+          # All features
+          - "--all-features"
         exclude:
           # All features on MSRV
           - rust: "1.76" # MSRV

--- a/crates/provider/src/ext/debug.rs
+++ b/crates/provider/src/ext/debug.rs
@@ -2,7 +2,7 @@
 use crate::Provider;
 use alloy_network::Network;
 use alloy_primitives::{hex, Bytes, TxHash, B256};
-use alloy_rpc_types_eth::{Block, BlockNumberOrTag, TransactionRequest};
+use alloy_rpc_types_eth::{Block, BlockId, BlockNumberOrTag, TransactionRequest};
 use alloy_rpc_types_trace::geth::{
     BlockTraceResult, GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace, TraceResult,
 };
@@ -268,7 +268,11 @@ mod test {
             .max_priority_fee_per_gas(gas_price + 1);
 
         let trace = provider
-            .debug_trace_call(tx, BlockNumberOrTag::Latest, GethDebugTracingCallOptions::default())
+            .debug_trace_call(
+                tx,
+                BlockNumberOrTag::Latest.into(),
+                GethDebugTracingCallOptions::default(),
+            )
             .await
             .unwrap();
 
@@ -284,7 +288,7 @@ mod test {
         let provider = ProviderBuilder::new().on_http(geth.endpoint_url());
 
         let rlp_header = provider
-            .debug_get_raw_header(BlockNumberOrTag::default())
+            .debug_get_raw_header(BlockId::Number(BlockNumberOrTag::Latest))
             .await
             .expect("debug_getRawHeader call should succeed");
 
@@ -298,7 +302,7 @@ mod test {
         let provider = ProviderBuilder::new().on_http(geth.endpoint_url());
 
         let rlp_block = provider
-            .debug_get_raw_block(BlockNumberOrTag::default())
+            .debug_get_raw_block(BlockId::Number(BlockNumberOrTag::Latest))
             .await
             .expect("debug_getRawBlock call should succeed");
 
@@ -311,7 +315,8 @@ mod test {
         let geth = Geth::new().disable_discovery().data_dir(temp_dir.path()).spawn();
         let provider = ProviderBuilder::new().on_http(geth.endpoint_url());
 
-        let result = provider.debug_get_raw_receipts(BlockNumberOrTag::default()).await;
+        let result =
+            provider.debug_get_raw_receipts(BlockId::Number(BlockNumberOrTag::Latest)).await;
         assert!(result.is_ok());
     }
 

--- a/crates/provider/src/ext/debug.rs
+++ b/crates/provider/src/ext/debug.rs
@@ -13,16 +13,16 @@ use alloy_transport::{Transport, TransportResult};
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 pub trait DebugApi<N, T>: Send + Sync {
     /// Returns an RLP-encoded header.
-    async fn debug_get_raw_header(&self, block: BlockNumberOrTag) -> TransportResult<Bytes>;
+    async fn debug_get_raw_header(&self, block: BlockId) -> TransportResult<Bytes>;
 
     /// Retrieves and returns the RLP encoded block by number, hash or tag.
-    async fn debug_get_raw_block(&self, block: BlockNumberOrTag) -> TransportResult<Bytes>;
+    async fn debug_get_raw_block(&self, block: BlockId) -> TransportResult<Bytes>;
 
     /// Returns an EIP-2718 binary-encoded transaction.
     async fn debug_get_raw_transaction(&self, hash: TxHash) -> TransportResult<Bytes>;
 
     /// Returns an array of EIP-2718 binary-encoded receipts.
-    async fn debug_get_raw_receipts(&self, block: BlockNumberOrTag) -> TransportResult<Vec<Bytes>>;
+    async fn debug_get_raw_receipts(&self, block: BlockId) -> TransportResult<Vec<Bytes>>;
 
     /// Returns an array of recent bad blocks that the client has seen on the network.
     async fn debug_get_bad_blocks(&self) -> TransportResult<Vec<Block>>;
@@ -109,7 +109,7 @@ pub trait DebugApi<N, T>: Send + Sync {
     async fn debug_trace_call(
         &self,
         tx: TransactionRequest,
-        block: BlockNumberOrTag,
+        block: BlockId,
         trace_options: GethDebugTracingCallOptions,
     ) -> TransportResult<GethTrace>;
 
@@ -123,7 +123,7 @@ pub trait DebugApi<N, T>: Send + Sync {
     async fn debug_trace_call_many(
         &self,
         txs: Vec<TransactionRequest>,
-        block: BlockNumberOrTag,
+        block: BlockId,
         trace_options: GethDebugTracingCallOptions,
     ) -> TransportResult<Vec<GethTrace>>;
 }
@@ -136,11 +136,11 @@ where
     T: Transport + Clone,
     P: Provider<T, N>,
 {
-    async fn debug_get_raw_header(&self, block: BlockNumberOrTag) -> TransportResult<Bytes> {
+    async fn debug_get_raw_header(&self, block: BlockId) -> TransportResult<Bytes> {
         self.client().request("debug_getRawHeader", (block,)).await
     }
 
-    async fn debug_get_raw_block(&self, block: BlockNumberOrTag) -> TransportResult<Bytes> {
+    async fn debug_get_raw_block(&self, block: BlockId) -> TransportResult<Bytes> {
         self.client().request("debug_getRawBlock", (block,)).await
     }
 
@@ -148,7 +148,7 @@ where
         self.client().request("debug_getRawTransaction", (hash,)).await
     }
 
-    async fn debug_get_raw_receipts(&self, block: BlockNumberOrTag) -> TransportResult<Vec<Bytes>> {
+    async fn debug_get_raw_receipts(&self, block: BlockId) -> TransportResult<Vec<Bytes>> {
         self.client().request("debug_getRawReceipts", (block,)).await
     }
 
@@ -200,7 +200,7 @@ where
     async fn debug_trace_call(
         &self,
         tx: TransactionRequest,
-        block: BlockNumberOrTag,
+        block: BlockId,
         trace_options: GethDebugTracingCallOptions,
     ) -> TransportResult<GethTrace> {
         self.client().request("debug_traceCall", (tx, block, trace_options)).await
@@ -209,7 +209,7 @@ where
     async fn debug_trace_call_many(
         &self,
         txs: Vec<TransactionRequest>,
-        block: BlockNumberOrTag,
+        block: BlockId,
         trace_options: GethDebugTracingCallOptions,
     ) -> TransportResult<Vec<GethTrace>> {
         self.client().request("debug_traceCallMany", (txs, block, trace_options)).await

--- a/crates/provider/src/ext/trace.rs
+++ b/crates/provider/src/ext/trace.rs
@@ -81,23 +81,20 @@ where
     /// # Note
     ///
     /// Not all nodes support this call.
-    async fn trace_block(
-        &self,
-        block: BlockNumberOrTag,
-    ) -> TransportResult<Vec<LocalizedTransactionTrace>>;
+    async fn trace_block(&self, block: BlockId) -> TransportResult<Vec<LocalizedTransactionTrace>>;
 
     /// Replays a transaction.
     async fn trace_replay_transaction(
         &self,
         hash: TxHash,
-        trace_type: &[TraceType],
+        trace_types: &[TraceType],
     ) -> TransportResult<TraceResults>;
 
     /// Replays all transactions in the given block.
     async fn trace_replay_block_transactions(
         &self,
-        block: BlockNumberOrTag,
-        trace_type: &[TraceType],
+        block: BlockId,
+        trace_types: &[TraceType],
     ) -> TransportResult<Vec<TraceResultsWithTransactionHash>>;
 }
 
@@ -112,10 +109,10 @@ where
     fn trace_call<'a, 'b>(
         &self,
         request: &'a <N as Network>::TransactionRequest,
-        trace_type: &'b [TraceType],
+        trace_types: &'b [TraceType],
     ) -> RpcWithBlock<T, (&'a <N as Network>::TransactionRequest, &'b [TraceType]), TraceResults>
     {
-        RpcWithBlock::new(self.weak_client(), "trace_call", (request, trace_type))
+        RpcWithBlock::new(self.weak_client(), "trace_call", (request, trace_types))
     }
 
     fn trace_call_many<'a>(
@@ -144,9 +141,9 @@ where
     async fn trace_raw_transaction(
         &self,
         data: &[u8],
-        trace_type: &[TraceType],
+        trace_types: &[TraceType],
     ) -> TransportResult<TraceResults> {
-        self.client().request("trace_rawTransaction", (data, trace_type)).await
+        self.client().request("trace_rawTransaction", (data, trace_types)).await
     }
 
     async fn trace_filter(
@@ -156,27 +153,24 @@ where
         self.client().request("trace_filter", (tracer,)).await
     }
 
-    async fn trace_block(
-        &self,
-        block: BlockNumberOrTag,
-    ) -> TransportResult<Vec<LocalizedTransactionTrace>> {
+    async fn trace_block(&self, block: BlockId) -> TransportResult<Vec<LocalizedTransactionTrace>> {
         self.client().request("trace_block", (block,)).await
     }
 
     async fn trace_replay_transaction(
         &self,
         hash: TxHash,
-        trace_type: &[TraceType],
+        trace_types: &[TraceType],
     ) -> TransportResult<TraceResults> {
-        self.client().request("trace_replayTransaction", (hash, trace_type)).await
+        self.client().request("trace_replayTransaction", (hash, trace_types)).await
     }
 
     async fn trace_replay_block_transactions(
         &self,
-        block: BlockNumberOrTag,
-        trace_type: &[TraceType],
+        block: BlockId,
+        trace_types: &[TraceType],
     ) -> TransportResult<Vec<TraceResultsWithTransactionHash>> {
-        self.client().request("trace_replayBlockTransactions", (block, trace_type)).await
+        self.client().request("trace_replayBlockTransactions", (block, trace_types)).await
     }
 }
 

--- a/crates/provider/src/ext/trace.rs
+++ b/crates/provider/src/ext/trace.rs
@@ -1,6 +1,6 @@
 //! This module extends the Ethereum JSON-RPC provider with the Trace namespace's RPC methods.
 use crate::{Provider, RpcWithBlock};
-use alloy_eips::BlockNumberOrTag;
+use alloy_eips::BlockId;
 use alloy_network::Network;
 use alloy_primitives::TxHash;
 use alloy_rpc_types_eth::Index;
@@ -177,6 +177,7 @@ where
 #[cfg(test)]
 mod test {
     use crate::ProviderBuilder;
+    use alloy_eips::BlockNumberOrTag;
 
     use super::*;
 
@@ -188,7 +189,7 @@ mod test {
     async fn test_trace_block() {
         init_tracing();
         let provider = ProviderBuilder::new().on_anvil();
-        let traces = provider.trace_block(BlockNumberOrTag::Latest).await.unwrap();
+        let traces = provider.trace_block(BlockId::Number(BlockNumberOrTag::Latest)).await.unwrap();
         assert_eq!(traces.len(), 0);
     }
 }

--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -251,7 +251,7 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
 
     /// Gets the balance of the account.
     ///
-    /// Defaults to the latest block. See also [`RpcWithBlock::block`].
+    /// Defaults to the latest block. See also [`RpcWithBlock::block_id`].
     fn get_balance(&self, address: Address) -> RpcWithBlock<T, Address, U256> {
         RpcWithBlock::new(self.weak_client(), "eth_getBalance", address)
     }

--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -251,7 +251,7 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
 
     /// Gets the balance of the account.
     ///
-    /// Defaults to the latest block. See also [`RpcWithBlock::block_id`].
+    /// Defaults to the latest block. See also [`RpcWithBlock::block`].
     fn get_balance(&self, address: Address) -> RpcWithBlock<T, Address, U256> {
         RpcWithBlock::new(self.weak_client(), "eth_getBalance", address)
     }
@@ -259,10 +259,10 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
     /// Gets a block by either its hash, tag, or number, with full transactions or only hashes.
     async fn get_block(
         &self,
-        id: BlockId,
+        block: BlockId,
         kind: BlockTransactionsKind,
     ) -> TransportResult<Option<Block>> {
-        match id {
+        match block {
             BlockId::Hash(hash) => self.get_block_by_hash(hash.into(), kind).await,
             BlockId::Number(number) => {
                 let full = matches!(kind, BlockTransactionsKind::Full);
@@ -323,9 +323,9 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
     /// Gets the selected block [BlockId] receipts.
     async fn get_block_receipts(
         &self,
-        id: BlockId,
+        block: BlockId,
     ) -> TransportResult<Option<Vec<N::ReceiptResponse>>> {
-        self.client().request("eth_getBlockReceipts", (id,)).await
+        self.client().request("eth_getBlockReceipts", (block,)).await
     }
 
     /// Gets the bytecode located at the corresponding [Address].

--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -1086,7 +1086,7 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "ws")]
+    #[cfg(all(feature = "ws", not(windows)))]
     #[tokio::test]
     async fn subscribe_blocks_ws() {
         use futures::stream::StreamExt;
@@ -1107,7 +1107,7 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "ws")]
+    #[cfg(all(feature = "ws", not(windows)))]
     #[tokio::test]
     async fn subscribe_blocks_ws_boxed() {
         use futures::stream::StreamExt;

--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -320,12 +320,12 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
         Ok(block)
     }
 
-    /// Gets the selected block [BlockNumberOrTag] receipts.
+    /// Gets the selected block [BlockId] receipts.
     async fn get_block_receipts(
         &self,
-        block: BlockNumberOrTag,
+        id: BlockId,
     ) -> TransportResult<Option<Vec<N::ReceiptResponse>>> {
-        self.client().request("eth_getBlockReceipts", (block,)).await
+        self.client().request("eth_getBlockReceipts", (id,)).await
     }
 
     /// Gets the bytecode located at the corresponding [Address].
@@ -1433,7 +1433,8 @@ mod tests {
     async fn gets_block_receipts() {
         init_tracing();
         let provider = ProviderBuilder::new().on_anvil();
-        let receipts = provider.get_block_receipts(BlockNumberOrTag::Latest).await.unwrap();
+        let receipts =
+            provider.get_block_receipts(BlockId::Number(BlockNumberOrTag::Latest)).await.unwrap();
         assert!(receipts.is_some());
     }
 

--- a/crates/provider/src/provider/with_block.rs
+++ b/crates/provider/src/provider/with_block.rs
@@ -11,7 +11,7 @@ use std::{
     task::Poll,
 };
 
-/// States of the
+/// States of the [`RpcWithBlock`] future.
 #[derive(Clone)]
 enum States<T, Params, Resp, Output = Resp, Map = fn(Resp) -> Output>
 where

--- a/crates/rpc-client/src/builtin.rs
+++ b/crates/rpc-client/src/builtin.rs
@@ -250,7 +250,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(feature = "ipc")]
+    #[cfg(all(feature = "ipc", not(windows)))]
     fn test_parsing_ipc() {
         use alloy_node_bindings::Anvil;
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Closes #1134 

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

- Aligns use with Reth implementation, using `BlockId` where implemented
  - See: [trace.rs](https://github.com/paradigmxyz/reth/blob/e907f0eab0d90f286f2197ee8935f10817ff1edf/crates/rpc/rpc/src/trace.rs)
  - See: [debug.rs](https://github.com/paradigmxyz/reth/blob/e907f0eab0d90f286f2197ee8935f10817ff1edf/crates/rpc/rpc/src/debug.rs)
- Fixes `get_block_receipts` as raised in https://github.com/foundry-rs/foundry/pull/8623
- Align parameter naming, prefer ambigious `block` for consistency
- Adds a new `--all-features` CI flag to make sure all features are actually tested, `trace` / `debug` (and presumably other) tests were not actually ran in the CI. Created https://github.com/alloy-rs/alloy/issues/1136 to investigate failing `subscribe_block_ws` and `subscribe_ws_boxed` tests on Windows now requiring skipping.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
