### PR TITLE
fix: value of TxEip1559.ty

### DIFF
--- a/crates/consensus/src/transaction/eip1559.rs
+++ b/crates/consensus/src/transaction/eip1559.rs
@@ -307,7 +307,7 @@ impl Transaction for TxEip1559 {
     }
 
     fn ty(&self) -> u8 {
-        TxType::Eip2930 as u8
+        TxType::Eip1559 as u8
     }
 
     fn access_list(&self) -> Option<&AccessList> {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

`TxEip1559::ty()` returns a value indicating EIP-2930 transactions without EIP-1559 features. This is not correct.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
Change the value

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
