### PR TITLE
fix: serde for `AnyTxEnvelope`

### DIFF
--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -552,7 +552,12 @@ mod serde_from {
     #[serde(untagged)]
     pub(crate) enum MaybeTaggedTxEnvelope {
         Tagged(TaggedTxEnvelope),
-        Untagged(Signed<TxLegacy>),
+        Untagged {
+            #[serde(default, rename = "type", deserialize_with = "alloy_serde::reject_if_some")]
+            _ty: Option<()>,
+            #[serde(flatten)]
+            tx: Signed<TxLegacy>,
+        },
     }
 
     #[derive(Debug, serde::Serialize, serde::Deserialize)]
@@ -574,7 +579,7 @@ mod serde_from {
         fn from(value: MaybeTaggedTxEnvelope) -> Self {
             match value {
                 MaybeTaggedTxEnvelope::Tagged(tagged) => tagged.into(),
-                MaybeTaggedTxEnvelope::Untagged(tx) => Self::Legacy(tx),
+                MaybeTaggedTxEnvelope::Untagged { tx, .. } => Self::Legacy(tx),
             }
         }
     }
@@ -1158,5 +1163,44 @@ mod tests {
         let tx = TxEnvelope::arbitrary(&mut unstructured).unwrap();
 
         assert!(tx.recover_signer().is_ok());
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn test_serde_untagged_legacy() {
+        let data = r#"{
+            "hash": "0x97efb58d2b42df8d68ab5899ff42b16c7e0af35ed86ae4adb8acaad7e444220c",
+            "input": "0x",
+            "r": "0x5d71a4a548503f2916d10c6b1a1557a0e7352eb041acb2bac99d1ad6bb49fd45",
+            "s": "0x2627bf6d35be48b0e56c61733f63944c0ebcaa85cb4ed6bc7cba3161ba85e0e8",
+            "v": "0x1c",
+            "gas": "0x15f90",
+            "from": "0x2a65aca4d5fc5b5c859090a6c34d164135398226",
+            "to": "0x8fbeb4488a08d60979b5aa9e13dd00b2726320b2",
+            "value": "0xf606682badd7800",
+            "nonce": "0x11f398",
+            "gasPrice": "0x4a817c800"
+        }"#;
+
+        let tx: TxEnvelope = serde_json::from_str(data).unwrap();
+
+        assert!(matches!(tx, TxEnvelope::Legacy(_)));
+
+        let data_with_wrong_type = r#"{
+            "hash": "0x97efb58d2b42df8d68ab5899ff42b16c7e0af35ed86ae4adb8acaad7e444220c",
+            "input": "0x",
+            "r": "0x5d71a4a548503f2916d10c6b1a1557a0e7352eb041acb2bac99d1ad6bb49fd45",
+            "s": "0x2627bf6d35be48b0e56c61733f63944c0ebcaa85cb4ed6bc7cba3161ba85e0e8",
+            "v": "0x1c",
+            "gas": "0x15f90",
+            "from": "0x2a65aca4d5fc5b5c859090a6c34d164135398226",
+            "to": "0x8fbeb4488a08d60979b5aa9e13dd00b2726320b2",
+            "value": "0xf606682badd7800",
+            "nonce": "0x11f398",
+            "gasPrice": "0x4a817c800",
+            "type": "0x12"
+        }"#;
+
+        assert!(serde_json::from_str::<TxEnvelope>(data_with_wrong_type).is_err());
     }
 }

--- a/crates/consensus/src/transaction/typed.rs
+++ b/crates/consensus/src/transaction/typed.rs
@@ -327,7 +327,12 @@ mod serde_from {
     #[serde(untagged)]
     pub(crate) enum MaybeTaggedTypedTransaction {
         Tagged(TaggedTypedTransaction),
-        Untagged(TxLegacy),
+        Untagged {
+            #[serde(default, rename = "type", deserialize_with = "alloy_serde::reject_if_some")]
+            _ty: Option<()>,
+            #[serde(flatten)]
+            tx: TxLegacy,
+        },
     }
 
     #[derive(Debug, serde::Serialize, serde::Deserialize)]
@@ -354,7 +359,7 @@ mod serde_from {
         fn from(value: MaybeTaggedTypedTransaction) -> Self {
             match value {
                 MaybeTaggedTypedTransaction::Tagged(tagged) => tagged.into(),
-                MaybeTaggedTypedTransaction::Untagged(tx) => Self::Legacy(tx),
+                MaybeTaggedTypedTransaction::Untagged { tx, .. } => Self::Legacy(tx),
             }
         }
     }

--- a/crates/network/src/any/mod.rs
+++ b/crates/network/src/any/mod.rs
@@ -19,6 +19,9 @@ pub type AnyRpcHeader = alloy_rpc_types_eth::Header<alloy_consensus::AnyHeader>;
 pub type AnyRpcBlock =
     WithOtherFields<Block<WithOtherFields<Transaction<AnyTxEnvelope>>, AnyRpcHeader>>;
 
+/// A catch-all transaction type for handling transactions on multiple networks.
+pub type AnyRpcTransaction = WithOtherFields<Transaction<AnyTxEnvelope>>;
+
 /// Types for a catch-all network.
 ///
 /// `AnyNetwork`'s associated types allow for many different types of
@@ -65,7 +68,7 @@ impl Network for AnyNetwork {
 
     type TransactionRequest = WithOtherFields<TransactionRequest>;
 
-    type TransactionResponse = WithOtherFields<Transaction<Self::TxEnvelope>>;
+    type TransactionResponse = AnyRpcTransaction;
 
     type ReceiptResponse = AnyTransactionReceipt;
 

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -22,8 +22,8 @@ pub use ethereum::{Ethereum, EthereumWallet};
 
 mod any;
 pub use any::{
-    AnyHeader, AnyNetwork, AnyReceiptEnvelope, AnyRpcBlock, AnyRpcHeader, AnyTxEnvelope, AnyTxType,
-    AnyTypedTransaction, UnknownTxEnvelope, UnknownTypedTransaction,
+    AnyHeader, AnyNetwork, AnyReceiptEnvelope, AnyRpcBlock, AnyRpcHeader, AnyRpcTransaction,
+    AnyTxEnvelope, AnyTxType, AnyTypedTransaction, UnknownTxEnvelope, UnknownTypedTransaction,
 };
 
 pub use alloy_eips::eip2718;

--- a/crates/serde/src/optional.rs
+++ b/crates/serde/src/optional.rs
@@ -11,3 +11,18 @@ where
 {
     Option::<T>::deserialize(deserializer).map(Option::unwrap_or_default)
 }
+
+/// For use with serde's `deserialize_with` on a field that must be missing.
+pub fn reject_if_some<'de, T, D>(deserializer: D) -> Result<Option<T>, D::Error>
+where
+    T: Deserialize<'de>,
+    D: Deserializer<'de>,
+{
+    let value = Option::<T>::deserialize(deserializer)?;
+
+    if value.is_some() {
+        return Err(serde::de::Error::custom("unexpected value"));
+    }
+
+    Ok(value)
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

RIght now `AnyTxType` is serialized as number but we should use quantity for it.

Also, `MaybeTaggedEnvelope` would correctly deserialize legacy transaction if map has all its fields and a different type flag. This is the case for deposit transaction breaking its deserialization in `AnyTxEnvelope` context

## Solution

Serialize and deserialize `AnyTxType` as `U8`

Fail `Untagged` variant deserialization if `type` is present.

Also fixed deserialization of transaction fields in `Transaction` trait impl. We had incorrect name for `gas` and didn't use quantity when deserializing integers.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
