### PR TITLE
feat(transport-http): Http with header auth

### DIFF
--- a/crates/transport-http/src/lib.rs
+++ b/crates/transport-http/src/lib.rs
@@ -27,7 +27,7 @@ pub use hyper;
 #[cfg(all(not(target_arch = "wasm32"), feature = "hyper"))]
 pub use hyper_util;
 
-use alloy_transport::utils::guess_local_url;
+use alloy_transport::{utils::guess_local_url, Authorization};
 use core::{marker::PhantomData, str::FromStr};
 use url::Url;
 
@@ -75,12 +75,18 @@ impl<T> FromStr for HttpConnect<T> {
 pub struct Http<T> {
     client: T,
     url: Url,
+    auth: Option<Authorization>,
 }
 
 impl<T> Http<T> {
     /// Create a new [`Http`] transport with a custom client.
     pub const fn with_client(client: T, url: Url) -> Self {
-        Self { client, url }
+        Self { client, url, auth: None }
+    }
+
+    /// Set the authorization header.
+    pub fn set_auth(&mut self, auth: Authorization) {
+        self.auth = Some(auth);
     }
 
     /// Set the URL.

--- a/crates/transport-http/src/reqwest_transport.rs
+++ b/crates/transport-http/src/reqwest_transport.rs
@@ -1,7 +1,8 @@
 use crate::{Http, HttpConnect};
 use alloy_json_rpc::{RequestPacket, ResponsePacket};
 use alloy_transport::{
-    utils::guess_local_url, TransportConnect, TransportError, TransportErrorKind, TransportFut,
+    utils::guess_local_url, Authorization, TransportConnect, TransportError, TransportErrorKind,
+    TransportFut,
 };
 use std::task;
 use tower::Service;
@@ -35,6 +36,12 @@ impl Http<Client> {
     /// Create a new [`Http`] transport.
     pub fn new(url: Url) -> Self {
         Self { client: Default::default(), url, auth: None }
+    }
+
+    /// With authorization header.
+    pub fn with_auth(mut self, auth: Option<Authorization>) -> Self {
+        self.auth = auth;
+        self
     }
 
     /// Make a request.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

There is no easy way to send authenticated HTTP requests. Users would have to write a custom transport client implementation. 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

- Adds a new field in the `transport-http::Http<T>` called `auth: Option<Authorization>`.

- Made accommodations for `reqwest` and `hyper` implementations to incorporate and set the `header` authorization if `auth` is set.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
