### PR TITLE
fix: change generics order for `Block`

### DIFF
--- a/crates/network/src/any/mod.rs
+++ b/crates/network/src/any/mod.rs
@@ -75,5 +75,5 @@ impl Network for AnyNetwork {
 
     type HeaderResponse = Header;
 
-    type BlockResponse = WithOtherFields<Block<Self::HeaderResponse, Self::TransactionResponse>>;
+    type BlockResponse = WithOtherFields<Block<Self::TransactionResponse, Self::HeaderResponse>>;
 }

--- a/crates/rpc-types-eth/src/block.rs
+++ b/crates/rpc-types-eth/src/block.rs
@@ -36,7 +36,7 @@ pub struct Block<T = Transaction, H = Header> {
     pub withdrawals: Option<Vec<Withdrawal>>,
 }
 
-impl<T: TransactionResponse> Block<T> {
+impl<T: TransactionResponse, H> Block<T, H> {
     /// Converts a block with Tx hashes into a full block.
     pub fn into_full_block(self, txs: Vec<T>) -> Self {
         Self { transactions: txs.into(), ..self }

--- a/crates/rpc-types-eth/src/block.rs
+++ b/crates/rpc-types-eth/src/block.rs
@@ -1,7 +1,7 @@
 //! Block RPC types.
 
 use crate::{ConversionError, Transaction, Withdrawal};
-use alloy_network_primitives::{BlockResponse, BlockTransactions, HeaderResponse};
+use alloy_network_primitives::{BlockResponse, BlockTransactions, HeaderResponse, TransactionResponse};
 use alloy_primitives::{Address, BlockHash, Bloom, Bytes, B256, B64, U256};
 use serde::{ser::Error, Deserialize, Serialize, Serializer};
 use std::{collections::BTreeMap, ops::Deref};
@@ -14,7 +14,7 @@ pub use alloy_eips::{
 /// Block representation
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct Block<H = Header, T = Transaction> {
+pub struct Block<T = Transaction, H = Header> {
     /// Header of the block.
     #[serde(flatten)]
     pub header: H,
@@ -36,9 +36,9 @@ pub struct Block<H = Header, T = Transaction> {
     pub withdrawals: Option<Vec<Withdrawal>>,
 }
 
-impl<H> Block<H> {
+impl<T: TransactionResponse> Block<T> {
     /// Converts a block with Tx hashes into a full block.
-    pub fn into_full_block(self, txs: Vec<Transaction>) -> Self {
+    pub fn into_full_block(self, txs: Vec<T>) -> Self {
         Self { transactions: txs.into(), ..self }
     }
 }
@@ -334,7 +334,7 @@ pub struct BlockOverrides {
     pub block_hash: Option<BTreeMap<u64, B256>>,
 }
 
-impl<H, T> BlockResponse for Block<H, T> {
+impl<T, H> BlockResponse for Block<T, H> {
     type Transaction = T;
     type Header = H;
 

--- a/crates/rpc-types-eth/src/block.rs
+++ b/crates/rpc-types-eth/src/block.rs
@@ -1,7 +1,9 @@
 //! Block RPC types.
 
 use crate::{ConversionError, Transaction, Withdrawal};
-use alloy_network_primitives::{BlockResponse, BlockTransactions, HeaderResponse, TransactionResponse};
+use alloy_network_primitives::{
+    BlockResponse, BlockTransactions, HeaderResponse, TransactionResponse,
+};
 use alloy_primitives::{Address, BlockHash, Bloom, Bytes, B256, B64, U256};
 use serde::{ser::Error, Deserialize, Serialize, Serializer};
 use std::{collections::BTreeMap, ops::Deref};


### PR DESCRIPTION


<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

https://github.com/alloy-rs/alloy/pull/1179 added header generic to block as a first one, resulting in a breaking change. I think it is safe to assume that users are more likely to change the transaction generic, especially given that we are already doing this across other codebases

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
