### PR TITLE
feat: add types for flat call tracer

### DIFF
--- a/crates/rpc-types-trace/src/geth/call.rs
+++ b/crates/rpc-types-trace/src/geth/call.rs
@@ -1,5 +1,6 @@
 //! Geth call tracer types.
 
+use crate::parity::LocalizedTransactionTrace;
 use alloy_primitives::{Address, Bytes, B256, U256};
 use serde::{Deserialize, Serialize};
 
@@ -84,6 +85,38 @@ impl CallConfig {
     /// Sets the with log flag.
     pub const fn with_log(mut self) -> Self {
         self.with_log = Some(true);
+        self
+    }
+}
+
+/// The response object for `debug_traceTransaction` with `"tracer": "flatCallTracer"`.
+///
+/// That is equivalent to parity's [`LocalizedTransactionTrace`]
+/// <https://github.com/ethereum/go-ethereum/blob/0dd173a727dd2d2409b8e401b22e85d20c25b71f/eth/tracers/native/call_flat.go#L62-L62>
+pub type FlatCallFrame = LocalizedTransactionTrace;
+
+/// The configuration for the flat call tracer.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FlatCallConfig {
+    /// If true, call tracer converts errors to parity format
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub convert_parity_errors: Option<bool>,
+    /// If true, call tracer includes calls to precompiled contracts
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub include_precompiles: Option<bool>,
+}
+
+impl FlatCallConfig {
+    /// Converts errors to parity format.
+    pub const fn parity_errors(mut self) -> Self {
+        self.convert_parity_errors = Some(true);
+        self
+    }
+
+    /// Include calls to precompiled contracts.
+    pub const fn with_precompiles(mut self) -> Self {
+        self.include_precompiles = Some(true);
         self
     }
 }

--- a/crates/rpc-types-trace/src/geth/mod.rs
+++ b/crates/rpc-types-trace/src/geth/mod.rs
@@ -1,14 +1,16 @@
 //! Geth tracing types.
 
-use crate::geth::mux::{MuxConfig, MuxFrame};
+use crate::geth::{
+    call::FlatCallFrame,
+    mux::{MuxConfig, MuxFrame},
+};
 use alloy_primitives::{Bytes, B256, U256};
 use alloy_rpc_types_eth::{state::StateOverride, BlockOverrides};
 use serde::{de::DeserializeOwned, ser::SerializeMap, Deserialize, Serialize, Serializer};
 use std::{collections::BTreeMap, time::Duration};
-
 // re-exports
 pub use self::{
-    call::{CallConfig, CallFrame, CallLogFrame},
+    call::{CallConfig, CallFrame, CallLogFrame, FlatCallConfig},
     four_byte::FourByteFrame,
     noop::NoopFrame,
     pre_state::{
@@ -118,6 +120,8 @@ pub enum GethTrace {
     Default(DefaultFrame),
     /// The response for call tracer
     CallTracer(CallFrame),
+    /// The response for the flat call tracer
+    FlatCallTracer(FlatCallFrame),
     /// The response for four byte tracer
     FourByteTracer(FourByteFrame),
     /// The response for pre-state byte tracer
@@ -143,6 +147,14 @@ impl GethTrace {
     pub fn try_into_call_frame(self) -> Result<CallFrame, UnexpectedTracerError> {
         match self {
             Self::CallTracer(inner) => Ok(inner),
+            _ => Err(UnexpectedTracerError(self)),
+        }
+    }
+
+    /// Try to convert the inner tracer to [FlatCallFrame]
+    pub fn try_into_flat_call_frame(self) -> Result<FlatCallFrame, UnexpectedTracerError> {
+        match self {
+            Self::FlatCallTracer(inner) => Ok(inner),
             _ => Err(UnexpectedTracerError(self)),
         }
     }
@@ -212,6 +224,12 @@ impl From<CallFrame> for GethTrace {
     }
 }
 
+impl From<FlatCallFrame> for GethTrace {
+    fn from(value: FlatCallFrame) -> Self {
+        Self::FlatCallTracer(value)
+    }
+}
+
 impl From<PreStateFrame> for GethTrace {
     fn from(value: PreStateFrame) -> Self {
         Self::PreStateTracer(value)
@@ -246,6 +264,10 @@ pub enum GethDebugBuiltInTracerType {
     /// with the top-level call at root and sub-calls as children of the higher levels.
     #[serde(rename = "callTracer")]
     CallTracer,
+    /// Tracks all call frames of a transaction and returns them in a flat format, i.e. as opposed
+    /// to the nested format of `callTracer`.
+    #[serde(rename = "flatCallTracer")]
+    FlatCallTracer,
     /// The prestate tracer has two modes: prestate and diff. The prestate mode returns the
     /// accounts necessary to execute a given transaction. diff mode returns the differences
     /// between the transaction's pre and post-state (i.e. what changed because the transaction
@@ -305,6 +327,14 @@ impl GethDebugTracerConfig {
 
     /// Returns the [CallConfig] if it is a call config.
     pub fn into_call_config(self) -> Result<CallConfig, serde_json::Error> {
+        if self.0.is_null() {
+            return Ok(Default::default());
+        }
+        self.from_value()
+    }
+
+    /// Returns the [FlatCallConfig] if it is a call config.
+    pub fn into_flat_call_config(self) -> Result<FlatCallConfig, serde_json::Error> {
         if self.0.is_null() {
             return Ok(Default::default());
         }


### PR DESCRIPTION
closes #1291

adds missing types, luckily the flatcallframe appears to be the same as parity's type