### PR TITLE
fix: `debug_traceCallMany` and `trace_callMany`

### DIFF
--- a/crates/node-bindings/src/nodes/reth.rs
+++ b/crates/node-bindings/src/nodes/reth.rs
@@ -590,10 +590,10 @@ mod tests {
         run_with_tempdir_sync("reth-test-", |temp_dir_path| {
             let reth = Reth::new().instance(0).data_dir(temp_dir_path).spawn();
 
-            assert_eq!(reth.http_port(), 8545);
-            assert_eq!(reth.ws_port(), 8546);
-            assert_eq!(reth.auth_port(), Some(8551));
-            assert_eq!(reth.p2p_port(), Some(30303));
+            assert_eq!(reth.http_port(), DEFAULT_HTTP_PORT);
+            assert_eq!(reth.ws_port(), DEFAULT_WS_PORT);
+            assert_eq!(reth.auth_port(), Some(DEFAULT_AUTH_PORT));
+            assert_eq!(reth.p2p_port(), Some(DEFAULT_P2P_PORT));
         });
 
         // Assert that only the HTTP port is set and the rest are default.

--- a/crates/provider/src/ext/debug.rs
+++ b/crates/provider/src/ext/debug.rs
@@ -2,7 +2,9 @@
 use crate::Provider;
 use alloy_network::Network;
 use alloy_primitives::{hex, Bytes, TxHash, B256};
-use alloy_rpc_types_eth::{Block, BlockId, BlockNumberOrTag, TransactionRequest};
+use alloy_rpc_types_eth::{
+    Block, BlockId, BlockNumberOrTag, Bundle, StateContext, TransactionRequest,
+};
 use alloy_rpc_types_trace::geth::{
     BlockTraceResult, GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace, TraceResult,
 };
@@ -122,8 +124,8 @@ pub trait DebugApi<N, T>: Send + Sync {
     /// Not all nodes support this call.
     async fn debug_trace_call_many(
         &self,
-        txs: Vec<TransactionRequest>,
-        block: BlockId,
+        bundles: Vec<Bundle>,
+        state_context: StateContext,
         trace_options: GethDebugTracingCallOptions,
     ) -> TransportResult<Vec<GethTrace>>;
 }
@@ -208,11 +210,11 @@ where
 
     async fn debug_trace_call_many(
         &self,
-        txs: Vec<TransactionRequest>,
-        block: BlockId,
+        bundles: Vec<Bundle>,
+        state_context: StateContext,
         trace_options: GethDebugTracingCallOptions,
     ) -> TransportResult<Vec<GethTrace>> {
-        self.client().request("debug_traceCallMany", (txs, block, trace_options)).await
+        self.client().request("debug_traceCallMany", (bundles, state_context, trace_options)).await
     }
 }
 
