### PR TITLE
eip7702: derive `arbitrary::Arbitrary` for `TxEip7702`

### DIFF
--- a/crates/consensus/src/transaction/eip7702.rs
+++ b/crates/consensus/src/transaction/eip7702.rs
@@ -10,6 +10,7 @@ use alloy_eips::eip7702::{constants::EIP7702_TX_TYPE_ID, SignedAuthorization};
 
 /// A transaction with a priority fee ([EIP-7702](https://eips.ethereum.org/EIPS/eip-7702)).
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[doc(alias = "Eip7702Transaction", alias = "TransactionEip7702", alias = "Eip7702Tx")]


### PR DESCRIPTION
Related https://github.com/paradigmxyz/reth/issues/9484

To be in agreement with https://github.com/paradigmxyz/reth/blob/b0f3949510418e327a39143df5c6c68a7c8fa6d3/crates/primitives/src/transaction/mod.rs#L90-L92 requirement