### PR TITLE
chore(consensus): Add missing getter trait methods for `alloy_consensus::Transaction`

### DIFF
--- a/crates/consensus/src/transaction/eip1559.rs
+++ b/crates/consensus/src/transaction/eip1559.rs
@@ -1,5 +1,5 @@
 use crate::{EncodableSignature, SignableTransaction, Signed, Transaction, TxType};
-use alloy_eips::eip2930::AccessList;
+use alloy_eips::{eip2930::AccessList, eip7702::SignedAuthorization};
 use alloy_primitives::{keccak256, Bytes, ChainId, Signature, TxKind, B256, U256};
 use alloy_rlp::{BufMut, Decodable, Encodable, Header};
 use core::mem;
@@ -290,6 +290,10 @@ impl Transaction for TxEip1559 {
         self.max_priority_fee_per_gas
     }
 
+    fn max_fee_per_blob_gas(&self) -> Option<u128> {
+        None
+    }
+
     fn to(&self) -> TxKind {
         self.to
     }
@@ -311,6 +315,10 @@ impl Transaction for TxEip1559 {
     }
 
     fn blob_versioned_hashes(&self) -> Option<&[B256]> {
+        None
+    }
+
+    fn authorization_list(&self) -> Option<&[SignedAuthorization]> {
         None
     }
 }

--- a/crates/consensus/src/transaction/eip2930.rs
+++ b/crates/consensus/src/transaction/eip2930.rs
@@ -1,5 +1,5 @@
 use crate::{EncodableSignature, SignableTransaction, Signed, Transaction, TxType};
-use alloy_eips::eip2930::AccessList;
+use alloy_eips::{eip2930::AccessList, eip7702::SignedAuthorization};
 use alloy_primitives::{keccak256, Bytes, ChainId, Signature, TxKind, B256, U256};
 use alloy_rlp::{length_of_length, BufMut, Decodable, Encodable, Header};
 use core::mem;
@@ -254,6 +254,10 @@ impl Transaction for TxEip2930 {
         self.gas_price
     }
 
+    fn max_fee_per_blob_gas(&self) -> Option<u128> {
+        None
+    }
+
     fn to(&self) -> TxKind {
         self.to
     }
@@ -275,6 +279,10 @@ impl Transaction for TxEip2930 {
     }
 
     fn blob_versioned_hashes(&self) -> Option<&[B256]> {
+        None
+    }
+
+    fn authorization_list(&self) -> Option<&[SignedAuthorization]> {
         None
     }
 }

--- a/crates/consensus/src/transaction/eip4844.rs
+++ b/crates/consensus/src/transaction/eip4844.rs
@@ -1,6 +1,6 @@
 use crate::{EncodableSignature, SignableTransaction, Signed, Transaction, TxType};
 
-use alloy_eips::{eip2930::AccessList, eip4844::DATA_GAS_PER_BLOB};
+use alloy_eips::{eip2930::AccessList, eip4844::DATA_GAS_PER_BLOB, eip7702::SignedAuthorization};
 use alloy_primitives::{keccak256, Address, Bytes, ChainId, Signature, TxKind, B256, U256};
 use alloy_rlp::{length_of_length, BufMut, Decodable, Encodable, Header};
 use core::mem;
@@ -237,6 +237,13 @@ impl Transaction for TxEip4844Variant {
         }
     }
 
+    fn max_fee_per_blob_gas(&self) -> Option<u128> {
+        match self {
+            Self::TxEip4844(tx) => tx.max_fee_per_blob_gas(),
+            Self::TxEip4844WithSidecar(tx) => tx.max_fee_per_blob_gas(),
+        }
+    }
+
     fn to(&self) -> TxKind {
         match self {
             Self::TxEip4844(tx) => tx.to,
@@ -275,6 +282,10 @@ impl Transaction for TxEip4844Variant {
             Self::TxEip4844(tx) => tx.blob_versioned_hashes(),
             Self::TxEip4844WithSidecar(tx) => tx.blob_versioned_hashes(),
         }
+    }
+
+    fn authorization_list(&self) -> Option<&[SignedAuthorization]> {
+        None
     }
 }
 
@@ -700,6 +711,10 @@ impl Transaction for TxEip4844 {
         self.max_priority_fee_per_gas
     }
 
+    fn max_fee_per_blob_gas(&self) -> Option<u128> {
+        Some(self.max_fee_per_blob_gas)
+    }
+
     fn to(&self) -> TxKind {
         self.to.into()
     }
