### PR TITLE
feat(consensus): move requests struct definition from reth

### DIFF
--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -26,6 +26,7 @@ alloy-serde = { workspace = true, optional = true }
 
 # kzg
 c-kzg = { workspace = true, features = ["serde"], optional = true }
+derive_more.workspace = true
 
 # arbitrary
 arbitrary = { workspace = true, features = ["derive"], optional = true }

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -26,7 +26,7 @@ pub use receipt::{
 };
 
 mod request;
-pub use request::Request;
+pub use request::{Request, Requests};
 
 pub mod transaction;
 #[cfg(feature = "kzg")]

--- a/crates/consensus/src/request.rs
+++ b/crates/consensus/src/request.rs
@@ -1,3 +1,4 @@
+use alloc::vec::Vec;
 use alloy_eips::{
     eip6110::DepositRequest,
     eip7002::WithdrawalRequest,

--- a/crates/consensus/src/request.rs
+++ b/crates/consensus/src/request.rs
@@ -4,7 +4,9 @@ use alloy_eips::{
     eip7251::ConsolidationRequest,
     eip7685::{Decodable7685, Eip7685Error, Encodable7685},
 };
+use alloy_primitives::{bytes, Bytes};
 use alloy_rlp::{Decodable, Encodable};
+use derive_more::{Deref, DerefMut, From, IntoIterator};
 
 /// Ethereum execution layer requests.
 ///
@@ -114,5 +116,39 @@ impl Decodable7685 for Request {
             2 => Self::ConsolidationRequest(ConsolidationRequest::decode(buf)?),
             ty => return Err(Eip7685Error::UnexpectedType(ty)),
         })
+    }
+}
+
+/// A list of EIP-7685 requests.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Hash, Deref, DerefMut, From, IntoIterator)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Requests(pub Vec<Request>);
+
+impl Encodable for Requests {
+    fn encode(&self, out: &mut dyn bytes::BufMut) {
+        let mut h = alloy_rlp::Header { list: true, payload_length: 0 };
+
+        let mut encoded = Vec::new();
+        for req in &self.0 {
+            let encoded_req = req.encoded_7685();
+            h.payload_length += encoded_req.len();
+            encoded.push(Bytes::from(encoded_req));
+        }
+
+        h.encode(out);
+        for req in encoded {
+            req.encode(out);
+        }
+    }
+}
+
+impl Decodable for Requests {
+    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        Ok(<Vec<Bytes> as Decodable>::decode(buf)?
+            .into_iter()
+            .map(|bytes| Request::decode_7685(&mut bytes.as_ref()))
+            .collect::<Result<Vec<_>, alloy_eips::eip7685::Eip7685Error>>()
+            .map(Self)?)
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->
It moves the `Requests` definition from reth to where `Request` is defined.

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
Related to: https://github.com/paradigmxyz/reth/issues/11082

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

