### PR TITLE
feat: derive serde for `ExecutionPayloadSidecar`

### DIFF
--- a/crates/rpc-types-engine/src/cancun.rs
+++ b/crates/rpc-types-engine/src/cancun.rs
@@ -22,6 +22,7 @@ pub struct CancunPayloadFields {
 
 /// A container type for [CancunPayloadFields] that may or may not be present.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MaybeCancunPayloadFields {
     fields: Option<CancunPayloadFields>,
 }

--- a/crates/rpc-types-engine/src/sidecar.rs
+++ b/crates/rpc-types-engine/src/sidecar.rs
@@ -8,6 +8,7 @@ use alloy_primitives::B256;
 /// Container type for all available additional `newPayload` request parameters that are not present
 /// in the `ExecutionPayload` object itself.
 #[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ExecutionPayloadSidecar {
     /// Cancun request params introduced in `engine_newPayloadV3` that are not present in the
     /// `ExecutionPayload`.


### PR DESCRIPTION
## Motivation

We have an interceptor in Reth that stores engine API messages, including extra fields, which are now present in the sidecar. This interceptor stores them on disk by serializing them with serde.

## Solution

Derive `Serialize`/`Deserialize` for the sidecar.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
