### PR TITLE
fix(eips): no-std compat

### DIFF
--- a/crates/eips/Cargo.toml
+++ b/crates/eips/Cargo.toml
@@ -36,7 +36,7 @@ derive_more = { workspace = true, features = [
     "as_ref",
     "deref",
     "deref_mut",
-], optional = true }
+], default-features = false, optional = true }
 once_cell = { workspace = true, features = ["race", "alloc"], optional = true }
 sha2 = { workspace = true, optional = true }
 

--- a/crates/eips/Cargo.toml
+++ b/crates/eips/Cargo.toml
@@ -59,7 +59,7 @@ serde_json.workspace = true
 
 [features]
 default = ["std", "kzg-sidecar"]
-std = ["alloy-primitives/std", "alloy-rlp/std",
+std = ["alloy-primitives/std", "alloy-rlp/std", "derive_more/std",
 "serde?/std", "c-kzg?/std", "once_cell?/std"]
 serde = ["dep:alloy-serde", "dep:serde", "alloy-primitives/serde", 
 "c-kzg?/serde", "alloy-eip2930/serde", "alloy-eip7702/serde"]


### PR DESCRIPTION
**Description**

Fixes alloy-eips to have `no_std` compat.