### PR TITLE
feat(network-primitives): expose more fields via block response traits

### DIFF
--- a/crates/network-primitives/src/traits.rs
+++ b/crates/network-primitives/src/traits.rs
@@ -68,16 +68,28 @@ pub trait HeaderResponse {
     /// Blob fee for the next block (if EIP-4844 is supported)
     fn next_block_blob_fee(&self) -> Option<u128>;
 
-    /// Miner/Coinbase of the block
-    fn miner(&self) -> Address;
+    /// Coinbase/Miner of the block
+    fn coinbase(&self) -> Address;
 
     /// Gas limit of the block
-    fn gas(&self) -> u128;
+    fn gas_limit(&self) -> u128;
 
     /// Mix hash of the block
+    ///
+    /// Before the merge this proves, combined with the nonce, that a sufficient amount of
+    /// computation has been carried out on this block: the Proof-of-Work (PoW).
+    ///
+    /// After the merge this is `prevRandao`: Randomness value for the generated payload.
+    ///
+    /// This is an Option because it is not always set by non-ethereum networks.
+    ///
+    /// See also <https://eips.ethereum.org/EIPS/eip-4399>
+    /// And <https://github.com/ethereum/execution-apis/issues/328>
     fn mix_hash(&self) -> Option<B256>;
 
     /// Difficulty of the block
+    ///
+    /// Unused after the Paris (AKA the merge) upgrade, and replaced by `prevrandao`.
     fn difficulty(&self) -> U256;
 }
 
@@ -193,12 +205,12 @@ impl<T: HeaderResponse> HeaderResponse for WithOtherFields<T> {
         self.inner.next_block_blob_fee()
     }
 
-    fn miner(&self) -> Address {
-        self.inner.miner()
+    fn coinbase(&self) -> Address {
+        self.inner.coinbase()
     }
 
-    fn gas(&self) -> u128 {
-        self.inner.gas()
+    fn gas_limit(&self) -> u128 {
+        self.inner.gas_limit()
     }
 
     fn mix_hash(&self) -> Option<B256> {

--- a/crates/network-primitives/src/traits.rs
+++ b/crates/network-primitives/src/traits.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::{Address, BlockHash, Bytes, TxHash, U256};
+use alloy_primitives::{Address, BlockHash, Bytes, TxHash, B256, U256};
 use alloy_serde::WithOtherFields;
 
 use crate::BlockTransactions;
@@ -67,6 +67,18 @@ pub trait HeaderResponse {
 
     /// Blob fee for the next block (if EIP-4844 is supported)
     fn next_block_blob_fee(&self) -> Option<u128>;
+
+    /// Miner/Coinbase of the block
+    fn miner(&self) -> Address;
+
+    /// Gas limit of the block
+    fn gas(&self) -> u128;
+
+    /// Mix hash of the block
+    fn mix_hash(&self) -> Option<B256>;
+
+    /// Difficulty of the block
+    fn difficulty(&self) -> U256;
 }
 
 /// Block JSON-RPC response.
@@ -170,5 +182,21 @@ impl<T: HeaderResponse> HeaderResponse for WithOtherFields<T> {
 
     fn next_block_blob_fee(&self) -> Option<u128> {
         self.inner.next_block_blob_fee()
+    }
+
+    fn miner(&self) -> Address {
+        self.inner.miner()
+    }
+
+    fn gas(&self) -> u128 {
+        self.inner.gas()
+    }
+
+    fn mix_hash(&self) -> Option<B256> {
+        self.inner.mix_hash()
+    }
+
+    fn difficulty(&self) -> U256 {
+        self.inner.difficulty()
     }
 }

--- a/crates/network-primitives/src/traits.rs
+++ b/crates/network-primitives/src/traits.rs
@@ -96,6 +96,11 @@ pub trait BlockResponse {
 
     /// Mutable reference to block transactions
     fn transactions_mut(&mut self) -> &mut BlockTransactions<Self::Transaction>;
+
+    /// Returns the `other` field from `WithOtherFields` type.
+    fn other_fields(&self) -> Option<&alloy_serde::OtherFields> {
+        None
+    }
 }
 
 impl<T: TransactionResponse> TransactionResponse for WithOtherFields<T> {
@@ -156,6 +161,10 @@ impl<T: BlockResponse> BlockResponse for WithOtherFields<T> {
 
     fn transactions_mut(&mut self) -> &mut BlockTransactions<Self::Transaction> {
         self.inner.transactions_mut()
+    }
+
+    fn other_fields(&self) -> Option<&alloy_serde::OtherFields> {
+        Some(&self.other)
     }
 }
 

--- a/crates/rpc-types-eth/src/block.rs
+++ b/crates/rpc-types-eth/src/block.rs
@@ -229,11 +229,11 @@ impl HeaderResponse for Header {
         self.next_block_blob_fee()
     }
 
-    fn miner(&self) -> Address {
+    fn coinbase(&self) -> Address {
         self.miner
     }
 
-    fn gas(&self) -> u128 {
+    fn gas_limit(&self) -> u128 {
         self.gas_limit
     }
 

--- a/crates/rpc-types-eth/src/block.rs
+++ b/crates/rpc-types-eth/src/block.rs
@@ -228,6 +228,22 @@ impl HeaderResponse for Header {
     fn next_block_blob_fee(&self) -> Option<u128> {
         self.next_block_blob_fee()
     }
+
+    fn miner(&self) -> Address {
+        self.miner
+    }
+
+    fn gas(&self) -> u128 {
+        self.gas_limit
+    }
+
+    fn mix_hash(&self) -> Option<B256> {
+        self.mix_hash
+    }
+
+    fn difficulty(&self) -> U256 {
+        self.difficulty
+    }
 }
 
 /// Error that can occur when converting other types to blocks


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

`HeaderResponse` exposed very limited fields. `BlockResponse` doesn't expose `other` fields in case of `WithOtherFields<Block>`. 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

- Expose `miner, gas_limit, mix_hash, difficulty` in `HeaderResponse`. Exposing these fields helps to initialize a `revm::BlockEnv` like so: 

```rust
BlockEnv {
    number: U256::from(block.header().number()),
    timestamp: U256::from(block.header().timestamp()),
    coinbase: block.header().miner(),
    difficulty: block.header().difficulty(),
    prevrandao: block.header().mix_hash(),
    basefee: U256::from(block.header().base_fee_per_gas().unwrap_or_default()),
    gas_limit: U256::from(block.header().gas()),
    ..Default::default()
}
```

- Add `other_fields(&self) -> Option<OtherFields>` to `BlockResponse` which returns `None` by default unless overridden. 

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
