### PR TITLE
fix: serde for `depositReceiptVersion`

### DIFF
--- a/crates/rpc-types-eth/src/transaction/optimism.rs
+++ b/crates/rpc-types-eth/src/transaction/optimism.rs
@@ -7,21 +7,17 @@ use serde::{Deserialize, Serialize};
 /// Optimism specific transaction fields: <https://github.com/ethereum-optimism/op-geth/blob/641e996a2dcf1f81bac9416cb6124f86a69f1de7/internal/ethapi/api.go#L1479-L1479>
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[doc(alias = "OptimismTxFields")]
+#[serde(rename_all = "camelCase")]
 pub struct OptimismTransactionFields {
     /// Hash that uniquely identifies the source of the deposit.
-    #[serde(default, rename = "sourceHash", skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source_hash: Option<B256>,
     /// The ETH value to mint on L2
-    #[serde(
-        default,
-        rename = "mint",
-        skip_serializing_if = "Option::is_none",
-        with = "alloy_serde::quantity::opt"
-    )]
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
     pub mint: Option<u128>,
     /// Field indicating whether the transaction is a system transaction, and therefore
     /// exempt from the L2 gas limit.
-    #[serde(default, rename = "isSystemTx", skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     #[doc(alias = "is_system_transaction")]
     pub is_system_tx: Option<bool>,
     /// Deposit receipt version for Optimism deposit transactions, post-Canyon only
@@ -30,7 +26,7 @@ pub struct OptimismTransactionFields {
     /// The deposit receipt version was introduced in Canyon to indicate an update to how
     /// receipt hashes should be computed when set. The state transition process
     /// ensures this is only set for post-Canyon deposit transactions.
-    #[serde(default, rename = "depositReceiptVersion", skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
     pub deposit_receipt_version: Option<u64>,
 }
 


### PR DESCRIPTION
Should we deprecate optimism types in favor of op-alloy's for the next release?