### PR TITLE
fix: wrap dashmap in Arc

### DIFF
--- a/crates/provider/src/fillers/nonce.rs
+++ b/crates/provider/src/fillers/nonce.rs
@@ -56,7 +56,7 @@ impl NonceManager for SimpleNonceManager {
 /// transaction count locally.
 #[derive(Clone, Debug, Default)]
 pub struct CachedNonceManager {
-    nonces: DashMap<Address, Arc<Mutex<u64>>>,
+    nonces: Arc<DashMap<Address, Arc<Mutex<u64>>>>,
 }
 
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]


### PR DESCRIPTION
ref #1491

dashmap is clone, which imo is a footgun, because dashmap acts as `Rwlock<HashMap>` not `Arc<Rwlock<HashMap>>`


> DashMap tries to be very simple to use and to be a direct replacement for RwLock<HashMap<K, V>>. To accomplish this, all methods take &self instead of modifying methods taking &mut self. This allows you to put a DashMap in an Arc<T> and share it between threads while being able to modify it.