### PR TITLE
chore(consensus): less derives for bincode compatible types

### DIFF
--- a/crates/consensus/src/header.rs
+++ b/crates/consensus/src/header.rs
@@ -844,9 +844,7 @@ pub(super) mod serde_bincode_compat {
     ///     header: Header,
     /// }
     /// ```
-    #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[derive(Debug, Serialize, Deserialize)]
     pub struct Header<'a> {
         parent_hash: B256,
         ommers_hash: B256,

--- a/crates/consensus/src/header.rs
+++ b/crates/consensus/src/header.rs
@@ -838,7 +838,7 @@ pub(super) mod serde_bincode_compat {
     /// use serde_with::serde_as;
     ///
     /// #[serde_as]
-    /// #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+    /// #[derive(Serialize, Deserialize)]
     /// struct Data {
     ///     #[serde_as(as = "serde_bincode_compat::Header")]
     ///     header: Header,

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -63,6 +63,7 @@ pub use signed::Signed;
 #[cfg(all(feature = "serde", feature = "serde-bincode-compat"))]
 pub mod serde_bincode_compat {
     pub use super::{
-        header::serde_bincode_compat::*, transaction::serde_bincode_compat as transaction,
+        header::serde_bincode_compat::*,
+        transaction::{serde_bincode_compat as transaction, serde_bincode_compat::*},
     };
 }

--- a/crates/consensus/src/transaction/eip1559.rs
+++ b/crates/consensus/src/transaction/eip1559.rs
@@ -468,7 +468,7 @@ pub(super) mod serde_bincode_compat {
     /// use serde_with::serde_as;
     ///
     /// #[serde_as]
-    /// #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+    /// #[derive(Serialize, Deserialize)]
     /// struct Data {
     ///     #[serde_as(as = "serde_bincode_compat::transaction::TxEip1559")]
     ///     transaction: TxEip1559,

--- a/crates/consensus/src/transaction/eip1559.rs
+++ b/crates/consensus/src/transaction/eip1559.rs
@@ -474,9 +474,7 @@ pub(super) mod serde_bincode_compat {
     ///     transaction: TxEip1559,
     /// }
     /// ```
-    #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[derive(Debug, Serialize, Deserialize)]
     pub struct TxEip1559<'a> {
         chain_id: ChainId,
         nonce: u64,

--- a/crates/consensus/src/transaction/eip2930.rs
+++ b/crates/consensus/src/transaction/eip2930.rs
@@ -431,9 +431,7 @@ pub(super) mod serde_bincode_compat {
     ///     transaction: TxEip2930,
     /// }
     /// ```
-    #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[derive(Debug, Serialize, Deserialize)]
     pub struct TxEip2930<'a> {
         chain_id: ChainId,
         nonce: u64,

--- a/crates/consensus/src/transaction/eip2930.rs
+++ b/crates/consensus/src/transaction/eip2930.rs
@@ -425,7 +425,7 @@ pub(super) mod serde_bincode_compat {
     /// use serde_with::serde_as;
     ///
     /// #[serde_as]
-    /// #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+    /// #[derive(Serialize, Deserialize)]
     /// struct Data {
     ///     #[serde_as(as = "serde_bincode_compat::transaction::TxEip2930")]
     ///     transaction: TxEip2930,

--- a/crates/consensus/src/transaction/legacy.rs
+++ b/crates/consensus/src/transaction/legacy.rs
@@ -413,9 +413,7 @@ pub(super) mod serde_bincode_compat {
     ///     header: TxLegacy,
     /// }
     /// ```
-    #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[derive(Debug, Serialize, Deserialize)]
     pub struct TxLegacy<'a> {
         #[serde(default, with = "alloy_serde::quantity::opt")]
         chain_id: Option<ChainId>,
@@ -484,7 +482,7 @@ pub(super) mod serde_bincode_compat {
         use super::super::{serde_bincode_compat, TxLegacy};
 
         #[test]
-        fn test_tx_eip1559_bincode_roundtrip() {
+        fn test_tx_legacy_bincode_roundtrip() {
             #[serde_as]
             #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
             struct Data {

--- a/crates/consensus/src/transaction/legacy.rs
+++ b/crates/consensus/src/transaction/legacy.rs
@@ -407,7 +407,7 @@ pub(super) mod serde_bincode_compat {
     /// use serde_with::serde_as;
     ///
     /// #[serde_as]
-    /// #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+    /// #[derive(Serialize, Deserialize)]
     /// struct Data {
     ///     #[serde_as(as = "serde_bincode_compat::transaction::TxLegacy")]
     ///     header: TxLegacy,


### PR DESCRIPTION
A small cleanup after https://github.com/alloy-rs/alloy/pull/1397. Changing the field names is non-breaking because bincode doesn't store any metadata for fields, including their names.