### PR TITLE
refactor: move hash memoization out of signed

### DIFF
--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -36,7 +36,7 @@ pub mod transaction;
 #[cfg(feature = "kzg")]
 pub use transaction::BlobTransactionValidationError;
 pub use transaction::{
-    SignableTransaction, Transaction, TxEip1559, TxEip2930, TxEip4844, TxEip4844Variant,
+    Enveloped, SignableTransaction, Transaction, TxEip1559, TxEip2930, TxEip4844, TxEip4844Variant,
     TxEip4844WithSidecar, TxEip7702, TxEnvelope, TxLegacy, TxType, TypedTransaction,
 };
 

--- a/crates/consensus/src/signed.rs
+++ b/crates/consensus/src/signed.rs
@@ -10,8 +10,6 @@ pub struct Signed<T, Sig = Signature> {
     tx: T,
     #[cfg_attr(feature = "serde", serde(flatten))]
     signature: Sig,
-    #[doc(alias = "tx_hash", alias = "transaction_hash")]
-    hash: B256,
 }
 
 impl<T, Sig> Signed<T, Sig> {
@@ -26,15 +24,9 @@ impl<T, Sig> Signed<T, Sig> {
         &self.signature
     }
 
-    /// Returns a reference to the transaction hash.
-    #[doc(alias = "tx_hash", alias = "transaction_hash")]
-    pub const fn hash(&self) -> &B256 {
-        &self.hash
-    }
-
     /// Splits the transaction into parts.
-    pub fn into_parts(self) -> (T, Sig, B256) {
-        (self.tx, self.signature, self.hash)
+    pub fn into_parts(self) -> (T, Sig) {
+        (self.tx, self.signature)
     }
 
     /// Returns the transaction without signature.
@@ -45,8 +37,8 @@ impl<T, Sig> Signed<T, Sig> {
 
 impl<T: SignableTransaction<Sig>, Sig> Signed<T, Sig> {
     /// Instantiate from a transaction and signature. Does not verify the signature.
-    pub const fn new_unchecked(tx: T, signature: Sig, hash: B256) -> Self {
-        Self { tx, signature, hash }
+    pub const fn new_unchecked(tx: T, signature: Sig) -> Self {
+        Self { tx, signature }
     }
 
     /// Calculate the signing hash for the transaction.

--- a/crates/consensus/src/transaction/eip2930.rs
+++ b/crates/consensus/src/transaction/eip2930.rs
@@ -1,7 +1,6 @@
 use crate::{EncodableSignature, SignableTransaction, Signed, Transaction, TxType};
-use alloc::vec::Vec;
 use alloy_eips::{eip2930::AccessList, eip7702::SignedAuthorization};
-use alloy_primitives::{keccak256, Bytes, ChainId, Parity, Signature, TxKind, B256, U256};
+use alloy_primitives::{Bytes, ChainId, Parity, Signature, TxKind, B256, U256};
 use alloy_rlp::{length_of_length, BufMut, Decodable, Encodable, Header};
 use core::mem;
 
@@ -312,11 +311,7 @@ impl SignableTransaction<Signature> for TxEip2930 {
         // signature.
         let signature = signature.with_parity_bool();
 
-        let mut buf = Vec::with_capacity(self.encoded_len_with_signature(&signature, false));
-        self.encode_with_signature(&signature, &mut buf, false);
-        let hash = keccak256(&buf);
-
-        Signed::new_unchecked(self, signature, hash)
+        Signed::new_unchecked(self, signature)
     }
 }
 
@@ -391,7 +386,7 @@ mod tests {
 
         let tx = request.into_signed(signature);
 
-        let envelope = TxEnvelope::Eip2930(tx);
+        let envelope: TxEnvelope = tx.into();
 
         let mut encoded = Vec::new();
         envelope.encode(&mut encoded);

--- a/crates/consensus/src/transaction/eip7702.rs
+++ b/crates/consensus/src/transaction/eip7702.rs
@@ -4,7 +4,7 @@ use alloy_eips::{
     eip2930::AccessList,
     eip7702::{constants::EIP7702_TX_TYPE_ID, SignedAuthorization},
 };
-use alloy_primitives::{keccak256, Address, Bytes, ChainId, Parity, Signature, TxKind, B256, U256};
+use alloy_primitives::{Address, Bytes, ChainId, Parity, Signature, TxKind, B256, U256};
 use alloy_rlp::{BufMut, Decodable, Encodable, Header};
 use core::mem;
 
@@ -355,11 +355,7 @@ impl SignableTransaction<Signature> for TxEip7702 {
         // signature.
         let signature = signature.with_parity_bool();
 
-        let mut buf = Vec::with_capacity(self.encoded_len_with_signature(&signature, false));
-        self.encode_with_signature(&signature, &mut buf, false);
-        let hash = keccak256(&buf);
-
-        Signed::new_unchecked(self, signature, hash)
+        Signed::new_unchecked(self, signature)
     }
 }
 

--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -395,6 +395,10 @@ impl Encodable2718 for TxEnvelope {
             }
         }
     }
+
+    fn trie_hash(&self) -> B256 {
+        self.tx_hash()
+    }
 }
 
 impl Transaction for TxEnvelope {

--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -580,15 +580,15 @@ mod serde_from {
     #[serde(tag = "type")]
     pub(crate) enum TaggedTxEnvelope {
         #[serde(rename = "0x0", alias = "0x00")]
-        Legacy(Enveloped<TxLegacy>),
+        Legacy(#[serde(with = "alloy_serde::sealed::flat_hash")] Enveloped<TxLegacy>),
         #[serde(rename = "0x1", alias = "0x01")]
-        Eip2930(Enveloped<TxEip2930>),
+        Eip2930(#[serde(with = "alloy_serde::sealed::flat_hash")] Enveloped<TxEip2930>),
         #[serde(rename = "0x2", alias = "0x02")]
-        Eip1559(Enveloped<TxEip1559>),
+        Eip1559(#[serde(with = "alloy_serde::sealed::flat_hash")] Enveloped<TxEip1559>),
         #[serde(rename = "0x3", alias = "0x03")]
-        Eip4844(Enveloped<TxEip4844Variant>),
+        Eip4844(#[serde(with = "alloy_serde::sealed::flat_hash")] Enveloped<TxEip4844Variant>),
         #[serde(rename = "0x4", alias = "0x04")]
-        Eip7702(Enveloped<TxEip7702>),
+        Eip7702(#[serde(with = "alloy_serde::sealed::flat_hash")] Enveloped<TxEip7702>),
     }
 
     impl From<MaybeTaggedTxEnvelope> for TxEnvelope {

--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -2,6 +2,7 @@ use crate::{
     transaction::eip4844::{TxEip4844, TxEip4844Variant, TxEip4844WithSidecar},
     Signed, Transaction, TxEip1559, TxEip2930, TxEip7702, TxLegacy,
 };
+use alloc::vec::Vec;
 use alloy_eips::{
     eip2718::{Decodable2718, Eip2718Error, Eip2718Result, Encodable2718},
     eip2930::AccessList,

--- a/crates/consensus/src/transaction/legacy.rs
+++ b/crates/consensus/src/transaction/legacy.rs
@@ -1,8 +1,7 @@
 use core::mem;
 
-use alloc::vec::Vec;
 use alloy_eips::{eip2930::AccessList, eip7702::SignedAuthorization};
-use alloy_primitives::{keccak256, Bytes, ChainId, Parity, Signature, TxKind, B256, U256};
+use alloy_primitives::{Bytes, ChainId, Parity, Signature, TxKind, B256, U256};
 use alloy_rlp::{length_of_length, BufMut, Decodable, Encodable, Header, Result};
 
 use crate::{EncodableSignature, SignableTransaction, Signed, Transaction, TxType};
@@ -296,10 +295,8 @@ impl SignableTransaction<Signature> for TxLegacy {
         } else {
             signature
         };
-        let mut buf = Vec::with_capacity(self.encoded_len_with_signature(&signature));
-        self.encode_with_signature_fields(&signature, &mut buf);
-        let hash = keccak256(&buf);
-        Signed::new_unchecked(self, signature, hash)
+
+        Signed::new_unchecked(self, signature)
     }
 }
 
@@ -372,9 +369,9 @@ mod tests {
         )
         .unwrap();
 
-        let signed_tx = tx.into_signed(sig);
+        let signed_tx: crate::TxEnvelope = tx.into_signed(sig).into();
 
-        assert_eq!(*signed_tx.hash(), hash, "Expected same hash");
+        assert_eq!(*signed_tx.tx_hash(), hash, "Expected same hash");
         assert_eq!(signed_tx.recover_signer().unwrap(), signer, "Recovering signer should pass.");
     }
 

--- a/crates/consensus/src/transaction/mod.rs
+++ b/crates/consensus/src/transaction/mod.rs
@@ -27,7 +27,7 @@ pub use eip4844::BlobTransactionValidationError;
 pub use eip4844::{TxEip4844, TxEip4844Variant, TxEip4844WithSidecar};
 
 mod envelope;
-pub use envelope::{TxEnvelope, TxType};
+pub use envelope::{Enveloped, TxEnvelope, TxType};
 
 mod legacy;
 pub use legacy::TxLegacy;

--- a/crates/consensus/src/transaction/typed.rs
+++ b/crates/consensus/src/transaction/typed.rs
@@ -80,11 +80,11 @@ impl From<TxEip7702> for TypedTransaction {
 impl From<TxEnvelope> for TypedTransaction {
     fn from(envelope: TxEnvelope) -> Self {
         match envelope {
-            TxEnvelope::Legacy(tx) => Self::Legacy(tx.strip_signature()),
-            TxEnvelope::Eip2930(tx) => Self::Eip2930(tx.strip_signature()),
-            TxEnvelope::Eip1559(tx) => Self::Eip1559(tx.strip_signature()),
-            TxEnvelope::Eip4844(tx) => Self::Eip4844(tx.strip_signature()),
-            TxEnvelope::Eip7702(tx) => Self::Eip7702(tx.strip_signature()),
+            TxEnvelope::Legacy(tx) => Self::Legacy(tx.into_inner().strip_signature()),
+            TxEnvelope::Eip2930(tx) => Self::Eip2930(tx.into_inner().strip_signature()),
+            TxEnvelope::Eip1559(tx) => Self::Eip1559(tx.into_inner().strip_signature()),
+            TxEnvelope::Eip4844(tx) => Self::Eip4844(tx.into_inner().strip_signature()),
+            TxEnvelope::Eip7702(tx) => Self::Eip7702(tx.into_inner().strip_signature()),
         }
     }
 }

--- a/crates/rpc-types-eth/src/transaction/mod.rs
+++ b/crates/rpc-types-eth/src/transaction/mod.rs
@@ -292,7 +292,7 @@ impl TryFrom<Transaction> for Signed<TxEip4844Variant> {
 
     fn try_from(tx: Transaction) -> Result<Self, Self::Error> {
         let tx: Signed<TxEip4844> = tx.try_into()?;
-        let (inner, signature, _) = tx.into_parts();
+        let (inner, signature) = tx.into_parts();
         let tx: TxEip4844Variant = inner.into();
 
         Ok(tx.into_signed(signature))
@@ -329,11 +329,11 @@ impl TryFrom<Transaction> for TxEnvelope {
 
     fn try_from(tx: Transaction) -> Result<Self, Self::Error> {
         match tx.transaction_type.unwrap_or_default().try_into()? {
-            TxType::Legacy => Ok(Self::Legacy(tx.try_into()?)),
-            TxType::Eip1559 => Ok(Self::Eip1559(tx.try_into()?)),
-            TxType::Eip2930 => Ok(Self::Eip2930(tx.try_into()?)),
-            TxType::Eip4844 => Ok(Self::Eip4844(tx.try_into()?)),
-            TxType::Eip7702 => Ok(Self::Eip7702(tx.try_into()?)),
+            TxType::Legacy => Ok(Signed::<TxLegacy>::try_from(tx)?.into()),
+            TxType::Eip1559 => Ok(Signed::<TxEip1559>::try_from(tx)?.into()),
+            TxType::Eip2930 => Ok(Signed::<TxEip2930>::try_from(tx)?.into()),
+            TxType::Eip4844 => Ok(Signed::<TxEip4844>::try_from(tx)?.into()),
+            TxType::Eip7702 => Ok(Signed::<TxEip7702>::try_from(tx)?.into()),
         }
     }
 }

--- a/crates/rpc-types-eth/src/transaction/request.rs
+++ b/crates/rpc-types-eth/src/transaction/request.rs
@@ -934,7 +934,7 @@ impl From<TxEnvelope> for TransactionRequest {
                 #[cfg(feature = "k256")]
                 {
                     let from = tx.recover_signer().ok();
-                    let tx: Self = tx.strip_signature().into();
+                    let tx: Self = tx.into_inner().strip_signature().into();
                     if let Some(from) = from {
                         tx.from(from)
                     } else {
@@ -944,14 +944,14 @@ impl From<TxEnvelope> for TransactionRequest {
 
                 #[cfg(not(feature = "k256"))]
                 {
-                    tx.strip_signature().into()
+                    tx.into_inner().strip_signature().into()
                 }
             }
             TxEnvelope::Eip2930(tx) => {
                 #[cfg(feature = "k256")]
                 {
                     let from = tx.recover_signer().ok();
-                    let tx: Self = tx.strip_signature().into();
+                    let tx: Self = tx.into_inner().strip_signature().into();
                     if let Some(from) = from {
                         tx.from(from)
                     } else {
@@ -961,14 +961,14 @@ impl From<TxEnvelope> for TransactionRequest {
 
                 #[cfg(not(feature = "k256"))]
                 {
-                    tx.strip_signature().into()
+                    tx.into_inner().strip_signature().into()
                 }
             }
             TxEnvelope::Eip1559(tx) => {
                 #[cfg(feature = "k256")]
                 {
                     let from = tx.recover_signer().ok();
-                    let tx: Self = tx.strip_signature().into();
+                    let tx: Self = tx.into_inner().strip_signature().into();
                     if let Some(from) = from {
                         tx.from(from)
                     } else {
@@ -978,14 +978,14 @@ impl From<TxEnvelope> for TransactionRequest {
 
                 #[cfg(not(feature = "k256"))]
                 {
-                    tx.strip_signature().into()
+                    tx.into_inner().strip_signature().into()
                 }
             }
             TxEnvelope::Eip4844(tx) => {
                 #[cfg(feature = "k256")]
                 {
                     let from = tx.recover_signer().ok();
-                    let tx: Self = tx.strip_signature().into();
+                    let tx: Self = tx.into_inner().strip_signature().into();
                     if let Some(from) = from {
                         tx.from(from)
                     } else {
@@ -995,14 +995,14 @@ impl From<TxEnvelope> for TransactionRequest {
 
                 #[cfg(not(feature = "k256"))]
                 {
-                    tx.strip_signature().into()
+                    tx.into_inner().strip_signature().into()
                 }
             }
             TxEnvelope::Eip7702(tx) => {
                 #[cfg(feature = "k256")]
                 {
                     let from = tx.recover_signer().ok();
-                    let tx: Self = tx.strip_signature().into();
+                    let tx: Self = tx.into_inner().strip_signature().into();
                     if let Some(from) = from {
                         tx.from(from)
                     } else {
@@ -1012,7 +1012,7 @@ impl From<TxEnvelope> for TransactionRequest {
 
                 #[cfg(not(feature = "k256"))]
                 {
-                    tx.strip_signature().into()
+                    tx.into_inner().strip_signature().into()
                 }
             }
             _ => Default::default(),

--- a/crates/serde/src/lib.rs
+++ b/crates/serde/src/lib.rs
@@ -23,6 +23,9 @@ pub use self::optional::*;
 
 pub mod quantity;
 
+/// Serialization for [`alloy_primitves::Sealed`].
+pub mod sealed;
+
 /// Storage related helpers.
 pub mod storage;
 pub use storage::JsonStorageKey;

--- a/crates/serde/src/lib.rs
+++ b/crates/serde/src/lib.rs
@@ -23,7 +23,9 @@ pub use self::optional::*;
 
 pub mod quantity;
 
-/// Serialization for [`alloy_primitves::Sealed`].
+/// Serialization options for [`Sealed`].
+///
+/// [`Sealed`]: alloy_primitives::Sealed
 pub mod sealed;
 
 /// Storage related helpers.

--- a/crates/serde/src/sealed.rs
+++ b/crates/serde/src/sealed.rs
@@ -1,0 +1,78 @@
+/// Serializes and Deserializes [`Sealed`], flattening the struct.
+pub mod flat {
+    use alloy_primitives::{Sealed, B256};
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    #[derive(Serialize)]
+    struct FlatSer<'a, T> {
+        seal: B256,
+        #[serde(flatten)]
+        t: &'a T,
+    }
+
+    #[derive(Deserialize)]
+    struct FlatDeser<T> {
+        seal: B256,
+        #[serde(flatten)]
+        t: T,
+    }
+
+    /// Serializes a [`Sealed`] with the given serializer.
+    pub fn serialize<S, T>(sealed: &Sealed<T>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+        T: Serialize,
+    {
+        FlatSer { seal: sealed.seal(), t: sealed.inner() }.serialize(serializer)
+    }
+
+    /// Deserializes a [`Sealed`] with the given deserializer.
+    pub fn deserialize<'de, D, T>(deserializer: D) -> Result<Sealed<T>, D::Error>
+    where
+        D: Deserializer<'de>,
+        T: Deserialize<'de>,
+    {
+        let FlatDeser { seal, t } = FlatDeser::deserialize(deserializer)?;
+        Ok(Sealed::new_unchecked(t, seal))
+    }
+}
+
+/// Serializes and Deserializes [`Sealed`], flattening the struct and renaming
+/// the `seal` key to `hash`.
+pub mod flat_hash {
+    use alloy_primitives::{Sealed, B256};
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    #[derive(Serialize)]
+    struct FlatSer<'a, T> {
+        hash: B256,
+        #[serde(flatten)]
+        t: &'a T,
+    }
+
+    #[derive(Deserialize)]
+    struct FlatDeser<T> {
+        hash: B256,
+        #[serde(flatten)]
+        t: T,
+    }
+
+    /// Serializes a [`Sealed`] with the given serializer.
+    pub fn serialize<S, T>(sealed: &Sealed<T>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+        T: Serialize,
+    {
+        FlatSer { hash: sealed.seal(), t: sealed.inner() }.serialize(serializer)
+    }
+
+    /// Deserializes a [`Sealed`] with the given deserializer.
+    pub fn deserialize<'de, D, T>(deserializer: D) -> Result<Sealed<T>, D::Error>
+    where
+        D: Deserializer<'de>,
+        T: Deserialize<'de>,
+    {
+        let FlatDeser { hash, t } = FlatDeser::deserialize(deserializer)?;
+        Ok(Sealed::new_unchecked(t, hash))
+    }
+}

--- a/crates/serde/src/sealed.rs
+++ b/crates/serde/src/sealed.rs
@@ -1,4 +1,6 @@
 /// Serializes and Deserializes [`Sealed`], flattening the struct.
+///
+/// [`Sealed`]: alloy_primitives::Sealed
 pub mod flat {
     use alloy_primitives::{Sealed, B256};
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -39,6 +41,8 @@ pub mod flat {
 
 /// Serializes and Deserializes [`Sealed`], flattening the struct and renaming
 /// the `seal` key to `hash`.
+///
+/// [`Sealed`]: alloy_primitives::Sealed
 pub mod flat_hash {
     use alloy_primitives::{Sealed, B256};
     use serde::{Deserialize, Deserializer, Serialize, Serializer};


### PR DESCRIPTION
This is a breaking change

## Motivation

See discussion in #1460 and #1483

Memoizing the hash in `Signed` is inappropriate, as the transaction does not know its full 2718 serialization without being embedded in an envelope. This breaks the hash out into a `Sealed` type that is produced when the `Envelope` is constructed. The sealed type is transparent to the user

## Solution

- Introduce `Enveloped` type alias
- ensure that `From<>` impls properly `Seal`
- ensure that `impl Encodable2718 for TxEnvelope` produces the correct `trie_hash` by returning the memoized hash. This previously produced incorrect hashes for 4844 txns with sidecars

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [x] Breaking changes
