### PR TITLE
fix: advance buffer during 2718 decoding

### DIFF
--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -636,9 +636,11 @@ mod tests {
         let tx_signed = tx.into_signed(signature);
         let tx_envelope: TxEnvelope = tx_signed.into();
         let encoded = tx_envelope.encoded_2718();
-        let decoded = TxEnvelope::decode_2718(&mut encoded.as_ref()).unwrap();
+        let mut slice = encoded.as_slice();
+        let decoded = TxEnvelope::decode_2718(&mut slice).unwrap();
         assert_eq!(encoded.len(), tx_envelope.encode_2718_len());
         assert_eq!(decoded, tx_envelope);
+        assert_eq!(slice.len(), 0);
     }
 
     #[test]

--- a/crates/eips/src/eip2718.rs
+++ b/crates/eips/src/eip2718.rs
@@ -113,7 +113,10 @@ pub trait Decodable2718: Sized {
     /// [EIP-2718]: https://eips.ethereum.org/EIPS/eip-2718
     fn decode_2718(buf: &mut &[u8]) -> Eip2718Result<Self> {
         Self::extract_type_byte(buf)
-            .map(|ty| Self::typed_decode(ty, &mut &buf[1..]))
+            .map(|ty| {
+                buf.advance(1);
+                Self::typed_decode(ty, buf)
+            })
             .unwrap_or_else(|| Self::fallback_decode(buf))
     }
 


### PR DESCRIPTION
## Motivation

This PR makes `decode_2718` advance the buffer it receives. Right now we only advance it when decoding legacy transactions

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
