### PR TITLE
feat: implement Arbitrary for transaction types

### DIFF
--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -24,11 +24,15 @@ alloy-primitives = { workspace = true, features = ["rlp"] }
 alloy-rlp.workspace = true
 alloy-serde = { workspace = true, optional = true }
 
+# k256
+k256 = { workspace = true, features = ["ecdsa"], optional = true }
+
 # kzg
 c-kzg = { workspace = true, features = ["serde"], optional = true }
 
 # arbitrary
 arbitrary = { workspace = true, features = ["derive"], optional = true }
+rand = { workspace = true, optional = true }
 
 # serde
 serde = { workspace = true, features = ["derive"], optional = true }
@@ -58,9 +62,9 @@ tokio = { workspace = true, features = ["macros"] }
 [features]
 default = ["std"]
 std = ["alloy-eips/std", "c-kzg?/std"]
-k256 = ["alloy-primitives/k256", "alloy-eips/k256"]
+k256 = ["dep:k256", "alloy-primitives/k256", "alloy-eips/k256"]
 kzg = ["dep:c-kzg", "alloy-eips/kzg", "std"]
-arbitrary = ["std", "dep:arbitrary", "alloy-eips/arbitrary"]
+arbitrary = ["std", "dep:rand", "dep:arbitrary", "alloy-eips/arbitrary"]
 serde = [
     "dep:serde",
     "alloy-primitives/serde",

--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -1154,6 +1154,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "k256")]
     fn test_arbitrary_envelope() {
         let mut unstructured = arbitrary::Unstructured::new(b"arbitrary tx envelope");
         let tx = TxEnvelope::arbitrary(&mut unstructured).unwrap();

--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -94,6 +94,7 @@ impl TryFrom<u8> for TxType {
     feature = "serde",
     serde(into = "serde_from::TaggedTxEnvelope", from = "serde_from::MaybeTaggedTxEnvelope")
 )]
+#[cfg_attr(all(any(test, feature = "arbitrary"), feature = "k256"), derive(arbitrary::Arbitrary))]
 #[doc(alias = "TransactionEnvelope")]
 #[non_exhaustive]
 pub enum TxEnvelope {
@@ -615,6 +616,7 @@ mod tests {
     #[allow(unused_imports)]
     use alloy_primitives::{b256, Bytes, TxKind};
     use alloy_primitives::{hex, Address, Parity, Signature, U256};
+    use arbitrary::Arbitrary;
     use std::{fs, path::PathBuf, str::FromStr, vec};
 
     #[cfg(not(feature = "std"))]
@@ -1149,5 +1151,13 @@ mod tests {
                 "018b2331d461a4aeedf6a1f9cc37463377578244e6a35216057a8370714e798f"
             )
         );
+    }
+
+    #[test]
+    fn test_arbitrary_envelope() {
+        let mut unstructured = arbitrary::Unstructured::new(b"arbitrary tx envelope");
+        let tx = TxEnvelope::arbitrary(&mut unstructured).unwrap();
+
+        assert!(tx.recover_signer().is_ok());
     }
 }

--- a/crates/consensus/src/transaction/typed.rs
+++ b/crates/consensus/src/transaction/typed.rs
@@ -22,6 +22,7 @@ use crate::{
         into = "serde_from::TaggedTypedTransaction"
     )
 )]
+#[cfg_attr(all(any(test, feature = "arbitrary"), feature = "k256"), derive(arbitrary::Arbitrary))]
 #[doc(alias = "TypedTx", alias = "TxTyped", alias = "TransactionTyped")]
 pub enum TypedTransaction {
     /// Legacy transaction

--- a/crates/rpc-types-eth/src/transaction/mod.rs
+++ b/crates/rpc-types-eth/src/transaction/mod.rs
@@ -35,7 +35,7 @@ pub use alloy_consensus::{
 /// Transaction object used in RPC
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-// #[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[cfg_attr(all(any(test, feature = "arbitrary"), feature = "k256"), derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[doc(alias = "Tx")]
 pub struct Transaction<T = TxEnvelope> {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

#1460 removed the arbitrary impl for rpc transaction because we didn't have it for tx envelope. This PR implements arbitrary for transaction types. It requires `k256` feature to be able to sign transactions and 7702 authorizations.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
