### PR TITLE
feat(rpc-types-trace): always serialize result if no error

### DIFF
--- a/crates/rpc-types-trace/src/parity.rs
+++ b/crates/rpc-types-trace/src/parity.rs
@@ -429,6 +429,7 @@ pub struct TransactionTrace {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
     /// Output of the trace, can be CALL or CREATE
+    #[serde(default)]
     pub result: Option<TraceOutput>,
     /// How many subtraces this trace has.
     pub subtraces: usize,
@@ -501,7 +502,7 @@ impl Serialize for LocalizedTransactionTrace {
         match result {
             Some(TraceOutput::Call(call)) => s.serialize_field("result", call)?,
             Some(TraceOutput::Create(create)) => s.serialize_field("result", create)?,
-            None => s.serialize_field("result", &None as &Option<u8>)?,
+            None => s.serialize_field("result", &None::<()>)?,
         }
 
         s.serialize_field("subtraces", &subtraces)?;

--- a/crates/rpc-types-trace/src/parity.rs
+++ b/crates/rpc-types-trace/src/parity.rs
@@ -818,6 +818,32 @@ mod tests {
         let serialized = serde_json::to_string_pretty(&trace).unwrap();
         similar_asserts::assert_eq!(serialized, reference_data);
     }
+
+    #[test]
+    fn test_transaction_trace_null_result() {
+        let trace = TransactionTrace {
+            action: Action::Call(CallAction {
+                from: Address::from_str("0x1234567890123456789012345678901234567890").unwrap(),
+                call_type: CallType::Call,
+                gas: 100000,
+                input: Bytes::from_str("0x1234").unwrap(),
+                to: Address::from_str("0x0987654321098765432109876543210987654321").unwrap(),
+                value: U256::from(0),
+            }),
+            ..Default::default()
+        };
+
+        let serialized = serde_json::to_string(&trace).unwrap();
+        let deserialized: serde_json::Value = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(deserialized["result"], serde_json::Value::Null);
+        assert!(deserialized.as_object().unwrap().contains_key("result"));
+        assert!(!deserialized.as_object().unwrap().contains_key("error"));
+
+        let deserialized_trace: TransactionTrace = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(deserialized_trace.result, None);
+    }
+
     #[test]
     fn test_nethermind_trace_result_null_output_value() {
         let reference_data = r#"{

--- a/crates/rpc-types-trace/src/parity.rs
+++ b/crates/rpc-types-trace/src/parity.rs
@@ -497,16 +497,12 @@ impl Serialize for LocalizedTransactionTrace {
 
         if let Some(error) = error {
             s.serialize_field("error", error)?;
-        }
-
-        match result {
-            Some(TraceOutput::Call(call)) => {
-                s.serialize_field("result", call)?;
+        } else {
+            match result {
+                Some(TraceOutput::Call(call)) => s.serialize_field("result", call)?,
+                Some(TraceOutput::Create(create)) => s.serialize_field("result", create)?,
+                None => s.serialize_field("result", &None as &Option<u8>)?,
             }
-            Some(TraceOutput::Create(create)) => {
-                s.serialize_field("result", create)?;
-            }
-            None => {}
         }
 
         s.serialize_field("subtraces", &subtraces)?;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
I'm checking with reth's trace results with erigon's, seems erigon will always return `result:null` if no error occurred:

<img width="1249" alt="image" src="https://github.com/user-attachments/assets/486d9354-cb32-46eb-afd4-4e32d169b8c4">

And found the OG OpenEthereum's serialized logic as below:

https://github.com/openethereum/openethereum/blob/main/crates/rpc/src/v1/types/trace.rs#L532

```rust
  match self.result {
        Res::Call(ref call) => struc.serialize_field("result", call)?,
        Res::Create(ref create) => struc.serialize_field("result", create)?,
        Res::FailedCall(ref error) => struc.serialize_field("error", &error.to_string())?,
        Res::FailedCreate(ref error) => struc.serialize_field("error", &error.to_string())?,
        Res::None => struc.serialize_field("result", &None as &Option<u8>)?,
    }
```

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
