### PR TITLE
feat: improve node bindings

### DIFF
--- a/crates/node-bindings/Cargo.toml
+++ b/crates/node-bindings/Cargo.toml
@@ -22,11 +22,9 @@ workspace = true
 alloy-primitives = { workspace = true, features = ["std", "k256", "serde"] }
 alloy-genesis.workspace = true
 k256.workspace = true
+rand.workspace = true
 serde_json = { workspace = true, features = ["std"] }
 tempfile.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 url.workspace = true
-
-[dev-dependencies]
-rand.workspace = true

--- a/crates/node-bindings/src/lib.rs
+++ b/crates/node-bindings/src/lib.rs
@@ -21,8 +21,7 @@ pub use nodes::{
 mod node;
 pub use node::*;
 
-mod utils;
-use utils::*;
+pub mod utils;
 
 /// 1 Ether = 1e18 Wei == 0x0de0b6b3a7640000 Wei
 pub const WEI_IN_ETHER: U256 = U256::from_limbs([0x0de0b6b3a7640000, 0x0, 0x0, 0x0]);

--- a/crates/node-bindings/src/node.rs
+++ b/crates/node-bindings/src/node.rs
@@ -1,5 +1,6 @@
 //! Node-related types and constants.
 
+use alloy_primitives::hex;
 use std::time::Duration;
 use thiserror::Error;
 
@@ -9,31 +10,9 @@ pub const NODE_STARTUP_TIMEOUT: Duration = Duration::from_secs(10);
 /// Timeout for waiting for the node to add a peer.
 pub const NODE_DIAL_LOOP_TIMEOUT: Duration = Duration::from_secs(20);
 
-/// Errors that can occur when working with a node instance.
-#[derive(Debug)]
-pub enum NodeInstanceError {
-    /// Timed out waiting for a message from node's stderr.
-    Timeout(String),
-
-    /// A line could not be read from the node's stderr.
-    ReadLineError(std::io::Error),
-
-    /// The child node process's stderr was not captured.
-    NoStderr,
-
-    /// The child node process's stdout was not captured.
-    NoStdout,
-}
-
-/// Errors that can occur when working with the node.
+/// Errors that can occur when working with the node instance.
 #[derive(Debug, Error)]
 pub enum NodeError {
-    /// The chain id was not set.
-    #[error("the chain ID was not set")]
-    ChainIdNotSet,
-    /// Could not create the data directory.
-    #[error("could not create directory: {0}")]
-    CreateDirError(std::io::Error),
     /// No stderr was captured from the child process.
     #[error("no stderr was captured from the process")]
     NoStderr,
@@ -49,6 +28,14 @@ pub enum NodeError {
     /// A line could not be read from the node stderr.
     #[error("could not read line from node stderr: {0}")]
     ReadLineError(std::io::Error),
+
+    /// The chain id was not set.
+    #[error("the chain ID was not set")]
+    ChainIdNotSet,
+    /// Could not create the data directory.
+    #[error("could not create directory: {0}")]
+    CreateDirError(std::io::Error),
+
     /// Genesis error
     #[error("genesis error occurred: {0}")]
     GenesisError(String),
@@ -65,4 +52,17 @@ pub enum NodeError {
     /// Clique private key error
     #[error("clique address error: {0}")]
     CliqueAddressError(String),
+
+    /// The private key could not be parsed.
+    #[error("could not parse private key")]
+    ParsePrivateKeyError,
+    /// An error occurred while deserializing a private key.
+    #[error("could not deserialize private key from bytes")]
+    DeserializePrivateKeyError,
+    /// An error occurred while parsing a hex string.
+    #[error(transparent)]
+    FromHexError(#[from] hex::FromHexError),
+    /// No keys available this node instance.
+    #[error("no keys available in this node instance")]
+    NoKeysAvailable,
 }

--- a/crates/node-bindings/src/nodes/anvil.rs
+++ b/crates/node-bindings/src/nodes/anvil.rs
@@ -10,8 +10,9 @@ use std::{
     str::FromStr,
     time::{Duration, Instant},
 };
-use thiserror::Error;
 use url::Url;
+
+use crate::NodeError;
 
 /// How long we will wait for anvil to indicate that it is ready.
 const ANVIL_STARTUP_TIMEOUT_MILLIS: u64 = 10_000;
@@ -87,42 +88,6 @@ impl Drop for AnvilInstance {
     fn drop(&mut self) {
         self.child.kill().expect("could not kill anvil");
     }
-}
-
-/// Errors that can occur when working with the [`Anvil`].
-#[derive(Debug, Error)]
-pub enum AnvilError {
-    /// Spawning the anvil process failed.
-    #[error("could not start anvil: {0}")]
-    SpawnError(std::io::Error),
-
-    /// Timed out waiting for a message from anvil's stderr.
-    #[error("timed out waiting for anvil to spawn; is anvil installed?")]
-    Timeout,
-
-    /// A line could not be read from the geth stderr.
-    #[error("could not read line from anvil stderr: {0}")]
-    ReadLineError(std::io::Error),
-
-    /// The child anvil process's stderr was not captured.
-    #[error("could not get stderr for anvil child process")]
-    NoStderr,
-
-    /// The private key could not be parsed.
-    #[error("could not parse private key")]
-    ParsePrivateKeyError,
-
-    /// An error occurred while deserializing a private key.
-    #[error("could not deserialize private key from bytes")]
-    DeserializePrivateKeyError,
-
-    /// An error occurred while parsing a hex string.
-    #[error(transparent)]
-    FromHexError(#[from] hex::FromHexError),
-
-    /// No keys available in anvil instance.
-    #[error("no keys available in anvil instance")]
-    NoKeysAvailable,
 }
 
 /// Builder for launching `anvil`.
@@ -288,7 +253,7 @@ impl Anvil {
     }
 
     /// Consumes the builder and spawns `anvil`. If spawning fails, returns an error.
-    pub fn try_spawn(self) -> Result<AnvilInstance, AnvilError> {
+    pub fn try_spawn(self) -> Result<AnvilInstance, NodeError> {
         let mut cmd = self.program.as_ref().map_or_else(|| Command::new("anvil"), Command::new);
         cmd.stdout(std::process::Stdio::piped()).stderr(std::process::Stdio::inherit());
         let mut port = self.port.unwrap_or_default();
@@ -316,9 +281,9 @@ impl Anvil {
 
         cmd.args(self.args);
 
-        let mut child = cmd.spawn().map_err(AnvilError::SpawnError)?;
+        let mut child = cmd.spawn().map_err(NodeError::SpawnError)?;
 
-        let stdout = child.stdout.take().ok_or(AnvilError::NoStderr)?;
+        let stdout = child.stdout.take().ok_or(NodeError::NoStderr)?;
 
         let start = Instant::now();
         let mut reader = BufReader::new(stdout);
@@ -331,11 +296,11 @@ impl Anvil {
             if start + Duration::from_millis(self.timeout.unwrap_or(ANVIL_STARTUP_TIMEOUT_MILLIS))
                 <= Instant::now()
             {
-                return Err(AnvilError::Timeout);
+                return Err(NodeError::Timeout);
             }
 
             let mut line = String::new();
-            reader.read_line(&mut line).map_err(AnvilError::ReadLineError)?;
+            reader.read_line(&mut line).map_err(NodeError::ReadLineError)?;
             trace!(target: "anvil", line);
             if let Some(addr) = line.strip_prefix("Listening on") {
                 // <Listening on 127.0.0.1:8545>
@@ -352,10 +317,10 @@ impl Anvil {
 
             if is_private_key && line.starts_with('(') {
                 let key_str =
-                    line.split("0x").last().ok_or(AnvilError::ParsePrivateKeyError)?.trim();
-                let key_hex = hex::decode(key_str).map_err(AnvilError::FromHexError)?;
+                    line.split("0x").last().ok_or(NodeError::ParsePrivateKeyError)?.trim();
+                let key_hex = hex::decode(key_str).map_err(NodeError::FromHexError)?;
                 let key = K256SecretKey::from_bytes((&key_hex[..]).into())
-                    .map_err(|_| AnvilError::DeserializePrivateKeyError)?;
+                    .map_err(|_| NodeError::DeserializePrivateKeyError)?;
                 addresses.push(Address::from_public_key(SigningKey::from(&key).verifying_key()));
                 private_keys.push(key);
             }

--- a/crates/node-bindings/src/nodes/geth.rs
+++ b/crates/node-bindings/src/nodes/geth.rs
@@ -1,8 +1,8 @@
 //! Utilities for launching a Geth dev-mode instance.
 
 use crate::{
-    extract_endpoint, extract_value, unused_port, NodeError, NodeInstanceError,
-    NODE_DIAL_LOOP_TIMEOUT, NODE_STARTUP_TIMEOUT,
+    utils::{extract_endpoint, extract_value, unused_port},
+    NodeError, NODE_DIAL_LOOP_TIMEOUT, NODE_STARTUP_TIMEOUT,
 };
 use alloy_genesis::{CliqueConfig, Genesis};
 use alloy_primitives::Address;
@@ -139,22 +139,22 @@ impl GethInstance {
     ///
     /// This leaves a `None` in its place, so calling methods that require a stderr to be present
     /// will fail if called after this.
-    pub fn stderr(&mut self) -> Result<ChildStderr, NodeInstanceError> {
-        self.pid.stderr.take().ok_or(NodeInstanceError::NoStderr)
+    pub fn stderr(&mut self) -> Result<ChildStderr, NodeError> {
+        self.pid.stderr.take().ok_or(NodeError::NoStderr)
     }
 
     /// Blocks until geth adds the specified peer, using 20s as the timeout.
     ///
     /// Requires the stderr to be present in the `GethInstance`.
-    pub fn wait_to_add_peer(&mut self, id: &str) -> Result<(), NodeInstanceError> {
-        let mut stderr = self.pid.stderr.as_mut().ok_or(NodeInstanceError::NoStderr)?;
+    pub fn wait_to_add_peer(&mut self, id: &str) -> Result<(), NodeError> {
+        let mut stderr = self.pid.stderr.as_mut().ok_or(NodeError::NoStderr)?;
         let mut err_reader = BufReader::new(&mut stderr);
         let mut line = String::new();
         let start = Instant::now();
 
         while start.elapsed() < NODE_DIAL_LOOP_TIMEOUT {
             line.clear();
-            err_reader.read_line(&mut line).map_err(NodeInstanceError::ReadLineError)?;
+            err_reader.read_line(&mut line).map_err(NodeError::ReadLineError)?;
 
             // geth ids are truncated
             let truncated_id = if id.len() > 16 { &id[..16] } else { id };
@@ -162,7 +162,7 @@ impl GethInstance {
                 return Ok(());
             }
         }
-        Err(NodeInstanceError::Timeout("Timed out waiting for geth to add a peer".into()))
+        Err(NodeError::Timeout)
     }
 }
 
@@ -622,33 +622,20 @@ impl Geth {
 // These tests should use a different datadir for each `geth` spawned.
 #[cfg(test)]
 mod tests {
+    use crate::utils::run_with_tempdir_sync;
+
     use super::*;
-    use std::path::Path;
 
     #[test]
     fn port_0() {
-        run_with_tempdir(|_| {
+        run_with_tempdir_sync("geth-test-", |_| {
             let _geth = Geth::new().disable_discovery().port(0u16).spawn();
         });
     }
 
-    /// Allows running tests with a temporary directory, which is cleaned up after the function is
-    /// called.
-    ///
-    /// Helps with tests that spawn a helper instance, which has to be dropped before the temporary
-    /// directory is cleaned up.
-    #[track_caller]
-    fn run_with_tempdir(f: impl Fn(&Path)) {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let temp_dir_path = temp_dir.path();
-        f(temp_dir_path);
-        #[cfg(not(windows))]
-        temp_dir.close().unwrap();
-    }
-
     #[test]
     fn p2p_port() {
-        run_with_tempdir(|temp_dir_path| {
+        run_with_tempdir_sync("geth-test-", |temp_dir_path| {
             let geth = Geth::new().disable_discovery().data_dir(temp_dir_path).spawn();
             let p2p_port = geth.p2p_port();
             assert!(p2p_port.is_some());
@@ -657,7 +644,7 @@ mod tests {
 
     #[test]
     fn explicit_p2p_port() {
-        run_with_tempdir(|temp_dir_path| {
+        run_with_tempdir_sync("geth-test-", |temp_dir_path| {
             // if a p2p port is explicitly set, it should be used
             let geth = Geth::new().p2p_port(1234).data_dir(temp_dir_path).spawn();
             let p2p_port = geth.p2p_port();
@@ -667,7 +654,7 @@ mod tests {
 
     #[test]
     fn dev_mode() {
-        run_with_tempdir(|temp_dir_path| {
+        run_with_tempdir_sync("geth-test-", |temp_dir_path| {
             // dev mode should not have a p2p port, and dev should be the default
             let geth = Geth::new().data_dir(temp_dir_path).spawn();
             let p2p_port = geth.p2p_port();
@@ -679,7 +666,7 @@ mod tests {
     #[ignore = "fails on geth >=1.14"]
     #[allow(deprecated)]
     fn clique_correctly_configured() {
-        run_with_tempdir(|temp_dir_path| {
+        run_with_tempdir_sync("geth-test-", |temp_dir_path| {
             let private_key = SigningKey::random(&mut rand::thread_rng());
             let geth = Geth::new()
                 .set_clique_private_key(private_key)

--- a/crates/node-bindings/src/nodes/reth.rs
+++ b/crates/node-bindings/src/nodes/reth.rs
@@ -1,6 +1,6 @@
 //! Utilities for launching a Reth dev-mode instance.
 
-use crate::{extract_endpoint, NodeError, NodeInstanceError, NODE_STARTUP_TIMEOUT};
+use crate::{utils::extract_endpoint, NodeError, NODE_STARTUP_TIMEOUT};
 use alloy_genesis::Genesis;
 use std::{
     fs::create_dir,
@@ -95,8 +95,8 @@ impl RethInstance {
     ///
     /// This leaves a `None` in its place, so calling methods that require a stdout to be present
     /// will fail if called after this.
-    pub fn stdout(&mut self) -> Result<ChildStdout, NodeInstanceError> {
-        self.pid.stdout.take().ok_or(NodeInstanceError::NoStdout)
+    pub fn stdout(&mut self) -> Result<ChildStdout, NodeError> {
+        self.pid.stdout.take().ok_or(NodeError::NoStdout)
     }
 }
 
@@ -425,13 +425,14 @@ impl Reth {
 // These tests should use a different datadir for each `reth` instance spawned.
 #[cfg(test)]
 mod tests {
+    use crate::utils::run_with_tempdir_sync;
+
     use super::*;
-    use std::path::Path;
 
     #[test]
     #[cfg(not(windows))]
     fn can_launch_reth() {
-        run_with_tempdir(|temp_dir_path| {
+        run_with_tempdir_sync("reth-test-", |temp_dir_path| {
             let reth = Reth::new().data_dir(temp_dir_path).spawn();
 
             assert_ports(&reth, false);
@@ -441,7 +442,7 @@ mod tests {
     #[test]
     #[cfg(not(windows))]
     fn can_launch_reth_sepolia() {
-        run_with_tempdir(|temp_dir_path| {
+        run_with_tempdir_sync("reth-test-", |temp_dir_path| {
             let reth = Reth::new().chain_or_path("sepolia").data_dir(temp_dir_path).spawn();
 
             assert_ports(&reth, false);
@@ -451,7 +452,7 @@ mod tests {
     #[test]
     #[cfg(not(windows))]
     fn can_launch_reth_dev() {
-        run_with_tempdir(|temp_dir_path| {
+        run_with_tempdir_sync("reth-test-", |temp_dir_path| {
             let reth = Reth::new().dev().disable_discovery().data_dir(temp_dir_path).spawn();
 
             assert_ports(&reth, true);
@@ -461,7 +462,7 @@ mod tests {
     #[test]
     #[cfg(not(windows))]
     fn can_launch_reth_dev_custom_genesis() {
-        run_with_tempdir(|temp_dir_path| {
+        run_with_tempdir_sync("reth-test-", |temp_dir_path| {
             let reth = Reth::new()
                 .dev()
                 .disable_discovery()
@@ -476,7 +477,7 @@ mod tests {
     #[test]
     #[cfg(not(windows))]
     fn can_launch_reth_dev_custom_blocktime() {
-        run_with_tempdir(|temp_dir_path| {
+        run_with_tempdir_sync("reth-test-", |temp_dir_path| {
             let reth = Reth::new()
                 .dev()
                 .disable_discovery()
@@ -491,7 +492,7 @@ mod tests {
     #[test]
     #[cfg(not(windows))]
     fn can_launch_reth_p2p_instance1() {
-        run_with_tempdir(|temp_dir_path| {
+        run_with_tempdir_sync("reth-test-", |temp_dir_path| {
             let reth = Reth::new().instance(1).data_dir(temp_dir_path).spawn();
 
             assert_eq!(reth.http_port(), 8545);
@@ -504,7 +505,7 @@ mod tests {
     #[test]
     #[cfg(not(windows))]
     fn can_launch_reth_p2p_instance2() {
-        run_with_tempdir(|temp_dir_path| {
+        run_with_tempdir_sync("reth-test-", |temp_dir_path| {
             let reth = Reth::new().instance(2).data_dir(temp_dir_path).spawn();
 
             assert_eq!(reth.http_port(), 8544);
@@ -512,19 +513,6 @@ mod tests {
             assert_eq!(reth.auth_port(), Some(8651));
             assert_eq!(reth.p2p_port(), Some(30304));
         });
-    }
-
-    /// Allows running tests with a temporary directory, which is cleaned up after the function is
-    /// called.
-    ///
-    /// Helps with tests that spawn a helper instance, which has to be dropped before the temporary
-    /// directory is cleaned up.
-    #[track_caller]
-    fn run_with_tempdir(f: impl Fn(&Path)) {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let temp_dir_path = temp_dir.path();
-        f(temp_dir_path);
-        temp_dir.close().unwrap();
     }
 
     // Asserts that the ports are set correctly for the given reth instance.

--- a/crates/provider/src/builder.rs
+++ b/crates/provider/src/builder.rs
@@ -371,7 +371,7 @@ impl<L, F, N> ProviderBuilder<L, F, N> {
 type JoinedEthereumWalletFiller<F> = JoinFill<F, WalletFiller<alloy_network::EthereumWallet>>;
 
 #[cfg(any(test, feature = "anvil-node"))]
-type AnvilProviderResult<T> = Result<T, alloy_node_bindings::anvil::AnvilError>;
+type AnvilProviderResult<T> = Result<T, alloy_node_bindings::NodeError>;
 
 // Enabled when the `anvil` feature is enabled, or when both in test and the
 // `reqwest` feature is enabled.
@@ -490,9 +490,8 @@ impl<L, F> ProviderBuilder<L, F, Ethereum> {
         let url = anvil_layer.endpoint_url();
 
         let default_keys = anvil_layer.instance().keys().to_vec();
-        let (default_key, remaining_keys) = default_keys
-            .split_first()
-            .ok_or(alloy_node_bindings::anvil::AnvilError::NoKeysAvailable)?;
+        let (default_key, remaining_keys) =
+            default_keys.split_first().ok_or(alloy_node_bindings::NodeError::NoKeysAvailable)?;
 
         let default_signer = alloy_signer_local::LocalSigner::from(default_key.clone());
         let mut wallet = alloy_network::EthereumWallet::from(default_signer);

--- a/crates/provider/src/ext/admin.rs
+++ b/crates/provider/src/ext/admin.rs
@@ -85,39 +85,43 @@ where
 
 #[cfg(test)]
 mod test {
-    use crate::ProviderBuilder;
-
     use super::*;
-    use alloy_node_bindings::Geth;
-    use tempfile::TempDir;
+    use crate::ProviderBuilder;
+    use alloy_node_bindings::{utils::run_with_tempdir, Geth};
 
     #[tokio::test]
     async fn node_info() {
-        let temp_dir = TempDir::with_prefix("geth-test-").unwrap();
-        let geth = Geth::new().disable_discovery().data_dir(temp_dir.path()).spawn();
-        let provider = ProviderBuilder::new().on_http(geth.endpoint_url());
-        let node_info = provider.node_info().await.unwrap();
-        assert!(node_info.enode.starts_with("enode://"));
+        run_with_tempdir("geth-test-", |temp_dir| async move {
+            let geth = Geth::new().disable_discovery().data_dir(temp_dir).spawn();
+            let provider = ProviderBuilder::new().on_http(geth.endpoint_url());
+            let node_info = provider.node_info().await.unwrap();
+            assert!(node_info.enode.starts_with("enode://"));
+        })
+        .await;
     }
 
     #[tokio::test]
     async fn admin_peers() {
-        let temp_dir = TempDir::with_prefix("geth-test-1").unwrap();
-        let temp_dir_2 = TempDir::with_prefix("geth-test-2").unwrap();
-        let geth1 = Geth::new().disable_discovery().data_dir(temp_dir.path()).spawn();
-        let mut geth2 =
-            Geth::new().disable_discovery().port(0u16).data_dir(temp_dir_2.path()).spawn();
+        run_with_tempdir("geth-test-1", |temp_dir_1| async move {
+            run_with_tempdir("geth-test-2", |temp_dir_2| async move {
+                let geth1 = Geth::new().disable_discovery().data_dir(&temp_dir_1).spawn();
+                let mut geth2 =
+                    Geth::new().disable_discovery().port(0u16).data_dir(&temp_dir_2).spawn();
 
-        let provider1 = ProviderBuilder::new().on_http(geth1.endpoint_url());
-        let provider2 = ProviderBuilder::new().on_http(geth2.endpoint_url());
-        let node1_info = provider1.node_info().await.unwrap();
-        let node1_id = node1_info.id;
-        let node1_enode = node1_info.enode;
+                let provider1 = ProviderBuilder::new().on_http(geth1.endpoint_url());
+                let provider2 = ProviderBuilder::new().on_http(geth2.endpoint_url());
+                let node1_info = provider1.node_info().await.unwrap();
+                let node1_id = node1_info.id;
+                let node1_enode = node1_info.enode;
 
-        let added = provider2.add_peer(&node1_enode).await.unwrap();
-        assert!(added);
-        geth2.wait_to_add_peer(&node1_id).unwrap();
-        let peers = provider2.peers().await.unwrap();
-        assert_eq!(peers[0].enode, node1_enode);
+                let added = provider2.add_peer(&node1_enode).await.unwrap();
+                assert!(added);
+                geth2.wait_to_add_peer(&node1_id).unwrap();
+                let peers = provider2.peers().await.unwrap();
+                assert_eq!(peers[0].enode, node1_enode);
+            })
+            .await;
+        })
+        .await;
     }
 }

--- a/crates/provider/src/ext/debug.rs
+++ b/crates/provider/src/ext/debug.rs
@@ -283,50 +283,58 @@ mod test {
 
     #[tokio::test]
     async fn call_debug_get_raw_header() {
-        let temp_dir = tempfile::TempDir::with_prefix("geth-test-").unwrap();
-        let geth = Geth::new().disable_discovery().data_dir(temp_dir.path()).spawn();
-        let provider = ProviderBuilder::new().on_http(geth.endpoint_url());
+        run_with_tempdir("geth-test-", |temp_dir| async move {
+            let geth = Geth::new().disable_discovery().data_dir(temp_dir.path()).spawn();
+            let provider = ProviderBuilder::new().on_http(geth.endpoint_url());
 
-        let rlp_header = provider
-            .debug_get_raw_header(BlockId::Number(BlockNumberOrTag::Latest))
-            .await
-            .expect("debug_getRawHeader call should succeed");
+            let rlp_header = provider
+                .debug_get_raw_header(BlockId::Number(BlockNumberOrTag::Latest))
+                .await
+                .expect("debug_getRawHeader call should succeed");
 
-        assert!(!rlp_header.is_empty());
+            assert!(!rlp_header.is_empty());
+        })
+        .await
     }
 
     #[tokio::test]
     async fn call_debug_get_raw_block() {
-        let temp_dir = tempfile::TempDir::with_prefix("geth-test-").unwrap();
-        let geth = Geth::new().disable_discovery().data_dir(temp_dir.path()).spawn();
-        let provider = ProviderBuilder::new().on_http(geth.endpoint_url());
+        run_with_tempdir("geth-test-", |temp_dir| async move {
+            let geth = Geth::new().disable_discovery().data_dir(temp_dir.path()).spawn();
+            let provider = ProviderBuilder::new().on_http(geth.endpoint_url());
 
-        let rlp_block = provider
-            .debug_get_raw_block(BlockId::Number(BlockNumberOrTag::Latest))
-            .await
-            .expect("debug_getRawBlock call should succeed");
+            let rlp_block = provider
+                .debug_get_raw_block(BlockId::Number(BlockNumberOrTag::Latest))
+                .await
+                .expect("debug_getRawBlock call should succeed");
 
-        assert!(!rlp_block.is_empty());
+            assert!(!rlp_block.is_empty());
+        })
+        .await
     }
 
     #[tokio::test]
     async fn call_debug_get_raw_receipts() {
-        let temp_dir = tempfile::TempDir::with_prefix("geth-test-").unwrap();
-        let geth = Geth::new().disable_discovery().data_dir(temp_dir.path()).spawn();
-        let provider = ProviderBuilder::new().on_http(geth.endpoint_url());
+        run_with_tempdir("geth-test-", |temp_dir| async move {
+            let geth = Geth::new().disable_discovery().data_dir(temp_dir.path()).spawn();
+            let provider = ProviderBuilder::new().on_http(geth.endpoint_url());
 
-        let result =
-            provider.debug_get_raw_receipts(BlockId::Number(BlockNumberOrTag::Latest)).await;
-        assert!(result.is_ok());
+            let result =
+                provider.debug_get_raw_receipts(BlockId::Number(BlockNumberOrTag::Latest)).await;
+            assert!(result.is_ok());
+        })
+        .await
     }
 
     #[tokio::test]
     async fn call_debug_get_bad_blocks() {
-        let temp_dir = tempfile::TempDir::with_prefix("geth-test-").unwrap();
-        let geth = Geth::new().disable_discovery().data_dir(temp_dir.path()).spawn();
-        let provider = ProviderBuilder::new().on_http(geth.endpoint_url());
+        run_with_tempdir("geth-test-", |temp_dir| async move {
+            let geth = Geth::new().disable_discovery().data_dir(temp_dir.path()).spawn();
+            let provider = ProviderBuilder::new().on_http(geth.endpoint_url());
 
-        let result = provider.debug_get_bad_blocks().await;
-        assert!(result.is_ok());
+            let result = provider.debug_get_bad_blocks().await;
+            assert!(result.is_ok());
+        })
+        .await
     }
 }

--- a/crates/provider/src/ext/debug.rs
+++ b/crates/provider/src/ext/debug.rs
@@ -222,7 +222,7 @@ mod test {
 
     use super::*;
     use alloy_network::TransactionBuilder;
-    use alloy_node_bindings::Geth;
+    use alloy_node_bindings::{utils::run_with_tempdir, Geth};
     use alloy_primitives::{address, U256};
 
     fn init_tracing() {
@@ -284,7 +284,7 @@ mod test {
     #[tokio::test]
     async fn call_debug_get_raw_header() {
         run_with_tempdir("geth-test-", |temp_dir| async move {
-            let geth = Geth::new().disable_discovery().data_dir(temp_dir.path()).spawn();
+            let geth = Geth::new().disable_discovery().data_dir(temp_dir).spawn();
             let provider = ProviderBuilder::new().on_http(geth.endpoint_url());
 
             let rlp_header = provider
@@ -300,7 +300,7 @@ mod test {
     #[tokio::test]
     async fn call_debug_get_raw_block() {
         run_with_tempdir("geth-test-", |temp_dir| async move {
-            let geth = Geth::new().disable_discovery().data_dir(temp_dir.path()).spawn();
+            let geth = Geth::new().disable_discovery().data_dir(temp_dir).spawn();
             let provider = ProviderBuilder::new().on_http(geth.endpoint_url());
 
             let rlp_block = provider
@@ -316,7 +316,7 @@ mod test {
     #[tokio::test]
     async fn call_debug_get_raw_receipts() {
         run_with_tempdir("geth-test-", |temp_dir| async move {
-            let geth = Geth::new().disable_discovery().data_dir(temp_dir.path()).spawn();
+            let geth = Geth::new().disable_discovery().data_dir(temp_dir).spawn();
             let provider = ProviderBuilder::new().on_http(geth.endpoint_url());
 
             let result =
@@ -329,7 +329,7 @@ mod test {
     #[tokio::test]
     async fn call_debug_get_bad_blocks() {
         run_with_tempdir("geth-test-", |temp_dir| async move {
-            let geth = Geth::new().disable_discovery().data_dir(temp_dir.path()).spawn();
+            let geth = Geth::new().disable_discovery().data_dir(temp_dir).spawn();
             let provider = ProviderBuilder::new().on_http(geth.endpoint_url());
 
             let result = provider.debug_get_bad_blocks().await;

--- a/crates/provider/src/ext/net.rs
+++ b/crates/provider/src/ext/net.rs
@@ -46,7 +46,7 @@ mod test {
     #[tokio::test]
     async fn call_net_version() {
         run_with_tempdir("geth-test-", |temp_dir| async move {
-            let geth = Geth::new().disable_discovery().data_dir(temp_dir.path()).spawn();
+            let geth = Geth::new().disable_discovery().data_dir(temp_dir).spawn();
             let provider = ProviderBuilder::new().on_http(geth.endpoint_url());
 
             let version = provider.net_version().await.expect("net_version call should succeed");
@@ -58,7 +58,7 @@ mod test {
     #[tokio::test]
     async fn call_net_peer_count() {
         run_with_tempdir("geth-test-", |temp_dir| async move {
-            let geth = Geth::new().disable_discovery().data_dir(temp_dir.path()).spawn();
+            let geth = Geth::new().disable_discovery().data_dir(temp_dir).spawn();
             let provider = ProviderBuilder::new().on_http(geth.endpoint_url());
 
             let count = provider.net_peer_count().await.expect("net_peerCount call should succeed");
@@ -70,7 +70,7 @@ mod test {
     #[tokio::test]
     async fn call_net_listening() {
         run_with_tempdir("geth-test-", |temp_dir| async move {
-            let geth = Geth::new().disable_discovery().data_dir(temp_dir.path()).spawn();
+            let geth = Geth::new().disable_discovery().data_dir(temp_dir).spawn();
             let provider = ProviderBuilder::new().on_http(geth.endpoint_url());
 
             let listening =

--- a/crates/provider/src/ext/net.rs
+++ b/crates/provider/src/ext/net.rs
@@ -41,35 +41,42 @@ mod test {
     use crate::ProviderBuilder;
 
     use super::*;
-    use alloy_node_bindings::Geth;
+    use alloy_node_bindings::{utils::run_with_tempdir, Geth};
 
     #[tokio::test]
     async fn call_net_version() {
-        let temp_dir = tempfile::TempDir::with_prefix("geth-test-").unwrap();
-        let geth = Geth::new().disable_discovery().data_dir(temp_dir.path()).spawn();
-        let provider = ProviderBuilder::new().on_http(geth.endpoint_url());
+        run_with_tempdir("geth-test-", |temp_dir| async move {
+            let geth = Geth::new().disable_discovery().data_dir(temp_dir.path()).spawn();
+            let provider = ProviderBuilder::new().on_http(geth.endpoint_url());
 
-        let version = provider.net_version().await.expect("net_version call should succeed");
-        assert_eq!(version, 1);
+            let version = provider.net_version().await.expect("net_version call should succeed");
+            assert_eq!(version, 1);
+        })
+        .await;
     }
 
     #[tokio::test]
     async fn call_net_peer_count() {
-        let temp_dir = tempfile::TempDir::with_prefix("geth-test-").unwrap();
-        let geth = Geth::new().disable_discovery().data_dir(temp_dir.path()).spawn();
-        let provider = ProviderBuilder::new().on_http(geth.endpoint_url());
+        run_with_tempdir("geth-test-", |temp_dir| async move {
+            let geth = Geth::new().disable_discovery().data_dir(temp_dir.path()).spawn();
+            let provider = ProviderBuilder::new().on_http(geth.endpoint_url());
 
-        let count = provider.net_peer_count().await.expect("net_peerCount call should succeed");
-        assert_eq!(count, 0);
+            let count = provider.net_peer_count().await.expect("net_peerCount call should succeed");
+            assert_eq!(count, 0);
+        })
+        .await;
     }
 
     #[tokio::test]
     async fn call_net_listening() {
-        let temp_dir = tempfile::TempDir::with_prefix("geth-test-").unwrap();
-        let geth = Geth::new().disable_discovery().data_dir(temp_dir.path()).spawn();
-        let provider = ProviderBuilder::new().on_http(geth.endpoint_url());
+        run_with_tempdir("geth-test-", |temp_dir| async move {
+            let geth = Geth::new().disable_discovery().data_dir(temp_dir.path()).spawn();
+            let provider = ProviderBuilder::new().on_http(geth.endpoint_url());
 
-        let listening = provider.net_listening().await.expect("net_listening call should succeed");
-        assert!(listening);
+            let listening =
+                provider.net_listening().await.expect("net_listening call should succeed");
+            assert!(listening);
+        })
+        .await;
     }
 }

--- a/crates/provider/src/ext/txpool.rs
+++ b/crates/provider/src/ext/txpool.rs
@@ -82,37 +82,45 @@ mod tests {
 
     #[tokio::test]
     async fn test_txpool_content() {
-        let temp_dir = tempfile::TempDir::with_prefix("geth-test-").unwrap();
-        let geth = Geth::new().disable_discovery().data_dir(temp_dir.path()).spawn();
-        let provider = ProviderBuilder::new().on_http(geth.endpoint_url());
-        let content = provider.txpool_content().await.unwrap();
-        assert_eq!(content, TxpoolContent::default());
+        run_with_tempdir("geth-test-", |temp_dir| async move {
+            let geth = Geth::new().disable_discovery().data_dir(temp_dir.path()).spawn();
+            let provider = ProviderBuilder::new().on_http(geth.endpoint_url());
+            let content = provider.txpool_content().await.unwrap();
+            assert_eq!(content, TxpoolContent::default());
+        })
+        .await;
     }
 
     #[tokio::test]
     async fn test_txpool_content_from() {
-        let temp_dir = tempfile::TempDir::with_prefix("geth-test-").unwrap();
-        let geth = Geth::new().disable_discovery().data_dir(temp_dir.path()).spawn();
-        let provider = ProviderBuilder::new().on_http(geth.endpoint_url());
-        let content = provider.txpool_content_from(Address::default()).await.unwrap();
-        assert_eq!(content, TxpoolContentFrom::default());
+        run_with_tempdir("geth-test-", |temp_dir| async move {
+            let geth = Geth::new().disable_discovery().data_dir(temp_dir.path()).spawn();
+            let provider = ProviderBuilder::new().on_http(geth.endpoint_url());
+            let content = provider.txpool_content_from(Address::default()).await.unwrap();
+            assert_eq!(content, TxpoolContentFrom::default());
+        })
+        .await;
     }
 
     #[tokio::test]
     async fn test_txpool_inspect() {
-        let temp_dir = tempfile::TempDir::with_prefix("geth-test-").unwrap();
-        let geth = Geth::new().disable_discovery().data_dir(temp_dir.path()).spawn();
-        let provider = ProviderBuilder::new().on_http(geth.endpoint_url());
-        let content = provider.txpool_inspect().await.unwrap();
-        assert_eq!(content, TxpoolInspect::default());
+        run_with_tempdir("geth-test-", |temp_dir| async move {
+            let geth = Geth::new().disable_discovery().data_dir(temp_dir.path()).spawn();
+            let provider = ProviderBuilder::new().on_http(geth.endpoint_url());
+            let content = provider.txpool_inspect().await.unwrap();
+            assert_eq!(content, TxpoolInspect::default());
+        })
+        .await;
     }
 
     #[tokio::test]
     async fn test_txpool_status() {
-        let temp_dir = tempfile::TempDir::with_prefix("geth-test-").unwrap();
-        let geth = Geth::new().disable_discovery().data_dir(temp_dir.path()).spawn();
-        let provider = ProviderBuilder::new().on_http(geth.endpoint_url());
-        let content = provider.txpool_status().await.unwrap();
-        assert_eq!(content, TxpoolStatus::default());
+        run_with_tempdir("geth-test-", |temp_dir| async move {
+            let geth = Geth::new().disable_discovery().data_dir(temp_dir.path()).spawn();
+            let provider = ProviderBuilder::new().on_http(geth.endpoint_url());
+            let content = provider.txpool_status().await.unwrap();
+            assert_eq!(content, TxpoolStatus::default());
+        })
+        .await;
     }
 }

--- a/crates/provider/src/ext/txpool.rs
+++ b/crates/provider/src/ext/txpool.rs
@@ -78,12 +78,12 @@ mod tests {
     use crate::ProviderBuilder;
 
     use super::*;
-    use alloy_node_bindings::Geth;
+    use alloy_node_bindings::{utils::run_with_tempdir, Geth};
 
     #[tokio::test]
     async fn test_txpool_content() {
         run_with_tempdir("geth-test-", |temp_dir| async move {
-            let geth = Geth::new().disable_discovery().data_dir(temp_dir.path()).spawn();
+            let geth = Geth::new().disable_discovery().data_dir(temp_dir).spawn();
             let provider = ProviderBuilder::new().on_http(geth.endpoint_url());
             let content = provider.txpool_content().await.unwrap();
             assert_eq!(content, TxpoolContent::default());
@@ -94,7 +94,7 @@ mod tests {
     #[tokio::test]
     async fn test_txpool_content_from() {
         run_with_tempdir("geth-test-", |temp_dir| async move {
-            let geth = Geth::new().disable_discovery().data_dir(temp_dir.path()).spawn();
+            let geth = Geth::new().disable_discovery().data_dir(temp_dir).spawn();
             let provider = ProviderBuilder::new().on_http(geth.endpoint_url());
             let content = provider.txpool_content_from(Address::default()).await.unwrap();
             assert_eq!(content, TxpoolContentFrom::default());
@@ -105,7 +105,7 @@ mod tests {
     #[tokio::test]
     async fn test_txpool_inspect() {
         run_with_tempdir("geth-test-", |temp_dir| async move {
-            let geth = Geth::new().disable_discovery().data_dir(temp_dir.path()).spawn();
+            let geth = Geth::new().disable_discovery().data_dir(temp_dir).spawn();
             let provider = ProviderBuilder::new().on_http(geth.endpoint_url());
             let content = provider.txpool_inspect().await.unwrap();
             assert_eq!(content, TxpoolInspect::default());
@@ -116,7 +116,7 @@ mod tests {
     #[tokio::test]
     async fn test_txpool_status() {
         run_with_tempdir("geth-test-", |temp_dir| async move {
-            let geth = Geth::new().disable_discovery().data_dir(temp_dir.path()).spawn();
+            let geth = Geth::new().disable_discovery().data_dir(temp_dir).spawn();
             let provider = ProviderBuilder::new().on_http(geth.endpoint_url());
             let content = provider.txpool_status().await.unwrap();
             assert_eq!(content, TxpoolStatus::default());

--- a/crates/rpc-client/tests/it/ipc.rs
+++ b/crates/rpc-client/tests/it/ipc.rs
@@ -4,16 +4,14 @@ use alloy_rpc_client::{ClientBuilder, RpcCall};
 use alloy_transport_ipc::IpcConnect;
 
 #[tokio::test]
-async fn it_makes_a_request() {
-    let temp_dir = tempfile::TempDir::with_prefix("geth-test-").unwrap();
-
+async fn can_make_a_request() {
     run_with_tempdir("geth-test-", |temp_dir| async move {
         let geth = Geth::new()
             .disable_discovery()
-            .ipc_path(temp_dir.path().join("alloy.ipc"))
+            .ipc_path(temp_dir.join("alloy.ipc"))
             .enable_ipc()
             .block_time(1u64)
-            .data_dir(temp_dir.path())
+            .data_dir(temp_dir)
             .spawn();
 
         let connect = IpcConnect::new(geth.ipc_endpoint());

--- a/crates/rpc-client/tests/it/ipc.rs
+++ b/crates/rpc-client/tests/it/ipc.rs
@@ -1,4 +1,4 @@
-use alloy_node_bindings::Geth;
+use alloy_node_bindings::{utils::run_with_tempdir, Geth};
 use alloy_primitives::U64;
 use alloy_rpc_client::{ClientBuilder, RpcCall};
 use alloy_transport_ipc::IpcConnect;
@@ -6,19 +6,23 @@ use alloy_transport_ipc::IpcConnect;
 #[tokio::test]
 async fn it_makes_a_request() {
     let temp_dir = tempfile::TempDir::with_prefix("geth-test-").unwrap();
-    let geth = Geth::new()
-        .disable_discovery()
-        .ipc_path(temp_dir.path().join("alloy.ipc"))
-        .enable_ipc()
-        .block_time(1u64)
-        .data_dir(temp_dir.path())
-        .spawn();
 
-    let connect = IpcConnect::new(geth.ipc_endpoint());
-    let client = ClientBuilder::default().pubsub(connect).await.unwrap();
+    run_with_tempdir("geth-test-", |temp_dir| async move {
+        let geth = Geth::new()
+            .disable_discovery()
+            .ipc_path(temp_dir.path().join("alloy.ipc"))
+            .enable_ipc()
+            .block_time(1u64)
+            .data_dir(temp_dir.path())
+            .spawn();
 
-    let req: RpcCall<_, _, U64> = client.request_noparams("eth_blockNumber");
-    let timeout = tokio::time::timeout(std::time::Duration::from_secs(2), req);
-    let res = timeout.await.unwrap().unwrap();
-    assert!(res.to::<u64>() <= 3);
+        let connect = IpcConnect::new(geth.ipc_endpoint());
+        let client = ClientBuilder::default().pubsub(connect).await.unwrap();
+
+        let req: RpcCall<_, _, U64> = client.request_noparams("eth_blockNumber");
+        let timeout = tokio::time::timeout(std::time::Duration::from_secs(2), req);
+        let res = timeout.await.unwrap().unwrap();
+        assert!(res.to::<u64>() <= 3);
+    })
+    .await;
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Improves on existing Reth bindings:

Preferably blocked until https://github.com/alloy-rs/alloy/pull/1278 is merged so that the tests can be updated to use the new utilities.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

- Now picks random instance for Reth by default to reduce flakiness in tests (busy ports)
- Adds `run_with_tempdir_*` methods for proper handling and clean up when using tempdirs + updating tests
- Unifies Anvil errors with other node errors and generalizes

I've decided not to include the hardcoded `keys` and `addresses` as proposed in https://github.com/alloy-rs/alloy/pull/1076 as it is easy to derive if necessary.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
