### PR TITLE
fix: remove `OtherFields` from Transaction and Block

### DIFF
--- a/crates/rpc-types-eth/src/block.rs
+++ b/crates/rpc-types-eth/src/block.rs
@@ -3,7 +3,6 @@
 use crate::{ConversionError, Transaction, Withdrawal};
 use alloy_network_primitives::BlockTransactions;
 use alloy_primitives::{Address, BlockHash, Bloom, Bytes, B256, B64, U256};
-use alloy_serde::OtherFields;
 use serde::{ser::Error, Deserialize, Serialize, Serializer};
 use std::{collections::BTreeMap, ops::Deref};
 
@@ -35,9 +34,6 @@ pub struct Block<T = Transaction> {
     /// Withdrawals in the block.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub withdrawals: Option<Vec<Withdrawal>>,
-    /// Support for arbitrary additional fields.
-    #[serde(flatten)]
-    pub other: OtherFields,
 }
 
 impl Block {
@@ -374,7 +370,6 @@ mod tests {
             transactions: vec![B256::with_last_byte(18)].into(),
             size: Some(U256::from(19)),
             withdrawals: Some(vec![]),
-            other: Default::default(),
         };
         let serialized = serde_json::to_string(&block).unwrap();
         assert_eq!(
@@ -417,7 +412,6 @@ mod tests {
             transactions: BlockTransactions::Uncle,
             size: Some(U256::from(19)),
             withdrawals: None,
-            other: Default::default(),
         };
         let serialized = serde_json::to_string(&block).unwrap();
         assert_eq!(
@@ -460,7 +454,6 @@ mod tests {
             transactions: vec![B256::with_last_byte(18)].into(),
             size: Some(U256::from(19)),
             withdrawals: None,
-            other: Default::default(),
         };
         let serialized = serde_json::to_string(&block).unwrap();
         assert_eq!(

--- a/crates/rpc-types-eth/src/transaction/mod.rs
+++ b/crates/rpc-types-eth/src/transaction/mod.rs
@@ -7,7 +7,6 @@ use alloy_consensus::{
 use alloy_eips::eip7702::SignedAuthorization;
 use alloy_network_primitives::TransactionResponse;
 use alloy_primitives::{Address, BlockHash, Bytes, ChainId, TxHash, TxKind, B256, U256};
-use alloy_serde::OtherFields;
 use serde::{Deserialize, Serialize};
 
 pub use alloy_consensus::BlobTransactionSidecar;
@@ -112,11 +111,6 @@ pub struct Transaction {
     /// signer desires to execute in the context of their EOA and their signature.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub authorization_list: Option<Vec<SignedAuthorization>>,
-    /// Arbitrary extra fields.
-    ///
-    /// This captures fields that are not native to ethereum but included in ethereum adjacent networks, for example fields the [optimism `eth_getTransactionByHash` request](https://docs.alchemy.com/alchemy/apis/optimism/eth-gettransactionbyhash) returns additional fields that this type will capture
-    #[serde(flatten)]
-    pub other: OtherFields,
 }
 
 impl Transaction {
@@ -378,7 +372,6 @@ mod tests {
                 nonce: 1u64,
             })
             .into_signed(AlloySignature::from_str("48b55bfa915ac795c431978d8a6a992b628d557da5ff759b307d495a36649353efffd310ac743f371de3b9f7f9cb56c0b28ad43601b4ab949f53faa07bd2c8041b").unwrap())]),
-            other: Default::default(),
         };
         let serialized = serde_json::to_string(&transaction).unwrap();
         assert_eq!(
@@ -422,7 +415,6 @@ mod tests {
                 nonce: 1u64,
             })
             .into_signed(AlloySignature::from_str("48b55bfa915ac795c431978d8a6a992b628d557da5ff759b307d495a36649353efffd310ac743f371de3b9f7f9cb56c0b28ad43601b4ab949f53faa07bd2c8041b").unwrap())]),
-            other: Default::default(),
         };
         let serialized = serde_json::to_string(&transaction).unwrap();
         assert_eq!(


### PR DESCRIPTION
## Motivation

Those currently consume all extra data, forcing `AnyNetwork` users to do `value.inner.other` instead of just `value.other`.

Should be merged after https://github.com/alloy-rs/alloy/pull/1106 which makes block responses use `WithOtherFields<Block>` while with this PR returned blocks are just `Block` which will miss extra fields

## Solution

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [x] Breaking changes
