### PR TITLE
fix: use `impl From<RangeInclusive> for FilterBlockOption` instead of `Range` 

### DIFF
--- a/crates/rpc-types-eth/src/filter.rs
+++ b/crates/rpc-types-eth/src/filter.rs
@@ -12,7 +12,7 @@ use std::{
         HashSet,
     },
     hash::Hash,
-    ops::{Range, RangeFrom, RangeTo},
+    ops::{RangeFrom, RangeInclusive, RangeToInclusive},
 };
 use thiserror::Error;
 
@@ -277,16 +277,17 @@ impl From<u64> for FilterBlockOption {
     }
 }
 
-impl<T: Into<BlockNumberOrTag>> From<Range<T>> for FilterBlockOption {
-    fn from(r: Range<T>) -> Self {
-        let from_block = Some(r.start.into());
-        let to_block = Some(r.end.into());
+impl<T: Into<BlockNumberOrTag>> From<RangeInclusive<T>> for FilterBlockOption {
+    fn from(r: RangeInclusive<T>) -> Self {
+        let (start, end) = r.into_inner();
+        let from_block = Some(start.into());
+        let to_block = Some(end.into());
         Self::Range { from_block, to_block }
     }
 }
 
-impl<T: Into<BlockNumberOrTag>> From<RangeTo<T>> for FilterBlockOption {
-    fn from(r: RangeTo<T>) -> Self {
+impl<T: Into<BlockNumberOrTag>> From<RangeToInclusive<T>> for FilterBlockOption {
+    fn from(r: RangeToInclusive<T>) -> Self {
         let to_block = Some(r.end.into());
         Self::Range { from_block: Some(BlockNumberOrTag::Earliest), to_block }
     }

--- a/crates/rpc-types-eth/src/filter.rs
+++ b/crates/rpc-types-eth/src/filter.rs
@@ -372,7 +372,7 @@ impl Filter {
     /// ```rust
     /// # use alloy_rpc_types_eth::Filter;
     /// # fn main() {
-    /// let filter = Filter::new().select(0u64..100u64);
+    /// let filter = Filter::new().select(0u64..=100u64);
     /// # }
     /// ```
     ///
@@ -390,7 +390,7 @@ impl Filter {
     /// ```rust
     /// # use alloy_rpc_types_eth::Filter;
     /// # fn main() {
-    /// let filter = Filter::new().select(..1337u64);
+    /// let filter = Filter::new().select(..=1337u64);
     /// # }
     /// ```
     #[must_use]


### PR DESCRIPTION
## Motivation
`FilterBlockOption` deals with inclusive ranges.

https://github.com/alloy-rs/alloy/blob/02ccb77a26f11198f1dfeacec875f7d871aa4504/crates/rpc-types-eth/src/filter.rs#L171-L179

While passing an exclusive range (eg `.select(start..end)`), it was wrongly including the end range in the filter.

## Solution

Only allow conversion from `RangeInclusive` instead of `Range`, since decrementing a block tag is not possible.
