### PR TITLE
dep: add full feature to `derive_more`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,7 +137,7 @@ semver = "1.0"
 thiserror = "1.0"
 thiserror-no-std = "2.0.2"
 url = "2.5"
-derive_more = { version = "1.0.0", default-features = false, features = ["full"] }
+derive_more = { version = "1.0.0", default-features = false }
 http = "1.1.0"
 
 ## serde

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,7 +137,7 @@ semver = "1.0"
 thiserror = "1.0"
 thiserror-no-std = "2.0.2"
 url = "2.5"
-derive_more = { version = "1.0.0", default-features = false }
+derive_more = { version = "1.0.0", default-features = false, features = ["full"] }
 http = "1.1.0"
 
 ## serde

--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -26,7 +26,7 @@ alloy-serde = { workspace = true, optional = true }
 
 # kzg
 c-kzg = { workspace = true, features = ["serde"], optional = true }
-derive_more.workspace = true
+derive_more = { workspace = true, features = ["deref", "deref_mut", "from", "into_iterator"] }
 
 # arbitrary
 arbitrary = { workspace = true, features = ["derive"], optional = true }


### PR DESCRIPTION
As per the `derive_more` documentation and specifically https://github.com/JelteF/derive_more?tab=readme-ov-file#installation, it seems that in last versions of Rust, to compile properly, we need to specify features to avoid errors of this type:

```shell
error[E0432]: unresolved imports `derive_more::Deref`, `derive_more::DerefMut`, `derive_more::From`, `derive_more::IntoIterator`
   --> crates/consensus/src/request.rs:10:19
    |
10  | use derive_more::{Deref, DerefMut, From, IntoIterator};
    |                   ^^^^^  ^^^^^^^^  ^^^^  ^^^^^^^^^^^^ no `IntoIterator` in the root
    |                   |      |         |
    |                   |      |         no `From` in the root
    |                   |      no `DerefMut` in the root
    |                   no `Deref` in the root
```

Since we are using quite a few elements currently, we are choosing the full configuration for now.