### PR TITLE
feat: make Pending transaction own the provider

### DIFF
--- a/crates/contract/src/call.rs
+++ b/crates/contract/src/call.rs
@@ -495,7 +495,7 @@ impl<T: Transport + Clone, P: Provider<T, N>, D: CallDecoder, N: Network> CallBu
     ///
     /// Returns a builder for configuring the pending transaction watcher.
     /// See [`Provider::send_transaction`] for more information.
-    pub async fn send(&self) -> Result<PendingTransactionBuilder<'_, T, N>> {
+    pub async fn send(&self) -> Result<PendingTransactionBuilder<T, N>> {
         Ok(self.provider.send_transaction(self.request.clone()).await?)
     }
 

--- a/crates/provider/src/fillers/mod.rs
+++ b/crates/provider/src/fillers/mod.rs
@@ -292,7 +292,7 @@ where
     async fn send_transaction_internal(
         &self,
         mut tx: SendableTx<N>,
-    ) -> TransportResult<PendingTransactionBuilder<'_, T, N>> {
+    ) -> TransportResult<PendingTransactionBuilder<T, N>> {
         tx = self.fill_inner(tx).await?;
 
         if let Some(builder) = tx.as_builder() {

--- a/crates/provider/src/heart.rs
+++ b/crates/provider/src/heart.rs
@@ -82,20 +82,20 @@ pub enum PendingTransactionError {
 #[must_use = "this type does nothing unless you call `register`, `watch` or `get_receipt`"]
 #[derive(Debug)]
 #[doc(alias = "PendingTxBuilder")]
-pub struct PendingTransactionBuilder<'a, T, N: Network> {
+pub struct PendingTransactionBuilder<T, N: Network> {
     config: PendingTransactionConfig,
-    provider: &'a RootProvider<T, N>,
+    provider: RootProvider<T, N>,
 }
 
-impl<'a, T: Transport + Clone, N: Network> PendingTransactionBuilder<'a, T, N> {
+impl<T: Transport + Clone, N: Network> PendingTransactionBuilder<T, N> {
     /// Creates a new pending transaction builder.
-    pub const fn new(provider: &'a RootProvider<T, N>, tx_hash: TxHash) -> Self {
+    pub const fn new(provider: RootProvider<T, N>, tx_hash: TxHash) -> Self {
         Self::from_config(provider, PendingTransactionConfig::new(tx_hash))
     }
 
     /// Creates a new pending transaction builder from the given configuration.
     pub const fn from_config(
-        provider: &'a RootProvider<T, N>,
+        provider: RootProvider<T, N>,
         config: PendingTransactionConfig,
     ) -> Self {
         Self { config, provider }
@@ -107,17 +107,17 @@ impl<'a, T: Transport + Clone, N: Network> PendingTransactionBuilder<'a, T, N> {
     }
 
     /// Consumes this builder, returning the inner configuration.
-    pub const fn into_inner(self) -> PendingTransactionConfig {
+    pub fn into_inner(self) -> PendingTransactionConfig {
         self.config
     }
 
     /// Returns the provider.
-    pub const fn provider(&self) -> &'a RootProvider<T, N> {
-        self.provider
+    pub const fn provider(&self) -> &RootProvider<T, N> {
+        &self.provider
     }
 
     /// Consumes this builder, returning the provider and the configuration.
-    pub const fn split(self) -> (&'a RootProvider<T, N>, PendingTransactionConfig) {
+    pub fn split(self) -> (RootProvider<T, N>, PendingTransactionConfig) {
         (self.provider, self.config)
     }
 
@@ -325,8 +325,8 @@ impl PendingTransactionConfig {
     /// Wraps this configuration with a provider to expose watching methods.
     pub const fn with_provider<T: Transport + Clone, N: Network>(
         self,
-        provider: &RootProvider<T, N>,
-    ) -> PendingTransactionBuilder<'_, T, N> {
+        provider: RootProvider<T, N>,
+    ) -> PendingTransactionBuilder<T, N> {
         PendingTransactionBuilder::from_config(provider, self)
     }
 }

--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -648,10 +648,10 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
     async fn send_raw_transaction(
         &self,
         encoded_tx: &[u8],
-    ) -> TransportResult<PendingTransactionBuilder<'_, T, N>> {
+    ) -> TransportResult<PendingTransactionBuilder<T, N>> {
         let rlp_hex = hex::encode_prefixed(encoded_tx);
         let tx_hash = self.client().request("eth_sendRawTransaction", (rlp_hex,)).await?;
-        Ok(PendingTransactionBuilder::new(self.root(), tx_hash))
+        Ok(PendingTransactionBuilder::new(self.root().clone(), tx_hash))
     }
 
     /// Broadcasts a transaction to the network.
@@ -677,7 +677,7 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
     async fn send_transaction(
         &self,
         tx: N::TransactionRequest,
-    ) -> TransportResult<PendingTransactionBuilder<'_, T, N>> {
+    ) -> TransportResult<PendingTransactionBuilder<T, N>> {
         self.send_transaction_internal(SendableTx::Builder(tx)).await
     }
 
@@ -688,7 +688,7 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
     async fn send_tx_envelope(
         &self,
         tx: N::TxEnvelope,
-    ) -> TransportResult<PendingTransactionBuilder<'_, T, N>> {
+    ) -> TransportResult<PendingTransactionBuilder<T, N>> {
         self.send_transaction_internal(SendableTx::Envelope(tx)).await
     }
 
@@ -703,7 +703,7 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
     async fn send_transaction_internal(
         &self,
         tx: SendableTx<N>,
-    ) -> TransportResult<PendingTransactionBuilder<'_, T, N>> {
+    ) -> TransportResult<PendingTransactionBuilder<T, N>> {
         // Make sure to initialize heartbeat before we submit transaction, so that
         // we don't miss it if user will subscriber to it immediately after sending.
         let _handle = self.root().get_heart();
@@ -712,7 +712,7 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
             SendableTx::Builder(mut tx) => {
                 alloy_network::TransactionBuilder::prep_for_submission(&mut tx);
                 let tx_hash = self.client().request("eth_sendTransaction", (tx,)).await?;
-                Ok(PendingTransactionBuilder::new(self.root(), tx_hash))
+                Ok(PendingTransactionBuilder::new(self.root().clone(), tx_hash))
             }
             SendableTx::Envelope(tx) => {
                 let mut encoded_tx = vec![];


### PR DESCRIPTION
RootProvider is an arc, this should just be cloned into the pendingtransactionbuilder

https://github.com/alloy-rs/alloy/blob/4c32ff922e2774ad581fbd6941e2f9cb026b7a44/crates/provider/src/provider/root.rs#L23-L26

so we can send a this type across boundaries.