### PR TITLE
tests: fix more ci only

### DIFF
--- a/crates/provider/Cargo.toml
+++ b/crates/provider/Cargo.toml
@@ -91,6 +91,7 @@ tower-http = { workspace = true, features = [
 http-body-util.workspace = true
 http.workspace = true
 alloy-rpc-types-engine = { workspace = true, features = ["jwt"] }
+ci_info.workspace = true
 
 [features]
 default = ["reqwest", "reqwest-default-tls"]

--- a/crates/provider/src/blocks.rs
+++ b/crates/provider/src/blocks.rs
@@ -185,10 +185,6 @@ mod tests {
     use alloy_primitives::U256;
     use std::{future::Future, time::Duration};
 
-    fn init_tracing() {
-        let _ = tracing_subscriber::fmt::try_init();
-    }
-
     async fn timeout<T: Future>(future: T) -> T::Output {
         try_timeout(future).await.expect("Timeout")
     }
@@ -207,8 +203,6 @@ mod tests {
         yield_block(true).await;
     }
     async fn yield_block(ws: bool) {
-        init_tracing();
-
         let anvil = Anvil::new().spawn();
 
         let url = if ws { anvil.ws_endpoint() } else { anvil.endpoint() };
@@ -239,8 +233,6 @@ mod tests {
     async fn yield_many_blocks(ws: bool) {
         // Make sure that we can process more blocks than fits in the cache.
         const BLOCKS_TO_MINE: usize = BLOCK_CACHE_SIZE.get() + 1;
-
-        init_tracing();
 
         let anvil = Anvil::new().spawn();
 

--- a/crates/provider/src/ext/mod.rs
+++ b/crates/provider/src/ext/mod.rs
@@ -44,3 +44,17 @@ pub use txpool::TxPoolApi;
 mod erc4337;
 #[cfg(feature = "erc4337-api")]
 pub use erc4337::Erc4337Api;
+
+#[cfg(test)]
+pub(crate) mod test {
+    /// Run the given function only if we are in a CI environment.
+    pub(crate) async fn async_ci_only<F, Fut>(f: F)
+    where
+        F: FnOnce() -> Fut,
+        Fut: std::future::Future<Output = ()>,
+    {
+        if ci_info::is_ci() {
+            f().await;
+        }
+    }
+}

--- a/crates/provider/src/ext/mod.rs
+++ b/crates/provider/src/ext/mod.rs
@@ -47,6 +47,7 @@ pub use erc4337::Erc4337Api;
 
 #[cfg(test)]
 pub(crate) mod test {
+    #[allow(dead_code)] // dead only when all features off
     /// Run the given function only if we are in a CI environment.
     pub(crate) async fn async_ci_only<F, Fut>(f: F)
     where

--- a/crates/provider/src/ext/net.rs
+++ b/crates/provider/src/ext/net.rs
@@ -38,44 +38,54 @@ where
 
 #[cfg(test)]
 mod test {
-    use crate::ProviderBuilder;
-
     use super::*;
+    use crate::{ext::test::async_ci_only, ProviderBuilder};
     use alloy_node_bindings::{utils::run_with_tempdir, Geth};
 
     #[tokio::test]
     async fn call_net_version() {
-        run_with_tempdir("geth-test-", |temp_dir| async move {
-            let geth = Geth::new().disable_discovery().data_dir(temp_dir).spawn();
-            let provider = ProviderBuilder::new().on_http(geth.endpoint_url());
+        async_ci_only(|| async move {
+            run_with_tempdir("geth-test-", |temp_dir| async move {
+                let geth = Geth::new().disable_discovery().data_dir(temp_dir).spawn();
+                let provider = ProviderBuilder::new().on_http(geth.endpoint_url());
 
-            let version = provider.net_version().await.expect("net_version call should succeed");
-            assert_eq!(version, 1);
+                let version =
+                    provider.net_version().await.expect("net_version call should succeed");
+                assert_eq!(version, 1);
+            })
+            .await;
         })
         .await;
     }
 
     #[tokio::test]
     async fn call_net_peer_count() {
-        run_with_tempdir("geth-test-", |temp_dir| async move {
-            let geth = Geth::new().disable_discovery().data_dir(temp_dir).spawn();
-            let provider = ProviderBuilder::new().on_http(geth.endpoint_url());
+        async_ci_only(|| async move {
+            run_with_tempdir("geth-test-", |temp_dir| async move {
+                let geth = Geth::new().disable_discovery().data_dir(temp_dir).spawn();
+                let provider = ProviderBuilder::new().on_http(geth.endpoint_url());
 
-            let count = provider.net_peer_count().await.expect("net_peerCount call should succeed");
-            assert_eq!(count, 0);
+                let count =
+                    provider.net_peer_count().await.expect("net_peerCount call should succeed");
+                assert_eq!(count, 0);
+            })
+            .await;
         })
         .await;
     }
 
     #[tokio::test]
     async fn call_net_listening() {
-        run_with_tempdir("geth-test-", |temp_dir| async move {
-            let geth = Geth::new().disable_discovery().data_dir(temp_dir).spawn();
-            let provider = ProviderBuilder::new().on_http(geth.endpoint_url());
+        async_ci_only(|| async move {
+            run_with_tempdir("geth-test-", |temp_dir| async move {
+                let geth = Geth::new().disable_discovery().data_dir(temp_dir).spawn();
+                let provider = ProviderBuilder::new().on_http(geth.endpoint_url());
 
-            let listening =
-                provider.net_listening().await.expect("net_listening call should succeed");
-            assert!(listening);
+                let listening =
+                    provider.net_listening().await.expect("net_listening call should succeed");
+                assert!(listening);
+            })
+            .await;
         })
         .await;
     }

--- a/crates/provider/src/ext/txpool.rs
+++ b/crates/provider/src/ext/txpool.rs
@@ -75,51 +75,62 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::ProviderBuilder;
-
     use super::*;
+    use crate::{ext::test::async_ci_only, ProviderBuilder};
     use alloy_node_bindings::{utils::run_with_tempdir, Geth};
 
     #[tokio::test]
     async fn test_txpool_content() {
-        run_with_tempdir("geth-test-", |temp_dir| async move {
-            let geth = Geth::new().disable_discovery().data_dir(temp_dir).spawn();
-            let provider = ProviderBuilder::new().on_http(geth.endpoint_url());
-            let content = provider.txpool_content().await.unwrap();
-            assert_eq!(content, TxpoolContent::default());
+        async_ci_only(|| async move {
+            run_with_tempdir("geth-test-", |temp_dir| async move {
+                let geth = Geth::new().disable_discovery().data_dir(temp_dir).spawn();
+                let provider = ProviderBuilder::new().on_http(geth.endpoint_url());
+                let content = provider.txpool_content().await.unwrap();
+                assert_eq!(content, TxpoolContent::default());
+            })
+            .await;
         })
         .await;
     }
 
     #[tokio::test]
     async fn test_txpool_content_from() {
-        run_with_tempdir("geth-test-", |temp_dir| async move {
-            let geth = Geth::new().disable_discovery().data_dir(temp_dir).spawn();
-            let provider = ProviderBuilder::new().on_http(geth.endpoint_url());
-            let content = provider.txpool_content_from(Address::default()).await.unwrap();
-            assert_eq!(content, TxpoolContentFrom::default());
+        async_ci_only(|| async move {
+            run_with_tempdir("geth-test-", |temp_dir| async move {
+                let geth = Geth::new().disable_discovery().data_dir(temp_dir).spawn();
+                let provider = ProviderBuilder::new().on_http(geth.endpoint_url());
+                let content = provider.txpool_content_from(Address::default()).await.unwrap();
+                assert_eq!(content, TxpoolContentFrom::default());
+            })
+            .await;
         })
         .await;
     }
 
     #[tokio::test]
     async fn test_txpool_inspect() {
-        run_with_tempdir("geth-test-", |temp_dir| async move {
-            let geth = Geth::new().disable_discovery().data_dir(temp_dir).spawn();
-            let provider = ProviderBuilder::new().on_http(geth.endpoint_url());
-            let content = provider.txpool_inspect().await.unwrap();
-            assert_eq!(content, TxpoolInspect::default());
+        async_ci_only(|| async move {
+            run_with_tempdir("geth-test-", |temp_dir| async move {
+                let geth = Geth::new().disable_discovery().data_dir(temp_dir).spawn();
+                let provider = ProviderBuilder::new().on_http(geth.endpoint_url());
+                let content = provider.txpool_inspect().await.unwrap();
+                assert_eq!(content, TxpoolInspect::default());
+            })
+            .await;
         })
         .await;
     }
 
     #[tokio::test]
     async fn test_txpool_status() {
-        run_with_tempdir("geth-test-", |temp_dir| async move {
-            let geth = Geth::new().disable_discovery().data_dir(temp_dir).spawn();
-            let provider = ProviderBuilder::new().on_http(geth.endpoint_url());
-            let content = provider.txpool_status().await.unwrap();
-            assert_eq!(content, TxpoolStatus::default());
+        async_ci_only(|| async move {
+            run_with_tempdir("geth-test-", |temp_dir| async move {
+                let geth = Geth::new().disable_discovery().data_dir(temp_dir).spawn();
+                let provider = ProviderBuilder::new().on_http(geth.endpoint_url());
+                let content = provider.txpool_status().await.unwrap();
+                assert_eq!(content, TxpoolStatus::default());
+            })
+            .await;
         })
         .await;
     }

--- a/crates/provider/src/fillers/gas.rs
+++ b/crates/provider/src/fillers/gas.rs
@@ -257,14 +257,8 @@ mod tests {
     use alloy_primitives::{address, U256};
     use alloy_rpc_types_eth::TransactionRequest;
 
-    fn init_tracing() {
-        let _ = tracing_subscriber::fmt::try_init();
-    }
-
     #[tokio::test]
     async fn no_gas_price_or_limit() {
-        init_tracing();
-
         let provider = ProviderBuilder::new().with_recommended_fillers().on_anvil_with_wallet();
 
         // GasEstimationLayer requires chain_id to be set to handle EIP-1559 tx
@@ -285,8 +279,6 @@ mod tests {
 
     #[tokio::test]
     async fn no_gas_limit() {
-        init_tracing();
-
         let provider = ProviderBuilder::new().with_recommended_fillers().on_anvil_with_wallet();
 
         let gas_price = provider.get_gas_price().await.unwrap();
@@ -306,8 +298,6 @@ mod tests {
 
     #[tokio::test]
     async fn no_max_fee_per_blob_gas() {
-        init_tracing();
-
         let provider = ProviderBuilder::new().with_recommended_fillers().on_anvil_with_wallet();
 
         let sidecar: SidecarBuilder<SimpleCoder> = SidecarBuilder::from_slice(b"Hello World");
@@ -335,8 +325,6 @@ mod tests {
 
     #[tokio::test]
     async fn zero_max_fee_per_blob_gas() {
-        init_tracing();
-
         let provider = ProviderBuilder::new().with_recommended_fillers().on_anvil_with_wallet();
 
         let sidecar: SidecarBuilder<SimpleCoder> = SidecarBuilder::from_slice(b"Hello World");

--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -1098,13 +1098,8 @@ mod tests {
     #[cfg(feature = "hyper")]
     use tower::{Layer, Service};
 
-    fn init_tracing() {
-        let _ = tracing_subscriber::fmt::try_init();
-    }
-
     #[tokio::test]
     async fn test_provider_builder() {
-        init_tracing();
         let provider =
             RootProvider::<BoxTransport, Ethereum>::builder().with_recommended_fillers().on_anvil();
         let num = provider.get_block_number().await.unwrap();
@@ -1113,7 +1108,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_builder_helper_fn() {
-        init_tracing();
         let provider = builder().with_recommended_fillers().on_anvil();
         let num = provider.get_block_number().await.unwrap();
         assert_eq!(0, num);
@@ -1122,7 +1116,6 @@ mod tests {
     #[cfg(feature = "hyper")]
     #[tokio::test]
     async fn test_default_hyper_transport() {
-        init_tracing();
         let anvil = Anvil::new().spawn();
         let hyper_t = alloy_transport_http::HyperTransport::new_hyper(anvil.endpoint_url());
 
@@ -1185,7 +1178,6 @@ mod tests {
         use tower_http::{
             sensitive_headers::SetSensitiveRequestHeadersLayer, set_header::SetRequestHeaderLayer,
         };
-        init_tracing();
         let anvil = Anvil::new().spawn();
         let hyper_client = Client::builder(TokioExecutor::new()).build_http::<Full<HyperBytes>>();
 
@@ -1231,43 +1223,46 @@ mod tests {
     #[cfg(all(feature = "hyper", not(windows)))]
     #[tokio::test]
     async fn test_auth_layer_transport() {
-        use alloy_node_bindings::Reth;
-        use alloy_rpc_types_engine::JwtSecret;
-        use alloy_transport_http::{AuthLayer, AuthService, Http, HyperClient};
+        crate::ext::test::async_ci_only(|| async move {
+            use alloy_node_bindings::Reth;
+            use alloy_rpc_types_engine::JwtSecret;
+            use alloy_transport_http::{AuthLayer, AuthService, Http, HyperClient};
 
-        init_tracing();
-        let secret = JwtSecret::random();
+            let secret = JwtSecret::random();
 
-        let reth = Reth::new().arg("--rpc.jwtsecret").arg(hex::encode(secret.as_bytes())).spawn();
+            let reth =
+                Reth::new().arg("--rpc.jwtsecret").arg(hex::encode(secret.as_bytes())).spawn();
 
-        let hyper_client = Client::builder(TokioExecutor::new()).build_http::<Full<HyperBytes>>();
+            let hyper_client =
+                Client::builder(TokioExecutor::new()).build_http::<Full<HyperBytes>>();
 
-        let service =
-            tower::ServiceBuilder::new().layer(AuthLayer::new(secret)).service(hyper_client);
+            let service =
+                tower::ServiceBuilder::new().layer(AuthLayer::new(secret)).service(hyper_client);
 
-        let layer_transport: HyperClient<
-            Full<HyperBytes>,
-            AuthService<
-                Client<
-                    alloy_transport_http::hyper_util::client::legacy::connect::HttpConnector,
-                    Full<HyperBytes>,
+            let layer_transport: HyperClient<
+                Full<HyperBytes>,
+                AuthService<
+                    Client<
+                        alloy_transport_http::hyper_util::client::legacy::connect::HttpConnector,
+                        Full<HyperBytes>,
+                    >,
                 >,
-            >,
-        > = HyperClient::with_service(service);
+            > = HyperClient::with_service(service);
 
-        let http_hyper = Http::with_client(layer_transport, reth.endpoint_url());
+            let http_hyper = Http::with_client(layer_transport, reth.endpoint_url());
 
-        let rpc_client = alloy_rpc_client::RpcClient::new(http_hyper, true);
+            let rpc_client = alloy_rpc_client::RpcClient::new(http_hyper, true);
 
-        let provider = RootProvider::<_, Ethereum>::new(rpc_client);
+            let provider = RootProvider::<_, Ethereum>::new(rpc_client);
 
-        let num = provider.get_block_number().await.unwrap();
-        assert_eq!(0, num);
+            let num = provider.get_block_number().await.unwrap();
+            assert_eq!(0, num);
+        })
+        .await;
     }
 
     #[tokio::test]
     async fn test_builder_helper_fn_any_network() {
-        init_tracing();
         let anvil = Anvil::new().spawn();
         let provider =
             builder::<AnyNetwork>().with_recommended_fillers().on_http(anvil.endpoint_url());
@@ -1278,7 +1273,6 @@ mod tests {
     #[cfg(feature = "reqwest")]
     #[tokio::test]
     async fn object_safety() {
-        init_tracing();
         let provider = ProviderBuilder::new().on_anvil();
 
         // These blocks are not necessary.
@@ -1314,8 +1308,6 @@ mod tests {
     #[cfg(feature = "ws")]
     #[tokio::test]
     async fn subscribe_blocks_http() {
-        init_tracing();
-
         let provider = ProviderBuilder::new().on_anvil_with_config(|a| a.block_time(1));
 
         let err = provider.subscribe_blocks().await.unwrap_err();
@@ -1344,7 +1336,6 @@ mod tests {
     async fn subscribe_blocks_ws() {
         use futures::stream::StreamExt;
 
-        init_tracing();
         let anvil = Anvil::new().block_time(1).spawn();
         let ws = alloy_rpc_client::WsConnect::new(anvil.ws_endpoint());
         let client = alloy_rpc_client::RpcClient::connect_pubsub(ws).await.unwrap();
@@ -1365,7 +1356,6 @@ mod tests {
     async fn subscribe_blocks_ws_boxed() {
         use futures::stream::StreamExt;
 
-        init_tracing();
         let anvil = Anvil::new().block_time(1).spawn();
         let ws = alloy_rpc_client::WsConnect::new(anvil.ws_endpoint());
         let client = alloy_rpc_client::RpcClient::connect_pubsub(ws).await.unwrap();
@@ -1387,7 +1377,6 @@ mod tests {
     async fn subscribe_blocks_ws_remote() {
         use futures::stream::StreamExt;
 
-        init_tracing();
         let url = "wss://eth-mainnet.g.alchemy.com/v2/viFmeVzhg6bWKVMIWWS8MhmzREB-D4f7";
         let ws = alloy_rpc_client::WsConnect::new(url);
         let Ok(client) = alloy_rpc_client::RpcClient::connect_pubsub(ws).await else { return };
@@ -1402,7 +1391,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_send_tx() {
-        init_tracing();
         let provider = ProviderBuilder::new().on_anvil();
         let tx = TransactionRequest {
             value: Some(U256::from(100)),
@@ -1426,7 +1414,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_watch_confirmed_tx() {
-        init_tracing();
         let provider = ProviderBuilder::new().on_anvil();
         let tx = TransactionRequest {
             value: Some(U256::from(100)),
@@ -1474,7 +1461,6 @@ mod tests {
 
     #[tokio::test]
     async fn gets_block_number() {
-        init_tracing();
         let provider = ProviderBuilder::new().on_anvil();
         let num = provider.get_block_number().await.unwrap();
         assert_eq!(0, num)
@@ -1482,7 +1468,6 @@ mod tests {
 
     #[tokio::test]
     async fn gets_block_number_with_raw_req() {
-        init_tracing();
         let provider = ProviderBuilder::new().on_anvil();
         let num: U64 =
             provider.raw_request("eth_blockNumber".into(), NoParams::default()).await.unwrap();
@@ -1492,7 +1477,6 @@ mod tests {
     #[cfg(feature = "anvil-api")]
     #[tokio::test]
     async fn gets_transaction_count() {
-        init_tracing();
         let provider = ProviderBuilder::new().on_anvil();
         let accounts = provider.get_accounts().await.unwrap();
         let sender = accounts[0];
@@ -1523,7 +1507,6 @@ mod tests {
 
     #[tokio::test]
     async fn gets_block_by_hash() {
-        init_tracing();
         let provider = ProviderBuilder::new().on_anvil();
         let num = 0;
         let tag: BlockNumberOrTag = num.into();
@@ -1536,7 +1519,6 @@ mod tests {
 
     #[tokio::test]
     async fn gets_block_by_hash_with_raw_req() {
-        init_tracing();
         let provider = ProviderBuilder::new().on_anvil();
         let num = 0;
         let tag: BlockNumberOrTag = num.into();
@@ -1551,7 +1533,6 @@ mod tests {
 
     #[tokio::test]
     async fn gets_block_by_number_full() {
-        init_tracing();
         let provider = ProviderBuilder::new().on_anvil();
         let num = 0;
         let tag: BlockNumberOrTag = num.into();
@@ -1561,7 +1542,6 @@ mod tests {
 
     #[tokio::test]
     async fn gets_block_by_number() {
-        init_tracing();
         let provider = ProviderBuilder::new().on_anvil();
         let num = 0;
         let tag: BlockNumberOrTag = num.into();
@@ -1571,7 +1551,6 @@ mod tests {
 
     #[tokio::test]
     async fn gets_client_version() {
-        init_tracing();
         let provider = ProviderBuilder::new().on_anvil();
         let version = provider.get_client_version().await.unwrap();
         assert!(version.contains("anvil"), "{version}");
@@ -1579,7 +1558,6 @@ mod tests {
 
     #[tokio::test]
     async fn gets_sha3() {
-        init_tracing();
         let provider = ProviderBuilder::new().on_anvil();
         let data = b"alloy";
         let hash = provider.get_sha3(data).await.unwrap();
@@ -1607,7 +1585,6 @@ mod tests {
 
     #[tokio::test]
     async fn gets_storage_at() {
-        init_tracing();
         let provider = ProviderBuilder::new().on_anvil();
         let addr = Address::with_last_byte(16);
         let storage = provider.get_storage_at(addr, U256::ZERO).await.unwrap();
@@ -1616,8 +1593,6 @@ mod tests {
 
     #[tokio::test]
     async fn gets_transaction_by_hash_not_found() {
-        init_tracing();
-
         let provider = ProviderBuilder::new().on_anvil();
         let tx_hash = b256!("5c03fab9114ceb98994b43892ade87ddfd9ae7e8f293935c3bd29d435dc9fd95");
         let tx = provider.get_transaction_by_hash(tx_hash).await.expect("failed to fetch tx");
@@ -1627,7 +1602,6 @@ mod tests {
 
     #[tokio::test]
     async fn gets_transaction_by_hash() {
-        init_tracing();
         let provider = ProviderBuilder::new().with_recommended_fillers().on_anvil_with_wallet();
 
         let req = TransactionRequest::default()
@@ -1649,7 +1623,6 @@ mod tests {
     #[tokio::test]
     #[ignore]
     async fn gets_logs() {
-        init_tracing();
         let provider = ProviderBuilder::new().on_anvil();
         let filter = Filter::new()
             .at_block_hash(b256!(
@@ -1665,7 +1638,6 @@ mod tests {
     #[tokio::test]
     #[ignore]
     async fn gets_tx_receipt() {
-        init_tracing();
         let provider = ProviderBuilder::new().on_anvil();
         let receipt = provider
             .get_transaction_receipt(b256!(
@@ -1683,14 +1655,12 @@ mod tests {
 
     #[tokio::test]
     async fn gets_max_priority_fee_per_gas() {
-        init_tracing();
         let provider = ProviderBuilder::new().on_anvil();
         let _fee = provider.get_max_priority_fee_per_gas().await.unwrap();
     }
 
     #[tokio::test]
     async fn gets_fee_history() {
-        init_tracing();
         let provider = ProviderBuilder::new().on_anvil();
         let block_number = provider.get_block_number().await.unwrap();
         let fee_history = provider
@@ -1706,7 +1676,6 @@ mod tests {
 
     #[tokio::test]
     async fn gets_block_receipts() {
-        init_tracing();
         let provider = ProviderBuilder::new().on_anvil();
         let receipts =
             provider.get_block_receipts(BlockId::Number(BlockNumberOrTag::Latest)).await.unwrap();
@@ -1715,7 +1684,6 @@ mod tests {
 
     #[tokio::test]
     async fn sends_raw_transaction() {
-        init_tracing();
         let provider = ProviderBuilder::new().on_anvil();
         let pending = provider
             .send_raw_transaction(
@@ -1731,7 +1699,6 @@ mod tests {
 
     #[tokio::test]
     async fn connect_boxed() {
-        init_tracing();
         let anvil = Anvil::new().spawn();
 
         let provider =
@@ -1754,7 +1721,6 @@ mod tests {
 
     #[tokio::test]
     async fn builtin_connect_boxed() {
-        init_tracing();
         let anvil = Anvil::new().spawn();
 
         let conn: BuiltInConnectionString = anvil.endpoint().parse().unwrap();
@@ -1771,7 +1737,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_uncle_count() {
-        init_tracing();
         let provider = ProviderBuilder::new().on_anvil();
 
         let count = provider.get_uncle_count(0.into()).await.unwrap();
@@ -1788,7 +1753,6 @@ mod tests {
         use alloy_network::TransactionBuilder;
         use alloy_sol_types::SolValue;
 
-        init_tracing();
         let url = "https://eth-mainnet.alchemyapi.io/v2/jGiK5vwDfC3F4r0bqukm-W2GqgdrxdSr";
         let provider = ProviderBuilder::new().on_http(url.parse().unwrap());
         let req = TransactionRequest::default()
@@ -1803,7 +1767,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_empty_transactions() {
-        init_tracing();
         let provider = ProviderBuilder::new().on_anvil();
 
         let block = provider.get_block_by_number(0.into(), false).await.unwrap().unwrap();


### PR DESCRIPTION
- Disable more geth/reth tests when not run in CI
- remove a bunch of bad-behavior `init_tracing` calls in tests to remove extraneous logs in test output

followup to #1393. That PR fixed `cargo t` this pr fixes `cargo t --all-features`

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
