### PR TITLE
fix: Change bound in RecommendedFillers to TxFiller<Self>

### DIFF
--- a/crates/provider/src/builder.rs
+++ b/crates/provider/src/builder.rs
@@ -127,7 +127,7 @@ impl<N> Default for ProviderBuilder<Identity, Identity, N> {
     }
 }
 
-impl<L, N> ProviderBuilder<L, Identity, N> {
+impl<L, N: Network> ProviderBuilder<L, Identity, N> {
     /// Add preconfigured set of layers handling gas estimation, nonce
     /// management, and chain-id fetching.
     pub fn with_recommended_fillers(

--- a/crates/provider/src/fillers/mod.rs
+++ b/crates/provider/src/fillers/mod.rs
@@ -310,9 +310,9 @@ where
 }
 
 /// A trait which may be used to configure default fillers for [Network] implementations.
-pub trait RecommendedFillers<N: Network = Ethereum> {
+pub trait RecommendedFillers: Network {
     /// Recommended fillers for this network.
-    type RecomendedFillers: TxFiller<N>;
+    type RecomendedFillers: TxFiller<Self>;
 
     /// Returns the recommended filler for this provider.
     fn recommended_fillers() -> Self::RecomendedFillers;


### PR DESCRIPTION
Follow-up from #1458

@klkvr proposed a better way to handle network bound.

There is a small downside: if someone has implemented `RecommendedFillers` for some type that doesn't implement `Network`, this change is breaking. The likelihood of that is very slow though, so probably it's fine.

