### PR TITLE
consensus: fix `HOLESKY_GENESIS_HASH`

### DIFF
--- a/crates/consensus/src/constants.rs
+++ b/crates/consensus/src/constants.rs
@@ -33,7 +33,7 @@ pub const SEPOLIA_GENESIS_HASH: B256 =
 
 /// Holesky genesis hash.
 pub const HOLESKY_GENESIS_HASH: B256 =
-    b256!("ff9006519a8ce843ac9c28549d24211420b546e12ce2d170c77a8cca7964f23d");
+    b256!("b5f7f912443c940f21fd611f12828d75b534364ed9e95ca4e307729a4661bde4");
 
 /// Testnet genesis hash.
 pub const DEV_GENESIS_HASH: B256 =


### PR DESCRIPTION
Not sure but seems like this hash was not correct as per:
- https://github.com/paradigmxyz/reth/blob/fcca8b1523fa7c1917754389fd08c9b21eb57987/crates/primitives-traits/src/constants/mod.rs#L74
- https://holesky.etherscan.io/block/0

![image](https://github.com/user-attachments/assets/5e8d07c0-daa5-4035-8175-607e825b0565)
