### PR TITLE
chore: remove async_trait from NetworkWallet

### DIFF
--- a/crates/network/src/ethereum/wallet.rs
+++ b/crates/network/src/ethereum/wallet.rs
@@ -2,7 +2,6 @@ use crate::{Network, NetworkWallet, TxSigner};
 use alloy_consensus::{SignableTransaction, TxEnvelope, TypedTransaction};
 use alloy_primitives::Address;
 use alloy_signer::Signature;
-use async_trait::async_trait;
 use std::{collections::BTreeMap, sync::Arc};
 
 /// A wallet capable of signing any transaction for the Ethereum network.
@@ -95,8 +94,6 @@ impl EthereumWallet {
     }
 }
 
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl<N> NetworkWallet<N> for EthereumWallet
 where
     N: Network<UnsignedTx = TypedTransaction, TxEnvelope = TxEnvelope>,

--- a/crates/network/src/transaction/signer.rs
+++ b/crates/network/src/transaction/signer.rs
@@ -15,8 +15,6 @@ use futures_utils_wasm::impl_future;
 /// Network wallets are expected to contain one or more signing credentials,
 /// keyed by signing address. The default signer address should be used when
 /// no specific signer address is specified.
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[auto_impl(&, &mut, Box, Rc, Arc)]
 pub trait NetworkWallet<N: Network>: std::fmt::Debug + Send + Sync {
     /// Get the default signer address. This address should be used
@@ -33,11 +31,11 @@ pub trait NetworkWallet<N: Network>: std::fmt::Debug + Send + Sync {
     /// Asynchronously sign an unsigned transaction, with a specified
     /// credential.
     #[doc(alias = "sign_tx_from")]
-    async fn sign_transaction_from(
+    fn sign_transaction_from(
         &self,
         sender: Address,
         tx: N::UnsignedTx,
-    ) -> alloy_signer::Result<N::TxEnvelope>;
+    ) -> impl_future!(<Output = alloy_signer::Result<N::TxEnvelope>>);
 
     /// Asynchronously sign an unsigned transaction.
     #[doc(alias = "sign_tx")]
@@ -50,13 +48,15 @@ pub trait NetworkWallet<N: Network>: std::fmt::Debug + Send + Sync {
 
     /// Asynchronously sign a transaction request, using the sender specified
     /// in the `from` field.
-    async fn sign_request(
+    fn sign_request(
         &self,
         request: N::TransactionRequest,
-    ) -> alloy_signer::Result<N::TxEnvelope> {
-        let sender = request.from().unwrap_or_else(|| self.default_signer_address());
-        let tx = request.build_unsigned().map_err(alloy_signer::Error::other)?;
-        self.sign_transaction_from(sender, tx).await
+    ) -> impl_future!(<Output = alloy_signer::Result<N::TxEnvelope>>) {
+        async move {
+            let sender = request.from().unwrap_or_else(|| self.default_signer_address());
+            let tx = request.build_unsigned().map_err(alloy_signer::Error::other)?;
+            self.sign_transaction_from(sender, tx).await
+        }
     }
 }
 


### PR DESCRIPTION
Not needed, and was never object-safe