### PR TITLE
feat(rpc-types): `debug_executionWitness`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ alloy-rpc-client = { version = "0.2", path = "crates/rpc-client", default-featur
 alloy-rpc-types-admin = { version = "0.2", path = "crates/rpc-types-admin", default-features = false }
 alloy-rpc-types-anvil = { version = "0.2", path = "crates/rpc-types-anvil", default-features = false }
 alloy-rpc-types-beacon = { version = "0.2", path = "crates/rpc-types-beacon", default-features = false }
+alloy-rpc-types-debug = { version = "0.2", path = "crates/rpc-types-debug", default-features = false }
 alloy-rpc-types-engine = { version = "0.2", path = "crates/rpc-types-engine", default-features = false }
 alloy-rpc-types-eth = { version = "0.2", path = "crates/rpc-types-eth", default-features = false }
 alloy-rpc-types-mev = { version = "0.2", path = "crates/rpc-types-mev", default-features = false }

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ This repository contains the following crates:
   - [`alloy-rpc-types-admin`] - Types for the `admin` Ethereum JSON-RPC namespace
   - [`alloy-rpc-types-anvil`] - Types for the [Anvil] development node's Ethereum JSON-RPC namespace
   - [`alloy-rpc-types-beacon`] - Types for the [Ethereum Beacon Node API][beacon-apis]
+  - [`alloy-rpc-types-debug`] - Types for the `debug` Ethereum JSON-RPC namespace
   - [`alloy-rpc-types-engine`] - Types for the `engine` Ethereum JSON-RPC namespace
   - [`alloy-rpc-types-eth`] - Types for the `eth` Ethereum JSON-RPC namespace
   - [`alloy-rpc-types-mev`] - Types for the MEV bundle JSON-RPC namespace

--- a/crates/rpc-types-debug/CHANGELOG.md
+++ b/crates/rpc-types-debug/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/crates/rpc-types-debug/Cargo.toml
+++ b/crates/rpc-types-debug/Cargo.toml
@@ -19,8 +19,6 @@ rustdoc-args = ["--cfg", "docsrs"]
 workspace = true
 
 [dependencies]
-alloy-genesis.workspace = true
 alloy-primitives = { workspace = true, features = ["serde", "std"] }
 
 serde.workspace = true
-serde_json.workspace = true

--- a/crates/rpc-types-debug/Cargo.toml
+++ b/crates/rpc-types-debug/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "alloy-rpc-types-debug"
+description = "Ethereum RPC debug types"
+
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+exclude.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
+[lints]
+workspace = true
+
+[dependencies]
+alloy-genesis.workspace = true
+alloy-primitives = { workspace = true, features = ["serde", "std"] }
+
+serde.workspace = true
+serde_json.workspace = true

--- a/crates/rpc-types-debug/README.md
+++ b/crates/rpc-types-debug/README.md
@@ -1,0 +1,3 @@
+# alloy-rpc-types-debug
+
+Types for the `debug` Ethereum JSON-RPC namespace.

--- a/crates/rpc-types-debug/src/debug.rs
+++ b/crates/rpc-types-debug/src/debug.rs
@@ -1,0 +1,16 @@
+//! Types for the `debug` API.
+
+use alloy_primitives::{Bytes, B256};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// Represents the execution witness of a block. Contains an optional map of state preimages.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExecutionWitness {
+    /// Map of all hashed trie nodes to their preimages that were required during the execution of
+    /// the block, including during state root recomputation.
+    pub witness: HashMap<B256, Bytes>,
+    /// Map of all hashed account addresses and storage slots to their preimages that were required
+    /// during the execution of the block, including during state root recomputation.
+    pub state_preimages: Option<HashMap<B256, Bytes>>,
+}

--- a/crates/rpc-types-debug/src/debug.rs
+++ b/crates/rpc-types-debug/src/debug.rs
@@ -10,7 +10,8 @@ pub struct ExecutionWitness {
     /// Map of all hashed trie nodes to their preimages that were required during the execution of
     /// the block, including during state root recomputation.
     pub witness: HashMap<B256, Bytes>,
-    /// Map of all hashed account addresses and storage slots to their preimages that were required
-    /// during the execution of the block.
+    /// Map of all hashed account addresses and storage slots to their preimages (unhashed account
+    /// addresses and storage slots, respectively) that were required during the execution of the
+    /// block. during the execution of the block.
     pub state_preimages: Option<HashMap<B256, Bytes>>,
 }

--- a/crates/rpc-types-debug/src/debug.rs
+++ b/crates/rpc-types-debug/src/debug.rs
@@ -11,6 +11,6 @@ pub struct ExecutionWitness {
     /// the block, including during state root recomputation.
     pub witness: HashMap<B256, Bytes>,
     /// Map of all hashed account addresses and storage slots to their preimages that were required
-    /// during the execution of the block, including during state root recomputation.
+    /// during the execution of the block.
     pub state_preimages: Option<HashMap<B256, Bytes>>,
 }

--- a/crates/rpc-types-debug/src/lib.rs
+++ b/crates/rpc-types-debug/src/lib.rs
@@ -1,0 +1,10 @@
+#![doc = include_str!("../README.md")]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/alloy-rs/core/main/assets/alloy.jpg",
+    html_favicon_url = "https://raw.githubusercontent.com/alloy-rs/core/main/assets/favicon.ico"
+)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+
+mod debug;
+pub use debug::*;

--- a/crates/rpc-types/Cargo.toml
+++ b/crates/rpc-types/Cargo.toml
@@ -23,6 +23,7 @@ alloy-serde.workspace = true
 alloy-rpc-types-admin = { workspace = true, optional = true }
 alloy-rpc-types-anvil = { workspace = true, optional = true }
 alloy-rpc-types-beacon = { workspace = true, optional = true }
+alloy-rpc-types-debug = { workspace = true, optional = true }
 alloy-rpc-types-engine = { workspace = true, optional = true }
 alloy-rpc-types-eth = { workspace = true, optional = true }
 alloy-rpc-types-mev = { workspace = true, optional = true }
@@ -38,6 +39,7 @@ default = ["eth", "alloy-rpc-types-engine?/default"]
 admin = ["dep:alloy-rpc-types-admin"]
 anvil = ["dep:alloy-rpc-types-anvil"]
 beacon = ["dep:alloy-rpc-types-beacon"]
+debug = ["dep:alloy-rpc-types-debug"]
 engine = ["dep:alloy-rpc-types-engine"]
 eth = ["dep:alloy-rpc-types-eth"]
 mev = ["dep:alloy-rpc-types-mev"]

--- a/crates/rpc-types/src/lib.rs
+++ b/crates/rpc-types/src/lib.rs
@@ -20,6 +20,9 @@ pub use alloy_rpc_types_anvil as anvil;
 #[cfg(feature = "beacon")]
 pub use alloy_rpc_types_beacon as beacon;
 
+#[cfg(feature = "debug")]
+pub use alloy_rpc_types_debug as debug;
+
 #[cfg(feature = "engine")]
 pub use alloy_rpc_types_engine as engine;
 


### PR DESCRIPTION
## Motivation

https://github.com/paradigmxyz/reth/issues/10404

## Solution

`debug_executionWitness` is a Reth-only JSON RPC method [recently introduced](https://github.com/paradigmxyz/reth/pull/9249) for generating historical execution witnesses.

This PR contains an updated version that includes state preimages that will be implemented in https://github.com/paradigmxyz/reth/issues/10404.

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
