### PR TITLE
refactor: separate transaction builders for tx types

### DIFF
--- a/crates/contract/src/call.rs
+++ b/crates/contract/src/call.rs
@@ -1,7 +1,7 @@
 use crate::{CallDecoder, Error, EthCall, Result};
 use alloy_dyn_abi::{DynSolValue, JsonAbiExt};
 use alloy_json_abi::Function;
-use alloy_network::{Ethereum, Network, TransactionBuilder};
+use alloy_network::{Ethereum, Network, TransactionBuilder, TransactionBuilder4844};
 use alloy_network_primitives::ReceiptResponse;
 use alloy_primitives::{Address, Bytes, ChainId, TxKind, U256};
 use alloy_provider::{PendingTransactionBuilder, Provider};
@@ -334,7 +334,10 @@ impl<T: Transport + Clone, P: Provider<T, N>, D: CallDecoder, N: Network> CallBu
     }
 
     /// Sets the `sidecar` field in the transaction to the provided value.
-    pub fn sidecar(mut self, blob_sidecar: BlobTransactionSidecar) -> Self {
+    pub fn sidecar(mut self, blob_sidecar: BlobTransactionSidecar) -> Self
+    where
+        N::TransactionRequest: TransactionBuilder4844,
+    {
         self.request.set_blob_sidecar(blob_sidecar);
         self
     }
@@ -371,7 +374,10 @@ impl<T: Transport + Clone, P: Provider<T, N>, D: CallDecoder, N: Network> CallBu
     }
 
     /// Sets the `max_fee_per_blob_gas` in the transaction to the provided value
