### PR TITLE
fix: Anvil builder default port

### DIFF
--- a/crates/node-bindings/src/anvil.rs
+++ b/crates/node-bindings/src/anvil.rs
@@ -291,7 +291,7 @@ impl Anvil {
     pub fn try_spawn(self) -> Result<AnvilInstance, AnvilError> {
         let mut cmd = self.program.as_ref().map_or_else(|| Command::new("anvil"), Command::new);
         cmd.stdout(std::process::Stdio::piped()).stderr(std::process::Stdio::inherit());
-        let mut port = self.port.unwrap_or(8545u16);
+        let mut port = self.port.unwrap_or_default();
         cmd.arg("-p").arg(port.to_string());
 
         if let Some(mnemonic) = self.mnemonic {
@@ -416,11 +416,5 @@ mod tests {
     fn assert_chain_id_without_rpc() {
         let anvil = Anvil::new().spawn();
         assert_eq!(anvil.chain_id(), 31337);
-    }
-
-    #[test]
-    fn assert_default_port() {
-        let anvil = Anvil::new().spawn();
-        assert_eq!(anvil.port(), 8545);
     }
 }

--- a/crates/node-bindings/src/anvil.rs
+++ b/crates/node-bindings/src/anvil.rs
@@ -164,7 +164,7 @@ pub struct Anvil {
 
 impl Anvil {
     /// Creates an empty Anvil builder.
-    /// The default port is 8545. The mnemonic is chosen randomly.
+    /// The default port and the mnemonic are chosen randomly.
     ///
     /// # Example
     ///

--- a/crates/node-bindings/src/anvil.rs
+++ b/crates/node-bindings/src/anvil.rs
@@ -291,7 +291,7 @@ impl Anvil {
     pub fn try_spawn(self) -> Result<AnvilInstance, AnvilError> {
         let mut cmd = self.program.as_ref().map_or_else(|| Command::new("anvil"), Command::new);
         cmd.stdout(std::process::Stdio::piped()).stderr(std::process::Stdio::inherit());
-        let mut port = self.port.unwrap_or_default();
+        let mut port = self.port.unwrap_or(8545u16);
         cmd.arg("-p").arg(port.to_string());
 
         if let Some(mnemonic) = self.mnemonic {
@@ -416,5 +416,11 @@ mod tests {
     fn assert_chain_id_without_rpc() {
         let anvil = Anvil::new().spawn();
         assert_eq!(anvil.chain_id(), 31337);
+    }
+
+    #[test]
+    fn assert_default_port() {
+        let anvil = Anvil::new().spawn();
+        assert_eq!(anvil.port(), 8545);
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Anvil builder `new()` method docs states the default port to be 8545. In practice, however, current code sets random port number.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Set default port inside `try_spawn()` to 8545, unless otherwise specified.
Unit test added.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [X] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
