### PR TITLE
fix(rpc-client): use wasm-compatible sleep

### DIFF
--- a/crates/rpc-client/Cargo.toml
+++ b/crates/rpc-client/Cargo.toml
@@ -43,6 +43,9 @@ url = { workspace = true, optional = true }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 alloy-transport-ipc = { workspace = true, optional = true }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasmtimer.workspace = true
+
 [dev-dependencies]
 alloy-primitives.workspace = true
 alloy-node-bindings.workspace = true

--- a/crates/rpc-client/src/poller.rs
+++ b/crates/rpc-client/src/poller.rs
@@ -11,8 +11,12 @@ use std::{
     time::Duration,
 };
 use tokio::sync::broadcast;
+#[cfg(not(target_arch = "wasm32"))]
+use tokio::time::sleep;
 use tokio_stream::wrappers::BroadcastStream;
 use tracing::Instrument;
+#[cfg(target_arch = "wasm32")]
+use wasmtimer::tokio::sleep;
 
 /// The number of retries for polling a request.
 const MAX_RETRIES: usize = 3;
@@ -195,7 +199,7 @@ where
             }
 
             trace!(duration=?self.poll_interval, "sleeping");
-            tokio::time::sleep(self.poll_interval).await;
+            sleep(self.poll_interval).await;
         }
     }
 


### PR DESCRIPTION
A follow up to PR #1426. A Tokio `sleep` is called, leading to a
runtime error on WASM targets.

@DaniPopes, upon trying to use the `main` with the last PR in, I got another error which is fixed in this PR.
