### PR TITLE
eips: add missing unit test for `MIN_PROTOCOL_BASE_FEE`

### DIFF
--- a/crates/eips/src/eip1559/constants.rs
+++ b/crates/eips/src/eip1559/constants.rs
@@ -51,3 +51,13 @@ pub(crate) const OP_MAINNET_EIP1559_DEFAULT_ELASTICITY_MULTIPLIER: u128 = 6;
 /// Base fee max change denominator for Base Sepolia as defined in the Optimism
 /// [transaction costs](https://community.optimism.io/docs/developers/build/differences/#transaction-costs) doc.
 pub(crate) const BASE_SEPOLIA_EIP1559_DEFAULT_ELASTICITY_MULTIPLIER: u128 = 10;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn min_protocol_sanity() {
+        assert_eq!(MIN_PROTOCOL_BASE_FEE_U256.to::<u64>(), MIN_PROTOCOL_BASE_FEE);
+    }
+}


### PR DESCRIPTION
As in reth we will eliminate unnecessary redeclarations here (to import alloy constants):

https://github.com/paradigmxyz/reth/blob/5e4da59b3a83c869647ad38b6f679f7594c11938/crates/primitives-traits/src/constants/mod.rs#L12-L24

We also need to make sure that the reth test:

https://github.com/paradigmxyz/reth/blob/5e4da59b3a83c869647ad38b6f679f7594c11938/crates/primitives-traits/src/constants/mod.rs#L83-L91

is in alloy in order to secure the implementation.