### PR TITLE
fix(consensus): transaction types should be able to deserialize old name

### DIFF
--- a/crates/consensus/src/transaction/eip1559.rs
+++ b/crates/consensus/src/transaction/eip1559.rs
@@ -22,7 +22,7 @@ pub struct TxEip1559 {
     /// this transaction. This is paid up-front, before any
     /// computation is done and may not be increased
     /// later; formally Tg.
-    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity", rename = "gas"))]
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity", alias = "gasLimit", rename = "gas"))]
     pub gas_limit: u64,
     /// A scalar value equal to the maximum
     /// amount of gas that should be used in executing

--- a/crates/consensus/src/transaction/eip2930.rs
+++ b/crates/consensus/src/transaction/eip2930.rs
@@ -33,7 +33,7 @@ pub struct TxEip2930 {
     /// this transaction. This is paid up-front, before any
     /// computation is done and may not be increased
     /// later; formally Tg.
-    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity", rename = "gas"))]
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity", alias = "gasLimit", rename = "gas"))]
     pub gas_limit: u64,
     /// The 160-bit address of the message call’s recipient or, for a contract creation
     /// transaction, ∅, used here to denote the only member of B0 ; formally Tt.

--- a/crates/consensus/src/transaction/eip4844.rs
+++ b/crates/consensus/src/transaction/eip4844.rs
@@ -403,7 +403,7 @@ pub struct TxEip4844 {
     /// this transaction. This is paid up-front, before any
     /// computation is done and may not be increased
     /// later; formally Tg.
-    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity", rename = "gas"))]
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity", alias = "gasLimit", rename = "gas"))]
     pub gas_limit: u64,
     /// A scalar value equal to the maximum
     /// amount of gas that should be used in executing

--- a/crates/consensus/src/transaction/eip7702.rs
+++ b/crates/consensus/src/transaction/eip7702.rs
@@ -30,7 +30,7 @@ pub struct TxEip7702 {
     /// this transaction. This is paid up-front, before any
     /// computation is done and may not be increased
     /// later; formally Tg.
-    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity", rename = "gas"))]
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity", alias = "gasLimit", rename = "gas"))]
     pub gas_limit: u64,
     /// A scalar value equal to the maximum
     /// amount of gas that should be used in executing

--- a/crates/consensus/src/transaction/legacy.rs
+++ b/crates/consensus/src/transaction/legacy.rs
@@ -41,7 +41,7 @@ pub struct TxLegacy {
     /// this transaction. This is paid up-front, before any
     /// computation is done and may not be increased
     /// later; formally Tg.
-    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity", rename = "gas"))]
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity", alias = "gasLimit", rename = "gas"))]
     pub gas_limit: u64,
     /// The 160-bit address of the message call’s recipient or, for a contract creation
     /// transaction, ∅, used here to denote the only member of B0 ; formally Tt.


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

the `gas_limit` field in the transaction types was recently renamed to serialize to `gas` instead of `gasLimit`

However, this causes old state dumps prior to this change to fail to load (in fact, downstream `foundry` tests were modified in order to accomodate for this, although I really don't think this should have happened) https://github.com/foundry-rs/foundry/commit/7b118faeff4848be480f9c30c11237b9e9e6eb31 .

## Solution

added `alias` so that `serde` knows it can also read from `gasLimit` if it doesn't find `gas` field.

manually verified that downstream foundry seems to work better with the legacy tests reverted to previous after making these changes.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes

## Other

Regarding tests, the downstream foundry tests should be reverted to their previous state (https://github.com/foundry-rs/foundry/commits/7b118faeff4848be480f9c30c11237b9e9e6eb31/crates/anvil/test-data/state-dump-legacy.json and https://github.com/foundry-rs/foundry/commits/7b118faeff4848be480f9c30c11237b9e9e6eb31/crates/anvil/test-data/state-dump-legacy-stress.json) once this change gets downstreamed to verify the change. However, in this repo, it seems we don't yet have serialization tests that verify decoding from json or other similar language. is there a reccomended way to add this?
