### PR TITLE
fix: Make RecommendedFillers generic over Network

### DIFF
--- a/crates/provider/src/fillers/mod.rs
+++ b/crates/provider/src/fillers/mod.rs
@@ -310,9 +310,9 @@ where
 }
 
 /// A trait which may be used to configure default fillers for [Network] implementations.
-pub trait RecommendedFillers {
+pub trait RecommendedFillers<N: Network = Ethereum> {
     /// Recommended fillers for this network.
-    type RecomendedFillers: TxFiller;
+    type RecomendedFillers: TxFiller<N>;
 
     /// Returns the recommended filler for this provider.
     fn recommended_fillers() -> Self::RecomendedFillers;


### PR DESCRIPTION
Makes `RecommendedFillers` generic over `Network`.

## Motivation

Associated type in the trait requires `TxFiller`, which is generic over `Network`; it just has `Ethereum` as default.
So it's impossible to implement custom fillers for a specific network, if they can't be implemented for `Ethereum` as well.

The solution is a bit awkward since now you can implement `RecommendedFillers<NetworkA>` and `RecommendedFillers<NetworkB>` for `NetworkA`, but the pro is that it's not a breaking change.
The alternative would be to introduce an associated type, but it would be breaking, since associated type defaults are unstable.

## Solution

Make `RecommendedFillers` generic over `Network` 😅 .

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
