### PR TITLE
feat(`node-bindings`): support appending extra args

### DIFF
--- a/crates/node-bindings/src/nodes/anvil.rs
+++ b/crates/node-bindings/src/nodes/anvil.rs
@@ -3,6 +3,7 @@
 use alloy_primitives::{hex, Address, ChainId};
 use k256::{ecdsa::SigningKey, SecretKey as K256SecretKey};
 use std::{
+    ffi::OsString,
     io::{BufRead, BufReader},
     net::SocketAddr,
     path::PathBuf,
@@ -123,7 +124,7 @@ pub struct Anvil {
     mnemonic: Option<String>,
     fork: Option<String>,
     fork_block_number: Option<u64>,
-    args: Vec<String>,
+    args: Vec<OsString>,
     timeout: Option<u64>,
 }
 
@@ -219,7 +220,7 @@ impl Anvil {
     }
 
     /// Adds an argument to pass to the `anvil`.
-    pub fn arg<T: Into<String>>(mut self, arg: T) -> Self {
+    pub fn arg<T: Into<OsString>>(mut self, arg: T) -> Self {
         self.args.push(arg.into());
         self
     }
@@ -228,7 +229,7 @@ impl Anvil {
     pub fn args<I, S>(mut self, args: I) -> Self
     where
         I: IntoIterator<Item = S>,
-        S: Into<String>,
+        S: Into<OsString>,
     {
         for arg in args {
             self = self.arg(arg);

--- a/crates/node-bindings/src/nodes/geth.rs
+++ b/crates/node-bindings/src/nodes/geth.rs
@@ -204,6 +204,7 @@ pub struct Geth {
     genesis: Option<Genesis>,
     mode: NodeMode,
     clique_private_key: Option<SigningKey>,
+    args: Vec<String>,
 }
 
 impl Geth {
@@ -364,6 +365,28 @@ impl Geth {
     /// Sets the port for authenticated RPC connections.
     pub const fn authrpc_port(mut self, port: u16) -> Self {
         self.authrpc_port = Some(port);
+        self
+    }
+
+    /// Adds an argument to pass to `geth`.
+    ///
+    /// Pass any arg that is not supported by the builder.
+    pub fn arg<T: Into<String>>(mut self, arg: T) -> Self {
+        self.args.push(arg.into());
+        self
+    }
+
+    /// Adds multiple arguments to pass to `geth`.
+    ///
+    /// Pass any args that is not supported by the builder.
+    pub fn args<I, S>(mut self, args: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        for arg in args {
+            self = self.arg(arg);
+        }
         self
     }
 
@@ -542,6 +565,8 @@ impl Geth {
         if let Some(ipc) = &self.ipc_path {
             cmd.arg("--ipcpath").arg(ipc);
         }
+
+        cmd.args(self.args);
 
         let mut child = cmd.spawn().map_err(NodeError::SpawnError)?;
 

--- a/crates/node-bindings/src/nodes/geth.rs
+++ b/crates/node-bindings/src/nodes/geth.rs
@@ -8,6 +8,7 @@ use alloy_genesis::{CliqueConfig, Genesis};
 use alloy_primitives::Address;
 use k256::ecdsa::SigningKey;
 use std::{
+    ffi::OsString,
     fs::{create_dir, File},
     io::{BufRead, BufReader},
     path::PathBuf,
@@ -204,7 +205,7 @@ pub struct Geth {
     genesis: Option<Genesis>,
     mode: NodeMode,
     clique_private_key: Option<SigningKey>,
-    args: Vec<String>,
+    args: Vec<OsString>,
 }
 
 impl Geth {
@@ -371,7 +372,7 @@ impl Geth {
     /// Adds an argument to pass to `geth`.
     ///
     /// Pass any arg that is not supported by the builder.
-    pub fn arg<T: Into<String>>(mut self, arg: T) -> Self {
+    pub fn arg<T: Into<OsString>>(mut self, arg: T) -> Self {
         self.args.push(arg.into());
         self
     }
@@ -382,7 +383,7 @@ impl Geth {
     pub fn args<I, S>(mut self, args: I) -> Self
     where
         I: IntoIterator<Item = S>,
-        S: Into<String>,
+        S: Into<OsString>,
     {
         for arg in args {
             self = self.arg(arg);

--- a/crates/node-bindings/src/nodes/reth.rs
+++ b/crates/node-bindings/src/nodes/reth.rs
@@ -160,6 +160,7 @@ pub struct Reth {
     data_dir: Option<PathBuf>,
     chain_or_path: Option<String>,
     genesis: Option<Genesis>,
+    args: Vec<String>,
 }
 
 impl Reth {
@@ -184,6 +185,7 @@ impl Reth {
             data_dir: None,
             chain_or_path: None,
             genesis: None,
+            args: Vec::new(),
         }
     }
 
@@ -306,6 +308,28 @@ impl Reth {
         self
     }
 
+    /// Adds an argument to pass to `reth`.
+    ///
+    /// Pass any arg that is not supported by the builder.
+    pub fn arg<T: Into<String>>(mut self, arg: T) -> Self {
+        self.args.push(arg.into());
+        self
+    }
+
+    /// Adds multiple arguments to pass to `reth`.
+    ///
+    /// Pass any args that is not supported by the builder.
+    pub fn args<I, S>(mut self, args: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        for arg in args {
+            self = self.arg(arg);
+        }
+        self
+    }
+
     /// Consumes the builder and spawns `reth`.
     ///
     /// # Panics
@@ -412,6 +436,9 @@ impl Reth {
 
         // Disable color output to make parsing logs easier.
         cmd.arg("--color").arg("never");
+
+        // Add any additional arguments.
+        cmd.args(self.args);
 
         let mut child = cmd.spawn().map_err(NodeError::SpawnError)?;
 

--- a/crates/node-bindings/src/nodes/reth.rs
+++ b/crates/node-bindings/src/nodes/reth.rs
@@ -4,6 +4,7 @@ use crate::{utils::extract_endpoint, NodeError, NODE_STARTUP_TIMEOUT};
 use alloy_genesis::Genesis;
 use rand::Rng;
 use std::{
+    ffi::OsString,
     fs::create_dir,
     io::{BufRead, BufReader},
     path::PathBuf,
@@ -160,7 +161,7 @@ pub struct Reth {
     data_dir: Option<PathBuf>,
     chain_or_path: Option<String>,
     genesis: Option<Genesis>,
-    args: Vec<String>,
+    args: Vec<OsString>,
 }
 
 impl Reth {
@@ -311,7 +312,7 @@ impl Reth {
     /// Adds an argument to pass to `reth`.
     ///
     /// Pass any arg that is not supported by the builder.
-    pub fn arg<T: Into<String>>(mut self, arg: T) -> Self {
+    pub fn arg<T: Into<OsString>>(mut self, arg: T) -> Self {
         self.args.push(arg.into());
         self
     }
@@ -322,7 +323,7 @@ impl Reth {
     pub fn args<I, S>(mut self, args: I) -> Self
     where
         I: IntoIterator<Item = S>,
-        S: Into<String>,
+        S: Into<OsString>,
     {
         for arg in args {
             self = self.arg(arg);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Currently, users cannot append any extra args to pass to `reth` or `geth`. We can only launch their respective instances with settings we have available in the builder api. 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Adds `args: Vec<OsString>` to both `Reth` and `Geth` that get appended to the `cmd` before spawning the instance.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
