### PR TITLE
fix(`rpc-types-eth`): receipt deser

### DIFF
--- a/crates/consensus/src/receipt/envelope.rs
+++ b/crates/consensus/src/receipt/envelope.rs
@@ -232,3 +232,36 @@ where
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    #[cfg(feature = "serde")]
+    #[test]
+    fn deser_pre658_receipt_envelope() {
+        use alloy_primitives::b256;
+
+        let receipt = super::ReceiptWithBloom::<()> {
+            receipt: super::Receipt {
+                status: super::Eip658Value::PostState(b256!(
+                    "284d35bf53b82ef480ab4208527325477439c64fb90ef518450f05ee151c8e10"
+                )),
+                cumulative_gas_used: 0,
+                logs: Default::default(),
+            },
+            logs_bloom: Default::default(),
+        };
+
+        let json = serde_json::to_string(&receipt).unwrap();
+
+        println!("Serialized {}", json);
+
+        let receipt: super::ReceiptWithBloom<()> = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(
+            receipt.receipt.status,
+            super::Eip658Value::PostState(b256!(
+                "284d35bf53b82ef480ab4208527325477439c64fb90ef518450f05ee151c8e10"
+            ))
+        );
+    }
+}

--- a/crates/consensus/src/receipt/receipts.rs
+++ b/crates/consensus/src/receipt/receipts.rs
@@ -319,4 +319,21 @@ mod test {
             r#"{"root":"0x0000000000000000000000000000000000000000000000000000000000000000","cumulativeGasUsed":"0x0","logs":[]}"#
         );
     }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn deser_pre658() {
+        use alloy_primitives::b256;
+
+        let json = r#"{"root":"0x284d35bf53b82ef480ab4208527325477439c64fb90ef518450f05ee151c8e10","cumulativeGasUsed":"0x0","logs":[]}"#;
+
+        let receipt: super::Receipt<()> = serde_json::from_str(json).unwrap();
+
+        assert_eq!(
+            receipt.status,
+            super::Eip658Value::PostState(b256!(
+                "284d35bf53b82ef480ab4208527325477439c64fb90ef518450f05ee151c8e10"
+            ))
+        );
+    }
 }

--- a/crates/rpc-types-eth/src/transaction/receipt.rs
+++ b/crates/rpc-types-eth/src/transaction/receipt.rs
@@ -70,7 +70,7 @@ pub struct TransactionReceipt<T = ReceiptEnvelope<Log>> {
     /// The post-transaction stateroot (pre Byzantium)
     ///
     /// EIP98 makes this optional field, if it's missing then skip serializing it
-    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none", rename = "root"))]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub state_root: Option<B256>,
     /// The authorization list is a list of tuples that store the address to code which the signer
     /// desires to execute in the context of their EOA.

--- a/crates/rpc-types-eth/src/transaction/receipt.rs
+++ b/crates/rpc-types-eth/src/transaction/receipt.rs
@@ -406,4 +406,48 @@ mod test {
         assert_eq!(other.gas_used_for_l1, "0x2c906");
         assert_eq!(other.l1_block_number, "0x1323b96");
     }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn deserialize_pre_eip658_receipt() {
+        let receipt_json = r#"
+        {
+            "transactionHash": "0xea1093d492a1dcb1bef708f771a99a96ff05dcab81ca76c31940300177fcf49f",
+            "blockHash": "0x8e38b4dbf6b11fcc3b9dee84fb7986e29ca0a02cecd8977c161ff7333329681e",
+            "blockNumber": "0xf4240",
+            "logsBloom": "0x00000000000000000000000000000000000800000000000000000000000800000000000000000400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000400000000000000000",
+            "gasUsed": "0x723c",
+            "root": "0x284d35bf53b82ef480ab4208527325477439c64fb90ef518450f05ee151c8e10",
+            "contractAddress": null,
+            "cumulativeGasUsed": "0x723c",
+            "transactionIndex": "0x0",
+            "from": "0x39fa8c5f2793459d6622857e7d9fbb4bd91766d3",
+            "to": "0xc083e9947cf02b8ffc7d3090ae9aea72df98fd47",
+            "type": "0x0",
+            "effectiveGasPrice": "0x12bfb19e60",
+            "logs": [
+                {
+                    "blockHash": "0x8e38b4dbf6b11fcc3b9dee84fb7986e29ca0a02cecd8977c161ff7333329681e",
+                    "address": "0xc083e9947cf02b8ffc7d3090ae9aea72df98fd47",
+                    "logIndex": "0x0",
+                    "data": "0x00000000000000000000000039fa8c5f2793459d6622857e7d9fbb4bd91766d30000000000000000000000000000000000000000000000056bc75e2d63100000",
+                    "removed": false,
+                    "topics": [
+                    "0xe1fffcc4923d04b559f4d29a8bfc6cda04eb5b0d3c460751c2402c5c5cc9109c"
+                    ],
+                    "blockNumber": "0xf4240",
+                    "transactionIndex": "0x0",
+                    "transactionHash": "0xea1093d492a1dcb1bef708f771a99a96ff05dcab81ca76c31940300177fcf49f"
+                }
+            ]
+        }
+        "#;
+
+        let receipt = serde_json::from_str::<TransactionReceipt>(receipt_json).unwrap();
+
+        assert_eq!(
+            receipt.transaction_hash,
+            b256!("ea1093d492a1dcb1bef708f771a99a96ff05dcab81ca76c31940300177fcf49f")
+        );
+    }
 }

--- a/crates/rpc-types-eth/src/transaction/receipt.rs
+++ b/crates/rpc-types-eth/src/transaction/receipt.rs
@@ -67,11 +67,6 @@ pub struct TransactionReceipt<T = ReceiptEnvelope<Log>> {
     pub to: Option<Address>,
     /// Contract address created, or None if not a deployment.
     pub contract_address: Option<Address>,
-    /// The post-transaction stateroot (pre Byzantium)
-    ///
-    /// EIP98 makes this optional field, if it's missing then skip serializing it
-    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    pub state_root: Option<B256>,
     /// The authorization list is a list of tuples that store the address to code which the signer
     /// desires to execute in the context of their EOA.
     #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
@@ -134,7 +129,6 @@ impl<T> TransactionReceipt<T> {
             from: self.from,
             to: self.to,
             contract_address: self.contract_address,
-            state_root: self.state_root,
             authorization_list: self.authorization_list,
         }
     }
@@ -204,7 +198,7 @@ impl<T: TxReceipt<Log>> ReceiptResponse for TransactionReceipt<T> {
     }
 
     fn state_root(&self) -> Option<B256> {
-        self.state_root
+        self.inner.status_or_post_state().as_post_state()
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Closes #1493 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

`state_root` in `TransactionReceipt` would conflict with `Eip658::PostState(root)` in `Receipt` as both have serde aliases set as `root`. Remove `state_root`. 

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [x] Breaking changes
