### PR TITLE
fix(`provider`): make `Caller` `EthCall` specific

### DIFF
--- a/crates/provider/src/provider/caller.rs
+++ b/crates/provider/src/provider/caller.rs
@@ -20,10 +20,10 @@ where
     ///
     /// This method handles serialization of the params and sends the request to relevant data
     /// source and returns a `ProviderCall`.
-    fn call<'req>(
+    fn call(
         &self,
         method: Cow<'static, str>,
-        params: EthCallParams<'req, N>,
+        params: EthCallParams<'_, N>,
     ) -> TransportResult<ProviderCall<T, serde_json::Value, Resp>>;
 }
 

--- a/crates/provider/src/provider/caller.rs
+++ b/crates/provider/src/provider/caller.rs
@@ -15,8 +15,7 @@ where
 {
     /// Method that needs to be implemented to convert to a `ProviderCall`.
     ///
-    /// This method handles serialization of the params and sends the request to relevant data
-    /// source and returns a `ProviderCall`.
+    /// This method sends the request to relevant data source and returns a `ProviderCall`.
     fn call(
         &self,
         method: Cow<'static, str>,

--- a/crates/provider/src/provider/caller.rs
+++ b/crates/provider/src/provider/caller.rs
@@ -4,7 +4,6 @@ use alloy_json_rpc::RpcReturn;
 use alloy_network::Network;
 use alloy_rpc_client::WeakClient;
 use alloy_transport::{Transport, TransportErrorKind, TransportResult};
-use std::borrow::Cow;
 
 /// Trait that helpes convert `EthCall` into a `ProviderCall`.
 pub trait Caller<T, N, Resp>: Send + Sync
@@ -18,7 +17,13 @@ where
     /// This method sends the request to relevant data source and returns a `ProviderCall`.
     fn call(
         &self,
-        method: Cow<'static, str>,
+        params: EthCallParams<'_, N>,
+    ) -> TransportResult<ProviderCall<T, EthCallParams<'static, N>, Resp>>;
+
+    /// Method that needs to be implemented for estimating gas using "eth_estimateGas" for the
+    /// transaction.
+    fn estimate_gas(
+        &self,
         params: EthCallParams<'_, N>,
     ) -> TransportResult<ProviderCall<T, EthCallParams<'static, N>, Resp>>;
 }
@@ -31,13 +36,27 @@ where
 {
     fn call(
         &self,
-        method: Cow<'static, str>,
         params: EthCallParams<'_, N>,
     ) -> TransportResult<ProviderCall<T, EthCallParams<'static, N>, Resp>> {
-        let client = self.upgrade().ok_or_else(TransportErrorKind::backend_gone)?;
-
-        let rpc_call = client.request(method, params.into_owned());
-
-        Ok(ProviderCall::RpcCall(rpc_call))
+        provider_rpc_call(self, "eth_call", params)
     }
+
+    fn estimate_gas(
+        &self,
+        params: EthCallParams<'_, N>,
+    ) -> TransportResult<ProviderCall<T, EthCallParams<'static, N>, Resp>> {
+        provider_rpc_call(self, "eth_estimateGas", params)
+    }
+}
+
+fn provider_rpc_call<T: Transport + Clone, N: Network, Resp: RpcReturn>(
+    client: &WeakClient<T>,
+    method: &'static str,
+    params: EthCallParams<'_, N>,
+) -> TransportResult<ProviderCall<T, EthCallParams<'static, N>, Resp>> {
+    let client = client.upgrade().ok_or_else(TransportErrorKind::backend_gone)?;
+
+    let rpc_call = client.request(method, params.into_owned());
+
+    Ok(ProviderCall::RpcCall(rpc_call))
 }

--- a/crates/provider/src/provider/caller.rs
+++ b/crates/provider/src/provider/caller.rs
@@ -1,39 +1,42 @@
 use crate::ProviderCall;
-use alloy_json_rpc::{RpcParam, RpcReturn};
+use alloy_json_rpc::RpcReturn;
+use alloy_network::Network;
 use alloy_rpc_client::WeakClient;
 use alloy_transport::{RpcError, Transport, TransportErrorKind, TransportResult};
 use std::borrow::Cow;
 
+use super::EthCallParams;
+
 // TODO: Make `EthCall` specific. Ref: https://github.com/alloy-rs/alloy/pull/788#discussion_r1748862509.
 
 /// Trait that helpes convert `EthCall` into a `ProviderCall`.
-pub trait Caller<T, Params, Resp>: Send + Sync
+pub trait Caller<T, N, Resp>: Send + Sync
 where
     T: Transport + Clone,
