### PR TITLE
chore: remove self from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @danipopes @gakonst @mattsse @onbjerg @prestwich @evalir @emhane
+* @danipopes @gakonst @mattsse @onbjerg @evalir @emhane


### PR DESCRIPTION

## Motivation

I can't be subscribed to notifications on my own PRs without also getting email/github notifications for every PR

## Solution

Remove self from codeowners

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
