### PR TITLE
fix: Add network generic to RecommendedFillers bound in ProviderBuilder

### DIFF
--- a/crates/provider/src/builder.rs
+++ b/crates/provider/src/builder.rs
@@ -127,14 +127,14 @@ impl<N> Default for ProviderBuilder<Identity, Identity, N> {
     }
 }
 
-impl<L, N> ProviderBuilder<L, Identity, N> {
+impl<L, N: Network> ProviderBuilder<L, Identity, N> {
     /// Add preconfigured set of layers handling gas estimation, nonce
     /// management, and chain-id fetching.
     pub fn with_recommended_fillers(
         self,
     ) -> ProviderBuilder<L, JoinFill<Identity, N::RecomendedFillers>, N>
     where
-        N: RecommendedFillers,
+        N: RecommendedFillers<N>,
     {
         self.filler(N::recommended_fillers())
     }

--- a/crates/provider/src/fillers/mod.rs
+++ b/crates/provider/src/fillers/mod.rs
@@ -333,7 +333,7 @@ impl RecommendedFillers for Ethereum {
     }
 }
 
-impl RecommendedFillers for AnyNetwork {
+impl RecommendedFillers<Self> for AnyNetwork {
     type RecomendedFillers =
         JoinFill<GasFiller, JoinFill<BlobGasFiller, JoinFill<NonceFiller, ChainIdFiller>>>;
 
@@ -345,5 +345,15 @@ impl RecommendedFillers for AnyNetwork {
                 JoinFill::new(NonceFiller::default(), ChainIdFiller::default()),
             ),
         )
+    }
+}
+
+// Additional implementation in case someone will use `AnyNetwork` in generic context specialized
+// for `Ethereum`.
+impl RecommendedFillers<Ethereum> for AnyNetwork {
+    type RecomendedFillers = <Self as RecommendedFillers<Self>>::RecomendedFillers;
+
+    fn recommended_fillers() -> Self::RecomendedFillers {
+        <Self as RecommendedFillers<Self>>::recommended_fillers()
     }
 }


### PR DESCRIPTION
Follow-up to #1458; I initially didn't notice that `RecommendedFillers` is used as a bound in `ProviderBuilder`.
Without this, `with_recommended_fillers` method is not available for custom networks.