### PR TITLE
fix: proposer_index rustdoc

### DIFF
--- a/crates/rpc-types-beacon/src/events/mod.rs
+++ b/crates/rpc-types-beacon/src/events/mod.rs
@@ -334,7 +334,6 @@ pub struct PayloadAttributesData {
     pub parent_block_number: u64,
     /// the execution block hash of the parent block.
     pub parent_block_hash: B256,
-    /// The execution block number of the parent block.
     /// the validator index of the proposer at `proposal_slot` on the chain identified by
     /// `parent_block_root`.
     #[serde_as(as = "DisplayFromStr")]


### PR DESCRIPTION
`proposer_index` is not "The execution block number of the parent block".