### PR TITLE
chore: apply same member order

### DIFF
--- a/crates/consensus/src/block.rs
+++ b/crates/consensus/src/block.rs
@@ -76,14 +76,14 @@ mod block_rlp {
     }
 
     impl<T: Encodable> Encodable for Block<T> {
-        fn length(&self) -> usize {
-            let helper: HelperRef<'_, T> = self.into();
-            helper.length()
-        }
-
         fn encode(&self, out: &mut dyn alloy_rlp::bytes::BufMut) {
             let helper: HelperRef<'_, T> = self.into();
             helper.encode(out)
+        }
+
+        fn length(&self) -> usize {
+            let helper: HelperRef<'_, T> = self.into();
+            helper.length()
         }
     }
 

--- a/crates/consensus/src/transaction/eip1559.rs
+++ b/crates/consensus/src/transaction/eip1559.rs
@@ -288,12 +288,12 @@ impl Transaction for TxEip1559 {
         Some(self.max_priority_fee_per_gas)
     }
 
-    fn priority_fee_or_price(&self) -> u128 {
-        self.max_priority_fee_per_gas
-    }
-
     fn max_fee_per_blob_gas(&self) -> Option<u128> {
         None
+    }
+
+    fn priority_fee_or_price(&self) -> u128 {
+        self.max_priority_fee_per_gas
     }
 
     fn to(&self) -> TxKind {

--- a/crates/consensus/src/transaction/eip2930.rs
+++ b/crates/consensus/src/transaction/eip2930.rs
@@ -252,12 +252,12 @@ impl Transaction for TxEip2930 {
         None
     }
 
-    fn priority_fee_or_price(&self) -> u128 {
-        self.gas_price
-    }
-
     fn max_fee_per_blob_gas(&self) -> Option<u128> {
         None
+    }
+
+    fn priority_fee_or_price(&self) -> u128 {
+        self.gas_price
     }
 
     fn to(&self) -> TxKind {

--- a/crates/consensus/src/transaction/eip4844.rs
+++ b/crates/consensus/src/transaction/eip4844.rs
@@ -228,17 +228,17 @@ impl Transaction for TxEip4844Variant {
         }
     }
 
-    fn priority_fee_or_price(&self) -> u128 {
-        match self {
-            Self::TxEip4844(tx) => tx.priority_fee_or_price(),
-            Self::TxEip4844WithSidecar(tx) => tx.priority_fee_or_price(),
-        }
-    }
-
     fn max_fee_per_blob_gas(&self) -> Option<u128> {
         match self {
             Self::TxEip4844(tx) => tx.max_fee_per_blob_gas(),
             Self::TxEip4844WithSidecar(tx) => tx.max_fee_per_blob_gas(),
+        }
+    }
+
+    fn priority_fee_or_price(&self) -> u128 {
+        match self {
+            Self::TxEip4844(tx) => tx.priority_fee_or_price(),
+            Self::TxEip4844WithSidecar(tx) => tx.priority_fee_or_price(),
         }
     }
 
@@ -709,12 +709,12 @@ impl Transaction for TxEip4844 {
         Some(self.max_priority_fee_per_gas)
     }
 
-    fn priority_fee_or_price(&self) -> u128 {
-        self.max_priority_fee_per_gas
-    }
-
     fn max_fee_per_blob_gas(&self) -> Option<u128> {
         Some(self.max_fee_per_blob_gas)
+    }
+
+    fn priority_fee_or_price(&self) -> u128 {
+        self.max_priority_fee_per_gas
     }
 
     fn to(&self) -> TxKind {
@@ -982,12 +982,12 @@ impl Transaction for TxEip4844WithSidecar {
         self.tx.max_priority_fee_per_gas()
     }
 
-    fn priority_fee_or_price(&self) -> u128 {
-        self.tx.priority_fee_or_price()
-    }
-
     fn max_fee_per_blob_gas(&self) -> Option<u128> {
         self.tx.max_fee_per_blob_gas()
+    }
+
+    fn priority_fee_or_price(&self) -> u128 {
+        self.tx.priority_fee_or_price()
     }
 
     fn to(&self) -> TxKind {

--- a/crates/consensus/src/transaction/eip7702.rs
+++ b/crates/consensus/src/transaction/eip7702.rs
@@ -298,12 +298,12 @@ impl Transaction for TxEip7702 {
         Some(self.max_priority_fee_per_gas)
     }
 
-    fn priority_fee_or_price(&self) -> u128 {
-        self.max_priority_fee_per_gas
-    }
-
     fn max_fee_per_blob_gas(&self) -> Option<u128> {
         None
+    }
+
+    fn priority_fee_or_price(&self) -> u128 {
+        self.max_priority_fee_per_gas
     }
 
     fn to(&self) -> TxKind {

--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -382,6 +382,16 @@ impl Transaction for TxEnvelope {
         }
     }
 
+    fn nonce(&self) -> u64 {
+        match self {
+            Self::Legacy(tx) => tx.tx().nonce(),
+            Self::Eip2930(tx) => tx.tx().nonce(),
+            Self::Eip1559(tx) => tx.tx().nonce(),
+            Self::Eip4844(tx) => tx.tx().nonce(),
+            Self::Eip7702(tx) => tx.tx().nonce(),
+        }
+    }
+
     fn gas_limit(&self) -> u64 {
         match self {
             Self::Legacy(tx) => tx.tx().gas_limit(),
@@ -422,16 +432,6 @@ impl Transaction for TxEnvelope {
         }
     }
 
-    fn priority_fee_or_price(&self) -> u128 {
-        match self {
-            Self::Legacy(tx) => tx.tx().priority_fee_or_price(),
-            Self::Eip2930(tx) => tx.tx().priority_fee_or_price(),
-            Self::Eip1559(tx) => tx.tx().priority_fee_or_price(),
-            Self::Eip4844(tx) => tx.tx().priority_fee_or_price(),
-            Self::Eip7702(tx) => tx.tx().priority_fee_or_price(),
-        }
-    }
-
     fn max_fee_per_blob_gas(&self) -> Option<u128> {
         match self {
             Self::Legacy(tx) => tx.tx().max_fee_per_blob_gas(),
@@ -442,23 +442,13 @@ impl Transaction for TxEnvelope {
         }
     }
 
-    fn input(&self) -> &[u8] {
+    fn priority_fee_or_price(&self) -> u128 {
         match self {
-            Self::Legacy(tx) => tx.tx().input(),
-            Self::Eip2930(tx) => tx.tx().input(),
-            Self::Eip1559(tx) => tx.tx().input(),
-            Self::Eip4844(tx) => tx.tx().input(),
-            Self::Eip7702(tx) => tx.tx().input(),
-        }
-    }
-
-    fn nonce(&self) -> u64 {
-        match self {
-            Self::Legacy(tx) => tx.tx().nonce(),
-            Self::Eip2930(tx) => tx.tx().nonce(),
-            Self::Eip1559(tx) => tx.tx().nonce(),
-            Self::Eip4844(tx) => tx.tx().nonce(),
-            Self::Eip7702(tx) => tx.tx().nonce(),
+            Self::Legacy(tx) => tx.tx().priority_fee_or_price(),
+            Self::Eip2930(tx) => tx.tx().priority_fee_or_price(),
+            Self::Eip1559(tx) => tx.tx().priority_fee_or_price(),
+            Self::Eip4844(tx) => tx.tx().priority_fee_or_price(),
+            Self::Eip7702(tx) => tx.tx().priority_fee_or_price(),
         }
     }
 
@@ -479,6 +469,16 @@ impl Transaction for TxEnvelope {
             Self::Eip1559(tx) => tx.tx().value(),
             Self::Eip4844(tx) => tx.tx().value(),
             Self::Eip7702(tx) => tx.tx().value(),
+        }
+    }
+
+    fn input(&self) -> &[u8] {
+        match self {
+            Self::Legacy(tx) => tx.tx().input(),
+            Self::Eip2930(tx) => tx.tx().input(),
+            Self::Eip1559(tx) => tx.tx().input(),
+            Self::Eip4844(tx) => tx.tx().input(),
+            Self::Eip7702(tx) => tx.tx().input(),
         }
     }
 

--- a/crates/consensus/src/transaction/legacy.rs
+++ b/crates/consensus/src/transaction/legacy.rs
@@ -230,12 +230,12 @@ impl Transaction for TxLegacy {
         None
     }
 
-    fn priority_fee_or_price(&self) -> u128 {
-        self.gas_price
-    }
-
     fn max_fee_per_blob_gas(&self) -> Option<u128> {
         None
+    }
+
+    fn priority_fee_or_price(&self) -> u128 {
+        self.gas_price
     }
 
     fn to(&self) -> TxKind {

--- a/crates/consensus/src/transaction/typed.rs
+++ b/crates/consensus/src/transaction/typed.rs
@@ -196,16 +196,6 @@ impl Transaction for TypedTransaction {
         }
     }
 
-    fn priority_fee_or_price(&self) -> u128 {
-        match self {
-            Self::Legacy(tx) => tx.priority_fee_or_price(),
-            Self::Eip2930(tx) => tx.priority_fee_or_price(),
-            Self::Eip1559(tx) => tx.priority_fee_or_price(),
-            Self::Eip4844(tx) => tx.priority_fee_or_price(),
-            Self::Eip7702(tx) => tx.priority_fee_or_price(),
-        }
-    }
-
     fn max_fee_per_blob_gas(&self) -> Option<u128> {
         match self {
             Self::Legacy(tx) => tx.max_fee_per_blob_gas(),
@@ -213,6 +203,16 @@ impl Transaction for TypedTransaction {
             Self::Eip1559(tx) => tx.max_fee_per_blob_gas(),
             Self::Eip4844(tx) => tx.max_fee_per_blob_gas(),
             Self::Eip7702(tx) => tx.max_fee_per_blob_gas(),
+        }
+    }
+
+    fn priority_fee_or_price(&self) -> u128 {
+        match self {
+            Self::Legacy(tx) => tx.priority_fee_or_price(),
+            Self::Eip2930(tx) => tx.priority_fee_or_price(),
+            Self::Eip1559(tx) => tx.priority_fee_or_price(),
+            Self::Eip4844(tx) => tx.priority_fee_or_price(),
+            Self::Eip7702(tx) => tx.priority_fee_or_price(),
         }
     }
 

--- a/crates/rpc-types-eth/src/block.rs
+++ b/crates/rpc-types-eth/src/block.rs
@@ -372,8 +372,8 @@ pub struct BlockOverrides {
 }
 
 impl<T: TransactionResponse, H: HeaderResponse> BlockResponse for Block<T, H> {
-    type Transaction = T;
     type Header = H;
+    type Transaction = T;
 
     fn header(&self) -> &Self::Header {
         &self.header


### PR DESCRIPTION
this reorders all impls so that it matches the trait

