### PR TITLE
feat(alloy-rpc-types-eth): Optional serde

### DIFF
--- a/crates/contract/Cargo.toml
+++ b/crates/contract/Cargo.toml
@@ -22,7 +22,7 @@ workspace = true
 alloy-network.workspace = true
 alloy-network-primitives.workspace = true
 alloy-provider.workspace = true
-alloy-rpc-types-eth.workspace = true
+alloy-rpc-types-eth = { workspace = true, features = ["serde"] }
 alloy-transport.workspace = true
 
 alloy-dyn-abi = { workspace = true, features = ["std"] }

--- a/crates/network/Cargo.toml
+++ b/crates/network/Cargo.toml
@@ -24,7 +24,7 @@ alloy-eips = { workspace = true, features = ["serde"] }
 alloy-json-rpc.workspace = true
 alloy-network-primitives.workspace = true
 alloy-primitives.workspace = true
-alloy-rpc-types-eth.workspace = true
+alloy-rpc-types-eth = { workspace = true, features = ["std", "serde"] }
 alloy-signer.workspace = true
 alloy-serde.workspace = true
 alloy-sol-types.workspace = true

--- a/crates/provider/Cargo.toml
+++ b/crates/provider/Cargo.toml
@@ -29,7 +29,7 @@ alloy-signer-local = { workspace = true, optional = true }
 alloy-rpc-client.workspace = true
 alloy-rpc-types-admin = { workspace = true, optional = true }
 alloy-rpc-types-anvil = { workspace = true, optional = true }
-alloy-rpc-types-eth.workspace = true
+alloy-rpc-types-eth = { workspace = true, features = ["serde"] }
 alloy-rpc-types-trace = { workspace = true, optional = true }
 alloy-rpc-types-txpool = { workspace = true, optional = true }
 alloy-rpc-types-engine = { workspace = true, optional = true }

--- a/crates/rpc-types-engine/Cargo.toml
+++ b/crates/rpc-types-engine/Cargo.toml
@@ -23,7 +23,7 @@ workspace = true
 alloy-rlp = { workspace = true, features = ["arrayvec", "derive"] }
 alloy-primitives = { workspace = true, features = ["rlp", "serde"] }
 alloy-consensus = { workspace = true, features = ["std"] }
-alloy-rpc-types-eth.workspace = true
+alloy-rpc-types-eth = { workspace = true, features = ["std", "serde"] }
 alloy-serde.workspace = true
 alloy-eips = { workspace = true, features = ["serde"] }
 

--- a/crates/rpc-types-eth/Cargo.toml
+++ b/crates/rpc-types-eth/Cargo.toml
@@ -19,18 +19,19 @@ rustdoc-args = ["--cfg", "docsrs"]
 workspace = true
 
 [dependencies]
+alloy-eips.workspace = true
 alloy-serde.workspace = true
+alloy-consensus.workspace = true
 alloy-network-primitives.workspace = true
 alloy-rlp = { workspace = true, features = ["arrayvec", "derive"] }
-alloy-primitives = { workspace = true, features = ["rlp", "serde"] }
-alloy-consensus = { workspace = true, features = ["serde"] }
-alloy-eips = { workspace = true, features = ["serde"] }
-
-derive_more = { workspace = true, features = ["display"] }
+alloy-primitives = { workspace = true, features = ["rlp"] }
 
 itertools.workspace = true
-serde = { workspace = true, features = ["derive"] }
-serde_json.workspace = true
+derive_more = { workspace = true, features = ["display"] }
+
+# serde
+serde = { workspace = true, features = ["derive"], optional = true }
+serde_json = { workspace = true, optional = true }
 
 # `no_std` compatibility
 cfg-if.workspace = true
@@ -59,8 +60,9 @@ similar-asserts.workspace = true
 assert_matches.workspace = true
 
 [features]
-default = ["std"]
+default = ["std", "serde"]
 std = ["alloy-primitives/std", "alloy-consensus/std", "alloy-eips/std"]
+serde = ["dep:serde", "dep:serde_json", "alloy-primitives/serde", "alloy-consensus/serde", "alloy-eips/serde"]
 arbitrary = [
     "std",
     "dep:arbitrary",

--- a/crates/rpc-types-eth/src/account.rs
+++ b/crates/rpc-types-eth/src/account.rs
@@ -1,6 +1,5 @@
 use alloy_primitives::{Address, Bytes, B256, B512, U256};
 use alloy_serde::storage::JsonStorageKey;
-use serde::{Deserialize, Serialize};
 
 use alloc::{string::String, vec::Vec};
 
@@ -8,15 +7,17 @@ use alloc::{string::String, vec::Vec};
 pub use alloy_consensus::Account;
 
 /// Account information.
-#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AccountInfo {
     /// Account name
     pub name: String,
 }
 
 /// Data structure with proof for one single storage-entry
-#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct EIP1186StorageProof {
     /// Storage key.
     pub key: JsonStorageKey,
@@ -27,8 +28,9 @@ pub struct EIP1186StorageProof {
 }
 
 /// Response for EIP-1186 account proof `eth_getProof`
-#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct EIP1186AccountProofResponse {
     /// The account address.
     pub address: Address,
@@ -37,7 +39,7 @@ pub struct EIP1186AccountProofResponse {
     /// The hash of the code of the account.
     pub code_hash: B256,
     /// The account nonce.
-    #[serde(with = "alloy_serde::quantity")]
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
     pub nonce: u64,
     /// The hash of the storage of the account.
     pub storage_hash: B256,
@@ -48,22 +50,24 @@ pub struct EIP1186AccountProofResponse {
 }
 
 /// Extended account information (used by `parity_allAccountInfo`).
-#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ExtAccountInfo {
     /// Account name
     pub name: String,
     /// Account meta JSON
     pub meta: String,
     /// Account UUID (`None` for address book entries)
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub uuid: Option<String>,
 }
 
 /// account derived from a signature
 /// as well as information that tells if it is valid for
 /// the current chain
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct RecoveredAccount {
     /// address of the recovered account
     pub address: Address,
@@ -76,6 +80,7 @@ pub struct RecoveredAccount {
 }
 
 #[test]
+#[cfg(feature = "serde")]
 fn test_eip_1186_account_without_storage_proof() {
     let response = r#"{
        "address":"0xc36442b4a4522e871399cd717abdd847ab11fe88",

--- a/crates/rpc-types-eth/src/block.rs
+++ b/crates/rpc-types-eth/src/block.rs
@@ -7,7 +7,6 @@ use alloy_network_primitives::{
 };
 use alloy_primitives::{Address, BlockHash, Bloom, Bytes, B256, B64, U256};
 use alloy_serde::WithOtherFields;
-use serde::{Deserialize, Serialize};
 
 use alloc::vec::Vec;
 
@@ -17,27 +16,28 @@ pub use alloy_eips::{
 };
 
 /// Block representation
-#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct Block<T = Transaction, H = Header> {
     /// Header of the block.
-    #[serde(flatten)]
+    #[cfg_attr(feature = "serde", serde(flatten))]
     pub header: H,
     /// Uncles' hashes.
-    #[serde(default)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub uncles: Vec<B256>,
     /// Block Transactions. In the case of an uncle block, this field is not included in RPC
     /// responses, and when deserialized, it will be set to [BlockTransactions::Uncle].
-    #[serde(
+    #[cfg_attr(feature = "serde", serde(
         default = "BlockTransactions::uncle",
         skip_serializing_if = "BlockTransactions::is_uncle"
-    )]
+    ))]
     pub transactions: BlockTransactions<T>,
     /// Integer the size of this block in bytes.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
     pub size: Option<U256>,
     /// Withdrawals in the block.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
     pub withdrawals: Option<Vec<Withdrawal>>,
 }
 
@@ -50,15 +50,16 @@ impl<T: TransactionResponse, H> Block<T, H> {
 
 /// Block header representation.
 #[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
-#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct Header {
     /// Hash of the block
     pub hash: BlockHash,
     /// Hash of the parent
     pub parent_hash: B256,
     /// Hash of the uncles
-    #[serde(rename = "sha3Uncles")]
+    #[cfg_attr(feature = "serde", serde(rename = "sha3Uncles"))]
     pub uncles_hash: B256,
     /// Alias of `author`
     pub miner: Address,
@@ -73,19 +74,19 @@ pub struct Header {
     /// Difficulty
     pub difficulty: U256,
     /// Block number
-    #[serde(with = "alloy_serde::quantity")]
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
     pub number: u64,
     /// Gas Limit
-    #[serde(default, with = "alloy_serde::quantity")]
+    #[cfg_attr(feature = "serde", serde(default, with = "alloy_serde::quantity"))]
     pub gas_limit: u128,
     /// Gas Used
-    #[serde(default, with = "alloy_serde::quantity")]
+    #[cfg_attr(feature = "serde", serde(default, with = "alloy_serde::quantity"))]
     pub gas_used: u128,
     /// Timestamp
-    #[serde(default, with = "alloy_serde::quantity")]
+    #[cfg_attr(feature = "serde", serde(default, with = "alloy_serde::quantity"))]
     pub timestamp: u64,
     /// Total difficulty
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
     pub total_difficulty: Option<U256>,
     /// Extra data
     pub extra_data: Bytes,
@@ -100,28 +101,28 @@ pub struct Header {
     ///
     /// See also <https://eips.ethereum.org/EIPS/eip-4399>
     /// And <https://github.com/ethereum/execution-apis/issues/328>
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
     pub mix_hash: Option<B256>,
     /// Nonce
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
     pub nonce: Option<B64>,
     /// Base fee per unit of gas (if past London)
-    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt"))]
     pub base_fee_per_gas: Option<u128>,
     /// Withdrawals root hash added by EIP-4895 and is ignored in legacy headers.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
     pub withdrawals_root: Option<B256>,
     /// Blob gas used
-    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt"))]
     pub blob_gas_used: Option<u128>,
     /// Excess blob gas
-    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt"))]
     pub excess_blob_gas: Option<u128>,
     /// EIP-4788 parent beacon block root
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
     pub parent_beacon_block_root: Option<B256>,
     /// EIP-7685 requests root.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
     pub requests_root: Option<B256>,
 }
 
@@ -282,43 +283,44 @@ impl From<Header> for WithOtherFields<Header> {
 }
 
 /// BlockOverrides is a set of header fields to override.
-#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(default, rename_all = "camelCase", deny_unknown_fields)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(default, rename_all = "camelCase", deny_unknown_fields))]
 pub struct BlockOverrides {
     /// Overrides the block number.
     ///
     /// For `eth_callMany` this will be the block number of the first simulated block. Each
     /// following block increments its block number by 1
     // Note: geth uses `number`, erigon uses `blockNumber`
-    #[serde(default, skip_serializing_if = "Option::is_none", alias = "blockNumber")]
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none", alias = "blockNumber"))]
     pub number: Option<U256>,
     /// Overrides the difficulty of the block.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
     pub difficulty: Option<U256>,
     /// Overrides the timestamp of the block.
     // Note: geth uses `time`, erigon uses `timestamp`
-    #[serde(
+    #[cfg_attr(feature = "serde", serde(
         default,
         skip_serializing_if = "Option::is_none",
         alias = "timestamp",
         with = "alloy_serde::quantity::opt"
-    )]
+    ))]
     pub time: Option<u64>,
     /// Overrides the gas limit of the block.
