### PR TITLE
Add trait methods `cumulative_gas_used` and `state_root` to `ReceiptResponse`

### DIFF
--- a/crates/network-primitives/src/traits.rs
+++ b/crates/network-primitives/src/traits.rs
@@ -51,6 +51,14 @@ pub trait ReceiptResponse {
 
     /// EIP-7702 Authorization list.
     fn authorization_list(&self) -> Option<&[SignedAuthorization]>;
+
+    /// Returns the cumulative gas used at this receipt.
+    fn cumulative_gas_used(&self) -> u128;
+
+    /// The post-transaction state root (pre Byzantium)
+    ///
+    /// EIP98 makes this field optional.
+    fn state_root(&self) -> Option<&B256>;
 }
 
 /// Transaction JSON-RPC response.
@@ -220,6 +228,14 @@ impl<T: ReceiptResponse> ReceiptResponse for WithOtherFields<T> {
 
     fn authorization_list(&self) -> Option<&[SignedAuthorization]> {
         self.inner.authorization_list()
+    }
+
+    fn cumulative_gas_used(&self) -> u128 {
+        self.inner.cumulative_gas_used()
+    }
+
+    fn state_root(&self) -> Option<&B256> {
+        self.inner.state_root()
     }
 }
 

--- a/crates/network-primitives/src/traits.rs
+++ b/crates/network-primitives/src/traits.rs
@@ -58,7 +58,7 @@ pub trait ReceiptResponse {
     /// The post-transaction state root (pre Byzantium)
     ///
     /// EIP98 makes this field optional.
-    fn state_root(&self) -> Option<&B256>;
+    fn state_root(&self) -> Option<B256>;
 }
 
 /// Transaction JSON-RPC response.
@@ -234,7 +234,7 @@ impl<T: ReceiptResponse> ReceiptResponse for WithOtherFields<T> {
         self.inner.cumulative_gas_used()
     }
 
-    fn state_root(&self) -> Option<&B256> {
+    fn state_root(&self) -> Option<B256> {
         self.inner.state_root()
     }
 }

--- a/crates/rpc-types-eth/src/transaction/receipt.rs
+++ b/crates/rpc-types-eth/src/transaction/receipt.rs
@@ -184,6 +184,14 @@ impl<T: TxReceipt<Log>> ReceiptResponse for TransactionReceipt<T> {
     fn authorization_list(&self) -> Option<&[SignedAuthorization]> {
         self.authorization_list.as_deref()
     }
+
+    fn cumulative_gas_used(&self) -> u128 {
+        self.inner.cumulative_gas_used()
+    }
+
+    fn state_root(&self) -> Option<&B256> {
+        self.state_root.as_ref()
+    }
 }
 
 #[cfg(test)]

--- a/crates/rpc-types-eth/src/transaction/receipt.rs
+++ b/crates/rpc-types-eth/src/transaction/receipt.rs
@@ -189,8 +189,8 @@ impl<T: TxReceipt<Log>> ReceiptResponse for TransactionReceipt<T> {
         self.inner.cumulative_gas_used()
     }
 
-    fn state_root(&self) -> Option<&B256> {
-        self.state_root.as_ref()
+    fn state_root(&self) -> Option<B256> {
+        self.state_root
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Use generic `ReceiptResponse` type in place of `alloy_rpc_types_eth::TransactionReceipt` in reth RPC

## Solution

Adds trait methods `ReceiptResponse::cumulative_gas_used` and `ReceiptResponse::state_root`

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