-    pub fn max_fee_per_blob_gas(mut self, max_fee_per_blob_gas: u128) -> Self {
+    pub fn max_fee_per_blob_gas(mut self, max_fee_per_blob_gas: u128) -> Self
+    where
+        N::TransactionRequest: TransactionBuilder4844,
+    {
         self.request.set_max_fee_per_blob_gas(max_fee_per_blob_gas);
         self
     }

--- a/crates/network/src/any/builder.rs
+++ b/crates/network/src/any/builder.rs
@@ -1,6 +1,6 @@
 use crate::{
     any::AnyNetwork, BuildResult, Network, NetworkWallet, TransactionBuilder,
-    TransactionBuilderError,
+    TransactionBuilder4844, TransactionBuilder7702, TransactionBuilderError,
 };
 use alloy_consensus::BlobTransactionSidecar;
 use alloy_eips::eip7702::SignedAuthorization;
@@ -86,14 +86,6 @@ impl TransactionBuilder<AnyNetwork> for WithOtherFields<TransactionRequest> {
         self.deref_mut().set_max_priority_fee_per_gas(max_priority_fee_per_gas);
     }
 
-    fn max_fee_per_blob_gas(&self) -> Option<u128> {
-        self.deref().max_fee_per_blob_gas()
-    }
-
-    fn set_max_fee_per_blob_gas(&mut self, max_fee_per_blob_gas: u128) {
-        self.deref_mut().set_max_fee_per_blob_gas(max_fee_per_blob_gas)
-    }
-
     fn gas_limit(&self) -> Option<u128> {
         self.deref().gas_limit()
     }
@@ -110,22 +102,6 @@ impl TransactionBuilder<AnyNetwork> for WithOtherFields<TransactionRequest> {
     /// Sets the EIP-2930 access list.
     fn set_access_list(&mut self, access_list: AccessList) {
         self.deref_mut().set_access_list(access_list)
-    }
-
-    fn blob_sidecar(&self) -> Option<&BlobTransactionSidecar> {
-        self.deref().blob_sidecar()
-    }
-
-    fn set_blob_sidecar(&mut self, sidecar: BlobTransactionSidecar) {
-        self.deref_mut().set_blob_sidecar(sidecar)
-    }
-
-    fn authorization_list(&self) -> Option<&Vec<SignedAuthorization>> {
-        self.deref().authorization_list()
-    }
-
-    fn set_authorization_list(&mut self, authorization_list: Vec<SignedAuthorization>) {
-        self.deref_mut().set_authorization_list(authorization_list)
     }
 
     fn complete_type(&self, ty: <AnyNetwork as Network>::TxType) -> Result<(), Vec<&'static str>> {
@@ -170,5 +146,33 @@ impl TransactionBuilder<AnyNetwork> for WithOtherFields<TransactionRequest> {
         wallet: &W,
     ) -> Result<<AnyNetwork as Network>::TxEnvelope, TransactionBuilderError<AnyNetwork>> {
         Ok(wallet.sign_request(self).await?)
+    }
+}
+
+impl TransactionBuilder4844 for WithOtherFields<TransactionRequest> {
+    fn max_fee_per_blob_gas(&self) -> Option<u128> {
+        self.deref().max_fee_per_blob_gas()
+    }
+
+    fn set_max_fee_per_blob_gas(&mut self, max_fee_per_blob_gas: u128) {
+        self.deref_mut().set_max_fee_per_blob_gas(max_fee_per_blob_gas)
+    }
+
+    fn blob_sidecar(&self) -> Option<&BlobTransactionSidecar> {
+        self.deref().blob_sidecar()
+    }
+
+    fn set_blob_sidecar(&mut self, sidecar: BlobTransactionSidecar) {
+        self.deref_mut().set_blob_sidecar(sidecar)
+    }
+}
+
+impl TransactionBuilder7702 for WithOtherFields<TransactionRequest> {
+    fn authorization_list(&self) -> Option<&Vec<SignedAuthorization>> {
+        self.deref().authorization_list()
+    }
+
+    fn set_authorization_list(&mut self, authorization_list: Vec<SignedAuthorization>) {
+        self.deref_mut().set_authorization_list(authorization_list)
     }
 }

--- a/crates/network/src/ethereum/builder.rs
+++ b/crates/network/src/ethereum/builder.rs
@@ -1,5 +1,6 @@
 use crate::{
-    BuildResult, Ethereum, Network, NetworkWallet, TransactionBuilder, TransactionBuilderError,
+    BuildResult, Ethereum, Network, NetworkWallet, TransactionBuilder, TransactionBuilder4844,
+    TransactionBuilder7702, TransactionBuilderError,
 };
 use alloy_consensus::{BlobTransactionSidecar, TxType, TypedTransaction};
 use alloy_eips::eip7702::SignedAuthorization;
@@ -83,14 +84,6 @@ impl TransactionBuilder<Ethereum> for TransactionRequest {
         self.max_priority_fee_per_gas = Some(max_priority_fee_per_gas);
     }
 
-    fn max_fee_per_blob_gas(&self) -> Option<u128> {
-        self.max_fee_per_blob_gas
-    }
-
-    fn set_max_fee_per_blob_gas(&mut self, max_fee_per_blob_gas: u128) {
-        self.max_fee_per_blob_gas = Some(max_fee_per_blob_gas)
-    }
-
     fn gas_limit(&self) -> Option<u128> {
         self.gas
     }
@@ -105,23 +98,6 @@ impl TransactionBuilder<Ethereum> for TransactionRequest {
 
     fn set_access_list(&mut self, access_list: AccessList) {
         self.access_list = Some(access_list);
-    }
-
-    fn blob_sidecar(&self) -> Option<&BlobTransactionSidecar> {
-        self.sidecar.as_ref()
-    }
-
-    fn set_blob_sidecar(&mut self, sidecar: BlobTransactionSidecar) {
-        self.sidecar = Some(sidecar);
-        self.populate_blob_hashes();
-    }
-
-    fn authorization_list(&self) -> Option<&Vec<SignedAuthorization>> {
-        self.authorization_list.as_ref()
-    }
-
-    fn set_authorization_list(&mut self, authorization_list: Vec<SignedAuthorization>) {
-        self.authorization_list = Some(authorization_list);
     }
 
     fn complete_type(&self, ty: TxType) -> Result<(), Vec<&'static str>> {
@@ -191,9 +167,40 @@ impl TransactionBuilder<Ethereum> for TransactionRequest {
     }
 }
 
+impl TransactionBuilder4844 for TransactionRequest {
+    fn max_fee_per_blob_gas(&self) -> Option<u128> {
+        self.max_fee_per_blob_gas
+    }
+
+    fn set_max_fee_per_blob_gas(&mut self, max_fee_per_blob_gas: u128) {
+        self.max_fee_per_blob_gas = Some(max_fee_per_blob_gas)
+    }
+
+    fn blob_sidecar(&self) -> Option<&BlobTransactionSidecar> {
+        self.sidecar.as_ref()
+    }
+
+    fn set_blob_sidecar(&mut self, sidecar: BlobTransactionSidecar) {
+        self.sidecar = Some(sidecar);
+        self.populate_blob_hashes();
+    }
+}
+
+impl TransactionBuilder7702 for TransactionRequest {
+    fn authorization_list(&self) -> Option<&Vec<SignedAuthorization>> {
+        self.authorization_list.as_ref()
+    }
+
+    fn set_authorization_list(&mut self, authorization_list: Vec<SignedAuthorization>) {
+        self.authorization_list = Some(authorization_list);
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use crate::{TransactionBuilder, TransactionBuilderError};
+    use crate::{
+        TransactionBuilder, TransactionBuilder4844, TransactionBuilder7702, TransactionBuilderError,
+    };
     use alloy_consensus::{BlobTransactionSidecar, TxEip1559, TxType, TypedTransaction};
     use alloy_eips::eip7702::Authorization;
     use alloy_primitives::{Address, Signature, U256};

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -13,8 +13,8 @@ use core::fmt::{Debug, Display};
 
 mod transaction;
 pub use transaction::{
-    BuildResult, NetworkWallet, TransactionBuilder, TransactionBuilderError, TxSigner,
-    TxSignerSync, UnbuiltTransactionError,
+    BuildResult, NetworkWallet, TransactionBuilder, TransactionBuilder4844, TransactionBuilder7702,
+    TransactionBuilderError, TxSigner, TxSignerSync, UnbuiltTransactionError,
 };
 
 mod ethereum;

--- a/crates/network/src/transaction/builder.rs
+++ b/crates/network/src/transaction/builder.rs
@@ -248,19 +248,6 @@ pub trait TransactionBuilder<N: Network>: Default + Sized + Send + Sync + 'stati
         self.set_max_priority_fee_per_gas(max_priority_fee_per_gas);
         self
     }
-
-    /// Get the max fee per blob gas for the transaction.
-    fn max_fee_per_blob_gas(&self) -> Option<u128>;
-
-    /// Set the max fee per blob gas  for the transaction.
-    fn set_max_fee_per_blob_gas(&mut self, max_fee_per_blob_gas: u128);
-
-    /// Builder-pattern method for setting max fee per blob gas .
-    fn with_max_fee_per_blob_gas(mut self, max_fee_per_blob_gas: u128) -> Self {
-        self.set_max_fee_per_blob_gas(max_fee_per_blob_gas);
-        self
-    }
-
     /// Get the gas limit for the transaction.
     fn gas_limit(&self) -> Option<u128>;
 
@@ -282,33 +269,6 @@ pub trait TransactionBuilder<N: Network>: Default + Sized + Send + Sync + 'stati
     /// Builder-pattern method for setting the access list.
     fn with_access_list(mut self, access_list: AccessList) -> Self {
         self.set_access_list(access_list);
-        self
-    }
-
-    /// Gets the EIP-4844 blob sidecar of the transaction.
-    fn blob_sidecar(&self) -> Option<&BlobTransactionSidecar>;
-
-    /// Sets the EIP-4844 blob sidecar of the transaction.
-    ///
-    /// Note: This will also set the versioned blob hashes accordingly:
-    /// [BlobTransactionSidecar::versioned_hashes]
-    fn set_blob_sidecar(&mut self, sidecar: BlobTransactionSidecar);
-
-    /// Builder-pattern method for setting the EIP-4844 blob sidecar of the transaction.
-    fn with_blob_sidecar(mut self, sidecar: BlobTransactionSidecar) -> Self {
-        self.set_blob_sidecar(sidecar);
-        self
-    }
-
-    /// Get the EIP-7702 authorization list for the transaction.
-    fn authorization_list(&self) -> Option<&Vec<SignedAuthorization>>;
-
-    /// Sets the EIP-7702 authorization list.
-    fn set_authorization_list(&mut self, authorization_list: Vec<SignedAuthorization>);
-
-    /// Builder-pattern method for setting the authorization list.
-    fn with_authorization_list(mut self, authorization_list: Vec<SignedAuthorization>) -> Self {
-        self.set_authorization_list(authorization_list);
         self
     }
 
@@ -382,4 +342,49 @@ pub trait TransactionBuilder<N: Network>: Default + Sized + Send + Sync + 'stati
         self,
         wallet: &W,
     ) -> impl_future!(<Output = Result<N::TxEnvelope, TransactionBuilderError<N>>>);
+}
+
+/// Transaction builder type supporting EIP-4844 transaction fields.
+pub trait TransactionBuilder4844: Default + Sized + Send + Sync + 'static {
+    /// Get the max fee per blob gas for the transaction.
+    fn max_fee_per_blob_gas(&self) -> Option<u128>;
+
+    /// Set the max fee per blob gas  for the transaction.
+    fn set_max_fee_per_blob_gas(&mut self, max_fee_per_blob_gas: u128);
+
+    /// Builder-pattern method for setting max fee per blob gas .
+    fn with_max_fee_per_blob_gas(mut self, max_fee_per_blob_gas: u128) -> Self {
+        self.set_max_fee_per_blob_gas(max_fee_per_blob_gas);
+        self
+    }
+
+    /// Gets the EIP-4844 blob sidecar of the transaction.
+    fn blob_sidecar(&self) -> Option<&BlobTransactionSidecar>;
+
+    /// Sets the EIP-4844 blob sidecar of the transaction.
+    ///
+    /// Note: This will also set the versioned blob hashes accordingly:
+    /// [BlobTransactionSidecar::versioned_hashes]
+    fn set_blob_sidecar(&mut self, sidecar: BlobTransactionSidecar);
+
+    /// Builder-pattern method for setting the EIP-4844 blob sidecar of the transaction.
+    fn with_blob_sidecar(mut self, sidecar: BlobTransactionSidecar) -> Self {
+        self.set_blob_sidecar(sidecar);
+        self
+    }
+}
+
+/// Transaction builder type supporting EIP-7702 transaction fields.
+pub trait TransactionBuilder7702: Default + Sized + Send + Sync + 'static {
+    /// Get the EIP-7702 authorization list for the transaction.
+    fn authorization_list(&self) -> Option<&Vec<SignedAuthorization>>;
+
+    /// Sets the EIP-7702 authorization list.
+    fn set_authorization_list(&mut self, authorization_list: Vec<SignedAuthorization>);
+
+    /// Builder-pattern method for setting the authorization list.
+    fn with_authorization_list(mut self, authorization_list: Vec<SignedAuthorization>) -> Self {
+        self.set_authorization_list(authorization_list);
+        self
+    }
 }

