### PR TITLE
rpc: add `ExtendedTransaction` type

### DIFF
--- a/crates/rpc-types-eth/src/transaction/mod.rs
+++ b/crates/rpc-types-eth/src/transaction/mod.rs
@@ -7,6 +7,7 @@ use alloy_consensus::{
 use alloy_eips::eip7702::SignedAuthorization;
 use alloy_network_primitives::TransactionResponse;
 use alloy_primitives::{Address, BlockHash, Bytes, ChainId, TxHash, TxKind, B256, U256};
+use alloy_serde::WithOtherFields;
 
 use alloc::vec::Vec;
 
@@ -35,6 +36,15 @@ mod signature;
 pub use signature::{Parity, Signature};
 
 pub use alloy_consensus::{AnyReceiptEnvelope, Receipt, ReceiptEnvelope, ReceiptWithBloom};
+
+/// A transaction object that allows capturing additional fields not defined in the standard
+/// [`Transaction`].
+///
+/// This struct wraps around a [`Transaction`] and includes any extra fields present during
+/// deserialization. It is useful for scenarios where non-standard fields might be encountered.
+///
+/// See [`WithOtherFields`] for more information.
+pub type ExtendedTransaction = WithOtherFields<Transaction>;
 
 /// Transaction object used in RPC
 #[derive(Clone, Debug, Default, PartialEq, Eq)]


### PR DESCRIPTION
In reth, we have quite a few places in the code where we are using `WithOtherFields<Transaction>` and this is quite cumbersome to manipulate and a little bit long to write/read.

https://github.com/paradigmxyz/reth/blob/05f862af41e74319ba00a1254d3a74192d304cce/crates/rpc/rpc/src/txpool.rs#L34

As a consequence an `ExtendedTransaction` could be useful for easier manipulations.