### PR TITLE
fix: use `requests_hash`

### DIFF
--- a/crates/consensus/src/header.rs
+++ b/crates/consensus/src/header.rs
@@ -864,7 +864,7 @@ pub(super) mod serde_bincode_compat {
         #[serde(default)]
         parent_beacon_block_root: Option<B256>,
         #[serde(default)]
-        requests_root: Option<B256>,
+        requests_hash: Option<B256>,
         extra_data: Cow<'a, Bytes>,
     }
 
@@ -890,7 +890,7 @@ pub(super) mod serde_bincode_compat {
                 blob_gas_used: value.blob_gas_used,
                 excess_blob_gas: value.excess_blob_gas,
                 parent_beacon_block_root: value.parent_beacon_block_root,
-                requests_root: value.requests_root,
+                requests_hash: value.requests_hash,
                 extra_data: Cow::Borrowed(&value.extra_data),
             }
         }
@@ -918,7 +918,7 @@ pub(super) mod serde_bincode_compat {
                 blob_gas_used: value.blob_gas_used,
                 excess_blob_gas: value.excess_blob_gas,
                 parent_beacon_block_root: value.parent_beacon_block_root,
-                requests_root: value.requests_root,
+                requests_hash: value.requests_hash,
                 extra_data: value.extra_data.into_owned(),
             }
         }


### PR DESCRIPTION

## Motivation

#1379 passed the PR checks, but somehow not on main.

## Solution

Remove remaining references to `requests_root`

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
