### PR TITLE
fix(rpc-types-trace): use rpc-types Log in OtsReceipt

### DIFF
--- a/crates/rpc-types-trace/src/otterscan.rs
+++ b/crates/rpc-types-trace/src/otterscan.rs
@@ -4,7 +4,7 @@
 //! <https://github.com/otterscan/otterscan/blob/develop/docs/custom-jsonrpc.md>
 
 use alloy_primitives::{Address, Bloom, Bytes, TxHash, B256, U256};
-use alloy_rpc_types_eth::{Block, Header, Transaction, TransactionReceipt, Withdrawal};
+use alloy_rpc_types_eth::{Block, Header, Log, Transaction, TransactionReceipt, Withdrawal};
 use serde::{
     de::{self, Unexpected},
     Deserialize, Deserializer, Serialize, Serializer,
@@ -204,7 +204,7 @@ pub struct OtsReceipt {
     /// The logs sent from contracts.
     ///
     /// Note: this is set to null.
-    pub logs: Option<Vec<alloy_primitives::Log>>,
+    pub logs: Option<Vec<Log>>,
     /// The bloom filter.
     ///
     /// Note: this is set to null.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Ref https://github.com/foundry-rs/foundry/issues/8830#issuecomment-2338108826

`OtsReceipt` uses `alloy_primitives::Log`. 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Use `rpc_types_eth::Log` instead of `alloy_primitives::Log` 

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
