### PR TITLE
feat: BuildTransactionErr abstract over builder type

### DIFF
--- a/crates/rpc-types-eth/src/transaction/request.rs
+++ b/crates/rpc-types-eth/src/transaction/request.rs
@@ -1032,9 +1032,9 @@ impl std::error::Error for TransactionInputError {}
 
 /// Error thrown when a transaction request cannot be built into a transaction.
 #[derive(Debug)]
-pub struct BuildTransactionErr {
+pub struct BuildTransactionErr<T = TransactionRequest> {
     /// Transaction request that failed to build into a transaction.
-    pub tx: TransactionRequest,
+    pub tx: T,
     /// Error message.
     pub error: String,
 }


### PR DESCRIPTION

## Motivation

Make the builder error generic over the builder for reuse during network implementation

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