-    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt"))]
     pub gas_limit: Option<u64>,
     /// Overrides the coinbase address of the block.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
     pub coinbase: Option<Address>,
     /// Overrides the prevrandao of the block.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
     pub random: Option<B256>,
     /// Overrides the basefee of the block.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
     pub base_fee: Option<U256>,
     /// A dictionary that maps blockNumber to a user-defined hash. It could be queried from the
     /// solidity opcode BLOCKHASH.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
     pub block_hash: Option<BTreeMap<u64, B256>>,
 }
 
@@ -355,7 +357,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "jsonrpsee-types")]
+    #[cfg(all(feature = "jsonrpsee-types", feature = "serde"))]
     fn serde_json_header() {
         use jsonrpsee_types::SubscriptionResponse;
         let resp = r#"{"jsonrpc":"2.0","method":"eth_subscribe","params":{"subscription":"0x7eef37ff35d471f8825b1c8f67a5d3c0","result":{"hash":"0x7a7ada12e140961a32395059597764416499f4178daf1917193fad7bd2cc6386","parentHash":"0xdedbd831f496e705e7f2ec3c8dcb79051040a360bf1455dbd7eb8ea6ad03b751","sha3Uncles":"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347","miner":"0x0000000000000000000000000000000000000000","stateRoot":"0x0000000000000000000000000000000000000000000000000000000000000000","transactionsRoot":"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421","receiptsRoot":"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421","number":"0x8","gasUsed":"0x0","gasLimit":"0x1c9c380","extraData":"0x","logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","timestamp":"0x642aa48f","difficulty":"0x0","mixHash":"0x0000000000000000000000000000000000000000000000000000000000000000","nonce":"0x0000000000000000"}}}"#;
@@ -366,6 +368,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "serde")]
     fn serde_block() {
         let block = Block {
             header: Header {
@@ -408,6 +411,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "serde")]
     fn serde_uncle_block() {
         let block = Block {
             header: Header {
@@ -450,6 +454,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "serde")]
     fn serde_block_with_withdrawals_set_as_none() {
         let block = Block {
             header: Header {
@@ -492,12 +497,14 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "serde")]
     fn block_overrides() {
         let s = r#"{"blockNumber": "0xe39dd0"}"#;
         let _overrides = serde_json::from_str::<BlockOverrides>(s).unwrap();
     }
 
     #[test]
+    #[cfg(feature = "serde")]
     fn serde_rich_block() {
         let s = r#"{
     "hash": "0xb25d0e54ca0104e3ebfb5a1dcdf9528140854d609886a300946fd6750dcb19f4",
@@ -531,6 +538,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "serde")]
     fn serde_missing_uncles_block() {
         let s = r#"{
             "baseFeePerGas":"0x886b221ad",
@@ -572,6 +580,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "serde")]
     fn serde_block_containing_uncles() {
         let s = r#"{
             "baseFeePerGas":"0x886b221ad",
@@ -615,6 +624,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "serde")]
     fn serde_empty_block() {
         let s = r#"{
     "hash": "0xb25d0e54ca0104e3ebfb5a1dcdf9528140854d609886a300946fd6750dcb19f4",
@@ -645,6 +655,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "serde")]
     fn recompute_block_hash() {
         let s = r#"{
     "hash": "0xb25d0e54ca0104e3ebfb5a1dcdf9528140854d609886a300946fd6750dcb19f4",

--- a/crates/rpc-types-eth/src/block.rs
+++ b/crates/rpc-types-eth/src/block.rs
@@ -28,10 +28,13 @@ pub struct Block<T = Transaction, H = Header> {
     pub uncles: Vec<B256>,
     /// Block Transactions. In the case of an uncle block, this field is not included in RPC
     /// responses, and when deserialized, it will be set to [BlockTransactions::Uncle].
-    #[cfg_attr(feature = "serde", serde(
-        default = "BlockTransactions::uncle",
-        skip_serializing_if = "BlockTransactions::is_uncle"
-    ))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(
+            default = "BlockTransactions::uncle",
+            skip_serializing_if = "BlockTransactions::is_uncle"
+        )
+    )]
     pub transactions: BlockTransactions<T>,
     /// Integer the size of this block in bytes.
     #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
@@ -107,16 +110,37 @@ pub struct Header {
     #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
     pub nonce: Option<B64>,
     /// Base fee per unit of gas (if past London)
-    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt"))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(
+            default,
+            skip_serializing_if = "Option::is_none",
+            with = "alloy_serde::quantity::opt"
+        )
+    )]
     pub base_fee_per_gas: Option<u128>,
     /// Withdrawals root hash added by EIP-4895 and is ignored in legacy headers.
     #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
     pub withdrawals_root: Option<B256>,
     /// Blob gas used
-    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt"))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(
+            default,
+            skip_serializing_if = "Option::is_none",
+            with = "alloy_serde::quantity::opt"
+        )
+    )]
     pub blob_gas_used: Option<u128>,
     /// Excess blob gas
-    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt"))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(
+            default,
+            skip_serializing_if = "Option::is_none",
+            with = "alloy_serde::quantity::opt"
+        )
+    )]
     pub excess_blob_gas: Option<u128>,
     /// EIP-4788 parent beacon block root
     #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
@@ -292,22 +316,35 @@ pub struct BlockOverrides {
     /// For `eth_callMany` this will be the block number of the first simulated block. Each
     /// following block increments its block number by 1
     // Note: geth uses `number`, erigon uses `blockNumber`
-    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none", alias = "blockNumber"))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(default, skip_serializing_if = "Option::is_none", alias = "blockNumber")
+    )]
     pub number: Option<U256>,
     /// Overrides the difficulty of the block.
     #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
     pub difficulty: Option<U256>,
     /// Overrides the timestamp of the block.
     // Note: geth uses `time`, erigon uses `timestamp`
-    #[cfg_attr(feature = "serde", serde(
-        default,
-        skip_serializing_if = "Option::is_none",
-        alias = "timestamp",
-        with = "alloy_serde::quantity::opt"
-    ))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(
+            default,
+            skip_serializing_if = "Option::is_none",
+            alias = "timestamp",
+            with = "alloy_serde::quantity::opt"
+        )
+    )]
     pub time: Option<u64>,
     /// Overrides the gas limit of the block.
-    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt"))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(
+            default,
+            skip_serializing_if = "Option::is_none",
+            with = "alloy_serde::quantity::opt"
+        )
+    )]
     pub gas_limit: Option<u64>,
     /// Overrides the coinbase address of the block.
     #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]

--- a/crates/rpc-types-eth/src/call.rs
+++ b/crates/rpc-types-eth/src/call.rs
@@ -1,6 +1,5 @@
 use crate::{request::TransactionRequest, BlockId, BlockOverrides};
 use alloy_primitives::Bytes;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use alloc::{
     format,
@@ -9,8 +8,9 @@ use alloc::{
 };
 
 /// Bundle of transactions
-#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(default, rename_all = "camelCase")]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct Bundle {
     /// All transactions to execute
     pub transactions: Vec<TransactionRequest>,
@@ -26,27 +26,29 @@ impl From<Vec<TransactionRequest>> for Bundle {
 }
 
 /// State context for callMany
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(default, rename_all = "camelCase")]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct StateContext {
     /// Block Number
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub block_number: Option<BlockId>,
     /// Inclusive number of tx to replay in block. -1 means replay all
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     #[doc(alias = "tx_index")]
     pub transaction_index: Option<TransactionIndex>,
 }
 
 /// CallResponse for eth_callMany
-#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(default, rename_all = "camelCase")]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct EthCallResponse {
     /// eth_call output (if no error)
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub value: Option<Bytes>,
     /// eth_call output (if error)
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub error: Option<String>,
 }
 
@@ -96,10 +98,11 @@ impl From<usize> for TransactionIndex {
     }
 }
 
