### PR TITLE
Define `TransactionRespConstructor`

### DIFF
--- a/crates/network-primitives/src/lib.rs
+++ b/crates/network-primitives/src/lib.rs
@@ -14,7 +14,8 @@ pub use transaction::TransactionInfo;
 
 mod traits;
 pub use traits::{
-    BlockResponse, Constructor, HeaderResponse, ReceiptResponse, TransactionResponse,
+    BlockResponse, Constructor, HeaderResponse, ReceiptResponse, TransactionRespConstructor,
+    TransactionResponse,
 };
 
 mod block;

--- a/crates/network-primitives/src/lib.rs
+++ b/crates/network-primitives/src/lib.rs
@@ -9,8 +9,13 @@
 
 extern crate alloc;
 
+pub mod transaction;
+pub use transaction::TransactionInfo;
+
 mod traits;
-pub use traits::{BlockResponse, HeaderResponse, ReceiptResponse, TransactionResponse};
+pub use traits::{
+    BlockResponse, Constructor, HeaderResponse, ReceiptResponse, TransactionResponse,
+};
 
 mod block;
 pub use block::{BlockTransactionHashes, BlockTransactions, BlockTransactionsKind};

--- a/crates/network-primitives/src/traits.rs
+++ b/crates/network-primitives/src/traits.rs
@@ -4,6 +4,15 @@ use alloy_serde::WithOtherFields;
 
 use crate::BlockTransactions;
 