-    Params: RpcParam,
+    N: Network,
     Resp: RpcReturn,
 {
     /// Method that needs to be implemented to convert to a `ProviderCall`.
     ///
     /// This method handles serialization of the params and sends the request to relevant data
     /// source and returns a `ProviderCall`.
-    fn call(
+    fn call<'req>(
         &self,
         method: Cow<'static, str>,
-        params: Params,
+        params: EthCallParams<'req, N>,
     ) -> TransportResult<ProviderCall<T, serde_json::Value, Resp>>;
 }
 
-impl<T, Params, Resp> Caller<T, Params, Resp> for WeakClient<T>
+impl<T, N, Resp> Caller<T, N, Resp> for WeakClient<T>
 where
     T: Transport + Clone,
-    Params: RpcParam,
+    N: Network,
     Resp: RpcReturn,
 {
     fn call(
         &self,
         method: Cow<'static, str>,
-        params: Params,
+        params: EthCallParams<'_, N>,
     ) -> TransportResult<ProviderCall<T, serde_json::Value, Resp>> {
         let client = self.upgrade().ok_or_else(TransportErrorKind::backend_gone)?;
 

--- a/crates/provider/src/provider/eth_call.rs
+++ b/crates/provider/src/provider/eth_call.rs
@@ -59,7 +59,7 @@ where
     Map: Fn(Resp) -> Output,
 {
     Preparing {
-        caller: Arc<dyn Caller<T, EthCallParams<'req, N>, Resp>>,
+        caller: Arc<dyn Caller<T, N, Resp>>,
         data: &'req N::TransactionRequest,
         overrides: Option<&'req StateOverride>,
         block: Option<BlockId>,
@@ -177,7 +177,7 @@ where
     Resp: RpcReturn,
     Map: Fn(Resp) -> Output,
 {
-    caller: Arc<dyn Caller<T, EthCallParams<'req, N>, Resp>>,
+    caller: Arc<dyn Caller<T, N, Resp>>,
     data: &'req N::TransactionRequest,
     overrides: Option<&'req StateOverride>,
     block: Option<BlockId>,
@@ -210,7 +210,7 @@ where
 {
     /// Create a new CallBuilder.
     pub fn new(
-        caller: impl Caller<T, EthCallParams<'req, N>, Resp> + 'static,
+        caller: impl Caller<T, N, Resp> + 'static,
         data: &'req N::TransactionRequest,
     ) -> Self {
         Self {
@@ -226,7 +226,7 @@ where
 
     /// Create new EthCall for gas estimates.
     pub fn gas_estimate(
-        caller: impl Caller<T, EthCallParams<'req, N>, Resp> + 'static,
+        caller: impl Caller<T, N, Resp> + 'static,
         data: &'req N::TransactionRequest,
     ) -> Self {
         Self {

--- a/crates/provider/src/provider/eth_call.rs
+++ b/crates/provider/src/provider/eth_call.rs
@@ -173,7 +173,8 @@ where
             overrides: overrides.map(Cow::Borrowed),
         };
 
-        let fut = caller.call(method.into(), params)?;
+        let fut =
+            if method.eq("eth_call") { caller.call(params) } else { caller.estimate_gas(params) }?;
 
         self.inner = EthCallFutInner::Running { map, fut };
 

--- a/crates/provider/src/provider/eth_call.rs
+++ b/crates/provider/src/provider/eth_call.rs
@@ -22,12 +22,12 @@ where
     N: Network,
 {
     /// Instantiates a new `EthCallParams` with the given data (transaction).
-    pub fn new(data: &'req N::TransactionRequest) -> Self {
+    pub const fn new(data: &'req N::TransactionRequest) -> Self {
         Self { data: Cow::Borrowed(data), block: None, overrides: None }
     }
 
     /// Sets the block to use for this call.
-    pub fn with_block(mut self, block: BlockId) -> Self {
+    pub const fn with_block(mut self, block: BlockId) -> Self {
         self.block = Some(block);
         self
     }
@@ -49,7 +49,7 @@ where
     }
 
     /// Returns the block.
-    pub fn block(&self) -> Option<BlockId> {
+    pub const fn block(&self) -> Option<BlockId> {
         self.block
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Closes #1471 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

- Change the `data` and `overrides` fields in `EthCallParams` to be `Cow`. 
- Accept `EthCallParams` as arg in `Caller.call(&self, method, params: EthCallParams<'_, N>)`.
- `ProviderCall` should be used over `EthCallParams`

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
