### PR TITLE
fix: `eth_simulateV1`

### DIFF
--- a/crates/rpc-types-eth/src/block.rs
+++ b/crates/rpc-types-eth/src/block.rs
@@ -347,13 +347,22 @@ pub struct BlockOverrides {
     )]
     pub gas_limit: Option<u64>,
     /// Overrides the coinbase address of the block.
-    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(default, skip_serializing_if = "Option::is_none", alias = "feeRecipient")
+    )]
     pub coinbase: Option<Address>,
     /// Overrides the prevrandao of the block.
-    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(default, skip_serializing_if = "Option::is_none", alias = "prevRandao")
+    )]
     pub random: Option<B256>,
     /// Overrides the basefee of the block.
-    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(default, skip_serializing_if = "Option::is_none", alias = "baseFeePerGas")
+    )]
     pub base_fee: Option<U256>,
     /// A dictionary that maps blockNumber to a user-defined hash. It could be queried from the
     /// solidity opcode BLOCKHASH.

--- a/crates/rpc-types-eth/src/simulate.rs
+++ b/crates/rpc-types-eth/src/simulate.rs
@@ -75,6 +75,7 @@ pub struct SimulatePayload {
     #[cfg_attr(feature = "serde", serde(default))]
     pub validation: bool,
     /// Flag to decide if full transactions should be returned instead of just their hashes.
+    #[serde(default)]
     pub return_full_transactions: bool,
 }
 

--- a/crates/rpc-types-eth/src/simulate.rs
+++ b/crates/rpc-types-eth/src/simulate.rs
@@ -75,7 +75,7 @@ pub struct SimulatePayload {
     #[cfg_attr(feature = "serde", serde(default))]
     pub validation: bool,
     /// Flag to decide if full transactions should be returned instead of just their hashes.
-    #[serde(default)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub return_full_transactions: bool,
 }
 


### PR DESCRIPTION
missing `serde(default)` + new aliases for block overrides fields to handle new names correctly on server side