+/// Universal constructor trait.
+pub trait Constructor {
+    /// Data needed to construct type.
+    type Data<'a>;
+
+    /// Instantiates a new type from given data.
+    fn new(data: Self::Data<'_>) -> Self;
+}
+
 /// Receipt JSON-RPC response.
 pub trait ReceiptResponse {
     /// Address of the created contract, or `None` if the transaction was not a deployment.
@@ -62,7 +71,7 @@ pub trait ReceiptResponse {
 }
 
 /// Transaction JSON-RPC response.
-pub trait TransactionResponse {
+pub trait TransactionResponse: Constructor {
     /// Hash of the transaction
     #[doc(alias = "transaction_hash")]
     fn tx_hash(&self) -> TxHash;
@@ -148,6 +157,14 @@ pub trait BlockResponse {
     /// Returns the `other` field from `WithOtherFields` type.
     fn other_fields(&self) -> Option<&alloy_serde::OtherFields> {
         None
+    }
+}
+
+impl<T: Constructor> Constructor for WithOtherFields<T> {
+    type Data<'a> = T::Data<'a>;
+
+    fn new(data: Self::Data<'_>) -> Self {
+        Self { inner: T::new(data), other: Default::default() }
     }
 }
 

--- a/crates/network-primitives/src/traits.rs
+++ b/crates/network-primitives/src/traits.rs
@@ -70,8 +70,18 @@ pub trait ReceiptResponse {
     fn state_root(&self) -> Option<B256>;
 }
 
+/// Constructs an RPC response transaction.
+pub trait TransactionRespConstructor: Constructor {
+    /// Transaction data.
+    type UnsignedTx;
+    /// Signature of transaction.
+    type Signature;
+    /// Block context required for assembling the transaction for a RPC response.
+    type BlockCtx;
+}
+
 /// Transaction JSON-RPC response.
-pub trait TransactionResponse: Constructor {
+pub trait TransactionResponse: TransactionRespConstructor {
     /// Hash of the transaction
     #[doc(alias = "transaction_hash")]
     fn tx_hash(&self) -> TxHash;
@@ -166,6 +176,12 @@ impl<T: Constructor> Constructor for WithOtherFields<T> {
     fn new(data: Self::Data<'_>) -> Self {
         Self { inner: T::new(data), other: Default::default() }
     }
+}
+
+impl<T: TransactionRespConstructor> TransactionRespConstructor for WithOtherFields<T> {
+    type UnsignedTx = T::UnsignedTx;
+    type Signature = T::Signature;
+    type BlockCtx = T::BlockCtx;
 }
 
 impl<T: TransactionResponse> TransactionResponse for WithOtherFields<T> {

--- a/crates/network-primitives/src/transaction.rs
+++ b/crates/network-primitives/src/transaction.rs
@@ -1,5 +1,5 @@
 //! Commonly used additional types that are not part of the JSON RPC spec but are often required
-//! when working with RPC types, such as [Transaction]
+//! when working with RPC type [`TransactionResponse`](crate::TransactionResponse).
 
 use alloy_primitives::{BlockHash, TxHash};
 

--- a/crates/network-primitives/src/transaction.rs
+++ b/crates/network-primitives/src/transaction.rs
@@ -1,7 +1,6 @@
 //! Commonly used additional types that are not part of the JSON RPC spec but are often required
 //! when working with RPC types, such as [Transaction]
 
-use crate::Transaction;
 use alloy_primitives::{BlockHash, TxHash};
 
 /// Additional fields in the context of a block that contains this transaction.
@@ -25,19 +24,5 @@ impl TransactionInfo {
     pub const fn with_base_fee(mut self, base_fee: u128) -> Self {
         self.base_fee = Some(base_fee);
         self
-    }
-}
-
-impl From<&Transaction> for TransactionInfo {
-    fn from(tx: &Transaction) -> Self {
-        Self {
-            hash: Some(tx.hash),
-            index: tx.transaction_index,
-            block_hash: tx.block_hash,
-            block_number: tx.block_number,
-            // We don't know the base fee of the block when we're constructing this from
-            // `Transaction`
-            base_fee: None,
-        }
     }
 }

--- a/crates/rpc-types-eth/Cargo.toml
+++ b/crates/rpc-types-eth/Cargo.toml
@@ -26,7 +26,7 @@ alloy-rlp = { workspace = true, features = ["arrayvec", "derive"] }
 alloy-primitives = { workspace = true, features = ["rlp"] }
 
 itertools.workspace = true
-derive_more = { workspace = true, features = ["display"] }
+derive_more = { workspace = true, features = ["display", "constructor"] }
 
 # serde
 alloy-serde = { workspace = true, optional = true }

--- a/crates/rpc-types-eth/src/transaction/mod.rs
+++ b/crates/rpc-types-eth/src/transaction/mod.rs
@@ -339,7 +339,7 @@ impl TryFrom<Transaction> for TxEnvelope {
 
 impl TransactionRespConstructor for Transaction {
     type UnsignedTx = TxEnvelope;
-    type Signature = Signature;
+    type Signature = alloy_primitives::Signature;
     type BlockCtx = TransactionInfo;
 }
 
@@ -390,7 +390,7 @@ impl Constructor for Transaction {
             gas_price: Some(gas_price),
             max_fee_per_gas,
             max_priority_fee_per_gas: tx.max_priority_fee_per_gas(),
-            signature: Some(signature),
+            signature: Some(signature.into()),
             gas: tx.gas_limit(),
             input: tx.input().to_vec().into(),
             chain_id: tx.chain_id(),

--- a/crates/rpc-types-eth/src/transaction/mod.rs
+++ b/crates/rpc-types-eth/src/transaction/mod.rs
@@ -361,11 +361,13 @@ impl Constructor for Transaction {
 
         let transaction_type = TxType::try_from(tx.ty()).expect("should decode");
 
+        // formats max fee per gas for the rpc response w.r.t. hard fork
         let max_fee_per_gas = match transaction_type {
             TxType::Legacy | TxType::Eip2930 => None,
             TxType::Eip1559 | TxType::Eip4844 | TxType::Eip7702 => Some(tx.max_fee_per_gas()),
         };
 
+        // formats gas price for the rpc response, as it should be shown w.r.t. hard fork
         let gas_price = match transaction_type {
             TxType::Legacy | TxType::Eip2930 => tx.max_fee_per_gas(),
             TxType::Eip1559 | TxType::Eip4844 | TxType::Eip7702 => {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Ref https://github.com/alloy-rs/alloy/issues/1315.

Integration into reth, and integration of op-alloy into reth.

Requires at least https://github.com/paradigmxyz/reth/issues/10750

## Solution

Adds constructor to `TransactionResponse` trait, without loss of generality.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
