### PR TITLE
chore: unify use Option ref

### DIFF
--- a/crates/node-bindings/src/nodes/geth.rs
+++ b/crates/node-bindings/src/nodes/geth.rs
@@ -121,19 +121,19 @@ impl GethInstance {
     }
 
     /// Returns the path to this instances' data directory
-    pub const fn data_dir(&self) -> &Option<PathBuf> {
-        &self.data_dir
+    pub const fn data_dir(&self) -> Option<&PathBuf> {
+        self.data_dir.as_ref()
     }
 
     /// Returns the genesis configuration used to configure this instance
-    pub const fn genesis(&self) -> &Option<Genesis> {
-        &self.genesis
+    pub const fn genesis(&self) -> Option<&Genesis> {
+        self.genesis.as_ref()
     }
 
     /// Returns the private key used to configure clique on this instance
     #[deprecated = "clique support was removed in geth >=1.14"]
-    pub const fn clique_private_key(&self) -> &Option<SigningKey> {
-        &self.clique_private_key
+    pub const fn clique_private_key(&self) -> Option<&SigningKey> {
+        self.clique_private_key.as_ref()
     }
 
     /// Takes the stderr contained in the child process.

--- a/crates/node-bindings/src/nodes/reth.rs
+++ b/crates/node-bindings/src/nodes/reth.rs
@@ -102,13 +102,13 @@ impl RethInstance {
     }
 
     /// Returns the path to this instances' data directory.
-    pub const fn data_dir(&self) -> &Option<PathBuf> {
-        &self.data_dir
+    pub const fn data_dir(&self) -> Option<&PathBuf> {
+        self.data_dir.as_ref()
     }
 
     /// Returns the genesis configuration used to configure this instance
-    pub const fn genesis(&self) -> &Option<Genesis> {
-        &self.genesis
+    pub const fn genesis(&self) -> Option<&Genesis> {
+        self.genesis.as_ref()
     }
 
     /// Takes the stdout contained in the child process.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
I see most places use Option<&T>,  I think maybe Option<&T> is better than &Option<T>. If it's not, please close it.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