@@ -722,6 +737,10 @@ impl Transaction for TxEip4844 {
 
     fn blob_versioned_hashes(&self) -> Option<&[B256]> {
         Some(&self.blob_versioned_hashes)
+    }
+
+    fn authorization_list(&self) -> Option<&[SignedAuthorization]> {
+        None
     }
 }
 
@@ -965,6 +984,10 @@ impl Transaction for TxEip4844WithSidecar {
         self.tx.priority_fee_or_price()
     }
 
+    fn max_fee_per_blob_gas(&self) -> Option<u128> {
+        self.tx.max_fee_per_blob_gas()
+    }
+
     fn to(&self) -> TxKind {
         self.tx.to()
     }
@@ -987,6 +1010,10 @@ impl Transaction for TxEip4844WithSidecar {
 
     fn blob_versioned_hashes(&self) -> Option<&[B256]> {
         self.tx.blob_versioned_hashes()
+    }
+
+    fn authorization_list(&self) -> Option<&[SignedAuthorization]> {
+        None
     }
 }
 

--- a/crates/consensus/src/transaction/eip7702.rs
+++ b/crates/consensus/src/transaction/eip7702.rs
@@ -313,6 +313,10 @@ impl Transaction for TxEip7702 {
         self.max_priority_fee_per_gas
     }
 
+    fn max_fee_per_blob_gas(&self) -> Option<u128> {
+        None
+    }
+
     fn to(&self) -> TxKind {
         self.to
     }
@@ -335,6 +339,10 @@ impl Transaction for TxEip7702 {
 
     fn blob_versioned_hashes(&self) -> Option<&[B256]> {
         None
+    }
+
+    fn authorization_list(&self) -> Option<&[SignedAuthorization]> {
+        Some(&self.authorization_list)
     }
 }
 

--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -468,6 +468,16 @@ impl Transaction for TxEnvelope {
         }
     }
 
+    fn max_fee_per_blob_gas(&self) -> Option<u128> {
+        match self {
+            Self::Legacy(tx) => tx.tx().max_fee_per_blob_gas(),
+            Self::Eip2930(tx) => tx.tx().max_fee_per_blob_gas(),
+            Self::Eip1559(tx) => tx.tx().max_fee_per_blob_gas(),
+            Self::Eip4844(tx) => tx.tx().max_fee_per_blob_gas(),
+            Self::Eip7702(tx) => tx.tx().max_fee_per_blob_gas(),
+        }
+    }
+
     fn input(&self) -> &[u8] {
         match self {
             Self::Legacy(tx) => tx.tx().input(),
@@ -535,6 +545,16 @@ impl Transaction for TxEnvelope {
             Self::Eip1559(tx) => tx.tx().blob_versioned_hashes(),
             Self::Eip4844(tx) => tx.tx().blob_versioned_hashes(),
             Self::Eip7702(tx) => tx.tx().blob_versioned_hashes(),
+        }
+    }
+
+    fn authorization_list(&self) -> Option<&[alloy_eips::eip7702::SignedAuthorization]> {
+        match self {
+            Self::Legacy(tx) => tx.tx().authorization_list(),
+            Self::Eip2930(tx) => tx.tx().authorization_list(),
+            Self::Eip1559(tx) => tx.tx().authorization_list(),
+            Self::Eip4844(tx) => tx.tx().authorization_list(),
+            Self::Eip7702(tx) => tx.tx().authorization_list(),
         }
     }
 }

--- a/crates/consensus/src/transaction/legacy.rs
+++ b/crates/consensus/src/transaction/legacy.rs
@@ -1,6 +1,6 @@
 use core::mem;
 
-use alloy_eips::eip2930::AccessList;
+use alloy_eips::{eip2930::AccessList, eip7702::SignedAuthorization};
 use alloy_primitives::{keccak256, Bytes, ChainId, Signature, TxKind, B256, U256};
 use alloy_rlp::{length_of_length, BufMut, Decodable, Encodable, Header, Result};
 
@@ -232,6 +232,10 @@ impl Transaction for TxLegacy {
         self.gas_price
     }
 
+    fn max_fee_per_blob_gas(&self) -> Option<u128> {
+        None
+    }
+
     fn to(&self) -> TxKind {
         self.to
     }
@@ -253,6 +257,10 @@ impl Transaction for TxLegacy {
     }
 
     fn blob_versioned_hashes(&self) -> Option<&[B256]> {
+        None
+    }
+
+    fn authorization_list(&self) -> Option<&[SignedAuthorization]> {
         None
     }
 }

