### PR TITLE
consensus: add `Debug` trait bound for `Transaction` trait

### DIFF
--- a/crates/consensus/src/transaction/mod.rs
+++ b/crates/consensus/src/transaction/mod.rs
@@ -4,7 +4,7 @@ use crate::Signed;
 use alloc::vec::Vec;
 use alloy_eips::{eip2930::AccessList, eip7702::SignedAuthorization};
 use alloy_primitives::{keccak256, Address, Bytes, ChainId, TxKind, B256, U256};
-use core::any;
+use core::{any, fmt};
 
 mod eip1559;
 pub use eip1559::TxEip1559;
@@ -46,7 +46,7 @@ pub mod serde_bincode_compat {
 
 /// Represents a minimal EVM transaction.
 #[doc(alias = "Tx")]
-pub trait Transaction: any::Any + Send + Sync + 'static {
+pub trait Transaction: fmt::Debug + any::Any + Send + Sync + 'static {
     /// Get `chain_id`.
     fn chain_id(&self) -> Option<ChainId>;
 


### PR DESCRIPTION
Nice to have at an alloy level to remove the bound here https://github.com/paradigmxyz/reth/blob/20dc0c7da0a12e31ab0c896ccf4208585658ad07/crates/primitives-traits/src/transaction/mod.rs#L19