### PR TITLE
pub decoder for CallBuilder

### DIFF
--- a/crates/contract/src/call.rs
+++ b/crates/contract/src/call.rs
@@ -128,7 +128,7 @@ pub struct CallBuilder<T, P, D, N: Network = Ethereum> {
     /// The provider.
     // NOTE: This is public due to usage in `sol!`, please avoid changing it.
     pub provider: P,
-    decoder: D,
+    pub decoder: D,
     transport: PhantomData<T>,
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
I'm trying to migrate Multicall from Ethers to Alloy. But the field decoder is private, which makes Multicall impossible!

I'm using the code from this pull request, which was ignored!
https://github.com/alloy-rs/alloy/pull/442
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Make the decoder field public 
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
