### PR TITLE
rpc: derive `Default` for `JwtSecret`

### DIFF
--- a/crates/rpc-types-engine/src/jwt.rs
+++ b/crates/rpc-types-engine/src/jwt.rs
@@ -160,7 +160,7 @@ impl Default for Claims {
 /// for the JWT, which is included in the JWT along with its payload.
 ///
 /// See also: [Secret key - Engine API specs](https://github.com/ethereum/execution-apis/blob/main/src/engine/authentication.md#key-distribution)
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq, Default)]
 pub struct JwtSecret([u8; 32]);
 
 impl JwtSecret {


### PR DESCRIPTION
Should be useful for:
- Testing configurations
- Be able to derive `Default` for https://github.com/paradigmxyz/reth/blob/21d911abb2cf594834c1818d2f723718b5109f8b/crates/rpc/rpc-builder/src/auth.rs#L89-L97