--- a/crates/network/src/transaction/mod.rs
+++ b/crates/network/src/transaction/mod.rs
@@ -1,6 +1,7 @@
 mod builder;
 pub use builder::{
-    BuildResult, TransactionBuilder, TransactionBuilderError, UnbuiltTransactionError,
+    BuildResult, TransactionBuilder, TransactionBuilder4844, TransactionBuilder7702,
+    TransactionBuilderError, UnbuiltTransactionError,
 };
 
 mod signer;

--- a/crates/provider/src/builder.rs
+++ b/crates/provider/src/builder.rs
@@ -1,7 +1,7 @@
 use crate::{
     fillers::{
         CachedNonceManager, ChainIdFiller, FillerControlFlow, GasFiller, JoinFill, NonceFiller,
-        NonceManager, RecommendedFiller, SimpleNonceManager, TxFiller, WalletFiller,
+        NonceManager, RecommendedFillers, SimpleNonceManager, TxFiller, WalletFiller,
     },
     provider::SendableTx,
     Provider, RootProvider,
@@ -130,8 +130,13 @@ impl<N> Default for ProviderBuilder<Identity, Identity, N> {
 impl<L, N> ProviderBuilder<L, Identity, N> {
     /// Add preconfigured set of layers handling gas estimation, nonce
     /// management, and chain-id fetching.
-    pub fn with_recommended_fillers(self) -> ProviderBuilder<L, RecommendedFiller, N> {
-        self.filler(GasFiller).filler(NonceFiller::default()).filler(ChainIdFiller::default())
+    pub fn with_recommended_fillers(
+        self,
+    ) -> ProviderBuilder<L, JoinFill<Identity, N::RecomendedFillters>, N>
+    where
+        N: RecommendedFillers,
+    {
+        self.filler(N::recommended_fillers())
     }
 
     /// Add gas estimation to the stack being built.

--- a/crates/provider/src/fillers/gas.rs
+++ b/crates/provider/src/fillers/gas.rs
@@ -155,7 +155,7 @@ impl<N: Network> TxFiller<N> for GasFiller {
         P: Provider<T, N>,
         T: Transport + Clone,
     {
-        if tx.gas_price().is_some() {
+        if tx.gas_price().is_some() || tx.access_list().is_some() {
             self.prepare_legacy(provider, tx).await
         } else {
             match self.prepare_1559(provider, tx).await {

--- a/crates/provider/src/fillers/gas.rs
+++ b/crates/provider/src/fillers/gas.rs
@@ -155,7 +155,7 @@ impl<N: Network> TxFiller<N> for GasFiller {
         P: Provider<T, N>,
         T: Transport + Clone,
     {
-        if tx.gas_price().is_some() || tx.access_list().is_some() {
+        if tx.gas_price().is_some() {
             self.prepare_legacy(provider, tx).await
         } else {
             match self.prepare_1559(provider, tx).await {
@@ -288,25 +288,5 @@ mod tests {
         let receipt = tx.get_receipt().await.unwrap();
 
         assert_eq!(receipt.gas_used, 0x5208);
-    }
-
-    #[tokio::test]
-    async fn non_eip1559_network() {
-        let provider = ProviderBuilder::new().with_recommended_fillers().on_anvil();
-
-        let tx = TransactionRequest {
-            from: Some(address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266")),
-            value: Some(U256::from(100)),
-            to: Some(address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045").into()),
-            // access list forces legacy gassing
-            access_list: Some(vec![Default::default()].into()),
-            ..Default::default()
-        };
-
-        let tx = provider.send_transaction(tx).await.unwrap();
-
-        let receipt = tx.get_receipt().await.unwrap();
-
-        assert_eq!(receipt.effective_gas_price, 2000000000);
     }
 }

--- a/crates/provider/src/fillers/gas.rs
+++ b/crates/provider/src/fillers/gas.rs
@@ -7,7 +7,7 @@ use crate::{
     Provider,
 };
 use alloy_json_rpc::RpcError;
-use alloy_network::{Network, TransactionBuilder};
+use alloy_network::{Network, TransactionBuilder, TransactionBuilder4844};
 use alloy_network_primitives::{BlockResponse, HeaderResponse};
 use alloy_rpc_types_eth::BlockNumberOrTag;
 use alloy_transport::{Transport, TransportResult};
@@ -19,7 +19,6 @@ use futures::FutureExt;
 pub enum GasFillable {
     Legacy { gas_limit: u128, gas_price: u128 },
     Eip1559 { gas_limit: u128, estimate: Eip1559Estimation },
-    Eip4844 { gas_limit: u128, estimate: Eip1559Estimation, max_fee_per_blob_gas: u128 },
 }
 
 /// A [`TxFiller`] that populates gas related fields in transaction requests if
@@ -64,6 +63,10 @@ pub enum GasFillable {
 /// ```
 #[derive(Clone, Copy, Debug, Default)]
 pub struct GasFiller;
+
+/// Filler for the `max_fee_per_blob_gas` field in EIP-4844 transactions.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct BlobGasFiller;
 
 impl GasFiller {
     async fn prepare_legacy<P, T, N>(
@@ -119,52 +122,6 @@ impl GasFiller {
 
         Ok(GasFillable::Eip1559 { gas_limit, estimate })
     }
-
-    async fn prepare_4844<P, T, N>(
-        &self,
-        provider: &P,
-        tx: &N::TransactionRequest,
-    ) -> TransportResult<GasFillable>
-    where
-        P: Provider<T, N>,
-        T: Transport + Clone,
-        N: Network,
-    {
-        let gas_limit_fut = tx.gas_limit().map_or_else(
-            || provider.estimate_gas(tx).into_future().right_future(),
-            |gas_limit| async move { Ok(gas_limit) }.left_future(),
-        );
-
-        let eip1559_fees_fut = if let (Some(max_fee_per_gas), Some(max_priority_fee_per_gas)) =
-            (tx.max_fee_per_gas(), tx.max_priority_fee_per_gas())
-        {
-            async move { Ok(Eip1559Estimation { max_fee_per_gas, max_priority_fee_per_gas }) }
-                .left_future()
-        } else {
-            provider.estimate_eip1559_fees(None).right_future()
-        };
-
-        let max_fee_per_blob_gas_fut = tx.max_fee_per_blob_gas().map_or_else(
-            || {
-                async {
-                    provider
-                        .get_block_by_number(BlockNumberOrTag::Latest, false)
-                        .await?
-                        .ok_or(RpcError::NullResp)?
-                        .header()
-                        .next_block_blob_fee()
-                        .ok_or(RpcError::UnsupportedFeature("eip4844"))
-                }
-                .right_future()
-            },
-            |max_fee_per_blob_gas| async move { Ok(max_fee_per_blob_gas) }.left_future(),
-        );
-
-        let (gas_limit, estimate, max_fee_per_blob_gas) =
-            futures::try_join!(gas_limit_fut, eip1559_fees_fut, max_fee_per_blob_gas_fut)?;
-
-        Ok(GasFillable::Eip4844 { gas_limit, estimate, max_fee_per_blob_gas })
-    }
 }
 
 impl<N: Network> TxFiller<N> for GasFiller {
@@ -176,18 +133,8 @@ impl<N: Network> TxFiller<N> for GasFiller {
             return FillerControlFlow::Finished;
         }
 
-        // 4844
-        if tx.max_fee_per_blob_gas().is_some()
-            && tx.max_fee_per_gas().is_some()
-            && tx.max_priority_fee_per_gas().is_some()
-            && tx.gas_limit().is_some()
-        {
-            return FillerControlFlow::Finished;
-        }
-
         // eip1559
-        if tx.blob_sidecar().is_none()
-            && tx.max_fee_per_gas().is_some()
+        if tx.max_fee_per_gas().is_some()
             && tx.max_priority_fee_per_gas().is_some()
             && tx.gas_limit().is_some()
         {
@@ -208,10 +155,8 @@ impl<N: Network> TxFiller<N> for GasFiller {
         P: Provider<T, N>,
         T: Transport + Clone,
     {
-        if tx.gas_price().is_some() || tx.access_list().is_some() {
+        if tx.gas_price().is_some() {
             self.prepare_legacy(provider, tx).await
-        } else if tx.blob_sidecar().is_some() {
-            self.prepare_4844(provider, tx).await
         } else {
             match self.prepare_1559(provider, tx).await {
                 // fallback to legacy
@@ -238,14 +183,58 @@ impl<N: Network> TxFiller<N> for GasFiller {
                     builder.set_max_fee_per_gas(estimate.max_fee_per_gas);
                     builder.set_max_priority_fee_per_gas(estimate.max_priority_fee_per_gas);
                 }
-                GasFillable::Eip4844 { gas_limit, estimate, max_fee_per_blob_gas } => {
-                    builder.set_gas_limit(gas_limit);
-                    builder.set_max_fee_per_gas(estimate.max_fee_per_gas);
-                    builder.set_max_priority_fee_per_gas(estimate.max_priority_fee_per_gas);
-                    builder.set_max_fee_per_blob_gas(max_fee_per_blob_gas);
-                }
             }
         };
+        Ok(tx)
+    }
+}
+
+impl<N: Network> TxFiller<N> for BlobGasFiller
+where
+    N::TransactionRequest: TransactionBuilder4844,
+{
+    type Fillable = u128;
+
+    fn status(&self, tx: &<N as Network>::TransactionRequest) -> FillerControlFlow {
+        // nothing to fill if non-eip4844 tx or max_fee_per_blob_gas is already set
+        if tx.blob_sidecar().is_none() || tx.max_fee_per_blob_gas().is_some() {
+            return FillerControlFlow::Finished;
+        }
+
+        FillerControlFlow::Ready
+    }
+
+    fn fill_sync(&self, _tx: &mut SendableTx<N>) {}
+
+    async fn prepare<P, T>(
+        &self,
+        provider: &P,
+        tx: &<N as Network>::TransactionRequest,
+    ) -> TransportResult<Self::Fillable>
+    where
+        P: Provider<T, N>,
+        T: Transport + Clone,
+    {
+        if let Some(max_fee_per_blob_gas) = tx.max_fee_per_blob_gas() {
+            return Ok(max_fee_per_blob_gas);
+        }
+        provider
+            .get_block_by_number(BlockNumberOrTag::Latest, false)
+            .await?
+            .ok_or(RpcError::NullResp)?
+            .header()
+            .next_block_blob_fee()
+            .ok_or(RpcError::UnsupportedFeature("eip4844"))
+    }
+
+    async fn fill(
+        &self,
+        fillable: Self::Fillable,
+        mut tx: SendableTx<N>,
+    ) -> TransportResult<SendableTx<N>> {
+        if let Some(builder) = tx.as_mut_builder() {
+            builder.set_max_fee_per_blob_gas(fillable);
+        }
         Ok(tx)
     }
 }

--- a/crates/provider/src/fillers/mod.rs
+++ b/crates/provider/src/fillers/mod.rs
@@ -16,7 +16,7 @@ mod nonce;
 pub use nonce::{CachedNonceManager, NonceFiller, NonceManager, SimpleNonceManager};
 
 mod gas;
-pub use gas::{GasFillable, GasFiller};
+pub use gas::{BlobGasFiller, GasFillable, GasFiller};
 
 mod join_fill;
 pub use join_fill::JoinFill;
@@ -27,7 +27,7 @@ use crate::{
     RootProvider,
 };
 use alloy_json_rpc::RpcError;
-use alloy_network::{Ethereum, Network};
+use alloy_network::{AnyNetwork, Ethereum, Network};
 use alloy_transport::{Transport, TransportResult};
 use async_trait::async_trait;
 use futures_utils_wasm::impl_future;
@@ -306,5 +306,44 @@ where
 
         // Errors in tx building happen further down the stack.
         self.inner.send_transaction_internal(tx).await
+    }
+}
+
+/// A trait which may be used to configure default fillers for [Network] implementations.
+pub trait RecommendedFillers {
+    /// Recommended fillers for this network.
+    type RecomendedFillters: TxFiller;
+
+    /// Returns the recommended filler for this provider.
+    fn recommended_fillers() -> Self::RecomendedFillters;
+}
+
+impl RecommendedFillers for Ethereum {
+    type RecomendedFillters =
+        JoinFill<GasFiller, JoinFill<BlobGasFiller, JoinFill<NonceFiller, ChainIdFiller>>>;
+
+    fn recommended_fillers() -> Self::RecomendedFillters {
+        JoinFill::new(
+            GasFiller,
+            JoinFill::new(
+                BlobGasFiller,
+                JoinFill::new(NonceFiller::default(), ChainIdFiller::default()),
+            ),
+        )
+    }
+}
+
+impl RecommendedFillers for AnyNetwork {
+    type RecomendedFillters =
+        JoinFill<GasFiller, JoinFill<BlobGasFiller, JoinFill<NonceFiller, ChainIdFiller>>>;
+
+    fn recommended_fillers() -> Self::RecomendedFillters {
+        JoinFill::new(
+            GasFiller,
+            JoinFill::new(
+                BlobGasFiller,
+                JoinFill::new(NonceFiller::default(), ChainIdFiller::default()),
+            ),
+        )
     }
 }


### PR DESCRIPTION
## Motivation

Not all netwoks support 7702 and 4844 transactions, however, current network abstraction requires `TransactionRequest` to contain setters for both of those tx types. This results in custom network implementations either having no-op setters/getters on builders, or introducing additional fallible steps during transaction conversion pipeline to reject attempts to construct unsupported transactions.

## Solution

Extracts part of `TransactionBuilder` methods into `TransactionBuilder4844` and `TransactionBuilder7702`. Extracts blob fee filling from `GasFiller` into `BlobGasFiller` which enforces `N::TxRequest: TransactionBuilder4844` bound.

Given that filling logic now depends on transaction request properties, I've extracted recomended fillers into `RecommendedFillers` trait which can be implemented on custom network implementations, adding support for filling custom transaction types. Right now it is implemented on `Ethereum` and `AnyNetwork`.

This makes it a bit harder to use transaction builder due to need to import 2 additional traits, so I'm wondering if we should consider adding some of the methods directly to it?

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [x] Breaking changes
