### PR TITLE
chore: use pending for next initial nonce

### DIFF
--- a/crates/provider/src/fillers/nonce.rs
+++ b/crates/provider/src/fillers/nonce.rs
@@ -42,7 +42,7 @@ impl NonceManager for SimpleNonceManager {
         N: Network,
         T: Transport + Clone,
     {
-        provider.get_transaction_count(address).await
+        provider.get_transaction_count(address).pending().await
     }
 }
 


### PR DESCRIPTION
imo we should use pending here so that the this doesn't pick an already pending nonce in the pool.

@klkvr not exactly sure how this impacts things like

https://github.com/foundry-rs/foundry/pull/9096