### PR TITLE
fix(wasm): support ws

### DIFF
--- a/crates/transport-ws/Cargo.toml
+++ b/crates/transport-ws/Cargo.toml
@@ -38,4 +38,3 @@ rustls = { workspace = true, features = ["ring"] }
 # WASM only
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 ws_stream_wasm = "0.7.4"
-wasmtimer.workspace = true

--- a/crates/transport-ws/src/wasm.rs
+++ b/crates/transport-ws/src/wasm.rs
@@ -15,6 +15,13 @@ pub struct WsConnect {
     pub url: String,
 }
 
+impl WsConnect {
+    /// Creates a new websocket connection configuration.
+    pub fn new<S: Into<String>>(url: S) -> Self {
+        Self { url: url.into() }
+    }
+}
+
 impl PubSubConnect for WsConnect {
     fn is_local(&self) -> bool {
         alloy_transport::utils::guess_local_url(&self.url)

--- a/crates/transport/Cargo.toml
+++ b/crates/transport/Cargo.toml
@@ -30,8 +30,12 @@ thiserror.workspace = true
 tower.workspace = true
 url.workspace = true
 tracing.workspace = true
+
+# non-WASM only
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { workspace = true, features = ["rt", "time"] }
 
+# WASM only
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen-futures = { version = "0.4", optional = true }
 wasmtimer.workspace = true

--- a/scripts/check_no_std.sh
+++ b/scripts/check_no_std.sh
@@ -1,18 +1,21 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-target=riscv32imac-unknown-none-elf
+target=wasm32-unknown-unknown
 crates=(
     alloy-eips
     alloy-genesis
     alloy-serde
     alloy-consensus
     alloy-network-primitives
+    alloy-rpc-client
     alloy-rpc-types-eth
     alloy-rpc-types-engine
+    alloy-transport
+    alloy-transport-ws
 )
 
-cmd=(cargo +stable hack check --no-default-features --target "$target")
+cmd=(cargo +stable hack check --no-default-features --ignore-unknown-features --features ws --target "$target")
 for crate in "${crates[@]}"; do
     cmd+=(-p "$crate")
 done


### PR DESCRIPTION
## Motivation

When attempting to make a browser dapp with Dioxus I found that alloy would not build with WebSocket support:

```
error[E0599]: no function or associated item named `new` found for struct `WsConnect` in the current scope
  --> /home/jbrown/alloy/crates/rpc-client/src/builtin.rs:84:64
   |
84 |             Self::Ws(url, _) => alloy_transport_ws::WsConnect::new(url.clone())
   |                                                                ^^^ function or associated item not found in `WsConnect`
```

It is critical that Alloy supports building browser dapps with WebSocket support.

## Solution

All that is required to fix this is adding missing function new() to WsConnect in `crates/transport-ws/src/wasm.rs`.

With this fix I verified that Alloy could connect to a local node from the browser via WS.

Additionally I updated `scripts/check_no_std.sh` to check affected crates and `ws` feature. The target was changed from `riscv32imac-unknown-none-elf` to `wasm32-unknown-unknown to facilitate this`.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
