### PR TITLE
feat(rpc-types-mev): Add support for `Bundle` inside `BundleItem`

### DIFF
--- a/crates/rpc-types-mev/src/mev_calls.rs
+++ b/crates/rpc-types-mev/src/mev_calls.rs
@@ -94,6 +94,12 @@ pub enum BundleItem {
         /// If true, the transaction can revert without the bundle being considered invalid.
         can_revert: bool,
     },
+    /// A nested bundle request. 
+    #[serde(rename_all = "camelCase")]
+    Bundle {
+        /// A bundle request of type SendBundleRequest
+        bundle: SendBundleRequest,
+    },
 }
 
 /// Optional fields to override simulation state.
@@ -278,6 +284,32 @@ mod tests {
         };
         let expected = serde_json::from_str::<Vec<SendBundleRequest>>(str).unwrap();
         assert_eq!(bundle, expected[0]);
+    }
+
+    #[test]
+    fn can_deserialize_nested_bundle_request() {
+        let str = r#"
+        [{
+            "version": "v0.1",
+            "inclusion": {
+                "block": "0x1"
+            },
+            "body": [{
+                "bundle": {
+                    "version": "v0.1",
+                    "inclusion": {
+                        "block": "0x1"
+                    },
+                    "body": [{
+                        "tx": "0x02f86b0180843b9aca00852ecc889a0082520894c87037874aed04e51c29f582394217a0a2b89d808080c080a0a463985c616dd8ee17d7ef9112af4e6e06a27b071525b42182fe7b0b5c8b4925a00af5ca177ffef2ff28449292505d41be578bebb77110dfc09361d2fb56998260",
+                        "canRevert": false
+                    }]
+                }
+            }]
+        }]  
+        "#;
+        let res: Result<Vec<SendBundleRequest>, _> = serde_json::from_str(str);
+        assert!(res.is_ok());
     }
 
     #[test]

--- a/crates/rpc-types-mev/src/mev_calls.rs
+++ b/crates/rpc-types-mev/src/mev_calls.rs
@@ -94,7 +94,7 @@ pub enum BundleItem {
         /// If true, the transaction can revert without the bundle being considered invalid.
         can_revert: bool,
     },
-    /// A nested bundle request. 
+    /// A nested bundle request.
     #[serde(rename_all = "camelCase")]
     Bundle {
         /// A bundle request of type SendBundleRequest


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

According to [mev-share specs](https://github.com/flashbots/mev-share/blob/main/specs/bundles/v0.1.md#bundle-composition) there should be support for nested bundles inside the bundle request, but in mev_calls.rs, `BundleItem` did not have `Bundle`. This was found during implementation of `mev_simBundle` on reth ([comment](https://github.com/paradigmxyz/reth/issues/9472#issuecomment-2388573965))

fixes #1416 

also ref: https://github.com/paradigmxyz/mev-share-rs/issues/44

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Added support for `Bundle` inside `BundleItem`, and added a test to check if a nested bundle request can be deserialized.

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
