### PR TITLE
feat(rpc-types-beacon): `BuilderBlockValidationRequestV3`

### DIFF
--- a/crates/rpc-types-beacon/src/relay.rs
+++ b/crates/rpc-types-beacon/src/relay.rs
@@ -211,6 +211,20 @@ pub struct BuilderBlockValidationRequestV2 {
     pub withdrawals_root: B256,
 }
 
+/// A Request to validate a [SubmitBlockRequest] <https://github.com/flashbots/builder/blob/7577ac81da21e760ec6693637ce2a81fe58ac9f8/eth/block-validation/api.go#L198-L202>
+#[serde_as]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BuilderBlockValidationRequestV3 {
+    /// The [SubmitBlockRequest] data to be validated.
+    #[serde(flatten)]
+    pub request: SubmitBlockRequest,
+    /// The registered gas limit for the validation request.
+    #[serde_as(as = "DisplayFromStr")]
+    pub registered_gas_limit: u64,
+    /// The parent beacon block root for the validation request.
+    pub parent_beacon_block_root: B256,
+}
+
 /// Query for the GET `/relay/v1/data/bidtraces/proposer_payload_delivered`
 ///
 /// Provides [BidTrace]s for payloads that were delivered to proposers.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

I'd like to add support for `flashbots_validateBuilderSubmissionV3` to reth, but we need the `BuilderBlockValidationRequestV3` for the rpc request param.

## Solution

This adds the aforementioned struct.  Note that the new struct does _not_ contain the `withdrawls_root` field present in `V2`.  I went through the latest flashbots/builder code and this parameter was [removed from the `V2` requests](https://github.com/flashbots/builder/blob/7577ac81da21e760ec6693637ce2a81fe58ac9f8/eth/block-validation/api.go#L159-L162), and is not present in `V3`:

https://github.com/flashbots/builder/blob/7577ac81da21e760ec6693637ce2a81fe58ac9f8/eth/block-validation/api.go#L198-L202

Furthermore the ultrasoundmoney implementation doesn't contain it either: https://github.com/ultrasoundmoney/reth-payload-validator/blob/main/src/rpc/types.rs#L12-L20

I did _not_ remove it from the `BuilderBlockValidationRequestV2` struct since that's potentially a breaking change, which seemed worth avoiding.

Finally, I'm unsure if I should add a `BuilderBlockValidationRequestV4` for Pectra: since `request` is a `SubmitBlockRequest` which uses the `ExecutionPayload` enum the `V3` and `V4` structs would have the exact same fields.  Alternatively, we could add `SubmitBlockRequestV3/V4` structs that use the explicit `ExecutionPayloadV3/V4` structs instead of the enum, but that would break the pattern established in `V2`. 

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
