### PR TITLE
feat: make eth_call and eth_estimateGas default to using Pending block

### DIFF
--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -153,7 +153,7 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
     #[doc(alias = "eth_call")]
     #[doc(alias = "call_with_overrides")]
     fn call<'req>(&self, tx: &'req N::TransactionRequest) -> EthCall<'req, T, N, Bytes> {
-        EthCall::new(self.weak_client(), tx)
+        EthCall::new(self.weak_client(), tx).block(BlockNumberOrTag::Pending.into())
     }
 
     /// Executes an arbitrary number of transactions on top of the requested state.
@@ -196,7 +196,9 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
     ///
     /// Not all client implementations support state overrides for eth_estimateGas.
     fn estimate_gas<'req>(&self, tx: &'req N::TransactionRequest) -> EthCall<'req, T, N, U64, u64> {
-        EthCall::gas_estimate(self.weak_client(), tx).map_resp(utils::convert_u64)
+        EthCall::gas_estimate(self.weak_client(), tx)
+            .block(BlockNumberOrTag::Pending.into())
+            .map_resp(utils::convert_u64)
     }
 
     /// Estimates the EIP1559 `maxFeePerGas` and `maxPriorityFeePerGas` fields.

--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -128,7 +128,7 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
     ///
     /// This function returns [`EthCall`] which can be used to execute the
     /// call, or to add [`StateOverride`] or a [`BlockId`]. If no overrides
-    /// or block ID is provided, the call will be executed on the latest block
+    /// or block ID is provided, the call will be executed on the pending block
     /// with the current state.
     ///
     /// [`StateOverride`]: alloy_rpc_types_eth::state::StateOverride
@@ -185,10 +185,13 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
         self.client().request("eth_createAccessList", request).into()
     }
 
-    /// This function returns an [`EthCall`] which can be used to get a gas estimate,
-    /// or to add [`StateOverride`] or a [`BlockId`]. If no overrides
-    /// or block ID is provided, the gas estimate will be computed for the latest block
-    /// with the current state.
+    /// Create an [`EthCall`] future to estimate the gas required for a
+    /// transaction.
+    ///
+    /// The future can be used to specify a [`StateOverride`] or [`BlockId`]
+    /// before dispatching the call. If no overrides or block ID is provided,
+    /// the gas estimate will be computed for the pending block with the
+    /// current state.
     ///
     /// [`StateOverride`]: alloy_rpc_types_eth::state::StateOverride
     ///


### PR DESCRIPTION
Changes default behavior of `eth_call` and `eth_estimateGas` to use the `"pending"` block tag.

## Motivation

per discussion in slack channel

Users do not expect to simulate on latest height and timestamp, and will get subtly incorrect outputs when calls read `block.height` or `block.timestamp`. Users generally expect the _next_ value when simulating, as they are anticipating submitting a transaction. This changes default client behavior to specify `"pending"` for those calls

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
