### PR TITLE
feat(transport): retry http errors with 503 status code

### DIFF
--- a/crates/transport/src/error.rs
+++ b/crates/transport/src/error.rs
@@ -84,7 +84,9 @@ impl TransportErrorKind {
         match self {
             // Missing batch response errors can be retried.
             Self::MissingBatchResponse(_) => true,
-            Self::HttpError(http_err) => http_err.is_rate_limit_err(),
+            Self::HttpError(http_err) => {
+                http_err.is_rate_limit_err() || http_err.is_temporarily_unavailable()
+            }
             Self::Custom(err) => {
                 let msg = err.to_string();
                 msg.contains("429 Too Many Requests")
@@ -108,6 +110,15 @@ impl HttpError {
     /// Checks the `status` to determine whether the request should be retried.
     pub const fn is_rate_limit_err(&self) -> bool {
         if self.status == 429 {
+            return true;
+        }
+        false
+    }
+
+    /// Checks the `status` to determine whether the service was temporarily unavailable and should
+    /// be retried.
+    pub const fn is_temporarily_unavailable(&self) -> bool {
+        if self.status == 503 {
             return true;
         }
         false

--- a/crates/transport/src/error.rs
+++ b/crates/transport/src/error.rs
@@ -109,19 +109,13 @@ pub struct HttpError {
 impl HttpError {
     /// Checks the `status` to determine whether the request should be retried.
     pub const fn is_rate_limit_err(&self) -> bool {
-        if self.status == 429 {
-            return true;
-        }
-        false
+        self.status == 429
     }
 
     /// Checks the `status` to determine whether the service was temporarily unavailable and should
     /// be retried.
     pub const fn is_temporarily_unavailable(&self) -> bool {
-        if self.status == 503 {
-            return true;
-        }
-        false
+        self.status == 503
     }
 }
 


### PR DESCRIPTION
## Motivation
I received a 503 status code from Alchemy indicating the service was temporarily unavailable. This caused a long-running process to abort so naturally I started to add the RetryBackoffLayer functionality but noticed it only retried HTTP errors involving rate limits. The 503 status code represents a temporarily unavailable service and may even indicate when to try the request again making this error a good candidate to retry.

## Solution
Return true in the `is_retry_err` function when the status code is 503

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
