### PR TITLE
feat(rpc-types-beacon): `BuilderBlockValidationRequestV4`

### DIFF
--- a/crates/rpc-types-beacon/src/relay.rs
+++ b/crates/rpc-types-beacon/src/relay.rs
@@ -225,6 +225,9 @@ pub struct BuilderBlockValidationRequestV3 {
     pub parent_beacon_block_root: B256,
 }
 
+/// A Request to validate a [SubmitBlockRequest] <https://github.com/flashbots/builder/blob/7577ac81da21e760ec6693637ce2a81fe58ac9f8/eth/block-validation/api.go#L198-L202>
+type BuilderBlockValidationRequestV4 = BuilderBlockValidationRequestV3;
+
 /// Query for the GET `/relay/v1/data/bidtraces/proposer_payload_delivered`
 ///
 /// Provides [BidTrace]s for payloads that were delivered to proposers.

--- a/crates/rpc-types-beacon/src/relay.rs
+++ b/crates/rpc-types-beacon/src/relay.rs
@@ -226,7 +226,7 @@ pub struct BuilderBlockValidationRequestV3 {
 }
 
 /// A Request to validate a [SubmitBlockRequest] <https://github.com/flashbots/builder/blob/7577ac81da21e760ec6693637ce2a81fe58ac9f8/eth/block-validation/api.go#L198-L202>
-type BuilderBlockValidationRequestV4 = BuilderBlockValidationRequestV3;
+pub type BuilderBlockValidationRequestV4 = BuilderBlockValidationRequestV3;
 
 /// Query for the GET `/relay/v1/data/bidtraces/proposer_payload_delivered`
 ///


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

As suggested by @mattsse [here](https://github.com/alloy-rs/alloy/pull/1310#issuecomment-2360727290) this is a simple type alias for `BuilderBlockValidationRequestV4`.

I still think we should consider refactoring these structs to use an explicit versioned `ExecutionPayloadV*` instead of the enum, but I'm not sure how we feel about breaking compat on the V1 and V2 structs.

We could also move them from `::relay` to `::validation` to mirror the layout in reth: https://github.com/paradigmxyz/reth/blob/3daec1d9b97c2d654c7f84e8521ac552dcaf4928/crates/rpc/rpc-api/src/validation.rs

## Solution

Anyways the type alias works for Pectra in the short-term, but happy to make the other changes if people are ok with that.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
