### PR TITLE
eip5792: use `ChainId` in `WalletCapabilities`

### DIFF
--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -23,7 +23,6 @@ alloy-eips = { workspace = true, features = ["kzg-sidecar"] }
 alloy-primitives = { workspace = true, features = ["rlp"] }
 alloy-rlp.workspace = true
 alloy-serde = { workspace = true, optional = true }
-alloy-genesis.workspace = true
 
 # k256
 k256 = { workspace = true, features = ["ecdsa"], optional = true }

--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -23,6 +23,7 @@ alloy-eips = { workspace = true, features = ["kzg-sidecar"] }
 alloy-primitives = { workspace = true, features = ["rlp"] }
 alloy-rlp.workspace = true
 alloy-serde = { workspace = true, optional = true }
+alloy-genesis.workspace = true
 
 # k256
 k256 = { workspace = true, features = ["ecdsa"], optional = true }

--- a/crates/eip5792/Cargo.toml
+++ b/crates/eip5792/Cargo.toml
@@ -13,7 +13,7 @@ exclude.workspace = true
 
 [dependencies]
 alloy-primitives = { workspace = true, features = ["serde", "map"] }
-alloy-serde = { workspace = true, optional = true }
+alloy-serde.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 

--- a/crates/eip5792/src/wallet.rs
+++ b/crates/eip5792/src/wallet.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::{map::HashMap, Address, ChainId, U64};
+use alloy_primitives::{map::HashMap, Address, ChainId};
 use serde::{Deserialize, Serialize};
 
 /// The capability to perform [EIP-7702][eip-7702] delegations, sponsored by the sequencer.
@@ -21,26 +21,27 @@ pub struct Capabilities {
 }
 
 /// A map of wallet capabilities per chain ID.
-// NOTE(onbjerg): We use `U64` to serialize the chain ID as a quantity. This can be changed back to `ChainId` with https://github.com/alloy-rs/alloy/issues/1502
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
-pub struct WalletCapabilities(pub HashMap<U64, Capabilities>);
+pub struct WalletCapabilities(
+    #[serde(with = "alloy_serde::quantity::hashmap")] pub HashMap<ChainId, Capabilities>,
+);
 
 impl WalletCapabilities {
     /// Get the capabilities of the wallet API for the specified chain ID.
     pub fn get(&self, chain_id: ChainId) -> Option<&Capabilities> {
-        self.0.get(&U64::from(chain_id))
+        self.0.get(&chain_id)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_primitives::{address, map::HashMap, U64};
+    use alloy_primitives::{address, map::HashMap};
 
     #[test]
     fn ser() {
         let caps = WalletCapabilities(HashMap::from_iter([(
-            U64::from(0x69420),
+            0x69420,
             Capabilities {
                 delegation: DelegationCapability {
                     addresses: vec![address!("90f79bf6eb2c4f870365e785982e1f101e93b906")],
@@ -66,7 +67,7 @@ mod tests {
         assert_eq!(
             caps,
             WalletCapabilities(HashMap::from_iter([(
-                U64::from(0x69420),
+                0x69420,
                 Capabilities {
                     delegation: DelegationCapability {
                         addresses: vec![address!("90f79bf6eb2c4f870365e785982e1f101e93b906")],
@@ -74,5 +75,45 @@ mod tests {
                 },
             )]))
         );
+    }
+
+    #[test]
+    fn test_get_capabilities() {
+        let caps = WalletCapabilities(HashMap::from_iter([(
+            0x69420,
+            Capabilities {
+                delegation: DelegationCapability {
+                    addresses: vec![address!("90f79bf6eb2c4f870365e785982e1f101e93b906")],
+                },
+            },
+        )]));
+
+        // Retrieve an existing chain ID.
+        let capabilities = caps.get(0x69420);
+        assert!(capabilities.is_some());
+        assert_eq!(
+            capabilities.unwrap().delegation.addresses[0],
+            address!("90f79bf6eb2c4f870365e785982e1f101e93b906")
+        );
+
+        // Try to retrieve a non-existing chain ID.
+        let non_existing_capabilities = caps.get(0x12345);
+        assert!(non_existing_capabilities.is_none());
+    }
+
+    #[test]
+    fn test_capabilities_with_empty_delegation() {
+        let caps = WalletCapabilities(HashMap::from_iter([(
+            0x12345,
+            Capabilities { delegation: DelegationCapability { addresses: vec![] } },
+        )]));
+
+        // Verify that delegation exists but contains no addresses.
+        let capabilities = caps.get(0x12345).unwrap();
+        assert!(capabilities.delegation.addresses.is_empty());
+
+        // Serialize and ensure JSON output is correct.
+        let serialized = serde_json::to_string(&caps).unwrap();
+        assert_eq!(serialized, "{\"0x12345\":{\"delegation\":{\"addresses\":[]}}}");
     }
 }


### PR DESCRIPTION
After https://github.com/alloy-rs/alloy/pull/1579 we can directly use `ChainId` (u64) instead of U64 big int in `WalletCapabilities`.