### PR TITLE
chore: enable serde types dependencies in rpc-types

### DIFF
--- a/crates/rpc-types/Cargo.toml
+++ b/crates/rpc-types/Cargo.toml
@@ -25,8 +25,8 @@ alloy-rpc-types-admin = { workspace = true, optional = true }
 alloy-rpc-types-anvil = { workspace = true, optional = true }
 alloy-rpc-types-beacon = { workspace = true, optional = true }
 alloy-rpc-types-debug = { workspace = true, optional = true }
-alloy-rpc-types-engine = { workspace = true, optional = true }
-alloy-rpc-types-eth = { workspace = true, optional = true }
+alloy-rpc-types-engine = { workspace = true, optional = true, features = ["serde"] }
+alloy-rpc-types-eth = { workspace = true, optional = true, features = ["serde"] }
 alloy-rpc-types-mev = { workspace = true, optional = true }
 alloy-rpc-types-trace = { workspace = true, optional = true }
 alloy-rpc-types-txpool = { workspace = true, optional = true }


### PR DESCRIPTION
closes #1453

imo this is reasonable because if you want those crates without serde you should not use rpc-types and use those crates directly.

the alternative is making serde a feature on all rpc types crates which I don't think is reasonable