### PR TITLE
refactor(`ProviderCall`): don't rely on `Caller` in `RpcWithBlock`

### DIFF
--- a/crates/json-rpc/src/request.rs
+++ b/crates/json-rpc/src/request.rs
@@ -78,6 +78,11 @@ impl<Params> Request<Params> {
     pub fn set_subscription_status(&mut self, sub: bool) {
         self.meta.set_subscription_status(sub);
     }
+
+    /// Change type of the request parameters.
+    pub fn map_params<NewParams>(self, map: impl Fn(Params) -> NewParams) -> Request<NewParams> {
+        Request { meta: self.meta, params: map(self.params) }
+    }
 }
 
 /// A [`Request`] that has been partially serialized. The request parameters

--- a/crates/json-rpc/src/request.rs
+++ b/crates/json-rpc/src/request.rs
@@ -80,7 +80,10 @@ impl<Params> Request<Params> {
     }
 
     /// Change type of the request parameters.
-    pub fn map_params<NewParams>(self, map: impl FnOnce(Params) -> NewParams) -> Request<NewParams> {
+    pub fn map_params<NewParams>(
+        self,
+        map: impl FnOnce(Params) -> NewParams,
+    ) -> Request<NewParams> {
         Request { meta: self.meta, params: map(self.params) }
     }
 }

--- a/crates/json-rpc/src/request.rs
+++ b/crates/json-rpc/src/request.rs
@@ -80,7 +80,7 @@ impl<Params> Request<Params> {
     }
 
     /// Change type of the request parameters.
-    pub fn map_params<NewParams>(self, map: impl Fn(Params) -> NewParams) -> Request<NewParams> {
+    pub fn map_params<NewParams>(self, map: impl FnOnce(Params) -> NewParams) -> Request<NewParams> {
         Request { meta: self.meta, params: map(self.params) }
     }
 }

--- a/crates/provider/src/ext/trace.rs
+++ b/crates/provider/src/ext/trace.rs
@@ -115,14 +115,14 @@ where
         trace_type: &'b [TraceType],
     ) -> RpcWithBlock<T, (&'a <N as Network>::TransactionRequest, &'b [TraceType]), TraceResults>
     {
-        RpcWithBlock::new(self.weak_client(), "trace_call", (request, trace_type))
+        self.client().request("trace_call", (request, trace_type)).into()
     }
 
     fn trace_call_many<'a>(
         &self,
         request: TraceCallList<'a, N>,
     ) -> RpcWithBlock<T, TraceCallList<'a, N>, TraceResults> {
