### PR TITLE
deps: bump alloy-eip7702

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,7 @@ alloy-chains = { version = "0.1.18", default-features = false }
 
 # eips
 alloy-eip2930 = { version = "0.1.0", default-features = false }
-alloy-eip7702 = { version = "0.3.1", default-features = false }
+alloy-eip7702 = { version = "0.3.2", default-features = false }
 
 # ethereum
 ethereum_ssz_derive = "0.8"


### PR DESCRIPTION
This includes breaking changes in the auth types, as `signature(&self)` now returns a `Result`