### PR TITLE
consensus: implement `root_slow` for `Receipts`

### DIFF
--- a/crates/consensus/src/receipt/receipts.rs
+++ b/crates/consensus/src/receipt/receipts.rs
@@ -1,6 +1,6 @@
 use crate::receipt::{Eip658Value, TxReceipt};
 use alloc::{vec, vec::Vec};
-use alloy_primitives::{Bloom, Log};
+use alloy_primitives::{Bloom, Log, B256};
 use alloy_rlp::{length_of_length, BufMut, Decodable, Encodable};
 use core::{borrow::Borrow, fmt};
 use derive_more::{DerefMut, From, IntoIterator};

--- a/crates/consensus/src/receipt/receipts.rs
+++ b/crates/consensus/src/receipt/receipts.rs
@@ -126,6 +126,12 @@ impl<T> Receipts<T> {
     pub fn push(&mut self, receipts: Vec<T>) {
         self.receipt_vec.push(receipts);
     }
+
+    /// Retrieves all recorded receipts from index and calculates the root using the given closure.
+    pub fn root_slow(&self, index: usize, f: impl FnOnce(&[&T]) -> B256) -> Option<B256> {
+        let receipts = self.receipt_vec.get(index)?.iter().collect::<Vec<_>>();
+        Some(f(receipts.as_slice()))
+    }
 }
 
 impl<T> From<Vec<T>> for Receipts<T> {


### PR DESCRIPTION
This is done to replace https://github.com/paradigmxyz/reth/blob/ba78e439385469925c6fc9df36444f1ef5a6a1bc/crates/primitives/src/receipt.rs#L104 in order to be used in reth

Related https://github.com/paradigmxyz/reth/pull/12059