-impl Serialize for TransactionIndex {
+#[cfg(feature = "serde")]
+impl serde::Serialize for TransactionIndex {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: Serializer,
+        S: serde::Serializer,
     {
         match self {
             Self::All => serializer.serialize_i8(-1),
@@ -108,10 +111,11 @@ impl Serialize for TransactionIndex {
     }
 }
 
-impl<'de> Deserialize<'de> for TransactionIndex {
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for TransactionIndex {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: Deserializer<'de>,
+        D: serde::Deserializer<'de>,
     {
         match isize::deserialize(deserializer)? {
             -1 => Ok(Self::All),
@@ -130,6 +134,7 @@ mod tests {
     use crate::BlockNumberOrTag;
 
     #[test]
+    #[cfg(feature = "serde")]
     fn transaction_index() {
         let s = "-1";
         let idx = serde_json::from_str::<TransactionIndex>(s).unwrap();
@@ -145,6 +150,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "serde")]
     fn serde_state_context() {
         let s = r#"{"blockNumber":"pending"}"#;
         let state_context = serde_json::from_str::<StateContext>(s).unwrap();
@@ -154,6 +160,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "serde")]
     fn serde_bundle() {
         let s = r#"{"transactions":[{"data":"0x70a08231000000000000000000000000000000dbc80bf780c6dc0ca16ed071b1f00cc000","to":"0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"}],"blockOverride":{"timestamp":1711546233}}"#;
         let bundle = serde_json::from_str::<Bundle>(s).unwrap();
@@ -162,6 +169,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "serde")]
     fn full_bundle() {
         // <https://github.com/paradigmxyz/reth/issues/7542>
         let s = r#"{"transactions":[{"from":"0x0000000000000011110000000000000000000000","to":"0x1100000000000000000000000000000000000000","value":"0x1111111","maxFeePerGas":"0x3a35294400","maxPriorityFeePerGas":"0x3b9aca00"}]}"#;

--- a/crates/rpc-types-eth/src/call.rs
+++ b/crates/rpc-types-eth/src/call.rs
@@ -15,7 +15,7 @@ pub struct Bundle {
     /// All transactions to execute
     pub transactions: Vec<TransactionRequest>,
     /// Block overrides to apply
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
     pub block_override: Option<BlockOverrides>,
 }
 

--- a/crates/rpc-types-eth/src/erc4337.rs
+++ b/crates/rpc-types-eth/src/erc4337.rs
@@ -1,40 +1,41 @@
 use crate::{collections::HashMap, Log, TransactionReceipt};
 use alloy_primitives::{Address, BlockNumber, Bytes, B256, U256};
-use serde::{Deserialize, Serialize};
 
 use alloc::vec::Vec;
 
 /// Options for conditional raw transaction submissions.
 // reference for the implementation <https://notes.ethereum.org/@yoav/SkaX2lS9j#>
 // See also <https://pkg.go.dev/github.com/aK0nshin/go-ethereum/arbitrum_types#ConditionalOptions>
-#[derive(Debug, Serialize, Deserialize, Clone, Default)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct ConditionalOptions {
     /// A map of account addresses to their expected storage states.
     /// Each account can have a specified storage root or explicit slot-value pairs.
-    #[serde(default)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub known_accounts: HashMap<Address, AccountStorage>,
     /// The minimal block number at which the transaction can be included.
     /// `None` indicates no minimum block number constraint.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
     pub block_number_min: Option<BlockNumber>,
     /// The maximal block number at which the transaction can be included.
     /// `None` indicates no maximum block number constraint.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
     pub block_number_max: Option<BlockNumber>,
     /// The minimal timestamp at which the transaction can be included.
     /// `None` indicates no minimum timestamp constraint.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
     pub timestamp_min: Option<u64>,
     /// The maximal timestamp at which the transaction can be included.
     /// `None` indicates no maximum timestamp constraint.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
     pub timestamp_max: Option<u64>,
 }
 
 /// Represents the expected state of an account for a transaction to be conditionally accepted.
-#[derive(Debug, Serialize, Deserialize, Clone)]
-#[serde(untagged)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(untagged))]
 pub enum AccountStorage {
     /// Expected storage root hash of the account.
     RootHash(B256),
@@ -43,8 +44,9 @@ pub enum AccountStorage {
 }
 
 /// [`UserOperation`] in the spec: Entry Point V0.6
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct UserOperation {
     /// The address of the smart contract account
     pub sender: Address,
@@ -72,8 +74,9 @@ pub struct UserOperation {
 }
 
 /// [`PackedUserOperation`] in the spec: Entry Point V0.7
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct PackedUserOperation {
     /// The account making the operation.
     pub sender: Address,
@@ -113,7 +116,8 @@ pub struct PackedUserOperation {
 }
 
 /// Send User Operation
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum SendUserOperation {
     /// User Operation
     EntryPointV06(UserOperation),
@@ -122,16 +126,18 @@ pub enum SendUserOperation {
 }
 
 /// Response to sending a user operation.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct SendUserOperationResponse {
     /// The hash of the user operation.
     pub user_op_hash: Bytes,
 }
 
 /// Represents the receipt of a user operation.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct UserOperationReceipt {
     /// The hash of the user operation.
     pub user_op_hash: Bytes,
@@ -158,8 +164,9 @@ pub struct UserOperationReceipt {
 }
 
 /// Represents the gas estimation for a user operation.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct UserOperationGasEstimation {
     /// The gas limit for the pre-verification.
     pub pre_verification_gas: U256,

--- a/crates/rpc-types-eth/src/fee.rs
+++ b/crates/rpc-types-eth/src/fee.rs
@@ -38,7 +38,10 @@ pub struct FeeHistory {
     /// # Note
     ///
     /// Empty list is skipped only for compatibility with Erigon and Geth.
-    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Vec::is_empty", with = "alloy_serde::quantity::vec"))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(default, skip_serializing_if = "Vec::is_empty", with = "alloy_serde::quantity::vec")
+    )]
     pub base_fee_per_gas: Vec<u128>,
     /// An array of block gas used ratios. These are calculated as the ratio
     /// of `gasUsed` and `gasLimit`.
@@ -46,7 +49,10 @@ pub struct FeeHistory {
     /// An array of block base fees per blob gas. This includes the next block after the newest
     /// of the returned range, because this value can be derived from the newest block. Zeroes
     /// are returned for pre-EIP-4844 blocks.
-    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Vec::is_empty", with = "alloy_serde::quantity::vec"))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(default, skip_serializing_if = "Vec::is_empty", with = "alloy_serde::quantity::vec")
+    )]
     pub base_fee_per_blob_gas: Vec<u128>,
     /// An array of block blob gas used ratios. These are calculated as the ratio of gasUsed and
     /// gasLimit.
@@ -57,11 +63,14 @@ pub struct FeeHistory {
     pub oldest_block: u64,
     /// An (optional) array of effective priority fee per gas data points from a single
     /// block. All zeroes are returned if the block is empty.
-    #[cfg_attr(feature = "serde", serde(
-        default,
-        skip_serializing_if = "Option::is_none",
-        with = "alloy_serde::u128_vec_vec_opt_via_ruint"
-    ))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(
+            default,
+            skip_serializing_if = "Option::is_none",
+            with = "alloy_serde::u128_vec_vec_opt_via_ruint"
+        )
+    )]
     pub reward: Option<Vec<Vec<u128>>>,
 }
 

--- a/crates/rpc-types-eth/src/fee.rs
+++ b/crates/rpc-types-eth/src/fee.rs
@@ -1,5 +1,3 @@
-use serde::{Deserialize, Serialize};
-
 use alloc::vec::Vec;
 
 /// Internal struct to calculate reward percentiles
@@ -28,8 +26,9 @@ impl Ord for TxGasAndReward {
 }
 
 /// Response type for `eth_feeHistory`
-#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Debug, Default, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct FeeHistory {
     /// An array of block base fees per gas.
     /// This includes the next block after the newest of the returned range,
@@ -39,7 +38,7 @@ pub struct FeeHistory {
     /// # Note
     ///
     /// Empty list is skipped only for compatibility with Erigon and Geth.
-    #[serde(default, skip_serializing_if = "Vec::is_empty", with = "alloy_serde::quantity::vec")]
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Vec::is_empty", with = "alloy_serde::quantity::vec"))]
     pub base_fee_per_gas: Vec<u128>,
     /// An array of block gas used ratios. These are calculated as the ratio
     /// of `gasUsed` and `gasLimit`.
@@ -47,22 +46,22 @@ pub struct FeeHistory {
     /// An array of block base fees per blob gas. This includes the next block after the newest
     /// of the returned range, because this value can be derived from the newest block. Zeroes
     /// are returned for pre-EIP-4844 blocks.
-    #[serde(default, skip_serializing_if = "Vec::is_empty", with = "alloy_serde::quantity::vec")]
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Vec::is_empty", with = "alloy_serde::quantity::vec"))]
     pub base_fee_per_blob_gas: Vec<u128>,
     /// An array of block blob gas used ratios. These are calculated as the ratio of gasUsed and
     /// gasLimit.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Vec::is_empty"))]
     pub blob_gas_used_ratio: Vec<f64>,
     /// Lowest number block of the returned range.
-    #[serde(default, with = "alloy_serde::quantity")]
+    #[cfg_attr(feature = "serde", serde(default, with = "alloy_serde::quantity"))]
     pub oldest_block: u64,
     /// An (optional) array of effective priority fee per gas data points from a single
     /// block. All zeroes are returned if the block is empty.
-    #[serde(
+    #[cfg_attr(feature = "serde", serde(
         default,
         skip_serializing_if = "Option::is_none",
         with = "alloy_serde::u128_vec_vec_opt_via_ruint"
-    )]
+    ))]
     pub reward: Option<Vec<Vec<u128>>>,
 }
 
@@ -110,6 +109,7 @@ mod tests {
     use similar_asserts::assert_eq;
 
     #[test]
+    #[cfg(feature = "serde")]
     fn test_fee_history_serde() {
         let sample = r#"{"baseFeePerGas":["0x342770c0","0x2da282a8"],"gasUsedRatio":[0.0],"baseFeePerBlobGas":["0x0","0x0"],"blobGasUsedRatio":[0.0],"oldestBlock":"0x1"}"#;
         let fee_history: FeeHistory = serde_json::from_str(sample).unwrap();
@@ -127,12 +127,14 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "serde")]
     fn test_fee_history_serde_2() {
         let json = r#"{"baseFeePerBlobGas":["0xc0","0xb2","0xab","0x98","0x9e","0x92","0xa4","0xb9","0xd0","0xea","0xfd"],"baseFeePerGas":["0x4cb8cf181","0x53075988e","0x4fb92ee18","0x45c209055","0x4e790dca2","0x58462e84e","0x5b7659f4e","0x5d66ea3aa","0x6283c6e45","0x5ecf0e1e5","0x5da59cf89"],"blobGasUsedRatio":[0.16666666666666666,0.3333333333333333,0,0.6666666666666666,0.16666666666666666,1,1,1,1,0.8333333333333334],"gasUsedRatio":[0.8288135,0.3407616666666667,0,0.9997232,0.999601,0.6444664333333333,0.5848306333333333,0.7189564,0.34952733333333336,0.4509799666666667],"oldestBlock":"0x59f94f","reward":[["0x59682f00"],["0x59682f00"],["0x0"],["0x59682f00"],["0x59682f00"],["0x3b9aca00"],["0x59682f00"],["0x59682f00"],["0x3b9aca00"],["0x59682f00"]]}"#;
         let _actual = serde_json::from_str::<FeeHistory>(json).unwrap();
     }
 
     #[test]
