### PR TITLE
chore(consensus): add `Transaction::size` into trait `Transaction`

### DIFF
--- a/crates/consensus/src/transaction/mod.rs
+++ b/crates/consensus/src/transaction/mod.rs
@@ -133,6 +133,9 @@ pub trait Transaction: any::Any + Send + Sync + 'static {
     ///
     /// Returns `None` if this transaction is not EIP-7702.
     fn authorization_list(&self) -> Option<&[SignedAuthorization]>;
+
+    /// Calculate a heuristic for the in-memory size of the transaction.
+    fn size(&self) -> usize;
 }
 
 /// A signable transaction.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

`Transaction::size` must be accessible via abstraction `Transaction` in reth sdk

Follows pattern of header primitive https://github.com/alloy-rs/alloy/pull/1414

## Solution

Add `Transaction::size` into trait method of `Transaction`

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
