### PR TITLE
chore(network-primitives): Remove alloc Vec Dep

### DIFF
--- a/crates/network-primitives/src/traits.rs
+++ b/crates/network-primitives/src/traits.rs
@@ -4,9 +4,6 @@ use alloy_serde::WithOtherFields;
 
 use crate::BlockTransactions;
 
-#[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
-
 /// Receipt JSON-RPC response.
 pub trait ReceiptResponse {
     /// Address of the created contract, or `None` if the transaction was not a deployment.


### PR DESCRIPTION
### Description

Small PR to remove the unused `alloc::vec::Vec` dependency in `alloy-network-primitives`.