+    #[cfg(feature = "serde")]
     fn test_fee_history_serde_3() {
         let json = r#"{"oldestBlock":"0xdee807","baseFeePerGas":["0x4ccf46253","0x4457de658","0x4531c5aee","0x3cfa33972","0x3d33403eb","0x399457884","0x40bdf9772","0x48d55e7c4","0x51e9ebf14","0x55f460bf9","0x4e31607e4"],"gasUsedRatio":[0.05909575012589385,0.5498182666666667,0.0249864,0.5146185,0.2633512,0.997582061117319,0.999914966153302,0.9986873805040722,0.6973219148223686,0.13879896448917434],"baseFeePerBlobGas":["0x0","0x0","0x0","0x0","0x0","0x0","0x0","0x0","0x0","0x0","0x0"],"blobGasUsedRatio":[0,0,0,0,0,0,0,0,0,0]}"#;
         let _actual = serde_json::from_str::<FeeHistory>(json).unwrap();

--- a/crates/rpc-types-eth/src/filter.rs
+++ b/crates/rpc-types-eth/src/filter.rs
@@ -1,7 +1,7 @@
 use crate::{BlockNumberOrTag, Log as RpcLog, Transaction};
+use alloc::{format, string::String, vec::Vec};
 use alloy_primitives::{keccak256, Address, BlockHash, Bloom, BloomInput, B256, U256, U64};
 use itertools::{EitherOrBoth::*, Itertools};
-use alloc::{format, string::String, vec::Vec};
 
 use crate::collections::{
     hash_set::{IntoIter, Iter},

--- a/crates/rpc-types-eth/src/filter.rs
+++ b/crates/rpc-types-eth/src/filter.rs
@@ -1,12 +1,6 @@
 use crate::{BlockNumberOrTag, Log as RpcLog, Transaction};
 use alloy_primitives::{keccak256, Address, BlockHash, Bloom, BloomInput, B256, U256, U64};
 use itertools::{EitherOrBoth::*, Itertools};
-use serde::{
-    de::{DeserializeOwned, MapAccess, Visitor},
-    ser::SerializeStruct,
-    Deserialize, Deserializer, Serialize, Serializer,
-};
-
 use alloc::{format, string::String, vec::Vec};
 
 use crate::collections::{
@@ -38,7 +32,8 @@ impl BloomFilter {
     }
 }
 
-#[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 /// FilterSet is a set of values that will be used to filter logs
 pub struct FilterSet<T: Eq + Hash>(HashSet<T>);
 
@@ -547,11 +542,14 @@ impl Filter {
     }
 }
 
-impl Serialize for Filter {
+#[cfg(feature = "serde")]
+impl serde::Serialize for Filter {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: Serializer,
+        S: serde::Serializer,
     {
+        use serde::ser::SerializeStruct;
+
         let mut s = serializer.serialize_struct("Filter", 5)?;
         match self.block_option {
             FilterBlockOption::Range { from_block, to_block } => {
@@ -589,14 +587,15 @@ impl Serialize for Filter {
 type RawAddressFilter = ValueOrArray<Option<Address>>;
 type RawTopicsFilter = Vec<Option<ValueOrArray<Option<B256>>>>;
 
-impl<'de> Deserialize<'de> for Filter {
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for Filter {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: Deserializer<'de>,
+        D: serde::Deserializer<'de>,
     {
         struct FilterVisitor;
 
-        impl<'de> Visitor<'de> for FilterVisitor {
+        impl<'de> serde::de::Visitor<'de> for FilterVisitor {
             type Value = Filter;
 
             fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -605,7 +604,7 @@ impl<'de> Deserialize<'de> for Filter {
 
             fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
             where
-                A: MapAccess<'de>,
+                A: serde::de::MapAccess<'de>,
             {
                 let mut from_block: Option<Option<BlockNumberOrTag>> = None;
                 let mut to_block: Option<Option<BlockNumberOrTag>> = None;
@@ -760,13 +759,14 @@ impl From<Vec<B256>> for ValueOrArray<B256> {
     }
 }
 
-impl<T> Serialize for ValueOrArray<T>
+#[cfg(feature = "serde")]
+impl<T> serde::Serialize for ValueOrArray<T>
 where
-    T: Serialize,
+    T: serde::Serialize,
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: Serializer,
+        S: serde::Serializer,
     {
         match self {
             Self::Value(inner) => inner.serialize(serializer),
@@ -775,13 +775,14 @@ where
     }
 }
 
-impl<'a, T> Deserialize<'a> for ValueOrArray<T>
+#[cfg(feature = "serde")]
+impl<'a, T> serde::Deserialize<'a> for ValueOrArray<T>
 where
-    T: DeserializeOwned,
+    T: serde::de::DeserializeOwned,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: Deserializer<'a>,
+        D: serde::Deserializer<'a>,
     {
         let value = serde_json::Value::deserialize(deserializer)?;
 
@@ -789,7 +790,7 @@ where
             return Ok(Self::Array(Vec::new()));
         }
 
-        #[derive(Deserialize)]
+        #[derive(serde::Deserialize)]
         #[serde(untagged)]
         enum Variadic<T> {
             Value(T),
@@ -935,11 +936,12 @@ impl FilteredParams {
 }
 
 /// Response of the `eth_getFilterChanges` RPC.
-#[derive(Default, Clone, Debug, PartialEq, Eq, Serialize)]
-#[serde(untagged)]
+#[derive(Default, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(untagged))]
 pub enum FilterChanges<T = Transaction> {
     /// Empty result.
-    #[serde(with = "empty_array")]
+    #[cfg_attr(feature = "serde", serde(with = "empty_array"))]
     #[default]
     Empty,
     /// New logs.
@@ -1017,6 +1019,7 @@ impl<T> FilterChanges<T> {
     }
 }
 
+#[cfg(feature = "serde")]
 mod empty_array {
     use serde::{Serialize, Serializer};
 
@@ -1028,15 +1031,16 @@ mod empty_array {
     }
 }
 
-impl<'de, T> Deserialize<'de> for FilterChanges<T>
+#[cfg(feature = "serde")]
+impl<'de, T> serde::Deserialize<'de> for FilterChanges<T>
 where
-    T: Deserialize<'de>,
+    T: serde::Deserialize<'de>,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: Deserializer<'de>,
+        D: serde::Deserializer<'de>,
     {
-        #[derive(Deserialize)]
+        #[derive(serde::Deserialize)]
         #[serde(untagged)]
         enum Changes<T = Transaction> {
             Hashes(Vec<B256>),
@@ -1073,9 +1077,10 @@ where
 }
 
 /// Owned equivalent of a `SubscriptionId`
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-#[serde(untagged)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
+#[cfg_attr(feature = "serde", serde(untagged))]
 pub enum FilterId {
     /// Numeric id
     Num(u64),
@@ -1129,13 +1134,14 @@ pub enum PendingTransactionFilterKind {
     Full,
 }
 
-impl Serialize for PendingTransactionFilterKind {
+#[cfg(feature = "serde")]
+impl serde::Serialize for PendingTransactionFilterKind {
     /// Serializes the `PendingTransactionFilterKind` into a boolean value:
     /// - `false` for `Hashes`
     /// - `true` for `Full`
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: Serializer,
+        S: serde::Serializer,
     {
         match self {
             Self::Hashes => false.serialize(serializer),
@@ -1144,13 +1150,14 @@ impl Serialize for PendingTransactionFilterKind {
     }
 }
 
-impl<'a> Deserialize<'a> for PendingTransactionFilterKind {
+#[cfg(feature = "serde")]
+impl<'a> serde::Deserialize<'a> for PendingTransactionFilterKind {
     /// Deserializes a boolean value into `PendingTransactionFilterKind`:
     /// - `false` becomes `Hashes`
     /// - `true` becomes `Full`
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: Deserializer<'a>,
+        D: serde::Deserializer<'a>,
     {
         let val = Option::<bool>::deserialize(deserializer)?;
         match val {
@@ -1165,11 +1172,13 @@ mod tests {
     use super::*;
     use serde_json::json;
 
+    #[cfg(feature = "serde")]
     fn serialize<T: serde::Serialize>(t: &T) -> serde_json::Value {
         serde_json::to_value(t).expect("Failed to serialize value")
     }
 
     #[test]
+    #[cfg(feature = "serde")]
     fn test_empty_filter_topics_list() {
         let s = r#"{"fromBlock": "0xfc359e", "toBlock": "0xfc359e", "topics": [["0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925"], [], ["0x0000000000000000000000000c17e776cd218252adfca8d4e761d3fe757e9778"]]}"#;
         let filter = serde_json::from_str::<Filter>(s).unwrap();
@@ -1216,6 +1225,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "serde")]
     fn test_block_hash() {
         let s =
             r#"{"blockHash":"0x58dc57ab582b282c143424bd01e8d923cddfdcda9455bad02a29522f6274a948"}"#;
@@ -1231,6 +1241,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "serde")]
     fn test_filter_topics_middle_wildcard() {
         let s = r#"{"fromBlock": "0xfc359e", "toBlock": "0xfc359e", "topics": [["0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925"], [], [null, "0x0000000000000000000000000c17e776cd218252adfca8d4e761d3fe757e9778"]]}"#;
         let filter = serde_json::from_str::<Filter>(s).unwrap();
@@ -1249,8 +1260,9 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "serde")]
     fn can_serde_value_or_array() {
-        #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+        #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
         struct Item {
             value: ValueOrArray<U256>,
         }
@@ -1267,6 +1279,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "serde")]
     fn filter_serialization_test() {
         let t1 = "0000000000000000000000009729a6fbefefc8f6005933898b13dc45c3a2c8b7"
             .parse::<B256>()
@@ -1506,6 +1519,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "serde")]
     fn can_convert_to_ethers_filter() {
         let json = json!(
                     {
@@ -1552,6 +1566,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "serde")]
     fn can_convert_to_ethers_filter_with_null_fields() {
         let json = json!(
                     {

--- a/crates/rpc-types-eth/src/index.rs
+++ b/crates/rpc-types-eth/src/index.rs
@@ -1,10 +1,6 @@
 use alloc::{format, string::String};
 use alloy_primitives::U256;
 use core::fmt;
-use serde::{
-    de::{Error, Visitor},
-    Deserialize, Deserializer, Serialize, Serializer,
-};
 
 /// A hex encoded or decimal index that's intended to be used as a rust index, hence it's
 /// deserialized into a `usize`.
@@ -29,23 +25,25 @@ impl From<usize> for Index {
     }
 }
 
-impl Serialize for Index {
+#[cfg(feature = "serde")]
+impl serde::Serialize for Index {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: Serializer,
+        S: serde::Serializer,
     {
         serializer.serialize_str(&format!("0x{:x}", self.0))
     }
 }
 
-impl<'a> Deserialize<'a> for Index {
+#[cfg(feature = "serde")]
+impl<'a> serde::Deserialize<'a> for Index {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: Deserializer<'a>,
+        D: serde::Deserializer<'a>,
     {
         struct IndexVisitor;
 
-        impl<'a> Visitor<'a> for IndexVisitor {
+        impl<'a> serde::de::Visitor<'a> for IndexVisitor {
             type Value = Index;
 
             fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -54,24 +52,24 @@ impl<'a> Deserialize<'a> for Index {
 
             fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
             where
-                E: Error,
+                E: serde::de::Error,
             {
                 Ok(Index(value as usize))
             }
 
             fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
             where
-                E: Error,
+                E: serde::de::Error,
             {
                 value.strip_prefix("0x").map_or_else(
                     || {
                         value.parse::<usize>().map(Index).map_err(|e| {
-                            Error::custom(format!("Failed to parse numeric index: {e}"))
+                            serde::de::Error::custom(format!("Failed to parse numeric index: {e}"))
                         })
                     },
                     |val| {
                         usize::from_str_radix(val, 16).map(Index).map_err(|e| {
-                            Error::custom(format!("Failed to parse hex encoded index value: {e}"))
+                            serde::de::Error::custom(format!("Failed to parse hex encoded index value: {e}"))
                         })
                     },
                 )
@@ -79,7 +77,7 @@ impl<'a> Deserialize<'a> for Index {
 
             fn visit_string<E>(self, value: String) -> Result<Self::Value, E>
             where
-                E: Error,
+                E: serde::de::Error,
             {
                 self.visit_str(value.as_ref())
             }
@@ -96,6 +94,7 @@ mod tests {
     use serde_json::json;
 
     #[test]
+    #[cfg(feature = "serde")]
     fn test_serde_index_rand() {
         let mut rng = thread_rng();
         for _ in 0..100 {
@@ -107,6 +106,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "serde")]
     fn test_serde_index_deserialization() {
         // Test decimal index
         let json_data = json!(42);

--- a/crates/rpc-types-eth/src/index.rs
+++ b/crates/rpc-types-eth/src/index.rs
@@ -69,7 +69,9 @@ impl<'a> serde::Deserialize<'a> for Index {
                     },
                     |val| {
                         usize::from_str_radix(val, 16).map(Index).map_err(|e| {
-                            serde::de::Error::custom(format!("Failed to parse hex encoded index value: {e}"))
+                            serde::de::Error::custom(format!(
+                                "Failed to parse hex encoded index value: {e}"
+                            ))
                         })
                     },
                 )

--- a/crates/rpc-types-eth/src/log.rs
+++ b/crates/rpc-types-eth/src/log.rs
@@ -1,36 +1,36 @@
 use alloy_primitives::{Address, BlockHash, LogData, TxHash, B256};
-use serde::{Deserialize, Serialize};
 
 /// Ethereum Log emitted by a transaction
-#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct Log<T = LogData> {
-    #[serde(flatten)]
+    #[cfg_attr(feature = "serde", serde(flatten))]
     /// Consensus log object
     pub inner: alloy_primitives::Log<T>,
     /// Hash of the block the transaction that emitted this log was mined in
     pub block_hash: Option<BlockHash>,
     /// Number of the block the transaction that emitted this log was mined in
-    #[serde(with = "alloy_serde::quantity::opt")]
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity::opt"))]
     pub block_number: Option<u64>,
     /// The timestamp of the block as proposed in:
     /// <https://ethereum-magicians.org/t/proposal-for-adding-blocktimestamp-to-logs-object-returned-by-eth-getlogs-and-related-requests>
     /// <https://github.com/ethereum/execution-apis/issues/295>
-    #[serde(skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt", default)]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt", default))]
     pub block_timestamp: Option<u64>,
     /// Transaction Hash
     #[doc(alias = "tx_hash")]
     pub transaction_hash: Option<TxHash>,
     /// Index of the Transaction in the block
-    #[serde(with = "alloy_serde::quantity::opt")]
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity::opt"))]
     #[doc(alias = "tx_index")]
     pub transaction_index: Option<u64>,
     /// Log Index in Block
-    #[serde(with = "alloy_serde::quantity::opt")]
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity::opt"))]
     pub log_index: Option<u64>,
     /// Geth Compatibility Field: whether this log was removed
-    #[serde(default)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub removed: bool,
 }
 
@@ -161,6 +161,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "serde")]
     fn serde_log() {
         let mut log = Log {
             inner: alloy_primitives::Log {

--- a/crates/rpc-types-eth/src/log.rs
+++ b/crates/rpc-types-eth/src/log.rs
@@ -17,7 +17,14 @@ pub struct Log<T = LogData> {
     /// The timestamp of the block as proposed in:
     /// <https://ethereum-magicians.org/t/proposal-for-adding-blocktimestamp-to-logs-object-returned-by-eth-getlogs-and-related-requests>
     /// <https://github.com/ethereum/execution-apis/issues/295>
-    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt", default))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(
+            skip_serializing_if = "Option::is_none",
+            with = "alloy_serde::quantity::opt",
+            default
+        )
+    )]
     pub block_timestamp: Option<u64>,
     /// Transaction Hash
     #[doc(alias = "tx_hash")]

--- a/crates/rpc-types-eth/src/pubsub.rs
+++ b/crates/rpc-types-eth/src/pubsub.rs
@@ -4,11 +4,11 @@ use crate::{Filter, Header, Log, Transaction};
 use alloc::{boxed::Box, format};
 use alloy_primitives::B256;
 use alloy_serde::WithOtherFields;
-use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
 
 /// Subscription result.
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
-#[serde(untagged)]
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(untagged))]
 pub enum SubscriptionResult<T = Transaction> {
     /// New block header.
     Header(Box<WithOtherFields<Header>>),
@@ -23,8 +23,9 @@ pub enum SubscriptionResult<T = Transaction> {
 }
 
 /// Response type for a SyncStatus subscription.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(untagged)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(untagged))]
 pub enum PubSubSyncStatus {
     /// If not currently syncing, this should always be `false`.
     Simple(bool),
@@ -33,8 +34,9 @@ pub enum PubSubSyncStatus {
 }
 
 /// Sync status metadata.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct SyncStatusMetadata {
     /// Whether the node is currently syncing.
     pub syncing: bool,
@@ -43,17 +45,18 @@ pub struct SyncStatusMetadata {
     /// The current block.
     pub current_block: u64,
     /// The highest block.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
     pub highest_block: Option<u64>,
 }
 
-impl<T> Serialize for SubscriptionResult<T>
+#[cfg(feature = "serde")]
+impl<T> serde::Serialize for SubscriptionResult<T>
 where
-    T: Serialize,
+    T: serde::Serialize,
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: Serializer,
+        S: serde::Serializer,
     {
         match *self {
             Self::Header(ref header) => header.serialize(serializer),
@@ -66,9 +69,10 @@ where
 }
 
 /// Subscription kind.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 pub enum SubscriptionKind {
     /// New block headers subscription.
     ///
@@ -126,10 +130,11 @@ impl Params {
     }
 }
 
-impl Serialize for Params {
+#[cfg(feature = "serde")]
+impl serde::Serialize for Params {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: Serializer,
+        S: serde::Serializer,
     {
         match self {
             Self::None => (&[] as &[serde_json::Value]).serialize(serializer),
@@ -139,11 +144,14 @@ impl Serialize for Params {
     }
 }
 
-impl<'a> Deserialize<'a> for Params {
+#[cfg(feature = "serde")]
+impl<'a> serde::Deserialize<'a> for Params {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: Deserializer<'a>,
+        D: serde::Deserializer<'a>,
     {
+        use serde::de::Error;
+
         let v = serde_json::Value::deserialize(deserializer)?;
 
         if v.is_null() {
@@ -165,6 +173,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[cfg(feature = "serde")]
     fn params_serde() {
         let s: Params = serde_json::from_str("true").unwrap();
         assert_eq!(s, Params::Bool(true));

--- a/crates/rpc-types-eth/src/simulate.rs
+++ b/crates/rpc-types-eth/src/simulate.rs
@@ -3,7 +3,6 @@
 use crate::{state::StateOverride, Block, BlockOverrides, Log, TransactionRequest};
 use alloc::{string::String, vec::Vec};
 use alloy_primitives::Bytes;
-use serde::{Deserialize, Serialize};
 
 /// The maximum number of blocks that can be simulated in a single request,
 pub const MAX_SIMULATE_BLOCKS: u64 = 256;
@@ -11,25 +10,27 @@ pub const MAX_SIMULATE_BLOCKS: u64 = 256;
 /// Represents a batch of calls to be simulated sequentially within a block.
 /// This struct includes block and state overrides as well as the transaction requests to be
 /// executed.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct SimBlock {
     /// Modifications to the default block characteristics.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
     pub block_overrides: Option<BlockOverrides>,
     /// State modifications to apply before executing the transactions.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
     pub state_overrides: Option<StateOverride>,
     /// A vector of transactions to be simulated.
     pub calls: Vec<TransactionRequest>,
 }
 
 /// Represents the result of simulating a block.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct SimulatedBlock<B = Block> {
     /// The simulated block.
-    #[serde(flatten)]
+    #[cfg_attr(feature = "serde", serde(flatten))]
     pub inner: B,
     /// A vector of results for each call in the block.
     pub calls: Vec<SimCallResult>,
@@ -37,22 +38,23 @@ pub struct SimulatedBlock<B = Block> {
 
 /// Captures the outcome of a transaction simulation.
 /// It includes the return value, logs produced, gas used, and the status of the transaction.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct SimCallResult {
     /// The raw bytes returned by the transaction.
     pub return_value: Bytes,
     /// Logs generated during the execution of the transaction.
-    #[serde(default)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub logs: Vec<Log>,
     /// The amount of gas used by the transaction.
-    #[serde(with = "alloy_serde::quantity")]
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
     pub gas_used: u64,
     /// The final status of the transaction, typically indicating success or failure.
-    #[serde(with = "alloy_serde::quantity")]
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
     pub status: bool,
     /// Error in case the call failed
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
     pub error: Option<SimulateError>,
 }
 
@@ -60,24 +62,26 @@ pub struct SimCallResult {
 ///
 /// This struct configures how simulations are executed, including whether to trace token transfers,
 /// validate transaction sequences, and whether to return full transaction objects.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct SimulatePayload {
     /// Array of block state calls to be executed at specific, optional block/state.
     pub block_state_calls: Vec<SimBlock>,
     /// Flag to determine whether to trace ERC20/ERC721 token transfers within transactions.
-    #[serde(default)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub trace_transfers: bool,
     /// Flag to enable or disable validation of the transaction sequence in the blocks.
-    #[serde(default)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub validation: bool,
     /// Flag to decide if full transactions should be returned instead of just their hashes.
     pub return_full_transactions: bool,
 }
 
 /// The error response returned by the `eth_simulateV1` method.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct SimulateError {
     /// Code error
     /// -3200: Execution reverted
@@ -94,6 +98,7 @@ mod tests {
     use serde_json::json;
 
     #[test]
+    #[cfg(feature = "serde")]
     fn test_eth_simulate_v1_account_not_precompile() {
         let request_json = json!({
             "jsonrpc": "2.0",

--- a/crates/rpc-types-eth/src/state.rs
+++ b/crates/rpc-types-eth/src/state.rs
@@ -16,7 +16,14 @@ pub struct AccountOverride {
     #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
     pub balance: Option<U256>,
     /// Fake nonce to set for the account before executing the call.
-    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt"))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(
+            default,
+            skip_serializing_if = "Option::is_none",
+            with = "alloy_serde::quantity::opt"
+        )
+    )]
     pub nonce: Option<u64>,
     /// Fake EVM bytecode to inject into the account before executing the call.
     #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
@@ -32,7 +39,14 @@ pub struct AccountOverride {
     /// Moves addresses precompile into the specified address. This move is done before the 'code'
     /// override is set. When the specified address is not a precompile, the behaviour is undefined
     /// and different clients might behave differently.
-    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none", rename = "movePrecompileToAddress"))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(
+            default,
+            skip_serializing_if = "Option::is_none",
+            rename = "movePrecompileToAddress"
+        )
+    )]
     pub move_precompile_to: Option<Address>,
 }
 

--- a/crates/rpc-types-eth/src/state.rs
+++ b/crates/rpc-types-eth/src/state.rs
@@ -3,36 +3,36 @@
 use crate::{collections::HashMap, BlockOverrides};
 use alloc::boxed::Box;
 use alloy_primitives::{Address, Bytes, B256, U256};
-use serde::{Deserialize, Serialize};
 
 /// A set of account overrides
 pub type StateOverride = HashMap<Address, AccountOverride>;
 
 /// Custom account override used in call
-#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(default, rename_all = "camelCase", deny_unknown_fields)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(default, rename_all = "camelCase", deny_unknown_fields))]
 pub struct AccountOverride {
     /// Fake balance to set for the account before executing the call.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
     pub balance: Option<U256>,
     /// Fake nonce to set for the account before executing the call.
-    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt"))]
     pub nonce: Option<u64>,
     /// Fake EVM bytecode to inject into the account before executing the call.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
     pub code: Option<Bytes>,
     /// Fake key-value mapping to override all slots in the account storage before executing the
     /// call.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
     pub state: Option<HashMap<B256, B256>>,
     /// Fake key-value mapping to override individual slots in the account storage before executing
     /// the call.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
     pub state_diff: Option<HashMap<B256, B256>>,
     /// Moves addresses precompile into the specified address. This move is done before the 'code'
     /// override is set. When the specified address is not a precompile, the behaviour is undefined
     /// and different clients might behave differently.
-    #[serde(default, skip_serializing_if = "Option::is_none", rename = "movePrecompileToAddress")]
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none", rename = "movePrecompileToAddress"))]
     pub move_precompile_to: Option<Address>,
 }
 
@@ -94,6 +94,17 @@ mod tests {
     use alloy_primitives::address;
 
     #[test]
+    fn test_default_account_override() {
+        let acc_override = AccountOverride::default();
+        assert!(acc_override.balance.is_none());
+        assert!(acc_override.nonce.is_none());
+        assert!(acc_override.code.is_none());
+        assert!(acc_override.state.is_none());
+        assert!(acc_override.state_diff.is_none());
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
     #[should_panic(expected = "invalid type")]
     fn test_invalid_json_structure() {
         let invalid_json = r#"{
@@ -106,6 +117,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "serde")]
     fn test_large_values_in_override() {
         let large_values_json = r#"{
             "0x1234567890123456789012345678901234567890": {
@@ -122,16 +134,7 @@ mod tests {
     }
 
     #[test]
-    fn test_default_account_override() {
-        let acc_override = AccountOverride::default();
-        assert!(acc_override.balance.is_none());
-        assert!(acc_override.nonce.is_none());
-        assert!(acc_override.code.is_none());
-        assert!(acc_override.state.is_none());
-        assert!(acc_override.state_diff.is_none());
-    }
-
-    #[test]
+    #[cfg(feature = "serde")]
     fn test_state_override() {
         let s = r#"{
             "0x0000000000000000000000000000000000000124": {
@@ -145,6 +148,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "serde")]
     fn test_state_override_state_diff() {
         let s = r#"{
                 "0x1b5212AF6b76113afD94cD2B5a78a73B7d7A8222": {

--- a/crates/rpc-types-eth/src/syncing.rs
+++ b/crates/rpc-types-eth/src/syncing.rs
@@ -1,11 +1,10 @@
-use alloy_primitives::{B512, U256};
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
-
 use alloc::{boxed::Box, collections::BTreeMap, string::String, vec::Vec};
+use alloy_primitives::{B512, U256};
 
 /// Syncing info
-#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct SyncInfo {
     /// Starting block
     pub starting_block: U256,
@@ -19,24 +18,26 @@ pub struct SyncInfo {
     pub warp_chunks_processed: Option<U256>,
     /// The details of the sync stages as an hashmap
     /// where the key is the name of the stage and the value is the block number.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
     pub stages: Option<Vec<Stage>>,
 }
 
 /// The detail of the sync stages.
-#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct Stage {
     /// The name of the sync stage.
-    #[serde(alias = "stage_name")]
+    #[cfg_attr(feature = "serde", serde(alias = "stage_name"))]
     pub name: String,
     /// Indicates the progress of the sync stage.
-    #[serde(alias = "block_number", with = "alloy_serde::quantity")]
+    #[cfg_attr(feature = "serde", serde(alias = "block_number", with = "alloy_serde::quantity"))]
     pub block: u64,
 }
 
 /// Peers info
-#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Peers {
     /// Number of active peers
     pub active: usize,
@@ -49,7 +50,8 @@ pub struct Peers {
 }
 
 /// Peer connection information
-#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PeerInfo {
     /// Public node id
     pub id: Option<String>,
@@ -64,8 +66,9 @@ pub struct PeerInfo {
 }
 
 /// Peer network information
-#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct PeerNetworkInfo {
     /// Remote endpoint address
     pub remote_address: String,
@@ -74,17 +77,19 @@ pub struct PeerNetworkInfo {
 }
 
 /// Peer protocols information
-#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PeerProtocolsInfo {
     /// Ethereum protocol information
     pub eth: Option<PeerEthProtocolInfo>,
     /// PIP protocol information.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
     pub pip: Option<PipProtocolInfo>,
 }
 
 /// Peer Ethereum protocol information
-#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PeerEthProtocolInfo {
     /// Negotiated ethereum protocol version
     pub version: u32,
@@ -95,7 +100,8 @@ pub struct PeerEthProtocolInfo {
 }
 
 /// Peer PIP protocol information
-#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PipProtocolInfo {
     /// Negotiated PIP protocol version
     pub version: u32,
@@ -114,12 +120,13 @@ pub enum SyncStatus {
     None,
 }
 
-impl<'de> Deserialize<'de> for SyncStatus {
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for SyncStatus {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: Deserializer<'de>,
+        D: serde::Deserializer<'de>,
     {
-        #[derive(Deserialize)]
+        #[derive(serde::Deserialize)]
         #[serde(untagged)]
         enum Syncing {
             /// When client is synced to the highest block, eth_syncing with return "false"
@@ -137,10 +144,11 @@ impl<'de> Deserialize<'de> for SyncStatus {
     }
 }
 
-impl Serialize for SyncStatus {
+#[cfg(feature = "serde")]
+impl serde::Serialize for SyncStatus {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: Serializer,
+        S: serde::Serializer,
     {
         match self {
             Self::Info(info) => info.serialize(serializer),
@@ -150,8 +158,9 @@ impl Serialize for SyncStatus {
 }
 
 /// Propagation statistics for pending transaction.
-#[derive(Clone, Debug, Default, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Debug, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[doc(alias = "TxStats")]
 pub struct TransactionStats {
     /// Block no this transaction was first seen.
@@ -161,8 +170,9 @@ pub struct TransactionStats {
 }
 
 /// Chain status.
-#[derive(Clone, Copy, Debug, Default, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Copy, Debug, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct ChainStatus {
     /// Describes the gap in the blockchain, if there is one: (first, last)
     pub block_gap: Option<(U256, U256)>,

--- a/crates/rpc-types-eth/src/transaction/mod.rs
+++ b/crates/rpc-types-eth/src/transaction/mod.rs
@@ -61,19 +61,47 @@ pub struct Transaction {
     /// Transferred value
     pub value: U256,
     /// Gas Price
-    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt"))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(
+            default,
+            skip_serializing_if = "Option::is_none",
+            with = "alloy_serde::quantity::opt"
+        )
+    )]
     pub gas_price: Option<u128>,
     /// Gas amount
     #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
     pub gas: u128,
     /// Max BaseFeePerGas the user is willing to pay.
-    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt"))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(
+            default,
+            skip_serializing_if = "Option::is_none",
+            with = "alloy_serde::quantity::opt"
+        )
+    )]
     pub max_fee_per_gas: Option<u128>,
     /// The miner's tip.
-    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt"))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(
+            default,
+            skip_serializing_if = "Option::is_none",
+            with = "alloy_serde::quantity::opt"
+        )
+    )]
     pub max_priority_fee_per_gas: Option<u128>,
     /// Configured max fee per blob gas for eip-4844 transactions
-    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt"))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(
+            default,
+            skip_serializing_if = "Option::is_none",
+            with = "alloy_serde::quantity::opt"
+        )
+    )]
     pub max_fee_per_blob_gas: Option<u128>,
     /// Data
     pub input: Bytes,
@@ -83,7 +111,14 @@ pub struct Transaction {
     #[cfg_attr(feature = "serde", serde(flatten, skip_serializing_if = "Option::is_none"))]
     pub signature: Option<Signature>,
     /// The chain id of the transaction, if any.
-    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt"))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(
+            default,
+            skip_serializing_if = "Option::is_none",
+            with = "alloy_serde::quantity::opt"
+        )
+    )]
     pub chain_id: Option<ChainId>,
     /// Contains the blob hashes for eip-4844 transactions.
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
@@ -98,12 +133,15 @@ pub struct Transaction {
     /// Transaction type,
     /// Some(4) for EIP-7702 transaction, Some(3) for EIP-4844 transaction, Some(2) for EIP-1559
     /// transaction, Some(1) for AccessList transaction, None or Some(0) for Legacy
-    #[cfg_attr(feature = "serde", serde(
-        default,
-        rename = "type",
-        skip_serializing_if = "Option::is_none",
-        with = "alloy_serde::quantity::opt"
-    ))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(
+            default,
+            rename = "type",
+            skip_serializing_if = "Option::is_none",
+            with = "alloy_serde::quantity::opt"
+        )
+    )]
     #[doc(alias = "tx_type")]
     pub transaction_type: Option<u8>,
     /// The signed authorization list is a list of tuples that store the address to code which the

--- a/crates/rpc-types-eth/src/transaction/mod.rs
+++ b/crates/rpc-types-eth/src/transaction/mod.rs
@@ -7,7 +7,6 @@ use alloy_consensus::{
 use alloy_eips::eip7702::SignedAuthorization;
 use alloy_network_primitives::TransactionResponse;
 use alloy_primitives::{Address, BlockHash, Bytes, ChainId, TxHash, TxKind, B256, U256};
-use serde::{Deserialize, Serialize};
 
 use alloc::vec::Vec;
 
@@ -35,24 +34,25 @@ pub use signature::{Parity, Signature};
 pub use alloy_consensus::{AnyReceiptEnvelope, Receipt, ReceiptEnvelope, ReceiptWithBloom};
 
 /// Transaction object used in RPC
-#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[doc(alias = "Tx")]
 pub struct Transaction {
     /// Hash
     pub hash: TxHash,
     /// Nonce
-    #[serde(with = "alloy_serde::quantity")]
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
     pub nonce: u64,
     /// Block hash
-    #[serde(default)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub block_hash: Option<BlockHash>,
     /// Block number
-    #[serde(default, with = "alloy_serde::quantity::opt")]
+    #[cfg_attr(feature = "serde", serde(default, with = "alloy_serde::quantity::opt"))]
     pub block_number: Option<u64>,
     /// Transaction Index
-    #[serde(default, with = "alloy_serde::quantity::opt")]
+    #[cfg_attr(feature = "serde", serde(default, with = "alloy_serde::quantity::opt"))]
     pub transaction_index: Option<u64>,
     /// Sender
     pub from: Address,
@@ -61,54 +61,54 @@ pub struct Transaction {
     /// Transferred value
     pub value: U256,
     /// Gas Price
-    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt"))]
     pub gas_price: Option<u128>,
     /// Gas amount
-    #[serde(with = "alloy_serde::quantity")]
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
     pub gas: u128,
     /// Max BaseFeePerGas the user is willing to pay.
-    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt"))]
     pub max_fee_per_gas: Option<u128>,
     /// The miner's tip.
-    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt"))]
     pub max_priority_fee_per_gas: Option<u128>,
     /// Configured max fee per blob gas for eip-4844 transactions
-    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt"))]
     pub max_fee_per_blob_gas: Option<u128>,
     /// Data
     pub input: Bytes,
     /// All _flattened_ fields of the transaction signature.
     ///
     /// Note: this is an option so special transaction types without a signature (e.g. <https://github.com/ethereum-optimism/optimism/blob/0bf643c4147b43cd6f25a759d331ef3a2a61a2a3/specs/deposits.md#the-deposited-transaction-type>) can be supported.
-    #[serde(flatten, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "serde", serde(flatten, skip_serializing_if = "Option::is_none"))]
     pub signature: Option<Signature>,
     /// The chain id of the transaction, if any.
-    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt"))]
     pub chain_id: Option<ChainId>,
     /// Contains the blob hashes for eip-4844 transactions.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub blob_versioned_hashes: Option<Vec<B256>>,
     /// EIP2930
     ///
     /// Pre-pay to warm storage access.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub access_list: Option<AccessList>,
     /// EIP2718
     ///
     /// Transaction type,
     /// Some(4) for EIP-7702 transaction, Some(3) for EIP-4844 transaction, Some(2) for EIP-1559
     /// transaction, Some(1) for AccessList transaction, None or Some(0) for Legacy
-    #[serde(
+    #[cfg_attr(feature = "serde", serde(
         default,
         rename = "type",
         skip_serializing_if = "Option::is_none",
         with = "alloy_serde::quantity::opt"
-    )]
+    ))]
     #[doc(alias = "tx_type")]
     pub transaction_type: Option<u8>,
     /// The signed authorization list is a list of tuples that store the address to code which the
     /// signer desires to execute in the context of their EOA and their signature.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
     pub authorization_list: Option<Vec<SignedAuthorization>>,
 }
 
@@ -339,6 +339,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "serde")]
     fn serde_transaction() {
         let transaction = Transaction {
             hash: B256::with_last_byte(1),
@@ -382,6 +383,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "serde")]
     fn serde_transaction_with_parity_bit() {
         let transaction = Transaction {
             hash: B256::with_last_byte(1),
@@ -425,6 +427,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "serde")]
     fn serde_minimal_transaction() {
         let transaction = Transaction {
             hash: B256::with_last_byte(1),
@@ -445,6 +448,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "serde")]
     fn into_request_legacy() {
         // cast rpc eth_getTransactionByHash
         // 0xe9e91f1ee4b56c0df2e9f06c2b8c27c6076195a88a7b8537ba8313d80e6f124e --rpc-url mainnet
@@ -457,6 +461,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "serde")]
     fn into_request_eip1559() {
         // cast rpc eth_getTransactionByHash
         // 0x0e07d8b53ed3d91314c80e53cf25bcde02084939395845cbb625b029d568135c --rpc-url mainnet

--- a/crates/rpc-types-eth/src/transaction/receipt.rs
+++ b/crates/rpc-types-eth/src/transaction/receipt.rs
@@ -266,7 +266,7 @@ mod test {
     #[cfg(feature = "serde")]
     fn deserialize_tx_receipt_op() {
         // OtherFields for Optimism
-        #[derive(Debug, Deserialize)]
+        #[derive(Debug, serde::Deserialize)]
         struct OpOtherFields {
             #[serde(rename = "l1BaseFeeScalar")]
             l1_base_fee_scalar: String,
@@ -342,7 +342,7 @@ mod test {
     #[cfg(feature = "serde")]
     fn deserialize_tx_receipt_arb() {
         // OtherFields for Arbitrum
-        #[derive(Debug, Deserialize)]
+        #[derive(Debug, serde::Deserialize)]
         struct ArbOtherFields {
             #[serde(rename = "gasUsedForL1")]
             gas_used_for_l1: String,

--- a/crates/rpc-types-eth/src/transaction/receipt.rs
+++ b/crates/rpc-types-eth/src/transaction/receipt.rs
@@ -44,10 +44,24 @@ pub struct TransactionReceipt<T = ReceiptEnvelope<Log>> {
     /// Blob gas used by the eip-4844 transaction
     ///
     /// This is None for non eip-4844 transactions
-    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt", default))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(
+            skip_serializing_if = "Option::is_none",
+            with = "alloy_serde::quantity::opt",
+            default
+        )
+    )]
     pub blob_gas_used: Option<u128>,
     /// The price paid by the eip-4844 transaction per blob gas.
-    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt", default))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(
+            skip_serializing_if = "Option::is_none",
+            with = "alloy_serde::quantity::opt",
+            default
+        )
+    )]
     pub blob_gas_price: Option<u128>,
     /// Address of the sender
     pub from: Address,

--- a/crates/rpc-types-eth/src/transaction/receipt.rs
+++ b/crates/rpc-types-eth/src/transaction/receipt.rs
@@ -4,7 +4,6 @@ use alloy_eips::eip7702::SignedAuthorization;
 use alloy_network_primitives::ReceiptResponse;
 use alloy_primitives::{Address, BlockHash, TxHash, B256};
 use alloy_serde::WithOtherFields;
-use serde::{Deserialize, Serialize};
 
 use alloc::vec::Vec;
 
@@ -12,42 +11,43 @@ use alloc::vec::Vec;
 ///
 /// This type is generic over an inner [`ReceiptEnvelope`] which contains
 /// consensus data and metadata.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[doc(alias = "TxReceipt")]
 pub struct TransactionReceipt<T = ReceiptEnvelope<Log>> {
     /// The receipt envelope, which contains the consensus receipt data..
-    #[serde(flatten)]
+    #[cfg_attr(feature = "serde", serde(flatten))]
     pub inner: T,
     /// Transaction Hash.
     #[doc(alias = "tx_hash")]
     pub transaction_hash: TxHash,
     /// Index within the block.
-    #[serde(default, with = "alloy_serde::quantity::opt")]
+    #[cfg_attr(feature = "serde", serde(default, with = "alloy_serde::quantity::opt"))]
     #[doc(alias = "tx_index")]
     pub transaction_index: Option<u64>,
     /// Hash of the block this transaction was included within.
-    #[serde(default)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub block_hash: Option<BlockHash>,
     /// Number of the block this transaction was included within.
-    #[serde(default, with = "alloy_serde::quantity::opt")]
+    #[cfg_attr(feature = "serde", serde(default, with = "alloy_serde::quantity::opt"))]
     pub block_number: Option<u64>,
     /// Gas used by this transaction alone.
-    #[serde(with = "alloy_serde::quantity")]
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
     pub gas_used: u128,
     /// The price paid post-execution by the transaction (i.e. base fee + priority fee). Both
     /// fields in 1559-style transactions are maximums (max fee + max priority fee), the amount
     /// that's actually paid by users can only be determined post-execution
-    #[serde(with = "alloy_serde::quantity")]
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
     pub effective_gas_price: u128,
     /// Blob gas used by the eip-4844 transaction
     ///
     /// This is None for non eip-4844 transactions
-    #[serde(skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt", default)]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt", default))]
     pub blob_gas_used: Option<u128>,
     /// The price paid by the eip-4844 transaction per blob gas.
-    #[serde(skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt", default)]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt", default))]
     pub blob_gas_price: Option<u128>,
     /// Address of the sender
     pub from: Address,
@@ -58,11 +58,11 @@ pub struct TransactionReceipt<T = ReceiptEnvelope<Log>> {
     /// The post-transaction stateroot (pre Byzantium)
     ///
     /// EIP98 makes this optional field, if it's missing then skip serializing it
-    #[serde(skip_serializing_if = "Option::is_none", rename = "root")]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none", rename = "root"))]
     pub state_root: Option<B256>,
     /// The authorization list is a list of tuples that store the address to code which the signer
     /// desires to execute in the context of their EOA.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
     pub authorization_list: Option<Vec<SignedAuthorization>>,
 }
 
@@ -205,6 +205,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "serde")]
     fn test_sanity() {
         let json_str = r#"{"transactionHash":"0x21f6554c28453a01e7276c1db2fc1695bb512b170818bfa98fa8136433100616","blockHash":"0x4acbdefb861ef4adedb135ca52865f6743451bfbfa35db78076f881a40401a5e","blockNumber":"0x129f4b9","logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000200000000000000000040000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000400000800000000000000000000000000000000004000000000000000000800000000100000020000000000000000000080000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000010000000000000000000000000000","gasUsed":"0xbde1","contractAddress":null,"cumulativeGasUsed":"0xa42aec","transactionIndex":"0x7f","from":"0x9a53bfba35269414f3b2d20b52ca01b15932c7b2","to":"0xdac17f958d2ee523a2206206994597c13d831ec7","type":"0x2","effectiveGasPrice":"0xfb0f6e8c9","logs":[{"blockHash":"0x4acbdefb861ef4adedb135ca52865f6743451bfbfa35db78076f881a40401a5e","address":"0xdac17f958d2ee523a2206206994597c13d831ec7","logIndex":"0x118","data":"0x00000000000000000000000000000000000000000052b7d2dcc80cd2e4000000","removed":false,"topics":["0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925","0x0000000000000000000000009a53bfba35269414f3b2d20b52ca01b15932c7b2","0x00000000000000000000000039e5dbb9d2fead31234d7c647d6ce77d85826f76"],"blockNumber":"0x129f4b9","transactionIndex":"0x7f","transactionHash":"0x21f6554c28453a01e7276c1db2fc1695bb512b170818bfa98fa8136433100616"}],"status":"0x1"}"#;
 
@@ -248,6 +249,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "serde")]
     fn deserialize_tx_receipt_op() {
         // OtherFields for Optimism
         #[derive(Debug, Deserialize)]
@@ -323,6 +325,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "serde")]
     fn deserialize_tx_receipt_arb() {
         // OtherFields for Arbitrum
         #[derive(Debug, Deserialize)]

--- a/crates/rpc-types-eth/src/transaction/request.rs
+++ b/crates/rpc-types-eth/src/transaction/request.rs
@@ -8,7 +8,6 @@ use alloy_consensus::{
 use alloy_eips::eip7702::SignedAuthorization;
 use alloy_primitives::{Address, Bytes, ChainId, TxKind, B256, U256};
 use core::hash::Hash;
-use serde::{Deserialize, Serialize};
 
 use alloc::{
     string::{String, ToString},
@@ -17,64 +16,65 @@ use alloc::{
 };
 
 /// Represents _all_ transaction requests to/from RPC.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
 #[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
-#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[doc(alias = "TxRequest")]
 pub struct TransactionRequest {
     /// The address of the transaction author.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
     pub from: Option<Address>,
     /// The destination address of the transaction.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
     pub to: Option<TxKind>,
     /// The legacy gas price.
-    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt"))]
     pub gas_price: Option<u128>,
     /// The max base fee per gas the sender is willing to pay.
-    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt"))]
     pub max_fee_per_gas: Option<u128>,
     /// The max priority fee per gas the sender is willing to pay, also called the miner tip.
-    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt"))]
     pub max_priority_fee_per_gas: Option<u128>,
     /// The max fee per blob gas for EIP-4844 blob transactions.
-    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt"))]
     pub max_fee_per_blob_gas: Option<u128>,
     /// The gas limit for the transaction.
-    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt"))]
     pub gas: Option<u128>,
     /// The value transferred in the transaction, in wei.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
     pub value: Option<U256>,
     /// Transaction data.
-    #[serde(default, flatten)]
+    #[cfg_attr(feature = "serde", serde(default, flatten))]
     pub input: TransactionInput,
     /// The nonce of the transaction.
-    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt"))]
     pub nonce: Option<u64>,
     /// The chain ID for the transaction.
-    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt"))]
     pub chain_id: Option<ChainId>,
     /// An EIP-2930 access list, which lowers cost for accessing accounts and storages in the list. See [EIP-2930](https://eips.ethereum.org/EIPS/eip-2930) for more information.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
     pub access_list: Option<AccessList>,
     /// The EIP-2718 transaction type. See [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718) for more information.
-    #[serde(
+    #[cfg_attr(feature = "serde", serde(
         default,
         rename = "type",
         skip_serializing_if = "Option::is_none",
         with = "alloy_serde::quantity::opt"
-    )]
+    ))]
     #[doc(alias = "tx_type")]
     pub transaction_type: Option<u8>,
     /// Blob versioned hashes for EIP-4844 transactions.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
     pub blob_versioned_hashes: Option<Vec<B256>>,
     /// Blob sidecar for EIP-4844 transactions.
-    #[serde(default, flatten, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "serde", serde(default, flatten, skip_serializing_if = "Option::is_none"))]
     pub sidecar: Option<BlobTransactionSidecar>,
     /// Authorization list for for EIP-7702 transactions.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
     pub authorization_list: Option<Vec<SignedAuthorization>>,
 }
 
@@ -610,16 +610,17 @@ impl TransactionRequest {
 /// If both fields are set, it is expected that they contain the same value, otherwise an error is
 /// returned.
 #[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
-#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[doc(alias = "TxInput")]
 pub struct TransactionInput {
     /// Transaction data
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
     pub input: Option<Bytes>,
     /// Transaction data
     ///
     /// This is the same as `input` but is used for backwards compatibility: <https://github.com/ethereum/go-ethereum/issues/15628>
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
     pub data: Option<Bytes>,
 }
 
@@ -963,6 +964,7 @@ mod tests {
 
     // <https://github.com/paradigmxyz/reth/issues/6670>
     #[test]
+    #[cfg(feature = "serde")]
     fn serde_from_to() {
         let s = r#"{"from":"0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266", "to":"0x70997970C51812dc3A010C7d01b50e0d17dc79C8" }"#;
         let req = serde_json::from_str::<TransactionRequest>(s).unwrap();
@@ -970,12 +972,14 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "serde")]
     fn serde_tx_request() {
         let s = r#"{"accessList":[],"data":"0x0902f1ac","to":"0xa478c2975ab1ea89e8196811f51a7b7ade33eb11","type":"0x02"}"#;
         let _req = serde_json::from_str::<TransactionRequest>(s).unwrap();
     }
 
     #[test]
+    #[cfg(feature = "serde")]
     fn serde_unique_call_input() {
         let s = r#"{"accessList":[],"data":"0x0902f1ac", "input":"0x0902f1ac","to":"0xa478c2975ab1ea89e8196811f51a7b7ade33eb11","type":"0x02"}"#;
         let req = serde_json::from_str::<TransactionRequest>(s).unwrap();
@@ -995,6 +999,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "serde")]
     fn serde_tx_request_additional_fields() {
         let s = r#"{"accessList":[],"data":"0x0902f1ac","to":"0xa478c2975ab1ea89e8196811f51a7b7ade33eb11","type":"0x02","sourceHash":"0xbf7e331f7f7c1dd2e05159666b3bf8bc7a8a3a9eb1d518969eab529dd9b88c1a"}"#;
         let req = serde_json::from_str::<WithOtherFields<TransactionRequest>>(s).unwrap();
@@ -1005,6 +1010,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "serde")]
     fn serde_tx_chain_id_field() {
         let chain_id: ChainId = 12345678;
 
@@ -1018,6 +1024,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "serde")]
     fn serde_empty() {
         let tx = TransactionRequest::default();
         let serialized = serde_json::to_string(&tx).unwrap();
@@ -1025,6 +1032,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "serde")]
     fn serde_tx_with_sidecar() {
         // Create a sidecar with some data.
         let s = r#"{

--- a/crates/rpc-types-eth/src/transaction/request.rs
+++ b/crates/rpc-types-eth/src/transaction/request.rs
@@ -29,19 +29,54 @@ pub struct TransactionRequest {
     #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
     pub to: Option<TxKind>,
     /// The legacy gas price.
-    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt"))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(
+            default,
+            skip_serializing_if = "Option::is_none",
+            with = "alloy_serde::quantity::opt"
+        )
+    )]
     pub gas_price: Option<u128>,
     /// The max base fee per gas the sender is willing to pay.
-    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt"))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(
+            default,
+            skip_serializing_if = "Option::is_none",
+            with = "alloy_serde::quantity::opt"
+        )
+    )]
     pub max_fee_per_gas: Option<u128>,
     /// The max priority fee per gas the sender is willing to pay, also called the miner tip.
-    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt"))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(
+            default,
+            skip_serializing_if = "Option::is_none",
+            with = "alloy_serde::quantity::opt"
+        )
+    )]
     pub max_priority_fee_per_gas: Option<u128>,
     /// The max fee per blob gas for EIP-4844 blob transactions.
-    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt"))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(
+            default,
+            skip_serializing_if = "Option::is_none",
+            with = "alloy_serde::quantity::opt"
+        )
+    )]
     pub max_fee_per_blob_gas: Option<u128>,
     /// The gas limit for the transaction.
-    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt"))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(
+            default,
+            skip_serializing_if = "Option::is_none",
+            with = "alloy_serde::quantity::opt"
+        )
+    )]
     pub gas: Option<u128>,
     /// The value transferred in the transaction, in wei.
     #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
@@ -50,28 +85,48 @@ pub struct TransactionRequest {
     #[cfg_attr(feature = "serde", serde(default, flatten))]
     pub input: TransactionInput,
     /// The nonce of the transaction.
-    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt"))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(
+            default,
+            skip_serializing_if = "Option::is_none",
+            with = "alloy_serde::quantity::opt"
+        )
+    )]
     pub nonce: Option<u64>,
     /// The chain ID for the transaction.
-    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt"))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(
+            default,
+            skip_serializing_if = "Option::is_none",
+            with = "alloy_serde::quantity::opt"
+        )
+    )]
     pub chain_id: Option<ChainId>,
     /// An EIP-2930 access list, which lowers cost for accessing accounts and storages in the list. See [EIP-2930](https://eips.ethereum.org/EIPS/eip-2930) for more information.
     #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
     pub access_list: Option<AccessList>,
     /// The EIP-2718 transaction type. See [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718) for more information.
-    #[cfg_attr(feature = "serde", serde(
-        default,
-        rename = "type",
-        skip_serializing_if = "Option::is_none",
-        with = "alloy_serde::quantity::opt"
-    ))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(
+            default,
+            rename = "type",
+            skip_serializing_if = "Option::is_none",
+            with = "alloy_serde::quantity::opt"
+        )
+    )]
     #[doc(alias = "tx_type")]
     pub transaction_type: Option<u8>,
     /// Blob versioned hashes for EIP-4844 transactions.
     #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
     pub blob_versioned_hashes: Option<Vec<B256>>,
     /// Blob sidecar for EIP-4844 transactions.
