### PR TITLE
Add blanket impl of Transaction, TxReceipt and BlockHeader references

### DIFF
--- a/crates/consensus/src/block/header.rs
+++ b/crates/consensus/src/block/header.rs
@@ -560,6 +560,7 @@ impl<'a> arbitrary::Arbitrary<'a> for Header {
 }
 
 /// Trait for extracting specific Ethereum block data from a header
+#[auto_impl::auto_impl(&, Arc)]
 pub trait BlockHeader {
     /// Retrieves the parent hash of the block
     fn parent_hash(&self) -> B256;

--- a/crates/consensus/src/transaction/mod.rs
+++ b/crates/consensus/src/transaction/mod.rs
@@ -53,6 +53,7 @@ pub mod serde_bincode_compat {
 
 /// Represents a minimal EVM transaction.
 #[doc(alias = "Tx")]
+#[auto_impl::auto_impl(&, Arc)]
 pub trait Transaction: fmt::Debug + any::Any + Send + Sync + 'static {
     /// Get `chain_id`.
     fn chain_id(&self) -> Option<ChainId>;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Improve usability of abstraction of data primitives. Ref https://github.com/paradigmxyz/reth/pull/12613.

## Solution

Add blanket implementations of `Transaction` and `BlockHeader` for `&T` and `Arc<T>`.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
