### PR TITLE
fix(provider): use wasmtimer for wasm32 target

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,7 @@ futures = "0.3"
 futures-util = "0.3"
 futures-executor = "0.3"
 futures-utils-wasm = "0.1"
+wasmtimer = "0.2.0"
 
 hyper = { version = "1.2", default-features = false }
 hyper-util = "0.1"

--- a/crates/provider/Cargo.toml
+++ b/crates/provider/Cargo.toml
@@ -60,6 +60,9 @@ tokio = { workspace = true, features = ["sync", "macros"] }
 tracing.workspace = true
 url = { workspace = true, optional = true }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasmtimer = "0.2.0"
+
 [dev-dependencies]
 alloy-consensus = { workspace = true, features = ["kzg"] }
 alloy-primitives = { workspace = true, features = ["rand"] }

--- a/crates/provider/Cargo.toml
+++ b/crates/provider/Cargo.toml
@@ -61,7 +61,7 @@ tracing.workspace = true
 url = { workspace = true, optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-wasmtimer = "0.2.0"
+wasmtimer.workspace = true
 
 [dev-dependencies]
 alloy-consensus = { workspace = true, features = ["kzg"] }

--- a/crates/provider/src/heart.rs
+++ b/crates/provider/src/heart.rs
@@ -9,23 +9,22 @@ use alloy_primitives::{
 };
 use alloy_transport::{utils::Spawnable, Transport, TransportError};
 use futures::{stream::StreamExt, FutureExt, Stream};
-#[cfg(not(target_arch = "wasm32"))]
-use std::time::{Duration, Instant};
 use std::{
     collections::{BTreeMap, VecDeque},
     fmt,
     future::Future,
+    time::Duration,
 };
-#[cfg(not(target_arch = "wasm32"))]
-use tokio::time::sleep_until;
-#[cfg(target_arch = "wasm32")]
-use tokio::time::Duration;
 use tokio::{
     select,
     sync::{mpsc, oneshot, watch},
 };
+
 #[cfg(target_arch = "wasm32")]
 use wasmtimer::{std::Instant, tokio::sleep_until};
+
+#[cfg(not(target_arch = "wasm32"))]
+use {std::time::Instant, tokio::time::sleep_until};
 
 /// Errors which may occur when watching a pending transaction.
 #[derive(Debug, thiserror::Error)]

--- a/crates/transport-ws/Cargo.toml
+++ b/crates/transport-ws/Cargo.toml
@@ -38,3 +38,4 @@ rustls = { workspace = true, features = ["ring"] }
 # WASM only
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 ws_stream_wasm = "0.7.4"
+wasmtimer.workspace = true

--- a/crates/transport-ws/src/native.rs
+++ b/crates/transport-ws/src/native.rs
@@ -4,11 +4,16 @@ use alloy_transport::{utils::Spawnable, Authorization, TransportErrorKind, Trans
 use futures::{SinkExt, StreamExt};
 use serde_json::value::RawValue;
 use std::time::Duration;
-use tokio::time::sleep;
 use tokio_tungstenite::{
     tungstenite::{self, client::IntoClientRequest, Message},
     MaybeTlsStream, WebSocketStream,
 };
+
+#[cfg(target_arch = "wasm32")]
+use wasmtimer::tokio::sleep;
+
+#[cfg(not(target_arch = "wasm32"))]
+use tokio::time::sleep;
 
 type TungsteniteStream = WebSocketStream<MaybeTlsStream<tokio::net::TcpStream>>;
 

--- a/crates/transport/Cargo.toml
+++ b/crates/transport/Cargo.toml
@@ -34,6 +34,7 @@ tokio = { workspace = true, features = ["rt", "time"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen-futures = { version = "0.4", optional = true }
+wasmtimer.workspace = true
 
 [features]
 wasm-bindgen = ["dep:wasm-bindgen-futures"]

--- a/crates/transport/src/layers/retry.rs
+++ b/crates/transport/src/layers/retry.rs
@@ -14,6 +14,12 @@ use std::{
 use tower::{Layer, Service};
 use tracing::trace;
 
+#[cfg(target_arch = "wasm32")]
+use wasmtimer::tokio::sleep;
+
+#[cfg(not(target_arch = "wasm32"))]
+use tokio::time::sleep;
+
 /// A Transport Layer that is responsible for retrying requests based on the
 /// error type. See [`TransportError`].
 ///
@@ -192,7 +198,7 @@ where
                         "(all in ms) backing off due to rate limit"
                     );
 
-                    tokio::time::sleep(total_backoff).await;
+                    sleep(total_backoff).await;
                 } else {
                     this.requests_enqueued.fetch_sub(1, Ordering::SeqCst);
                     return Err(err);


### PR DESCRIPTION
The `std::time` library is mostly not supported on the wasm32 target.
For this reason, we switch out some of these calls to use the crate
`wasmtimer`.

My first pull request. I was in a bit of a hurry to make this PR, I will allocate more time tomorrow or next week.

@DaniPopes, let me know if there's anything I can do to ease merging this PR. We'll probably want to test this internally first, when we've upgraded to version `0.4`.