-    #[cfg_attr(feature = "serde", serde(default, flatten, skip_serializing_if = "Option::is_none"))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(default, flatten, skip_serializing_if = "Option::is_none")
+    )]
     pub sidecar: Option<BlobTransactionSidecar>,
     /// Authorization list for for EIP-7702 transactions.
     #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]

--- a/crates/rpc-types-eth/src/transaction/signature.rs
+++ b/crates/rpc-types-eth/src/transaction/signature.rs
@@ -22,7 +22,10 @@ pub struct Signature {
     /// See also <https://ethereum.github.io/execution-apis/api-documentation/> and <https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_gettransactionbyhash>
     pub v: U256,
     /// The y parity of the signature. This is only used for typed (non-legacy) transactions.
-    #[cfg_attr(feature = "serde", serde(default, rename = "yParity", skip_serializing_if = "Option::is_none"))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(default, rename = "yParity", skip_serializing_if = "Option::is_none")
+    )]
     pub y_parity: Option<Parity>,
 }
 
@@ -33,7 +36,11 @@ pub struct Signature {
 #[derive(Default, Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Parity(
-    #[cfg_attr(feature = "serde", serde(serialize_with = "serialize_parity", deserialize_with = "deserialize_parity"))] pub bool,
+    #[cfg_attr(
+        feature = "serde",
+        serde(serialize_with = "serialize_parity", deserialize_with = "deserialize_parity")
+    )]
+    pub bool,
 );
 
 impl From<bool> for Parity {

--- a/crates/rpc-types-eth/src/transaction/signature.rs
+++ b/crates/rpc-types-eth/src/transaction/signature.rs
@@ -1,12 +1,12 @@
 //! Signature related RPC values
 use alloy_primitives::U256;
-use serde::{Deserialize, Serialize};
 
 use alloc::{format, string::String};
 
 /// Container type for all signature fields in RPC
 #[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Signature {
     /// The R field of the signature; the point on the curve.
     pub r: U256,
@@ -22,7 +22,7 @@ pub struct Signature {
     /// See also <https://ethereum.github.io/execution-apis/api-documentation/> and <https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_gettransactionbyhash>
     pub v: U256,
     /// The y parity of the signature. This is only used for typed (non-legacy) transactions.
-    #[serde(default, rename = "yParity", skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "serde", serde(default, rename = "yParity", skip_serializing_if = "Option::is_none"))]
     pub y_parity: Option<Parity>,
 }
 
@@ -30,9 +30,10 @@ pub struct Signature {
 ///
 /// This will be serialized as "0x0" if false, and "0x1" if true.
 #[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
-#[derive(Default, Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Default, Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Parity(
-    #[serde(serialize_with = "serialize_parity", deserialize_with = "deserialize_parity")] pub bool,
+    #[cfg_attr(feature = "serde", serde(serialize_with = "serialize_parity", deserialize_with = "deserialize_parity"))] pub bool,
 );
 
 impl From<bool> for Parity {
@@ -41,6 +42,7 @@ impl From<bool> for Parity {
     }
 }
 
+#[cfg(feature = "serde")]
 fn serialize_parity<S>(parity: &bool, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: serde::Serializer,
@@ -49,10 +51,12 @@ where
 }
 
 /// This implementation disallows serialization of the y parity bit that are not `"0x0"` or `"0x1"`.
+#[cfg(feature = "serde")]
 fn deserialize_parity<'de, D>(deserializer: D) -> Result<bool, D::Error>
 where
     D: serde::Deserializer<'de>,
 {
+    use serde::Deserialize;
     let s = String::deserialize(deserializer)?;
     match s.as_str() {
         "0x0" => Ok(false),
@@ -94,6 +98,7 @@ mod tests {
     use core::str::FromStr;
 
     #[test]
+    #[cfg(feature = "serde")]
     fn deserialize_without_parity() {
         let raw_signature_without_y_parity = r#"{
             "r":"0xc569c92f176a3be1a6352dd5005bfc751dcb32f57623dd2a23693e64bf4447b0",
@@ -115,6 +120,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "serde")]
     fn deserialize_with_parity() {
         let raw_signature_with_y_parity = r#"{
             "r":"0xc569c92f176a3be1a6352dd5005bfc751dcb32f57623dd2a23693e64bf4447b0",
@@ -137,6 +143,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "serde")]
     fn serialize_both_parity() {
         // this test should be removed if the struct moves to an enum based on tx type
         let signature = Signature {
@@ -156,6 +163,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "serde")]
     fn serialize_v_only() {
         // this test should be removed if the struct moves to an enum based on tx type
         let signature = Signature {
@@ -174,6 +182,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "serde")]
     fn serialize_parity() {
         let parity = Parity(true);
         let serialized = serde_json::to_string(&parity).unwrap();
@@ -185,6 +194,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "serde")]
     fn deserialize_parity() {
         let raw_parity = r#""0x1""#;
         let parity: Parity = serde_json::from_str(raw_parity).unwrap();
@@ -196,6 +206,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "serde")]
     fn deserialize_parity_invalid() {
         let raw_parity = r#""0x2""#;
         let parity: Result<Parity, _> = serde_json::from_str(raw_parity);

--- a/crates/rpc-types-eth/src/work.rs
+++ b/crates/rpc-types-eth/src/work.rs
@@ -1,5 +1,5 @@
-use core::fmt;
 use alloy_primitives::{B256, U256};
+use core::fmt;
 
 /// The result of an `eth_getWork` request
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]

