### PR TITLE
rpc: add `uncle_block_from_header` impl and test

### DIFF
--- a/crates/consensus/src/block.rs
+++ b/crates/consensus/src/block.rs
@@ -20,6 +20,13 @@ pub struct Block<T> {
     pub body: BlockBody<T>,
 }
 
+// impl<T> Block<T> {
+//     /// Creates a new empty uncle block.
+//     pub fn uncle(header: Header) -> Self {
+//         Self { header, body: Default::default() }
+//     }
+// }
+
 /// A response to `GetBlockBodies`, containing bodies if any bodies were found.
 ///
 /// Withdrawals can be optionally included at the end of the RLP encoded message.

--- a/crates/consensus/src/block.rs
+++ b/crates/consensus/src/block.rs
@@ -20,12 +20,12 @@ pub struct Block<T> {
     pub body: BlockBody<T>,
 }
 
-// impl<T> Block<T> {
-//     /// Creates a new empty uncle block.
-//     pub fn uncle(header: Header) -> Self {
-//         Self { header, body: Default::default() }
-//     }
-// }
+impl<T> Block<T> {
+    /// Creates a new empty uncle block.
+    pub fn uncle(header: Header) -> Self {
+        Self { header, body: Default::default() }
+    }
+}
 
 /// A response to `GetBlockBodies`, containing bodies if any bodies were found.
 ///

--- a/crates/rpc-types-eth/src/block.rs
+++ b/crates/rpc-types-eth/src/block.rs
@@ -63,18 +63,8 @@ impl<T> Block<T> {
             header: header.clone().seal_slow().into(),
             transactions: BlockTransactions::Uncle,
             withdrawals: None,
-            size: Some(U256::from(
-                alloy_consensus::Block {
-                    header,
-                    body: alloy_consensus::BlockBody::<TxEnvelope> {
-                        transactions: vec![],
-                        ommers: vec![],
-                        withdrawals: None,
-                    },
-                }
-                .length(),
-            )),
-        }
+            size: Some(U256::from(alloy_consensus::Block::<TxEnvelope>::uncle(header).length())),
+        };
     }
 }
 

--- a/crates/rpc-types-eth/src/block.rs
+++ b/crates/rpc-types-eth/src/block.rs
@@ -58,7 +58,7 @@ impl<T> Block<T> {
     /// This function creates a new [`Block`] structure for uncle blocks (ommer blocks),
     /// using the provided [`alloy_consensus::Header`].
     pub fn uncle_block_from_header(header: alloy_consensus::Header) -> Self {
-        Block {
+        Self {
             uncles: vec![],
             header: header.clone().seal(header.hash_slow()).into(),
             transactions: BlockTransactions::Uncle,

--- a/crates/rpc-types-eth/src/block.rs
+++ b/crates/rpc-types-eth/src/block.rs
@@ -62,7 +62,7 @@ impl<T> Block<T> {
             uncles: vec![],
             header: header.clone().seal(header.hash_slow()).into(),
             transactions: BlockTransactions::Uncle,
-            withdrawals: Some(vec![]),
+            withdrawals: None,
             size: Some(U256::from(
                 alloy_consensus::Block {
                     header,
@@ -946,7 +946,7 @@ mod tests {
                 uncles: vec![],
                 transactions: BlockTransactions::Uncle,
                 size: Some(U256::from(505)),
-                withdrawals: Some(vec![]),
+                withdrawals: None,
             }
         );
     }

--- a/crates/rpc-types-eth/src/block.rs
+++ b/crates/rpc-types-eth/src/block.rs
@@ -64,7 +64,7 @@ impl<T> Block<T> {
             transactions: BlockTransactions::Uncle,
             withdrawals: None,
             size: Some(U256::from(alloy_consensus::Block::<TxEnvelope>::uncle(header).length())),
-        };
+        }
     }
 }
 

--- a/crates/rpc-types-eth/src/block.rs
+++ b/crates/rpc-types-eth/src/block.rs
@@ -57,7 +57,7 @@ impl<T> Block<T> {
     ///
     /// This function creates a new [`Block`] structure for uncle blocks (ommer blocks),
     /// using the provided [`alloy_consensus::Header`].
-    pub fn uncle_block_from_header(header: alloy_consensus::Header) -> Self {
+    pub fn uncle_from_header(header: alloy_consensus::Header) -> Self {
         Self {
             uncles: vec![],
             header: header.clone().seal_slow().into(),
@@ -921,7 +921,7 @@ mod tests {
         let primitive_header: alloy_consensus::Header = header.clone().try_into().unwrap();
 
         // Convert the primitive header to a RPC uncle block
-        let block: Block<Transaction> = Block::uncle_block_from_header(primitive_header);
+        let block: Block<Transaction> = Block::uncle_from_header(primitive_header);
 
         // Ensure the block is correct
         assert_eq!(

--- a/crates/rpc-types-eth/src/block.rs
+++ b/crates/rpc-types-eth/src/block.rs
@@ -6,7 +6,7 @@ use alloy_consensus::{Sealed, TxEnvelope};
 use alloy_network_primitives::{
     BlockResponse, BlockTransactions, HeaderResponse, TransactionResponse,
 };
-use alloy_primitives::{Address, BlockHash, Bloom, Bytes, B256, B64, U256};
+use alloy_primitives::{Address, BlockHash, Bloom, Bytes, Sealable, B256, B64, U256};
 use alloy_rlp::Encodable;
 
 use alloc::vec::Vec;
@@ -60,7 +60,7 @@ impl<T> Block<T> {
     pub fn uncle_block_from_header(header: alloy_consensus::Header) -> Self {
         Self {
             uncles: vec![],
-            header: header.clone().seal(header.hash_slow()).into(),
+            header: header.clone().seal_slow().into(),
             transactions: BlockTransactions::Uncle,
             withdrawals: None,
             size: Some(U256::from(


### PR DESCRIPTION
The goal here is similar to https://github.com/alloy-rs/alloy/pull/1532

In reth we have: 

https://github.com/paradigmxyz/reth/blob/2ae93682b4978bf80bf27c777334ead30d3e04f5/crates/rpc/rpc-types-compat/src/block.rs#L178-L192

And I have found myself several times in the situation where I was forced to go through the `reth-rpc-types-compat` crate just for this small conversion.

Seems like more logical and smooth to have it directly in alloy since the target type is an alloy rpc type.

I did a test against reth implementation to check the results are the same

![image](https://github.com/user-attachments/assets/35dc3463-9c10-4a51-89f2-707477166f71)