-        RpcWithBlock::new(self.weak_client(), "trace_callMany", request)
+        self.client().request("trace_callMany", request).into()
     }
 
     async fn trace_transaction(

--- a/crates/provider/src/lib.rs
+++ b/crates/provider/src/lib.rs
@@ -42,7 +42,7 @@ pub mod layers;
 mod provider;
 pub use provider::{
     builder, Caller, EthCall, EthCallParams, FilterPollerBuilder, ParamsWithBlock, Provider,
-    ProviderCall, RootProvider, RpcWithBlock, SendableTx, WalletProvider, WithBlockFut,
+    ProviderCall, RootProvider, RpcWithBlock, SendableTx, WalletProvider,
 };
 
 pub mod utils;

--- a/crates/provider/src/provider/mod.rs
+++ b/crates/provider/src/provider/mod.rs
@@ -17,7 +17,7 @@ mod wallet;
 pub use wallet::WalletProvider;
 
 mod with_block;
-pub use with_block::{ParamsWithBlock, RpcWithBlock, WithBlockFut};
+pub use with_block::{ParamsWithBlock, RpcWithBlock};
 
 mod caller;
 pub use caller::Caller;

--- a/crates/provider/src/provider/prov_call.rs
+++ b/crates/provider/src/provider/prov_call.rs
@@ -27,7 +27,7 @@ where
     Conn: Transport + Clone,
     Params: RpcParam,
     Resp: RpcReturn,
-    Map: Fn(Resp) -> Output + Clone,
+    Map: Fn(Resp) -> Output,
 {
     /// An underlying call to an RPC server.
     RpcCall(RpcCall<Conn, Params, Resp, Output, Map>),
@@ -44,7 +44,7 @@ where
     Conn: Transport + Clone,
     Params: RpcParam,
     Resp: RpcReturn,
-    Map: Fn(Resp) -> Output + Clone,
+    Map: Fn(Resp) -> Output,
 {
     /// Instantiate a new [`ProviderCall`] from the output.
     pub const fn ready(output: Output) -> Self {
@@ -163,7 +163,7 @@ where
     Params: ToOwned,
     Params::Owned: RpcParam,
     Resp: RpcReturn,
-    Map: Fn(Resp) -> Output + Clone,
+    Map: Fn(Resp) -> Output,
 {
     /// Convert this call into one with owned params, by cloning the params.
     ///
@@ -200,7 +200,7 @@ where
     Conn: Transport + Clone,
     Params: RpcParam,
     Resp: RpcReturn,
-    Map: Fn(Resp) -> Output + Clone,
+    Map: Fn(Resp) -> Output,
 {
     fn from(call: RpcCall<Conn, Params, Resp, Output, Map>) -> Self {
         Self::RpcCall(call)
@@ -226,7 +226,7 @@ where
     Conn: Transport + Clone,
     Params: RpcParam,
     Resp: RpcReturn,
-    Map: Fn(Resp) -> Output + Clone,
+    Map: Fn(Resp) -> Output,
 {
     fn from(fut: Pin<Box<dyn Future<Output = TransportResult<Output>> + Send>>) -> Self {
         Self::BoxedFuture(fut)
@@ -251,7 +251,7 @@ where
     Params: RpcParam,
     Resp: RpcReturn,
     Output: 'static,
-    Map: Fn(Resp) -> Output + Clone,
+    Map: Fn(Resp) -> Output,
 {
     type Output = TransportResult<Output>;
 

--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -161,7 +161,7 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
         &self,
         request: &'a N::TransactionRequest,
     ) -> RpcWithBlock<T, &'a N::TransactionRequest, AccessListResult> {
-        RpcWithBlock::new(self.weak_client(), "eth_createAccessList", request)
+        self.client().request("eth_createAccessList", request).into()
     }
 
     /// This function returns an [`EthCall`] which can be used to get a gas estimate,
@@ -243,14 +243,14 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
     /// Retrieves account information ([Account](alloy_consensus::Account)) for the given [Address]
     /// at the particular [BlockId].
     fn get_account(&self, address: Address) -> RpcWithBlock<T, Address, alloy_consensus::Account> {
-        RpcWithBlock::new(self.weak_client(), "eth_getAccount", address)
+        self.client().request("eth_getAccount", address).into()
     }
 
     /// Gets the balance of the account.
     ///
     /// Defaults to the latest block. See also [`RpcWithBlock::block_id`].
     fn get_balance(&self, address: Address) -> RpcWithBlock<T, Address, U256, U256> {
-        RpcWithBlock::new(self.weak_client(), "eth_getBalance", address)
+        self.client().request("eth_getBalance", address).into()
     }
 
     /// Gets a block by either its hash, tag, or number, with full transactions or only hashes.
@@ -327,7 +327,7 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
 
     /// Gets the bytecode located at the corresponding [Address].
     fn get_code_at(&self, address: Address) -> RpcWithBlock<T, Address, Bytes> {
-        RpcWithBlock::new(self.weak_client(), "eth_getCode", address)
+        self.client().request("eth_getCode", address).into()
     }
 
     /// Watch for new blocks by polling the provider with
@@ -495,7 +495,7 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
         address: Address,
         keys: Vec<StorageKey>,
     ) -> RpcWithBlock<T, (Address, Vec<StorageKey>), EIP1186AccountProofResponse> {
-        RpcWithBlock::new(self.weak_client(), "eth_getProof", (address, keys))
+        self.client().request("eth_getProof", (address, keys)).into()
     }
 
     /// Gets the specified storage value from [Address].
@@ -504,7 +504,7 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
         address: Address,
         key: U256,
     ) -> RpcWithBlock<T, (Address, U256), StorageValue> {
-        RpcWithBlock::new(self.weak_client(), "eth_getStorageAt", (address, key))
+        self.client().request("eth_getStorageAt", (address, key)).into()
     }
 
     /// Gets a transaction by its [TxHash].
@@ -522,8 +522,10 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
         &self,
         address: Address,
     ) -> RpcWithBlock<T, Address, U64, u64, fn(U64) -> u64> {
-        RpcWithBlock::new(self.weak_client(), "eth_getTransactionCount", address)
+        self.client()
+            .request("eth_getTransactionCount", address)
             .map_resp(crate::utils::convert_u64 as fn(U64) -> u64)
+            .into()
     }
 
     /// Gets a transaction receipt if it exists, by its [TxHash].

--- a/crates/provider/src/provider/with_block.rs
+++ b/crates/provider/src/provider/with_block.rs
@@ -48,7 +48,9 @@ where
     Resp: RpcReturn,
     Map: Fn(Resp) -> Output,
 {
+    /// [RpcCall] which params are getting wrapped into [ParamsWithBlock] once the block id is set.
     RpcCall(RpcCall<T, Params, Resp, Output, Map>),
+    /// Closure that produces a [ProviderCall] once the block id is set.
     ProviderCall(ProviderCallProducer<T, Params, Resp, Output, Map>),
 }
 

--- a/crates/provider/src/provider/with_block.rs
+++ b/crates/provider/src/provider/with_block.rs
@@ -216,7 +216,7 @@ where
             WithBlockInner::BoxedFuture(get_fut) => {
                 ProviderCall::BoxedFuture(get_fut(self.block_id))
             }
-            WithBlockInner::Ready(f) => ProviderCall::Ready(Some(f(self.block_id)))
+            WithBlockInner::Ready(f) => ProviderCall::Ready(Some(f(self.block_id))),
         }
     }
 }

--- a/crates/provider/src/provider/with_block.rs
+++ b/crates/provider/src/provider/with_block.rs
@@ -37,6 +37,9 @@ impl<Params: RpcParam> serde::Serialize for ParamsWithBlock<Params> {
     }
 }
 
+type ProviderCallProducer<T, Params, Resp, Output, Map> =
+    Box<dyn Fn(BlockId) -> ProviderCall<T, ParamsWithBlock<Params>, Resp, Output, Map> + Send>;
+
 /// Container for varous types of calls dependent on a block id.
 enum WithBlockInner<T, Params, Resp, Output = Resp, Map = fn(Resp) -> Output>
 where
@@ -46,9 +49,7 @@ where
     Map: Fn(Resp) -> Output,
 {
     RpcCall(RpcCall<T, Params, Resp, Output, Map>),
-    ProviderCall(
-        Box<dyn Fn(BlockId) -> ProviderCall<T, ParamsWithBlock<Params>, Resp, Output, Map> + Send>,
-    ),
+    ProviderCall(ProviderCallProducer<T, Params, Resp, Output, Map>),
 }
 
 impl<T, Params, Resp, Output, Map> core::fmt::Debug for WithBlockInner<T, Params, Resp, Output, Map>

--- a/crates/provider/src/provider/with_block.rs
+++ b/crates/provider/src/provider/with_block.rs
@@ -122,6 +122,19 @@ where
     }
 }
 