--- a/crates/rpc-types-eth/src/work.rs
+++ b/crates/rpc-types-eth/src/work.rs
@@ -1,9 +1,5 @@
-use alloy_primitives::{B256, U256};
 use core::fmt;
-use serde::{
-    de::{Error, SeqAccess, Visitor},
-    Deserialize, Deserializer, Serialize, Serializer,
-};
+use alloy_primitives::{B256, U256};
 
 /// The result of an `eth_getWork` request
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -18,10 +14,11 @@ pub struct Work {
     pub number: Option<u64>,
 }
 
-impl Serialize for Work {
+#[cfg(feature = "serde")]
+impl serde::Serialize for Work {
     fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S: Serializer,
+        S: serde::Serializer,
     {
         match self.number.as_ref() {
             Some(num) => {
@@ -32,14 +29,15 @@ impl Serialize for Work {
     }
 }
 
-impl<'a> Deserialize<'a> for Work {
+#[cfg(feature = "serde")]
+impl<'a> serde::Deserialize<'a> for Work {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: Deserializer<'a>,
+        D: serde::Deserializer<'a>,
     {
         struct WorkVisitor;
 
-        impl<'a> Visitor<'a> for WorkVisitor {
+        impl<'a> serde::de::Visitor<'a> for WorkVisitor {
             type Value = Work;
 
             fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -48,8 +46,9 @@ impl<'a> Deserialize<'a> for Work {
 
             fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
             where
-                A: SeqAccess<'a>,
+                A: serde::de::SeqAccess<'a>,
             {
+                use serde::de::Error;
                 let pow_hash = seq
                     .next_element::<B256>()?
                     .ok_or_else(|| A::Error::custom("missing pow hash"))?;

--- a/crates/rpc-types-trace/Cargo.toml
+++ b/crates/rpc-types-trace/Cargo.toml
@@ -20,7 +20,7 @@ workspace = true
 
 [dependencies]
 alloy-primitives = { workspace = true, features = ["rlp", "serde"] }
-alloy-rpc-types-eth = { workspace = true, features = ["std"] }
+alloy-rpc-types-eth = { workspace = true, features = ["std", "serde"] }
 alloy-serde.workspace = true
 
 serde.workspace = true

--- a/crates/signer-trezor/Cargo.toml
+++ b/crates/signer-trezor/Cargo.toml
@@ -34,5 +34,5 @@ thiserror.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
-alloy-rpc-types-eth.workspace = true
+alloy-rpc-types-eth = { workspace = true, features = ["std", "serde"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }


### PR DESCRIPTION
### Description

Downstream crates would like to use types from `alloy-rpc-types-eth` without the need for `serde` support. This PR places serialization for core eth types behind the `serde` feature flag that is enabled-by-default.