### PR TITLE
fix(`rpc-types`): `FeeHistory` deser

### DIFF
--- a/crates/rpc-types-eth/src/fee.rs
+++ b/crates/rpc-types-eth/src/fee.rs
@@ -45,6 +45,7 @@ pub struct FeeHistory {
     pub base_fee_per_gas: Vec<u128>,
     /// An array of block gas used ratios. These are calculated as the ratio
     /// of `gasUsed` and `gasLimit`.
+    #[cfg_attr(feature = "serde", serde(deserialize_with = "gas_used_ratio_deser::deserialize"))]
     pub gas_used_ratio: Vec<f64>,
     /// An array of block base fees per blob gas. This includes the next block after the newest
     /// of the returned range, because this value can be derived from the newest block. Zeroes
@@ -112,6 +113,20 @@ impl FeeHistory {
     }
 }
 
+mod gas_used_ratio_deser {
+    use serde::{Deserialize, Deserializer};
+
+    pub(crate) fn deserialize<'de, D>(deserializer: D) -> Result<Vec<f64>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        // First try to deserialize as Option<Vec<f64>>
+        let opt = Option::<Vec<f64>>::deserialize(deserializer)?;
+        // Return empty vec if null, otherwise return the vec
+        Ok(opt.unwrap_or_default())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::FeeHistory;
@@ -146,6 +161,12 @@ mod tests {
     #[cfg(feature = "serde")]
     fn test_fee_history_serde_3() {
         let json = r#"{"oldestBlock":"0xdee807","baseFeePerGas":["0x4ccf46253","0x4457de658","0x4531c5aee","0x3cfa33972","0x3d33403eb","0x399457884","0x40bdf9772","0x48d55e7c4","0x51e9ebf14","0x55f460bf9","0x4e31607e4"],"gasUsedRatio":[0.05909575012589385,0.5498182666666667,0.0249864,0.5146185,0.2633512,0.997582061117319,0.999914966153302,0.9986873805040722,0.6973219148223686,0.13879896448917434],"baseFeePerBlobGas":["0x0","0x0","0x0","0x0","0x0","0x0","0x0","0x0","0x0","0x0","0x0"],"blobGasUsedRatio":[0,0,0,0,0,0,0,0,0,0]}"#;
+        let _actual = serde_json::from_str::<FeeHistory>(json).unwrap();
+    }
+
+    #[test]
+    fn test_fee_hist_null_gas_used_ratio() {
+        let json = r#"{"oldestBlock": "0x0", "gasUsedRatio": null}"#;
         let _actual = serde_json::from_str::<FeeHistory>(json).unwrap();
     }
 }

--- a/crates/rpc-types-eth/src/fee.rs
+++ b/crates/rpc-types-eth/src/fee.rs
@@ -45,7 +45,7 @@ pub struct FeeHistory {
     pub base_fee_per_gas: Vec<u128>,
     /// An array of block gas used ratios. These are calculated as the ratio
     /// of `gasUsed` and `gasLimit`.
-    #[cfg_attr(feature = "serde", serde(deserialize_with = "gas_used_ratio_deser::deserialize"))]
+    #[cfg_attr(feature = "serde", serde(deserialize_with = "alloy_serde::null_as_default"))]
     pub gas_used_ratio: Vec<f64>,
     /// An array of block base fees per blob gas. This includes the next block after the newest
     /// of the returned range, because this value can be derived from the newest block. Zeroes
@@ -110,20 +110,6 @@ impl FeeHistory {
             .copied()
             // Skip zero values that are returned for pre-EIP-4844 blocks.
             .filter(|fee| *fee != 0)
-    }
-}
-
-mod gas_used_ratio_deser {
-    use serde::{Deserialize, Deserializer};
-
-    pub(crate) fn deserialize<'de, D>(deserializer: D) -> Result<Vec<f64>, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        // First try to deserialize as Option<Vec<f64>>
-        let opt = Option::<Vec<f64>>::deserialize(deserializer)?;
-        // Return empty vec if null, otherwise return the vec
-        Ok(opt.unwrap_or_default())
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Currently we don't correctly handle a `eth_feeHistory` response in which `gasUsedRatio` is `null`.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Handle this case by deserializing to an empty vec. 

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
