### PR TITLE
feat: no_std network primitives

### DIFF
--- a/.github/workflows/no_std.yml
+++ b/.github/workflows/no_std.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        crate: ["alloy-eips", "alloy-consensus", "alloy-genesis"]
+        crate: ["alloy-eips", "alloy-consensus", "alloy-genesis", "alloy-network-primitives"]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,7 +124,7 @@ auto_impl = "1.2"
 base64 = "0.22"
 bimap = "0.6"
 home = "0.5"
-itertools = "0.13"
+itertools = { version = "0.13", default-features = false }
 once_cell = { version = "1.19", default-features = false }
 pin-project = "1.1"
 rand = "0.8"

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ When updating this, also update:
 - .github/workflows/ci.yml
 -->
 
-The current MSRV (minimum supported rust version) is 1.78.
+The current MSRV (minimum supported rust version) is 1.79.
 
 Alloy will keep a rolling MSRV policy of **at least** two versions behind the
 latest stable release (so if the latest stable release is 1.58, we would

--- a/crates/network-primitives/Cargo.toml
+++ b/crates/network-primitives/Cargo.toml
@@ -26,3 +26,7 @@ serde.workspace = true
 
 [dev-dependencies]
 rand.workspace = true
+
+[features]
+default = ["std"]
+std = ["alloy-primitives/std"]

--- a/crates/network-primitives/src/block.rs
+++ b/crates/network-primitives/src/block.rs
@@ -1,6 +1,9 @@
 use alloy_primitives::B256;
 use serde::{Deserialize, Serialize};
 
+use alloc::{vec, vec::Vec};
+use core::slice;
+
 use crate::TransactionResponse;
 
 /// Block Transactions depending on the boolean attribute of `eth_getBlockBy*`,
@@ -69,10 +72,10 @@ impl<T> BlockTransactions<T> {
 
     /// Returns an iterator over the transactions (if any). This will be empty if the block is not
     /// full.
-    pub fn into_transactions(self) -> std::vec::IntoIter<T> {
+    pub fn into_transactions(self) -> vec::IntoIter<T> {
         match self {
             Self::Full(txs) => txs.into_iter(),
-            _ => std::vec::IntoIter::default(),
+            _ => vec::IntoIter::default(),
         }
     }
 
@@ -149,8 +152,8 @@ pub struct BlockTransactionHashes<'a, T>(BlockTransactionHashesInner<'a, T>);
 
 #[derive(Clone, Debug)]
 enum BlockTransactionHashesInner<'a, T> {
-    Hashes(std::slice::Iter<'a, B256>),
-    Full(std::slice::Iter<'a, T>),
+    Hashes(slice::Iter<'a, B256>),
+    Full(slice::Iter<'a, T>),
     Uncle,
 }
 
@@ -209,6 +212,7 @@ impl<T: TransactionResponse> DoubleEndedIterator for BlockTransactionHashes<'_, 
     }
 }
 
+#[cfg(feature = "std")]
 impl<'a, T: TransactionResponse> std::iter::FusedIterator for BlockTransactionHashes<'a, T> {}
 
 /// Determines how the `transactions` field of block should be filled.

--- a/crates/network-primitives/src/lib.rs
+++ b/crates/network-primitives/src/lib.rs
@@ -5,6 +5,9 @@
 )]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
 
 mod traits;
 pub use traits::{BlockResponse, HeaderResponse, ReceiptResponse, TransactionResponse};

--- a/crates/rpc-types-eth/Cargo.toml
+++ b/crates/rpc-types-eth/Cargo.toml
@@ -23,8 +23,8 @@ alloy-rlp = { workspace = true, features = ["arrayvec", "derive"] }
 alloy-primitives = { workspace = true, features = ["rlp", "serde", "std"] }
 alloy-serde.workspace = true
 
-alloy-consensus = { workspace = true, features = ["std", "serde"] }
-alloy-eips = { workspace = true, features = ["std", "serde"] }
+alloy-consensus = { workspace = true, features = ["serde", "std"] }
+alloy-eips = { workspace = true, features = ["serde", "std"] }
 
 alloy-network-primitives.workspace = true
 


### PR DESCRIPTION
### Description

> [!NOTE]
>
> Stacked ontop of https://github.com/alloy-rs/alloy/pull/1250

Makes `alloy-network-primitives` support `no_std`.

This is a pre-requisite to supporting `no_std` in `alloy-rpc-types-eth`.