### PR TITLE
fix: hash handling

### DIFF
--- a/crates/consensus/src/transaction/eip4844.rs
+++ b/crates/consensus/src/transaction/eip4844.rs
@@ -246,17 +246,10 @@ impl RlpEcdsaTx for TxEip4844Variant {
         }
     }
 
-    fn rlp_encoded_length(&self) -> usize {
+    fn rlp_header_signed(&self, signature: &Signature) -> Header {
         match self {
-            Self::TxEip4844(inner) => inner.rlp_encoded_length(),
-            Self::TxEip4844WithSidecar(inner) => inner.rlp_encoded_length(),
-        }
-    }
-
-    fn rlp_encoded_length_with_signature(&self, signature: &Signature) -> usize {
-        match self {
-            Self::TxEip4844(inner) => inner.rlp_encoded_length_with_signature(signature),
-            Self::TxEip4844WithSidecar(inner) => inner.rlp_encoded_length_with_signature(signature),
+            Self::TxEip4844(inner) => inner.rlp_header_signed(signature),
+            Self::TxEip4844WithSidecar(inner) => inner.rlp_header_signed(signature),
         }
     }
 
@@ -289,21 +282,6 @@ impl RlpEcdsaTx for TxEip4844Variant {
         TxEip4844::rlp_decode_fields(buf).map(Into::into)
     }
 
-    fn rlp_decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
-        let header = Header::decode(buf)?;
-        if !header.list {
-            return Err(alloy_rlp::Error::UnexpectedString);
-        }
-        let remaining = buf.len();
-
-        let res = Self::rlp_decode_fields(buf)?;
-
-        if buf.len() + header.payload_length != remaining {
-            return Err(alloy_rlp::Error::UnexpectedLength);
-        }
-        Ok(res)
-    }
-
     fn rlp_decode_with_signature(buf: &mut &[u8]) -> alloy_rlp::Result<(Self, Signature)> {
         // We need to determine if this has a sidecar tx or not. The needle ref
         // is consumed to look for headers.
@@ -334,8 +312,10 @@ impl RlpEcdsaTx for TxEip4844Variant {
     }
 
     fn tx_hash_with_type(&self, signature: &Signature, ty: u8) -> alloy_primitives::TxHash {
-        // eip4844 tx_hash is always based on the non-sidecar encoding
-        self.tx().tx_hash_with_type(signature, ty)
+        match self {
+            Self::TxEip4844(inner) => inner.tx_hash_with_type(signature, ty),
+            Self::TxEip4844WithSidecar(inner) => inner.tx_hash_with_type(signature, ty),
+        }
     }
 }
 
@@ -779,7 +759,7 @@ impl SignableTransaction<Signature> for TxEip4844WithSidecar {
         let signature = signature.with_parity_bool();
 
         // important: must hash the tx WITHOUT the sidecar
-        let hash = self.tx.tx_hash(&signature);
+        let hash = self.tx_hash(&signature);
 
         Signed::new_unchecked(self, signature, hash)
     }
@@ -895,6 +875,7 @@ impl RlpEcdsaTx for TxEip4844WithSidecar {
     }
 
     fn tx_hash_with_type(&self, signature: &Signature, ty: u8) -> alloy_primitives::TxHash {
+        // eip4844 tx_hash is always based on the non-sidecar encoding
         self.tx.tx_hash_with_type(signature, ty)
     }
 }

--- a/crates/rpc-types-eth/src/transaction/mod.rs
+++ b/crates/rpc-types-eth/src/transaction/mod.rs
@@ -3,7 +3,7 @@
 use alloy_consensus::{
     Signed, TxEip1559, TxEip2930, TxEip4844, TxEip4844Variant, TxEip7702, TxEnvelope, TxLegacy,
 };
-use alloy_eips::eip7702::SignedAuthorization;
+use alloy_eips::{eip2718::Encodable2718, eip7702::SignedAuthorization};
 use alloy_network_primitives::TransactionResponse;
 use alloy_primitives::{Address, BlockHash, Bytes, ChainId, TxKind, B256, U256};
 
@@ -237,10 +237,9 @@ impl<T: TransactionTrait> TransactionTrait for Transaction<T> {
     }
 }
 
-impl<T: TransactionTrait> TransactionResponse for Transaction<T> {
+impl<T: TransactionTrait + Encodable2718> TransactionResponse for Transaction<T> {
     fn tx_hash(&self) -> B256 {
-        Default::default()
-        // self.hash
+        self.inner.trie_hash()
     }
 
     fn block_hash(&self) -> Option<BlockHash> {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

Fixes `TransactionResponse::tx_hash` implementation for rpc transaction type. It now relies on inner envelope to implement `Encodable2718`.

Also includes small clean-up in eip4844 removing unnecessarily overriden methods 

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
