### PR TITLE
fix: sidecar rlp decoding

### DIFF
--- a/crates/eips/src/eip4844/sidecar.rs
+++ b/crates/eips/src/eip4844/sidecar.rs
@@ -346,8 +346,8 @@ impl BlobTransactionSidecar {
     /// Decodes the [BlobTransactionSidecar] from RLP bytes.
     pub fn rlp_decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
         let header = Header::decode(buf)?;
-        if header.list {
-            return Err(alloy_rlp::Error::UnexpectedList);
+        if !header.list {
+            return Err(alloy_rlp::Error::UnexpectedString);
         }
         if buf.len() < header.payload_length {
             return Err(alloy_rlp::Error::InputTooShort);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Right now this encodes as list and expects string during decoding which is incorrect. 

I am wondering if we should remove those impls completely? Given that sidecar encoding on its own is not defined

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
