### PR TITLE
consensus: replace `to` by `kind` in Transaction trait

### DIFF
--- a/crates/consensus/src/transaction/eip1559.rs
+++ b/crates/consensus/src/transaction/eip1559.rs
@@ -296,7 +296,7 @@ impl Transaction for TxEip1559 {
         self.max_priority_fee_per_gas
     }
 
-    fn to(&self) -> TxKind {
+    fn kind(&self) -> TxKind {
         self.to
     }
 

--- a/crates/consensus/src/transaction/eip2930.rs
+++ b/crates/consensus/src/transaction/eip2930.rs
@@ -260,7 +260,7 @@ impl Transaction for TxEip2930 {
         self.gas_price
     }
 
-    fn to(&self) -> TxKind {
+    fn kind(&self) -> TxKind {
         self.to
     }
 

--- a/crates/consensus/src/transaction/eip4844.rs
+++ b/crates/consensus/src/transaction/eip4844.rs
@@ -242,7 +242,7 @@ impl Transaction for TxEip4844Variant {
         }
     }
 
-    fn to(&self) -> TxKind {
+    fn kind(&self) -> TxKind {
         match self {
             Self::TxEip4844(tx) => tx.to,
             Self::TxEip4844WithSidecar(tx) => tx.tx.to,
@@ -717,7 +717,7 @@ impl Transaction for TxEip4844 {
         self.max_priority_fee_per_gas
     }
 
-    fn to(&self) -> TxKind {
+    fn kind(&self) -> TxKind {
         self.to.into()
     }
 
@@ -990,8 +990,8 @@ impl Transaction for TxEip4844WithSidecar {
         self.tx.priority_fee_or_price()
     }
 
-    fn to(&self) -> TxKind {
-        self.tx.to()
+    fn kind(&self) -> TxKind {
+        self.tx.kind()
     }
 
     fn value(&self) -> U256 {

--- a/crates/consensus/src/transaction/eip7702.rs
+++ b/crates/consensus/src/transaction/eip7702.rs
@@ -306,7 +306,7 @@ impl Transaction for TxEip7702 {
         self.max_priority_fee_per_gas
     }
 
-    fn to(&self) -> TxKind {
+    fn kind(&self) -> TxKind {
         self.to.into()
     }
 

--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -447,13 +447,13 @@ impl Transaction for TxEnvelope {
         }
     }
 
-    fn to(&self) -> TxKind {
+    fn kind(&self) -> TxKind {
         match self {
-            Self::Legacy(tx) => tx.tx().to(),
-            Self::Eip2930(tx) => tx.tx().to(),
-            Self::Eip1559(tx) => tx.tx().to(),
-            Self::Eip4844(tx) => tx.tx().to(),
-            Self::Eip7702(tx) => tx.tx().to(),
+            Self::Legacy(tx) => tx.tx().kind(),
+            Self::Eip2930(tx) => tx.tx().kind(),
+            Self::Eip1559(tx) => tx.tx().kind(),
+            Self::Eip4844(tx) => tx.tx().kind(),
+            Self::Eip7702(tx) => tx.tx().kind(),
         }
     }
 
@@ -599,7 +599,7 @@ mod tests {
         };
 
         assert_eq!(
-            tx.tx().to(),
+            tx.tx().kind(),
             TxKind::Call(address!("11E9CA82A3a762b4B5bd264d4173a242e7a77064"))
         );
 

--- a/crates/consensus/src/transaction/legacy.rs
+++ b/crates/consensus/src/transaction/legacy.rs
@@ -238,7 +238,7 @@ impl Transaction for TxLegacy {
         self.gas_price
     }
 
-    fn to(&self) -> TxKind {
+    fn kind(&self) -> TxKind {
         self.to
     }
 

--- a/crates/consensus/src/transaction/mod.rs
+++ b/crates/consensus/src/transaction/mod.rs
@@ -109,7 +109,7 @@ pub trait Transaction: any::Any + Send + Sync + 'static {
             .map_or(Some(fee), |priority_fee| Some(fee.min(priority_fee)))
     }
 
-    /// Get `to`.
+    /// Returns the transaction kind.
     fn kind(&self) -> TxKind;
 
     /// Get `value`.

--- a/crates/consensus/src/transaction/mod.rs
+++ b/crates/consensus/src/transaction/mod.rs
@@ -110,7 +110,7 @@ pub trait Transaction: any::Any + Send + Sync + 'static {
     }
 
     /// Get `to`.
-    fn to(&self) -> TxKind;
+    fn kind(&self) -> TxKind;
 
     /// Get `value`.
     fn value(&self) -> U256;
@@ -243,8 +243,8 @@ impl<T: Transaction> Transaction for alloy_serde::WithOtherFields<T> {
         self.inner.priority_fee_or_price()
     }
 
-    fn to(&self) -> TxKind {
-        self.inner.to()
+    fn kind(&self) -> TxKind {
+        self.inner.kind()
     }
 
     fn value(&self) -> U256 {

--- a/crates/consensus/src/transaction/mod.rs
+++ b/crates/consensus/src/transaction/mod.rs
@@ -3,7 +3,7 @@
 use crate::Signed;
 use alloc::vec::Vec;
 use alloy_eips::{eip2930::AccessList, eip7702::SignedAuthorization};
-use alloy_primitives::{keccak256, ChainId, TxKind, B256, U256};
+use alloy_primitives::{keccak256, Address, ChainId, TxKind, B256, U256};
 use core::any;
 
 mod eip1559;
@@ -111,6 +111,14 @@ pub trait Transaction: any::Any + Send + Sync + 'static {
 
     /// Returns the transaction kind.
     fn kind(&self) -> TxKind;
+
+    /// Get the transaction's address of the contract that will be called, or the address that will
+    /// receive the transfer.
+    ///
+    /// Returns `None` if this is a `CREATE` transaction.
+    fn to(&self) -> Option<Address> {
+        self.kind().to().copied()
+    }
 
     /// Get `value`.
     fn value(&self) -> U256;

--- a/crates/consensus/src/transaction/typed.rs
+++ b/crates/consensus/src/transaction/typed.rs
@@ -216,13 +216,13 @@ impl Transaction for TypedTransaction {
         }
     }
 
-    fn to(&self) -> TxKind {
+    fn kind(&self) -> TxKind {
         match self {
-            Self::Legacy(tx) => tx.to(),
-            Self::Eip2930(tx) => tx.to(),
-            Self::Eip1559(tx) => tx.to(),
-            Self::Eip4844(tx) => tx.to(),
-            Self::Eip7702(tx) => tx.to(),
+            Self::Legacy(tx) => tx.kind(),
+            Self::Eip2930(tx) => tx.kind(),
+            Self::Eip1559(tx) => tx.kind(),
+            Self::Eip4844(tx) => tx.kind(),
+            Self::Eip7702(tx) => tx.kind(),
         }
     }
 

--- a/crates/network-primitives/src/traits.rs
+++ b/crates/network-primitives/src/traits.rs
@@ -82,7 +82,7 @@ pub trait TransactionResponse: Transaction {
 
     /// Recipient of the transaction. Returns `None` if transaction is a contract creation.
     fn to(&self) -> Option<Address> {
-        Transaction::to(self).to().copied()
+        self.kind().to().copied()
     }
 
     /// Gas Price, this is the RPC format for `max_fee_per_gas`, pre-eip-1559.

--- a/crates/rpc-types-eth/src/transaction/mod.rs
+++ b/crates/rpc-types-eth/src/transaction/mod.rs
@@ -375,7 +375,7 @@ impl alloy_consensus::Transaction for Transaction {
         self.max_fee_per_gas.unwrap_or_else(|| self.gas_price.unwrap_or_default())
     }
 
-    fn to(&self) -> TxKind {
+    fn kind(&self) -> TxKind {
         self.to.into()
     }
 

--- a/crates/signer-trezor/src/signer.rs
+++ b/crates/signer-trezor/src/signer.rs
@@ -176,7 +176,7 @@ impl TrezorSigner {
         let gas_limit = tx.gas_limit();
         let gas_limit = u64_to_trezor(gas_limit);
 
-        let to = match tx.to() {
+        let to = match tx.kind() {
             TxKind::Call(to) => address_to_trezor(&to),
             TxKind::Create => String::new(),
         };


### PR DESCRIPTION
`to` naming convention can be confusing because we already have a `to` function in most implementations and this `to` function designates the receiving address while here we are going to get the kind of the transaction.

For example here it could be really confusing with potential double `to().to()` to catch the final address:

https://github.com/paradigmxyz/reth/blob/c4d7b591834055bdf3afed96b696e0a2cef0f383/crates/primitives/src/transaction/mod.rs#L226-L247