### PR TITLE
fix: correct `encode_2718_len` for legacy transactions

### DIFF
--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -659,7 +659,10 @@ mod tests {
             value: U256::from(7_u64),
             ..Default::default()
         };
-        test_encode_decode_roundtrip(tx, Some(Signature::test_signature().with_parity(Parity::NonEip155(true))));
+        test_encode_decode_roundtrip(
+            tx,
+            Some(Signature::test_signature().with_parity(Parity::NonEip155(true))),
+        );
     }
 
     #[test]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

We did not include header length when calculating 2718 len for legacy transaction. This PR fixes this, refactors `rlp_payload_length` a bit and adds a test for legacy tx scenario

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
