### PR TITLE
feat: add error for pre prague requests

### DIFF
--- a/crates/rpc-types-engine/src/payload.rs
+++ b/crates/rpc-types-engine/src/payload.rs
@@ -816,7 +816,9 @@ pub enum PayloadError {
     /// blob transactions present in pre-prague payload.
     #[error("eip 7702 transactions present in pre-prague payload")]
     PrePragueBlockWithEip7702Transactions,
-
+    /// requests present in pre-prague payload.
+    #[error("requests present in pre-prague payload")]
+    PrePragueBlockRequests,
     /// Invalid payload block hash.
     #[error("block hash mismatch: want {consensus}, got {execution}")]
     BlockHash {


### PR DESCRIPTION
adds new variant for when requests are provided before prague, similar to `PreShanghaiBlockWithWitdrawals`