### PR TITLE
Return static `Eip658Value` from `TxReceipt` trait method

### DIFF
--- a/crates/consensus/src/receipt/any.rs
+++ b/crates/consensus/src/receipt/any.rs
@@ -87,7 +87,7 @@ impl<T> AnyReceiptEnvelope<T> {
 }
 
 impl<T> TxReceipt<T> for AnyReceiptEnvelope<T> {
-    fn status_or_post_state(&self) -> &Eip658Value {
+    fn status_or_post_state(&self) -> Eip658Value {
         self.inner.status_or_post_state()
     }
 

--- a/crates/consensus/src/receipt/envelope.rs
+++ b/crates/consensus/src/receipt/envelope.rs
@@ -1,4 +1,4 @@
-use crate::{Receipt, ReceiptWithBloom, TxReceipt, TxType};
+use crate::{Eip658Value, Receipt, ReceiptWithBloom, TxReceipt, TxType};
 use alloy_eips::eip2718::{Decodable2718, Eip2718Error, Eip2718Result, Encodable2718};
 use alloy_primitives::{Bloom, Log};
 use alloy_rlp::{length_of_length, BufMut, Decodable, Encodable};
@@ -108,8 +108,8 @@ impl<T> ReceiptEnvelope<T> {
 }
 
 impl<T> TxReceipt<T> for ReceiptEnvelope<T> {
-    fn status_or_post_state(&self) -> &crate::Eip658Value {
-        &self.as_receipt().unwrap().status
+    fn status_or_post_state(&self) -> Eip658Value {
+        self.as_receipt().unwrap().status
     }
 
     fn status(&self) -> bool {

--- a/crates/consensus/src/receipt/mod.rs
+++ b/crates/consensus/src/receipt/mod.rs
@@ -23,7 +23,7 @@ pub trait TxReceipt<T = Log> {
     /// is pre-[EIP-658].
     ///
     /// [EIP-658]: https://eips.ethereum.org/EIPS/eip-658
-    fn status_or_post_state(&self) -> &Eip658Value;
+    fn status_or_post_state(&self) -> Eip658Value;
 
     /// Returns true if the transaction was successful OR if the transaction is
     /// pre-[EIP-658]. Results for transactions before [EIP-658] are not

--- a/crates/consensus/src/receipt/receipts.rs
+++ b/crates/consensus/src/receipt/receipts.rs
@@ -73,8 +73,8 @@ impl<T> TxReceipt<T> for Receipt<T>
 where
     T: Borrow<Log>,
 {
-    fn status_or_post_state(&self) -> &Eip658Value {
-        &self.status
+    fn status_or_post_state(&self) -> Eip658Value {
+        self.status
     }
 
     fn status(&self) -> bool {
@@ -159,8 +159,8 @@ pub struct ReceiptWithBloom<T = Log> {
 }
 
 impl<T> TxReceipt<T> for ReceiptWithBloom<T> {
-    fn status_or_post_state(&self) -> &Eip658Value {
-        &self.receipt.status
+    fn status_or_post_state(&self) -> Eip658Value {
+        self.receipt.status
     }
 
     fn status(&self) -> bool {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Enable conversion from bool to `Eip658Value` in `TxReceipt::status_or_post_state` trait method body

## Solution

Changes signature `TxReceipt::status_or_post_state` from returning ref to `Eip658Value`, to returning static type

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [x] Breaking changes