@@ -222,7 +224,7 @@ mod test {
 
     use super::*;
     use alloy_network::TransactionBuilder;
-    use alloy_node_bindings::Geth;
+    use alloy_node_bindings::{Geth, Reth};
     use alloy_primitives::{address, U256};
 
     fn init_tracing() {
@@ -328,5 +330,52 @@ mod test {
 
         let result = provider.debug_get_bad_blocks().await;
         assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    #[cfg(not(windows))]
+    async fn debug_trace_call_many() {
+        let temp_dir = tempfile::TempDir::with_prefix("reth-test-").unwrap();
+        let reth = Reth::new().dev().disable_discovery().data_dir(temp_dir.path()).spawn();
+        let provider =
+            ProviderBuilder::new().with_recommended_fillers().on_http(reth.endpoint_url());
+
+        let tx1 = TransactionRequest::default()
+            .with_from(address!("0000000000000000000000000000000000000123"))
+            .with_to(address!("0000000000000000000000000000000000000456"));
+
+        let tx2 = TransactionRequest::default()
+            .with_from(address!("0000000000000000000000000000000000000456"))
+            .with_to(address!("0000000000000000000000000000000000000789"));
+
+        let bundles = vec![Bundle { transactions: vec![tx1, tx2], block_override: None }];
+        let state_context = StateContext::default();
+        let trace_options = GethDebugTracingCallOptions::default();
+        let result = provider.debug_trace_call_many(bundles, state_context, trace_options).await;
+        assert!(result.is_ok());
+
+        let traces = result.unwrap();
+        assert_eq!(
+            serde_json::to_string_pretty(&traces).unwrap().trim(),
+            r#"
+[
+  [
+    {
+      "failed": false,
+      "gas": 21000,
+      "returnValue": "",
+      "structLogs": []
+    },
+    {
+      "failed": false,
+      "gas": 21000,
+      "returnValue": "",
+      "structLogs": []
+    }
+  ]
+]
+"#
+            .trim(),
+        );
     }
 }

--- a/crates/provider/src/ext/trace.rs
+++ b/crates/provider/src/ext/trace.rs
@@ -11,7 +11,7 @@ use alloy_rpc_types_trace::{
 use alloy_transport::{Transport, TransportResult};
 
 /// List of trace calls for use with [`TraceApi::trace_call_many`]
-pub type TraceCallList<'a, N> = &'a [(<N as Network>::TransactionRequest, Vec<TraceType>)];
+pub type TraceCallList<'a, N> = &'a [(<N as Network>::TransactionRequest, &'a [TraceType])];
 
 /// Trace namespace rpc interface that gives access to several non-standard RPC methods.
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
@@ -43,7 +43,7 @@ where
     fn trace_call_many<'a>(
         &self,
         request: TraceCallList<'a, N>,
-    ) -> RpcWithBlock<T, TraceCallList<'a, N>, TraceResults>;
+    ) -> RpcWithBlock<T, (TraceCallList<'a, N>,), Vec<TraceResults>>;
 
     /// Parity trace transaction.
     async fn trace_transaction(
@@ -118,8 +118,8 @@ where
     fn trace_call_many<'a>(
         &self,
         request: TraceCallList<'a, N>,
-    ) -> RpcWithBlock<T, TraceCallList<'a, N>, TraceResults> {
-        RpcWithBlock::new(self.weak_client(), "trace_callMany", request)
+    ) -> RpcWithBlock<T, (TraceCallList<'a, N>,), Vec<TraceResults>> {
+        RpcWithBlock::new(self.weak_client(), "trace_callMany", (request,))
     }
 
     async fn trace_transaction(
@@ -178,6 +178,10 @@ where
 mod test {
     use crate::ProviderBuilder;
     use alloy_eips::BlockNumberOrTag;
+    use alloy_network::TransactionBuilder;
+    use alloy_node_bindings::Reth;
+    use alloy_primitives::address;
+    use alloy_rpc_types_eth::TransactionRequest;
 
     use super::*;
 
@@ -186,10 +190,136 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_trace_block() {
+    async fn trace_block() {
         init_tracing();
         let provider = ProviderBuilder::new().on_anvil();
         let traces = provider.trace_block(BlockId::Number(BlockNumberOrTag::Latest)).await.unwrap();
         assert_eq!(traces.len(), 0);
+    }
+
+    #[tokio::test]
+    #[cfg(not(windows))]
+    async fn trace_call() {
+        let temp_dir = tempfile::TempDir::with_prefix("reth-test-").unwrap();
+        let reth = Reth::new().dev().disable_discovery().data_dir(temp_dir.path()).spawn();
+        let provider = ProviderBuilder::new().on_http(reth.endpoint_url());
+
+        let tx = TransactionRequest::default()
+            .with_from(address!("0000000000000000000000000000000000000123"))
+            .with_to(address!("0000000000000000000000000000000000000456"));
+
+        let result = provider.trace_call(&tx, &[TraceType::Trace]).await;
+        assert!(result.is_ok());
+
+        let traces = result.unwrap();
+        assert_eq!(
+            serde_json::to_string_pretty(&traces).unwrap().trim(),
+            r#"
+{
+  "output": "0x",
+  "stateDiff": null,
+  "trace": [
+    {
+      "type": "call",
+      "action": {
+        "from": "0x0000000000000000000000000000000000000123",
+        "callType": "call",
+        "gas": "0x2fa9e78",
+        "input": "0x",
+        "to": "0x0000000000000000000000000000000000000456",
+        "value": "0x0"
+      },
+      "result": {
+        "gasUsed": "0x0",
+        "output": "0x"
+      },
+      "subtraces": 0,
+      "traceAddress": []
+    }
+  ],
+  "vmTrace": null
+}
+"#
+            .trim(),
+        );
+    }
+
+    #[tokio::test]
+    #[cfg(not(windows))]
+    async fn trace_call_many() {
+        let temp_dir = tempfile::TempDir::with_prefix("reth-test-").unwrap();
+        let reth = Reth::new().dev().disable_discovery().data_dir(temp_dir.path()).spawn();
+        let provider = ProviderBuilder::new().on_http(reth.endpoint_url());
+
+        let tx1 = TransactionRequest::default()
+            .with_from(address!("0000000000000000000000000000000000000123"))
+            .with_to(address!("0000000000000000000000000000000000000456"));
+
+        let tx2 = TransactionRequest::default()
+            .with_from(address!("0000000000000000000000000000000000000456"))
+            .with_to(address!("0000000000000000000000000000000000000789"));
+
+        let result = provider
+            .trace_call_many(&[(tx1, &[TraceType::Trace]), (tx2, &[TraceType::Trace])])
+            .await;
+        assert!(result.is_ok());
+
+        let traces = result.unwrap();
+        assert_eq!(
+            serde_json::to_string_pretty(&traces).unwrap().trim(),
+            r#"
+[
+  {
+    "output": "0x",
+    "stateDiff": null,
+    "trace": [
+      {
+        "type": "call",
+        "action": {
+          "from": "0x0000000000000000000000000000000000000123",
+          "callType": "call",
+          "gas": "0x2fa9e78",
+          "input": "0x",
+          "to": "0x0000000000000000000000000000000000000456",
+          "value": "0x0"
+        },
+        "result": {
+          "gasUsed": "0x0",
+          "output": "0x"
+        },
+        "subtraces": 0,
+        "traceAddress": []
+      }
+    ],
+    "vmTrace": null
+  },
+  {
+    "output": "0x",
+    "stateDiff": null,
+    "trace": [
+      {
+        "type": "call",
+        "action": {
+          "from": "0x0000000000000000000000000000000000000456",
+          "callType": "call",
+          "gas": "0x2fa9e78",
+          "input": "0x",
+          "to": "0x0000000000000000000000000000000000000789",
+          "value": "0x0"
+        },
+        "result": {
+          "gasUsed": "0x0",
+          "output": "0x"
+        },
+        "subtraces": 0,
+        "traceAddress": []
+      }
+    ],
+    "vmTrace": null
+  }
+]
+"#
+            .trim()
+        );
     }
 }

--- a/crates/rpc-types-eth/src/call.rs
+++ b/crates/rpc-types-eth/src/call.rs
@@ -15,6 +15,7 @@ pub struct Bundle {
     /// All transactions to execute
     pub transactions: Vec<TransactionRequest>,
     /// Block overrides to apply
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub block_override: Option<BlockOverrides>,
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Closes: https://github.com/alloy-rs/alloy/issues/1074

## Solution

- [x] Fix `debug_traceCallMany`
- [x] Fix `trace_callMany`

Does not include the addition of `eth_callMany`, to be added in https://github.com/alloy-rs/alloy/issues/1274 as it requires more consideration (i.e. it being integrated into `multicall` or the `EthCall` builder). Ties into #328 / #1119.

Excludes Reth binding improvements previously added in https://github.com/alloy-rs/alloy/pull/1076#event-14227702047.

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [x] Breaking changes