--- a/crates/consensus/src/transaction/mod.rs
+++ b/crates/consensus/src/transaction/mod.rs
@@ -1,7 +1,7 @@
 //! Transaction types.
 
 use crate::Signed;
-use alloy_eips::eip2930::AccessList;
+use alloy_eips::{eip2930::AccessList, eip7702::SignedAuthorization};
 use alloy_primitives::{keccak256, ChainId, TxKind, B256, U256};
 use core::any;
 
@@ -56,13 +56,20 @@ pub trait Transaction: any::Any + Send + Sync + 'static {
     ///
     /// For legacy transactions this is `gas_price`.
     ///
-    /// This is also commonly referred to as the "Gas Fee Cap" (`GasFeeCap`).
+    /// This is also commonly referred to as the "Gas Fee Cap".
     fn max_fee_per_gas(&self) -> u128;
 
     /// Returns the EIP-1559 Priority fee the caller is paying to the block author.
     ///
     /// This will return `None` for non-EIP1559 transactions
     fn max_priority_fee_per_gas(&self) -> Option<u128>;
+
+    /// Max fee per blob gas for EIP-4844 transaction.
+    ///
+    /// Returns `None` for non-eip4844 transactions.
+    ///
+    /// This is also commonly referred to as the "Blob Gas Fee Cap".
+    fn max_fee_per_blob_gas(&self) -> Option<u128>;
 
     /// Return the max priority fee per gas if the transaction is an EIP-1559 transaction, and
     /// otherwise return the gas price.
@@ -107,13 +114,18 @@ pub trait Transaction: any::Any + Send + Sync + 'static {
     /// Returns the transaction type
     fn ty(&self) -> u8;
 
-    /// Returns the EIP2930 `access_list` for the particular transaction type. Returns `None` for
+    /// Returns the EIP-2930 `access_list` for the particular transaction type. Returns `None` for
     /// older transaction types.
     fn access_list(&self) -> Option<&AccessList>;
 
     /// Blob versioned hashes for eip4844 transaction. For previous transaction types this is
     /// `None`.
     fn blob_versioned_hashes(&self) -> Option<&[B256]>;
+
+    /// Returns the [`SignedAuthorization`] list of the transaction.
+    ///
+    /// Returns `None` if this transaction is not EIP-7702.
+    fn authorization_list(&self) -> Option<&[SignedAuthorization]>;
 }
 
 /// A signable transaction.

--- a/crates/consensus/src/transaction/typed.rs
+++ b/crates/consensus/src/transaction/typed.rs
@@ -1,7 +1,7 @@
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
-use alloy_eips::eip2930::AccessList;
+use alloy_eips::{eip2930::AccessList, eip7702::SignedAuthorization};
 use alloy_primitives::{ChainId, TxKind, B256};
 
 use crate::{
@@ -209,6 +209,16 @@ impl Transaction for TypedTransaction {
         }
     }
 
+    fn max_fee_per_blob_gas(&self) -> Option<u128> {
+        match self {
+            Self::Legacy(tx) => tx.max_fee_per_blob_gas(),
+            Self::Eip2930(tx) => tx.max_fee_per_blob_gas(),
+            Self::Eip1559(tx) => tx.max_fee_per_blob_gas(),
+            Self::Eip4844(tx) => tx.max_fee_per_blob_gas(),
+            Self::Eip7702(tx) => tx.max_fee_per_blob_gas(),
+        }
+    }
+
     fn to(&self) -> TxKind {
         match self {
             Self::Legacy(tx) => tx.to(),
@@ -266,6 +276,16 @@ impl Transaction for TypedTransaction {
             Self::Eip1559(tx) => tx.blob_versioned_hashes(),
             Self::Eip4844(tx) => tx.blob_versioned_hashes(),
             Self::Eip7702(tx) => tx.blob_versioned_hashes(),
+        }
+    }
+
+    fn authorization_list(&self) -> Option<&[SignedAuthorization]> {
+        match self {
+            Self::Legacy(tx) => tx.authorization_list(),
+            Self::Eip2930(tx) => tx.authorization_list(),
+            Self::Eip1559(tx) => tx.authorization_list(),
+            Self::Eip4844(tx) => tx.authorization_list(),
+            Self::Eip7702(tx) => tx.authorization_list(),
         }
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Getters needed for making `alloy_network::Network::TransactionResponse` from `alloy_consensus::Transaction` types

## Solution

Adds missing getters to `alloy_consensus::Transaction`

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
