### PR TITLE
fix: serde for `eth_simulateV1`

### DIFF
--- a/crates/provider/src/fillers/nonce.rs
+++ b/crates/provider/src/fillers/nonce.rs
@@ -46,6 +46,8 @@ impl NonceManager for SimpleNonceManager {
     }
 }
 
+/// Cached nonce manager
+///
 /// This [`NonceManager`] implementation will fetch the transaction count for any new account it
 /// sees, store it locally and increment the locally stored nonce as transactions are sent via
 /// [`Provider::send_transaction`].

--- a/crates/rpc-types-eth/src/simulate.rs
+++ b/crates/rpc-types-eth/src/simulate.rs
@@ -1,9 +1,9 @@
 //! 'eth_simulateV1' Request / Response types: <https://github.com/ethereum/execution-apis/pull/484>
 
-use alloy_primitives::{Bytes};
+use alloy_primitives::Bytes;
 use serde::{Deserialize, Serialize};
 
-use crate::{state::StateOverride, Block, Log, BlockOverrides, TransactionRequest};
+use crate::{state::StateOverride, Block, BlockOverrides, Log, TransactionRequest};
 
 /// The maximum number of blocks that can be simulated in a single request,
 pub const MAX_SIMULATE_BLOCKS: u64 = 256;
@@ -147,11 +147,21 @@ mod tests {
         assert_eq!(sim_opts.block_state_calls.len(), 2);
 
         let block_state_call_1 = &sim_opts.block_state_calls[0];
-        assert!(block_state_call_1.state_overrides.contains_key(&address_1));
-        assert_eq!(block_state_call_1.state_overrides.get(&address_1).unwrap().nonce.unwrap(), 5);
+        assert!(block_state_call_1.state_overrides.as_ref().unwrap().contains_key(&address_1));
+        assert_eq!(
+            block_state_call_1
+                .state_overrides
+                .as_ref()
+                .unwrap()
+                .get(&address_1)
+                .unwrap()
+                .nonce
+                .unwrap(),
+            5
+        );
 
         let block_state_call_2 = &sim_opts.block_state_calls[1];
-        assert!(block_state_call_2.state_overrides.contains_key(&address_1));
+        assert!(block_state_call_2.state_overrides.as_ref().unwrap().contains_key(&address_1));
 
         assert_eq!(block_state_call_2.calls.len(), 2);
         assert_eq!(block_state_call_2.calls[0].from.unwrap(), address_1);

--- a/crates/rpc-types-eth/src/state.rs
+++ b/crates/rpc-types-eth/src/state.rs
@@ -29,6 +29,11 @@ pub struct AccountOverride {
     /// the call.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub state_diff: Option<HashMap<B256, B256>>,
+    /// Moves addresses precompile into the specified address. This move is done before the 'code'
+    /// override is set. When the specified address is not a precompile, the behaviour is undefined
+    /// and different clients might behave differently.
+    #[serde(default, skip_serializing_if = "Option::is_none", rename = "movePrecompileToAddress")]
+    pub move_precompile_to: Option<Address>,
 }
 
 /// Helper type that bundles various overrides for EVM Execution.


### PR DESCRIPTION
## Motivation

Updates serde for `eth_simulateV1` to match JSON encoding in geth. ref https://github.com/ethereum/go-ethereum/pull/27720

There's another change for `BlockOverrides` fields which I am not sure we should address now:

> Block override fields of eth_call and debug_traceCall have had the following fields renamed
> * `coinbase` -> `feeRecipient`
> * `random` -> `prevRandao`
> * `baseFee` -> `baseFeePerGas`

## Solution

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
