### PR TITLE
chore: derive more default features false

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,7 +133,7 @@ semver = "1.0"
 thiserror = "1.0"
 thiserror-no-std = "2.0.2"
 url = "2.5"
-derive_more = "1.0.0"
+derive_more = { version = "1.0.0", default-features = false }
 
 ## serde
 serde = { version = "1.0", default-features = false, features = [


### PR DESCRIPTION
> warning: /Users/Matthias/git/rust/alloy/crates/eips/Cargo.toml: `default-features` is ignored for derive_more, since `default-features` was not specified for `workspace.dependencies.derive_more`,