### PR TITLE
docs(prestate): comment prestate more clear

### DIFF
--- a/crates/provider/src/layers/cache.rs
+++ b/crates/provider/src/layers/cache.rs
@@ -58,12 +58,13 @@ where
     }
 }
 
-/// The [`CacheProvider`] holds the underlying in-memory LRU cache and overrides methods from the
-/// [`Provider`] trait that should attempt to fetch from cache and fallback to the RPC in case of a
-/// cache miss.
+/// The [`CacheProvider`] holds the underlying in-memory LRU cache and overrides methods
+/// from the [`Provider`] trait. It attempts to fetch from the cache and fallbacks to
+/// the RPC in case of a cache miss.
 ///
-/// Most importantly, the [`CacheProvider`] adds `save_cache` and `load_cache` methods to the
-/// provider interface to lets users save cache to the disk and load from it on demand.
+/// Most importantly, the [`CacheProvider`] adds `save_cache` and `load_cache` methods
+/// to the provider interface, allowing users to save the cache to disk and load it
+/// from there on demand.
 #[derive(Debug, Clone)]
 pub struct CacheProvider<P, T, N> {
     /// Inner provider.

--- a/crates/rpc-types-trace/src/geth/mod.rs
+++ b/crates/rpc-types-trace/src/geth/mod.rs
@@ -268,14 +268,18 @@ pub enum GethDebugBuiltInTracerType {
     /// to the nested format of `callTracer`.
     #[serde(rename = "flatCallTracer")]
     FlatCallTracer,
-    /// The prestate tracer has two modes: prestate and diff. The prestate mode returns the
-    /// accounts necessary to execute a given transaction. diff mode returns the differences
-    /// between the transaction's pre and post-state (i.e. what changed because the transaction
-    /// happened). The prestateTracer defaults to prestate mode. It reexecutes the given
-    /// transaction and tracks every part of state that is touched. This is similar to the concept
-    /// of a stateless witness, the difference being this tracer doesn't return any cryptographic
-    /// proof, rather only the trie leaves. The result is an object. The keys are addresses of
-    /// accounts.
+    /// The prestate tracer operates in two distinct modes: prestate and diff.
+    /// - In prestate mode, it retrieves the accounts required for executing a specified
+    ///   transaction.
+    /// - In diff mode, it identifies the changes between the transaction's initial and final
+    ///   states, detailing the modifications caused by the transaction.
+    ///
+    /// By default, the prestateTracer is set to prestate mode. It reexecutes the given transaction
+    /// and tracks every part of state that is accessed.
+    ///
+    /// This functionality is akin to a stateless witness, with the key distinction that this
+    /// tracer does not provide any cryptographic proofs; it only returns the trie leaves.
+    /// The output is an object where the keys correspond to account addresses.
     #[serde(rename = "prestateTracer")]
     PreStateTracer,
     /// This tracer is noop. It returns an empty object and is only meant for testing the setup.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->


1. fix an clippy warning:

```
warning: first doc comment paragraph is too long
  --> crates/provider/src/layers/cache.rs:61:1
   |
61 | / /// The [`CacheProvider`] holds the underlying in-memory LRU cache and overrides methods from the
62 | | /// [`Provider`] trait that should attempt to fetch from cache and fallback to the RPC in case of a
63 | | /// cache miss.
64 | | ///
65 | | /// Most importantly, the [`CacheProvider`] adds `save_cache` and `load_cache` methods to the
   | |_
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#too_long_first_doc_paragraph
   = note: `-W clippy::too-long-first-doc-paragraph` implied by `-W clippy::all`
   = help: to override `-W clippy::all` add `#[allow(clippy::too_long_first_doc_paragraph)]`

warning: `alloy-provider` (lib) generated 1 warning
```

2. make the prestate comments more clear

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
