### PR TITLE
feat(signer-local): add `keystore-geth-compat` feature

### DIFF
--- a/crates/signer-local/Cargo.toml
+++ b/crates/signer-local/Cargo.toml
@@ -58,6 +58,7 @@ yubihsm = { version = "0.42", features = ["mockhsm"] }
 
 [features]
 keystore = ["dep:eth-keystore", "dep:elliptic-curve"]
+keystore-geth-compat = ["keystore", "eth-keystore?/geth-compat"]
 mnemonic = ["dep:coins-bip32", "dep:coins-bip39"]
 mnemonic-all-languages = ["mnemonic", "coins-bip39?/all-langs"]
 yubihsm = ["dep:yubihsm", "dep:elliptic-curve"]

--- a/crates/signer-local/src/private_key.rs
+++ b/crates/signer-local/src/private_key.rs
@@ -253,6 +253,28 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "keystore-geth-compat")]
+    fn test_encrypted_json_keystore_with_address() {
+        // create and store an encrypted JSON keystore in this directory
+
+        use std::fs::File;
+
+        use eth_keystore::EthKeystore;
+        let dir = tempdir().unwrap();
+        let mut rng = rand::thread_rng();
+        let (key, uuid) =
+            LocalSigner::<SigningKey>::new_keystore(&dir, &mut rng, "randpsswd", None).unwrap();
+
+        let path = Path::new(dir.path()).join(uuid.clone());
+        let file = File::open(path).unwrap();
+        let keystore = serde_json::from_reader::<_, EthKeystore>(file).unwrap();
+
+        assert!(!keystore.address.is_zero());
+
+        test_encrypted_json_keystore(key, &uuid, dir.path());
+    }
+
+    #[test]
     fn signs_msg() {
         let message = "Some data";
         let hash = alloy_primitives::utils::eip191_hash_message(message);


### PR DESCRIPTION
Add `keystore-geth-compat` feature for `signer-local` crate, in order to enable the serialization of the `address` field in the keystore file.

## Motivation
 
Close #1376 .

## Solution

Add `keystore-geth-compat` feature, which requires the `keystore` one to be enabled, in the `Cargo.toml` file.

## PR Checklist

- [X] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
