### PR TITLE
consensus: impl `recover_signers` for `BlockBody<TxEnvelope>`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,6 +146,7 @@ derive_more = { version = "1.0.0", default-features = false }
 strum = { version = "0.26", default-features = false }
 http = "1.1.0"
 jsonwebtoken = "9.3.0"
+rayon = "1.7"
 
 ## serde
 serde = { version = "1.0", default-features = false, features = [

--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -42,6 +42,7 @@ derive_more = { workspace = true, features = [
     "into_iterator"
 ], default-features = false }
 auto_impl.workspace = true
+rayon = { workspace = true, optional = true }
 
 [dev-dependencies]
 alloy-eips = { workspace = true, features = ["arbitrary"] }
@@ -58,7 +59,7 @@ tokio = { workspace = true, features = ["macros"] }
 [features]
 default = ["std"]
 std = ["alloy-eips/std", "c-kzg?/std"]
-k256 = ["alloy-primitives/k256", "alloy-eips/k256"]
+k256 = ["alloy-primitives/k256", "alloy-eips/k256", "rayon"]
 kzg = ["dep:c-kzg", "alloy-eips/kzg", "std"]
 arbitrary = ["std", "dep:arbitrary", "alloy-eips/arbitrary"]
 serde = [

--- a/crates/consensus/src/block.rs
+++ b/crates/consensus/src/block.rs
@@ -1,8 +1,9 @@
 //! Block Type
 
-use crate::Header;
+use crate::{Header, TxEnvelope};
 use alloc::vec::Vec;
 use alloy_eips::eip4895::Withdrawals;
+use alloy_primitives::Address;
 use alloy_rlp::{Decodable, Encodable, RlpDecodable, RlpEncodable};
 
 /// Ethereum full block.
@@ -32,6 +33,14 @@ pub struct BlockBody<T> {
     pub ommers: Vec<Header>,
     /// Block withdrawals.
     pub withdrawals: Option<Withdrawals>,
+}
+
+impl BlockBody<TxEnvelope> {
+    /// Recover signer addresses for all transactions in the block body.
+    #[cfg(feature = "k256")]
+    pub fn recover_signers(&self) -> Result<Vec<Address>, alloy_primitives::SignatureError> {
+        TxEnvelope::recover_signers(&self.transactions, self.transactions.len())
+    }
 }
 
 /// We need to implement RLP traits manually because we currently don't have a way to flatten


### PR DESCRIPTION
Related https://github.com/paradigmxyz/reth/issues/11208

The ideal for the reth issue is to restrict the functions to be implemented as much as possible to the alloy `Transaction` trait however it doesn't make much sense to add a `recover_signer` or `recover_signers` method to the `Transaction` trait because we can only fetch the signer in the `Signed<Tx>` case, which is almost never the case when trying to implement `Transaction`.

So I think the simplest approach to replace https://github.com/paradigmxyz/reth/blob/0270128d4f7a9f6fad27dff69273095abdfa7452/crates/primitives/src/block.rs#L564-L566 is to do the similar implementation here in alloy using what already exists in `TxEnvelope` to recover the signers from an iterator of transactions `TxEnvelope`.