### PR TITLE
fix: RLP for `TxEip4844`

### DIFF
--- a/crates/consensus/src/transaction/eip4844.rs
+++ b/crates/consensus/src/transaction/eip4844.rs
@@ -859,6 +859,12 @@ impl RlpEcdsaTx for TxEip4844WithSidecar {
         self.sidecar.rlp_encode_fields(out);
     }
 
+    fn rlp_header_signed(&self, signature: &Signature) -> Header {
+        let payload_length = self.tx.rlp_encoded_length_with_signature(signature)
+            + self.sidecar.rlp_encoded_fields_length();
+        Header { list: true, payload_length }
+    }
+
     fn rlp_encode_signed(&self, signature: &Signature, out: &mut dyn BufMut) {
         self.rlp_header_signed(signature).encode(out);
         self.tx.rlp_encode_signed(signature, out);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Current implementation has a bug: 
https://github.com/alloy-rs/alloy/blob/193bcd8d8d204e89e74b25a51b395cbb5e8087e4/crates/consensus/src/transaction/eip4844.rs#L889

Here we need to use `..header.payload_length`

Also we didn't override `rlp_header_signer` for eip4844 tx with sidecar which resulted in invalid rlp in some edge cases

## Solution

Fix decoding methods and change them to use common flow of all other such methods without temporary buffer creation

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
