### PR TITLE
ci: add success job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,15 +195,22 @@ jobs:
           components: rustfmt
       - run: cargo fmt --all --check
 
-  cfg-check:
+  ci-success:
+    name: ci success
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    if: always()
+    needs:
+      - test
+      - doctest
+      - wasm-unknown
+      - wasm-wasi
+      - feature-checks
+      - check-no-std
+      - clippy
+      - docs
+      - fmt
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@nightly
+      - name: Decide whether the needed jobs succeeded or failed
+        uses: re-actors/alls-green@release/v1
         with:
-          toolchain: nightly
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
-      - run: cargo check -Zcheck-cfg --workspace
+          jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
Also removes the `cfg-check` job since it's no longer necessary as it's enabled by default since 1.80.