### PR TITLE
chore: remove redundant cfgs

### DIFF
--- a/crates/eips/src/eip2718.rs
+++ b/crates/eips/src/eip2718.rs
@@ -2,9 +2,7 @@
 //!
 //! [EIP-2718]: https://eips.ethereum.org/EIPS/eip-2718
 
-#[cfg(not(feature = "std"))]
-use crate::alloc::{vec, vec::Vec};
-
+use crate::alloc::vec::Vec;
 use alloy_primitives::{keccak256, Sealed, B256};
 use alloy_rlp::{Buf, BufMut, Header, EMPTY_STRING_CODE};
 use core::{

--- a/crates/eips/src/eip4844/builder.rs
+++ b/crates/eips/src/eip4844/builder.rs
@@ -2,12 +2,10 @@ use crate::eip4844::Blob;
 #[cfg(feature = "kzg")]
 use c_kzg::{KzgCommitment, KzgProof};
 
-#[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
-
 use crate::eip4844::{
     utils::WholeFe, BYTES_PER_BLOB, FIELD_ELEMENTS_PER_BLOB, MAX_BLOBS_PER_BLOCK,
 };
+use alloc::vec::Vec;
 
 #[cfg(feature = "kzg")]
 use crate::eip4844::env_settings::EnvKzgSettings;

--- a/crates/eips/src/eip4844/sidecar.rs
+++ b/crates/eips/src/eip4844/sidecar.rs
@@ -10,7 +10,6 @@ use alloy_rlp::{Decodable, Encodable};
 #[cfg(any(test, feature = "arbitrary"))]
 use crate::eip4844::MAX_BLOBS_PER_BLOCK;
 
-#[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
 /// The versioned hash version for KZG.


### PR DESCRIPTION
not needed