+impl<F, T, Params, Resp, Output, Map> From<F> for RpcWithBlock<T, Params, Resp, Output, Map>
+where
+    T: Transport + Clone,
+    Params: RpcParam,
+    Resp: RpcReturn,
+    Map: Fn(Resp) -> Output + Clone,
+    F: Fn(BlockId) -> ProviderCall<T, ParamsWithBlock<Params>, Resp, Output, Map> + Send + 'static,
+{
+    fn from(inner: F) -> Self {
+        Self::new_provider(inner)
+    }
+}
+
 impl<T, Params, Resp, Output, Map> RpcWithBlock<T, Params, Resp, Output, Map>
 where
     T: Transport + Clone,

--- a/crates/rpc-client/src/call.rs
+++ b/crates/rpc-client/src/call.rs
@@ -260,6 +260,22 @@ where
         };
         request.as_mut().expect("no request in prepared")
     }
+
+    /// Map the params of the request into a new type.
+    pub fn map_params<NewParams: RpcParam>(
+        self,
+        map: impl Fn(Params) -> NewParams,
+    ) -> RpcCall<Conn, NewParams, Resp, Output, Map> {
+        let CallState::Prepared { request, connection } = self.state else {
+            panic!("Cannot get request after request has been sent");
+        };
+        let request = request.expect("no request in prepared").map_params(map);
+        RpcCall {
+            state: CallState::Prepared { request: Some(request), connection },
+            map: self.map,
+            _pd: PhantomData,
+        }
+    }
 }
 
 impl<Conn, Params, Resp, Output, Map> RpcCall<Conn, &Params, Resp, Output, Map>


### PR DESCRIPTION
## Motivation

Proposing different approach for integrating `ProviderCall` into `RpcWithBlock`

## Solution

- Add `map_params` method to `RpcCall`, allowing to change request params type. Useful for conversion of `Params` into `ParamsWithBlock`
- Add `WithBlockInner` type, containing two variants: https://github.com/alloy-rs/alloy/blob/1d49e4bd41c25e42c2e82fb24e438efdde301329/crates/provider/src/provider/with_block.rs#L40-L55
  The idea is to allow people providing arbitrary `Fn(BlockId) -> ProviderCall` methods
- Change `RpcWithBlock::Future` to `ProviderCall`. When awaited, `RpcWithBlock` will convert `WithBlockInner` into `ProviderCall` by either changing rpc call params, or invoking function.
- Also changed `ProviderCall::Ready` inner value to `Result` to allow error propagation from synchronous sources.

Altogether this allows API like this in user-defined `Provider` implementations:
```rust
fn get_code_at(&self, address: Address) -> RpcWithBlock<T, Address, Bytes> {
    let db = self.db_client();
    (move |block_id| {
        ProviderCall::Ready(Some(db.get_code(address, block_id)))
    }).into()
}
```

Motivation for separate `RpcCall` variant is that it's still getting special treatment from both `ProviderCall` and `Provider` trait itself. It is the only `ProviderCall` variant holding `Params`, and some of `Provider` functions rely on being able to use non-`static` params making it impossible to box type producing such `RpcCall`.

Another option is to ensure that `RpcWithBlock` holds `Params`, changing `ProviderCallProducer` to also accept it, however this would require all user-defined implementations of provider to re-assemble the params as expected by RPC which might be inconvenient, especially if method implementation does not interact with RPC at all. 

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
