### PR TITLE
Implement conversion between signature types

### DIFF
--- a/crates/rpc-types-eth/src/transaction/signature.rs
+++ b/crates/rpc-types-eth/src/transaction/signature.rs
@@ -81,10 +81,7 @@ impl From<alloy_primitives::Signature> for Signature {
             v: U256::from(signature.v().to_u64()),
             r: signature.r(),
             s: signature.s(),
-            y_parity: Some(Parity::from(
-                signature.v().y_parity_byte_non_eip155().unwrap_or(signature.v().y_parity_byte())
-                    != 0,
-            )),
+            y_parity: Some(Parity::from(signature.v().y_parity())),
         }
     }
 }

--- a/crates/rpc-types-eth/src/transaction/signature.rs
+++ b/crates/rpc-types-eth/src/transaction/signature.rs
@@ -75,6 +75,20 @@ impl TryFrom<Signature> for alloy_primitives::Signature {
     }
 }
 
+impl From<alloy_primitives::Signature> for Signature {
+    fn from(signature: alloy_primitives::Signature) -> Self {
+        Self {
+            v: U256::from(signature.v().to_u64()),
+            r: signature.r(),
+            s: signature.s(),
+            y_parity: Some(Parity::from(
+                signature.v().y_parity_byte_non_eip155().unwrap_or(signature.v().y_parity_byte())
+                    != 0,
+            )),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Converting `alloy_consensus::Transaction` types into `alloy_network_primitives::TransactionResponse` types, requires conversion from `alloy_primitives::Signature` to `alloy_rpc_types_eth::Signature`

## Solution

Implement `From<alloy_primitives::Signature> for alloy_rpc_types_eth::Signature`  

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
