### PR TITLE
feat: replacing the map types  (#1365)

### DIFF
--- a/crates/contract/Cargo.toml
+++ b/crates/contract/Cargo.toml
@@ -27,13 +27,11 @@ alloy-transport.workspace = true
 
 alloy-dyn-abi = { workspace = true, features = ["std"] }
 alloy-json-abi.workspace = true
-alloy-primitives.workspace = true
 alloy-sol-types.workspace = true
-
 futures-util.workspace = true
 futures.workspace = true
 thiserror.workspace = true
-
+alloy-primitives = {  features = ["map"], workspace = true }
 alloy-pubsub = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/crates/contract/src/interface.rs
+++ b/crates/contract/src/interface.rs
@@ -2,8 +2,8 @@ use crate::{ContractInstance, Error, Result};
 use alloy_dyn_abi::{DynSolValue, FunctionExt, JsonAbiExt};
 use alloy_json_abi::{Function, JsonAbi};
 use alloy_primitives::{Address, Selector};
-use std::collections::{BTreeMap, HashMap};
-
+use std::collections::{BTreeMap};
+use alloy_primitives::map::{HashMap};
 /// A smart contract interface.
 #[derive(Clone, Debug)]
 pub struct Interface {

--- a/crates/contract/src/interface.rs
+++ b/crates/contract/src/interface.rs
@@ -3,12 +3,13 @@ use alloy_dyn_abi::{DynSolValue, FunctionExt, JsonAbiExt};
 use alloy_json_abi::{Function, JsonAbi};
 use alloy_primitives::{Address, Selector};
 use std::collections::{BTreeMap};
-use alloy_primitives::map::{HashMap};
+use alloy_primitives::map::{SelectorHashMap, FbBuildHasher};
+use alloy_primitives::FixedBytes;
 /// A smart contract interface.
 #[derive(Clone, Debug)]
 pub struct Interface {
     abi: JsonAbi,
-    functions: HashMap<Selector, (String, usize)>,
+    functions: SelectorHashMap<(String, usize)>,
 }
 
 // TODO: events/errors
@@ -127,13 +128,12 @@ impl Interface {
 
 /// Utility function for creating a mapping between a unique signature and a
 /// name-index pair for accessing contract ABI items.
-fn create_mapping<T, S, F>(
+fn create_mapping<T, F>(
     elements: &BTreeMap<String, Vec<T>>,
     signature: F,
-) -> HashMap<S, (String, usize)>
+) -> SelectorHashMap<(String, usize)>
 where
-    S: std::hash::Hash + Eq,
-    F: Fn(&T) -> S + Copy,
+    F: Fn(&T) ->  FixedBytes<4> + Copy,
 {
     elements
         .iter()
@@ -143,5 +143,15 @@ where
                 .enumerate()
                 .map(move |(index, element)| (signature(element), (name.to_owned(), index)))
         })
-        .collect()
+        .collect::<SelectorHashMap<(String, usize)>>()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_json_abi::{JsonAbi, Function};
+    use std::collections::BTreeMap;
+//     fn mock_abi() -> JsonAbi {
+//         let mut 
+// }
 }

--- a/crates/json-rpc/src/common.rs
+++ b/crates/json-rpc/src/common.rs
@@ -18,10 +18,10 @@ use std::fmt::Display;
 /// This type implements [`Hash`] so that it can be used as a key in a
 /// [`HashMap`] or an item in a [`HashSet`].
 ///
-/// [`BTreeMap`]: std::collections::BTreeMap
-/// [`BTreeSet`]: std::collections::BTreeSet
-/// [`HashMap`]: std::collections::HashMap
-/// [`HashSet`]: std::collections::HashSet
+/// [`BTreeMap`]:  alloy_primitives::map::BTreeMap
+/// [`BTreeSet`]: alloy_primitives::map::BTreeSet
+/// [`HashMap`]: alloy_primitives::map::HashMap
+/// [`HashSet`]: alloy_primitives::map::HashSet
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Id {
     /// A number.

--- a/crates/rpc-types-debug/Cargo.toml
+++ b/crates/rpc-types-debug/Cargo.toml
@@ -19,6 +19,6 @@ rustdoc-args = ["--cfg", "docsrs"]
 workspace = true
 
 [dependencies]
-alloy-primitives = { workspace = true, features = ["serde", "std"] }
+alloy-primitives = { workspace = true, features = ["serde", "std", "map"] }
 
 serde.workspace = true

--- a/crates/rpc-types-debug/src/debug.rs
+++ b/crates/rpc-types-debug/src/debug.rs
@@ -2,8 +2,8 @@
 
 use alloy_primitives::{Bytes, B256};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
-
+//use std::collections::HashMap;
+use alloy_primitives::map::HashMap;
 /// Represents the execution witness of a block. Contains an optional map of state preimages.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ExecutionWitness {
@@ -22,3 +22,4 @@ pub struct ExecutionWitness {
     #[serde(default)]
     pub keys: Option<HashMap<B256, Bytes>>,
 }
+

--- a/crates/rpc-types-eth/Cargo.toml
+++ b/crates/rpc-types-eth/Cargo.toml
@@ -23,7 +23,7 @@ alloy-eips.workspace = true
 alloy-consensus.workspace = true
 alloy-network-primitives.workspace = true
 alloy-rlp = { workspace = true, features = ["arrayvec", "derive"] }
-alloy-primitives = { workspace = true, features = ["rlp"] }
+alloy-primitives = { workspace = true, features = ["rlp", "map"] }
 
 itertools.workspace = true
 derive_more = { workspace = true, features = ["display"] }

--- a/crates/rpc-types-eth/src/lib.rs
+++ b/crates/rpc-types-eth/src/lib.rs
@@ -15,7 +15,7 @@ extern crate alloc;
 pub mod collections {
     cfg_if::cfg_if! {
         if #[cfg(feature = "std")] {
-            pub use std::collections::{hash_set, HashMap, HashSet};
+            pub use alloy_primitives::map::{hash_set, HashMap, HashSet};
             use hashbrown as _;
         } else {
             pub use hashbrown::{hash_set, HashMap, HashSet};

--- a/crates/rpc-types-eth/src/lib.rs
+++ b/crates/rpc-types-eth/src/lib.rs
@@ -12,16 +12,7 @@
 extern crate alloc;
 
 /// Standardized collections across `std` and `no_std` environments.
-pub mod collections {
-    cfg_if::cfg_if! {
-        if #[cfg(feature = "std")] {
-            pub use alloy_primitives::map::{hash_set, HashMap, HashSet};
-            use hashbrown as _;
-        } else {
-            pub use hashbrown::{hash_set, HashMap, HashSet};
-        }
-    }
-}
+
 
 pub use alloy_eips::eip4895::Withdrawal;
 

--- a/crates/rpc-types-trace/Cargo.toml
+++ b/crates/rpc-types-trace/Cargo.toml
@@ -19,7 +19,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 workspace = true
 
 [dependencies]
-alloy-primitives = { workspace = true, features = ["rlp", "serde"] }
+alloy-primitives = { workspace = true, features = ["rlp", "serde", "map"] }
 alloy-rpc-types-eth = { workspace = true, features = ["std", "serde"] }
 alloy-serde.workspace = true
 

--- a/crates/rpc-types-trace/src/filter.rs
+++ b/crates/rpc-types-trace/src/filter.rs
@@ -5,8 +5,7 @@ use crate::parity::{
 };
 use alloy_primitives::Address;
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
-
+use alloy_primitives::map::HashSet;
 /// Trace filter.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]

--- a/crates/rpc-types-trace/src/geth/mux.rs
+++ b/crates/rpc-types-trace/src/geth/mux.rs
@@ -2,7 +2,7 @@
 
 use crate::geth::{GethDebugBuiltInTracerType, GethDebugTracerConfig, GethTrace};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use alloy_primitives::map::HashMap;
 
 /// A `muxTracer` config that contains the configuration for running multiple tracers in one go.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/rpc-types-trace/src/tracerequest.rs
+++ b/crates/rpc-types-trace/src/tracerequest.rs
@@ -5,7 +5,8 @@ use alloy_rpc_types_eth::{
     request::TransactionRequest, state::StateOverride, BlockId, BlockOverrides,
 };
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
+
+use alloy_primitives::map::HashSet;
 
 /// Container type for `trace_call` arguments
 #[derive(Debug, Default, Serialize, Deserialize)]

--- a/crates/rpc-types/Cargo.toml
+++ b/crates/rpc-types/Cargo.toml
@@ -30,6 +30,7 @@ alloy-rpc-types-mev = { workspace = true, optional = true }
 alloy-rpc-types-trace = { workspace = true, optional = true }
 alloy-rpc-types-txpool = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive", "std"] }
+alloy-primitives = { version = "0.8.5", features = ["map"] }
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/crates/rpc-types/src/rpc.rs
+++ b/crates/rpc-types/src/rpc.rs
@@ -1,7 +1,6 @@
 //! Types for the `rpc` API.
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
-
+use alloy_primitives::map::HashMap;
 /// Represents the `rpc_modules` response, which returns the
 /// list of all available modules on that transport and their version
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -28,13 +27,16 @@ mod tests {
     #[test]
     fn test_parse_module_versions_roundtrip() {
         let s = r#"{"txpool":"1.0","trace":"1.0","eth":"1.0","web3":"1.0","net":"1.0"}"#;
-        let module_map = HashMap::from([
+        let mut module_map: HashMap<String, String> = HashMap::default(); // Change to FxHashMap
+
+         module_map.extend([
             ("txpool".to_owned(), "1.0".to_owned()),
             ("trace".to_owned(), "1.0".to_owned()),
             ("eth".to_owned(), "1.0".to_owned()),
             ("web3".to_owned(), "1.0".to_owned()),
             ("net".to_owned(), "1.0".to_owned()),
         ]);
+        
         let m = RpcModules::new(module_map);
         let de_serialized: RpcModules = serde_json::from_str(s).unwrap();
         assert_eq!(de_serialized, m);


### PR DESCRIPTION
- replacing the HashMap and HashSet from the std::collections to the alloy-primitives along with setting up the cargo file.

- setting the dependencies in the cargo files

- [ ]Bug fixes and new features should include tests: TBD.



## Motivation

to close the PR #1365 . 


## Solution

migrating the types as defined in the given issue.


## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
