### PR TITLE
fix: ensure `max_fee_per_blob_gas` field handles `Some(0)` gracefully

### DIFF
--- a/crates/provider/Cargo.toml
+++ b/crates/provider/Cargo.toml
@@ -61,6 +61,7 @@ tracing.workspace = true
 url = { workspace = true, optional = true }
 
 [dev-dependencies]
+alloy-consensus = { workspace = true, features = ["kzg"] }
 alloy-primitives = { workspace = true, features = ["rand"] }
 alloy-node-bindings.workspace = true
 alloy-rpc-client = { workspace = true, features = ["reqwest"] }

--- a/crates/provider/src/fillers/gas.rs
+++ b/crates/provider/src/fillers/gas.rs
@@ -279,7 +279,7 @@ mod tests {
 
         let receipt = tx.get_receipt().await.unwrap();
 
-        assert_eq!(receipt.effective_gas_price, 10_000_000_01);
+        assert_eq!(receipt.effective_gas_price, 1_000_000_001);
         assert_eq!(receipt.gas_used, 21000);
     }
 

--- a/crates/provider/src/fillers/gas.rs
+++ b/crates/provider/src/fillers/gas.rs
@@ -6,6 +6,7 @@ use crate::{
     utils::Eip1559Estimation,
     Provider,
 };
+use alloy_eips::eip4844::BLOB_TX_MIN_BLOB_GASPRICE;
 use alloy_json_rpc::RpcError;
 use alloy_network::{Network, TransactionBuilder, TransactionBuilder4844};
 use alloy_network_primitives::{BlockResponse, HeaderResponse};
@@ -216,7 +217,9 @@ where
         T: Transport + Clone,
     {
         if let Some(max_fee_per_blob_gas) = tx.max_fee_per_blob_gas() {
-            return Ok(max_fee_per_blob_gas);
+            if max_fee_per_blob_gas >= BLOB_TX_MIN_BLOB_GASPRICE {
+                return Ok(max_fee_per_blob_gas);
+            }
         }
         provider
             .get_block_by_number(BlockNumberOrTag::Latest, false)


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Closes: https://github.com/alloy-rs/alloy/issues/1371

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Related Foundry PR: https://github.com/foundry-rs/foundry/pull/8963 that depends on this implementation

If `max_fee_per_blob_gas` is `Some(0)` or `None` we set it to a valid value `next_block_blob_fee()`.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
