### PR TITLE
Auto-impl `alloy_consensus::TxReceipt` for ref

### DIFF
--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -33,12 +33,14 @@ arbitrary = { workspace = true, features = ["derive"], optional = true }
 # serde
 serde = { workspace = true, features = ["derive"], optional = true }
 
+# misc
 derive_more = { workspace = true, features = [
     "from",
     "deref",
     "deref_mut",
     "into_iterator"
 ], default-features = false }
+auto_impl.workspace = true
 
 [dev-dependencies]
 alloy-primitives = { workspace = true, features = ["arbitrary", "rand"] }

--- a/crates/consensus/src/receipt/mod.rs
+++ b/crates/consensus/src/receipt/mod.rs
@@ -14,6 +14,7 @@ pub use status::Eip658Value;
 
 /// Receipt is the result of a transaction execution.
 #[doc(alias = "TransactionReceipt")]
+#[auto_impl::auto_impl(&, Arc)]
 pub trait TxReceipt<T = Log> {
     /// Returns the status or post state of the transaction.
     ///


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Ease of usage of trait, especially in function signatures that return opaque type.

## Solution

Auto-impl `alloy_consensus::TxReceipt` for `&` and `Arc`

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
