### PR TITLE
chore(engine): `no_std` Checks

### DIFF
--- a/scripts/check_no_std.sh
+++ b/scripts/check_no_std.sh
@@ -9,6 +9,7 @@ crates=(
     alloy-consensus
     alloy-network-primitives
     alloy-rpc-types-eth
+    alloy-rpc-types-engine
 )
 
 cmd=(cargo +stable hack check --no-default-features --target "$target")


### PR DESCRIPTION
### Description

Adds `alloy-rpc-types-engine` to the `no_std` checks ci workflow.