### PR TITLE
fix: return more user-friendly error on tx timeout

### DIFF
--- a/crates/contract/src/error.rs
+++ b/crates/contract/src/error.rs
@@ -1,5 +1,6 @@
 use alloy_dyn_abi::Error as AbiError;
 use alloy_primitives::Selector;
+use alloy_provider::PendingTransactionError;
 use alloy_transport::TransportError;
 use thiserror::Error;
 
@@ -27,6 +28,9 @@ pub enum Error {
     /// An error occurred interacting with a contract over RPC.
     #[error(transparent)]
     TransportError(#[from] TransportError),
+    /// An error occured while waiting for a pending transaction.
+    #[error(transparent)]
+    PendingTransactionError(#[from] PendingTransactionError),
 }
 
 impl From<alloy_sol_types::Error> for Error {

--- a/crates/provider/Cargo.toml
+++ b/crates/provider/Cargo.toml
@@ -53,6 +53,7 @@ pin-project.workspace = true
 reqwest = { workspace = true, optional = true }
 serde_json.workspace = true
 serde.workspace = true
+thiserror.workspace = true
 tokio = { workspace = true, features = ["sync", "macros"] }
 tracing.workspace = true
 url = { workspace = true, optional = true }

--- a/crates/provider/src/heart.rs
+++ b/crates/provider/src/heart.rs
@@ -189,7 +189,7 @@ impl<'a, T: Transport + Clone, N: Network> PendingTransactionBuilder<'a, T, N> {
     /// - [`get_receipt`](Self::get_receipt) for fetching the receipt after the transaction has been
     ///   confirmed.
     pub async fn watch(self) -> Result<TxHash, PendingTransactionError> {
-        Ok(self.register().await?.await?)
+        self.register().await?.await
     }
 
     /// Waits for the transaction to confirm with the given number of confirmations, and

--- a/crates/provider/src/heart.rs
+++ b/crates/provider/src/heart.rs
@@ -5,7 +5,7 @@ use alloy_json_rpc::RpcError;
 use alloy_network::Network;
 use alloy_primitives::{TxHash, B256};
 use alloy_rpc_types_eth::Block;
-use alloy_transport::{utils::Spawnable, Transport, TransportErrorKind, TransportResult};
+use alloy_transport::{utils::Spawnable, Transport, TransportError};
 use futures::{stream::StreamExt, FutureExt, Stream};
 use std::{
     collections::{BTreeMap, HashMap, HashSet, VecDeque},
@@ -17,6 +17,26 @@ use tokio::{
     select,
     sync::{mpsc, oneshot, watch},
 };
+
+/// Errors which may occur when watching a pending transaction.
+#[derive(Debug, thiserror::Error)]
+pub enum PendingTransactionError {
+    /// Failed to register pending transaction in heartbeat.
+    #[error("failed to register pending transaction to watch")]
+    FailedToRegister,
+
+    /// Underlying transport error.
+    #[error(transparent)]
+    TransportError(#[from] TransportError),
+
+    /// Error occured while getting response from the heartbeat.
+    #[error(transparent)]
+    Recv(#[from] oneshot::error::RecvError),
+
+    /// Errors that may occur when watching a transaction.
+    #[error(transparent)]
+    TxWatcher(#[from] WatchTxError),
+}
 
 /// A builder for configuring a pending transaction watcher.
 ///
@@ -157,7 +177,7 @@ impl<'a, T: Transport + Clone, N: Network> PendingTransactionBuilder<'a, T, N> {
     /// - [`get_receipt`](Self::get_receipt) for fetching the receipt after the transaction has been
     ///   confirmed.
     #[doc(alias = "build")]
-    pub async fn register(self) -> TransportResult<PendingTransaction> {
+    pub async fn register(self) -> Result<PendingTransaction, PendingTransactionError> {
         self.provider.watch_pending_transaction(self.config).await
     }
 
@@ -168,8 +188,8 @@ impl<'a, T: Transport + Clone, N: Network> PendingTransactionBuilder<'a, T, N> {
     ///   confirmed.
     /// - [`get_receipt`](Self::get_receipt) for fetching the receipt after the transaction has been
     ///   confirmed.
-    pub async fn watch(self) -> TransportResult<TxHash> {
-        self.register().await?.await
+    pub async fn watch(self) -> Result<TxHash, PendingTransactionError> {
+        Ok(self.register().await?.await?)
     }
 
     /// Waits for the transaction to confirm with the given number of confirmations, and
@@ -183,7 +203,7 @@ impl<'a, T: Transport + Clone, N: Network> PendingTransactionBuilder<'a, T, N> {
     /// - [`register`](Self::register): for registering the transaction without waiting for it to be
     ///   confirmed.
     /// - [`watch`](Self::watch) for watching the transaction without fetching the receipt.
-    pub async fn get_receipt(self) -> TransportResult<N::ReceiptResponse> {
+    pub async fn get_receipt(self) -> Result<N::ReceiptResponse, PendingTransactionError> {
         let hash = self.config.tx_hash;
         let mut pending_tx = self.provider.watch_pending_transaction(self.config).await?;
 
@@ -209,7 +229,7 @@ impl<'a, T: Transport + Clone, N: Network> PendingTransactionBuilder<'a, T, N> {
             }
 
             if confirmed {
-                return Err(RpcError::NullResp);
+                return Err(RpcError::NullResp.into());
             }
         }
     }
@@ -303,20 +323,28 @@ impl PendingTransactionConfig {
     }
 }
 
+/// Errors which may occur in heartbeat when watching a transaction.
+#[derive(Debug, thiserror::Error)]
+pub enum WatchTxError {
+    /// Transaction was not confirmed after configured timeout.
+    #[error("transaction was not confirmed within the timeout")]
+    Timeout,
+}
+
 #[doc(alias = "TransactionWatcher")]
 struct TxWatcher {
     config: PendingTransactionConfig,
     /// The block at which the transaction was received. To be filled once known.
     /// Invariant: any confirmed transaction in `Heart` has this value set.
     received_at_block: Option<u64>,
-    tx: oneshot::Sender<()>,
+    tx: oneshot::Sender<Result<(), WatchTxError>>,
 }
 
 impl TxWatcher {
     /// Notify the waiter.
-    fn notify(self) {
+    fn notify(self, result: Result<(), WatchTxError>) {
         debug!(tx=%self.config.tx_hash, "notifying");
-        let _ = self.tx.send(());
+        let _ = self.tx.send(result);
     }
 }
 
@@ -332,7 +360,7 @@ pub struct PendingTransaction {
     pub(crate) tx_hash: TxHash,
     /// The receiver for the notification.
     // TODO: send a receipt?
-    pub(crate) rx: oneshot::Receiver<()>,
+    pub(crate) rx: oneshot::Receiver<Result<(), WatchTxError>>,
 }
 
 impl fmt::Debug for PendingTransaction {
@@ -345,7 +373,7 @@ impl PendingTransaction {
     /// Creates a ready pending transaction.
     pub fn ready(tx_hash: TxHash) -> Self {
         let (tx, rx) = oneshot::channel();
-        tx.send(()).ok(); // Make sure that the receiver is notified already.
+        tx.send(Ok(())).ok(); // Make sure that the receiver is notified already.
         Self { tx_hash, rx }
     }
 
@@ -357,15 +385,16 @@ impl PendingTransaction {
 }
 
 impl Future for PendingTransaction {
-    type Output = TransportResult<TxHash>;
+    type Output = Result<TxHash, PendingTransactionError>;
 
     fn poll(
         mut self: std::pin::Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Self::Output> {
-        self.rx
-            .poll_unpin(cx)
-            .map(|res| res.map(|()| self.tx_hash).map_err(|_| TransportErrorKind::backend_gone()))
+        self.rx.poll_unpin(cx).map(|res| {
+            res??;
+            Ok(self.tx_hash)
+        })
     }
 }
 
@@ -437,7 +466,7 @@ impl<S> Heartbeat<S> {
         let to_keep = self.waiting_confs.split_off(&(current_height + 1));
         let to_notify = std::mem::replace(&mut self.waiting_confs, to_keep);
         for watcher in to_notify.into_values().flatten() {
-            watcher.notify();
+            watcher.notify(Ok(()));
         }
     }
 
@@ -457,8 +486,9 @@ impl<S> Heartbeat<S> {
         let to_reap = std::mem::replace(&mut self.reap_at, to_keep);
 
         for tx_hash in to_reap.values() {
-            if self.unconfirmed.remove(tx_hash).is_some() {
+            if let Some(watcher) = self.unconfirmed.remove(tx_hash) {
                 debug!(tx=%tx_hash, "reaped");
+                watcher.notify(Err(WatchTxError::Timeout));
             }
         }
     }
@@ -510,7 +540,7 @@ impl<S> Heartbeat<S> {
                 let current_height = self.past_blocks.back().map(|(h, _)| *h).unwrap();
 
                 if confirmed_at <= current_height {
-                    to_watch.notify();
+                    to_watch.notify(Ok(()));
                 } else {
                     debug!(tx=%to_watch.config.tx_hash, %block_height, confirmations, "adding to waiting list");
                     self.waiting_confs.entry(confirmed_at).or_default().push(to_watch);
@@ -567,7 +597,7 @@ impl<S> Heartbeat<S> {
             // If `confirmations` is not more than 1 we can notify the watcher immediately.
             let confirmations = watcher.config.required_confirmations;
             if confirmations <= 1 {
-                watcher.notify();
+                watcher.notify(Ok(()));
                 continue;
             }
             // Otherwise add it to the waiting list.

--- a/crates/provider/src/lib.rs
+++ b/crates/provider/src/lib.rs
@@ -36,7 +36,10 @@ pub mod layers;
 mod chain;
 
 mod heart;
-pub use heart::{PendingTransaction, PendingTransactionBuilder, PendingTransactionConfig};
+pub use heart::{
+    PendingTransaction, PendingTransactionBuilder, PendingTransactionConfig,
+    PendingTransactionError, WatchTxError,
+};
 
 mod provider;
 pub use provider::{

--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -783,6 +783,8 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
     /// # Ok(())
     /// # }
     /// ```
+    /// 
+    /// [`TransportErrorKind::PubsubUnavailable`]: alloy_transport::TransportErrorKind::PubsubUnavailable
     #[cfg(feature = "pubsub")]
     async fn subscribe_full_pending_transactions(
         &self,
@@ -1070,7 +1072,7 @@ mod tests {
         let provider = ProviderBuilder::new().on_anvil_with_config(|a| a.block_time(1));
 
         let err = provider.subscribe_blocks().await.unwrap_err();
-        let alloy_json_rpc::RpcError::Transport(TransportErrorKind::PubsubUnavailable) = err else {
+        let alloy_json_rpc::RpcError::Transport(alloy_transport::TransportErrorKind::PubsubUnavailable) = err else {
             panic!("{err:?}");
         };
     }

--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -692,8 +692,8 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
     /// # Errors
     ///
     /// This method is only available on `pubsub` clients, such as WebSockets or IPC, and will
-    /// return a [`PubsubUnavailable`](TransportErrorKind::PubsubUnavailable) transport error if the
-    /// client does not support it.
+    /// return a [`PubsubUnavailable`](alloy_transport::TransportErrorKind::PubsubUnavailable)
+    /// transport error if the client does not support it.
     ///
     /// For a polling alternative available over HTTP, use [`Provider::watch_blocks`].
     /// However, be aware that polling increases RPC usage drastically.
@@ -724,8 +724,8 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
     /// # Errors
     ///
     /// This method is only available on `pubsub` clients, such as WebSockets or IPC, and will
-    /// return a [`PubsubUnavailable`](TransportErrorKind::PubsubUnavailable) transport error if the
-    /// client does not support it.
+    /// return a [`PubsubUnavailable`](alloy_transport::TransportErrorKind::PubsubUnavailable)
+    /// transport error if the client does not support it.
     ///
     /// For a polling alternative available over HTTP, use [`Provider::watch_pending_transactions`].
     /// However, be aware that polling increases RPC usage drastically.
@@ -762,8 +762,8 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
     /// # Errors
     ///
     /// This method is only available on `pubsub` clients, such as WebSockets or IPC, and will
-    /// return a [`PubsubUnavailable`](TransportErrorKind::PubsubUnavailable) transport error if the
-    /// client does not support it.
+    /// return a [`PubsubUnavailable`](alloy_transport::TransportErrorKind::PubsubUnavailable)
+    /// transport error if the client does not support it.
     ///
     /// For a polling alternative available over HTTP, use
     /// [`Provider::watch_full_pending_transactions`]. However, be aware that polling increases
@@ -783,8 +783,6 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
     /// # Ok(())
     /// # }
     /// ```
-    /// 
-    /// [`TransportErrorKind::PubsubUnavailable`]: alloy_transport::TransportErrorKind::PubsubUnavailable
     #[cfg(feature = "pubsub")]
     async fn subscribe_full_pending_transactions(
         &self,
@@ -799,8 +797,8 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
     /// # Errors
     ///
     /// This method is only available on `pubsub` clients, such as WebSockets or IPC, and will
-    /// return a [`PubsubUnavailable`](TransportErrorKind::PubsubUnavailable) transport error if the
-    /// client does not support it.
+    /// return a [`PubsubUnavailable`](alloy_transport::TransportErrorKind::PubsubUnavailable)
+    /// transport error if the client does not support it.
     ///
     /// For a polling alternative available over HTTP, use
     /// [`Provider::watch_logs`]. However, be aware that polling increases
@@ -897,6 +895,8 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
     /// # Ok(())
     /// # }
     /// ```
+    ///
+    /// [`PubsubUnavailable`]: alloy_transport::TransportErrorKind::PubsubUnavailable
     async fn raw_request<P, R>(&self, method: Cow<'static, str>, params: P) -> TransportResult<R>
     where
         P: RpcParam,
@@ -1072,7 +1072,10 @@ mod tests {
         let provider = ProviderBuilder::new().on_anvil_with_config(|a| a.block_time(1));
 
         let err = provider.subscribe_blocks().await.unwrap_err();
-        let alloy_json_rpc::RpcError::Transport(alloy_transport::TransportErrorKind::PubsubUnavailable) = err else {
+        let alloy_json_rpc::RpcError::Transport(
+            alloy_transport::TransportErrorKind::PubsubUnavailable,
+        ) = err
+        else {
             panic!("{err:?}");
         };
     }


### PR DESCRIPTION

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Currently on `TxWatcher` timeout we just drop it, resulting in `TransportError::BackendGone` error which is not really user-friendly.

## Solution


## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
