### PR TITLE
impl ConvertRuint for U256 to be compatible with alloy_serde

### DIFF
--- a/crates/serde/src/quantity.rs
+++ b/crates/serde/src/quantity.rs
@@ -302,6 +302,8 @@ pub mod btreemap {
 /// Private implementation details of the [`quantity`](self) module.
 #[allow(unnameable_types)]
 mod private {
+    use alloy_primitives::ruint;
+
     #[doc(hidden)]
     pub trait ConvertRuint: Copy + Sized {
         // We have to use `Try*` traits because `From` is not implemented by ruint types.
@@ -340,6 +342,11 @@ mod private {
         u32  = alloy_primitives::U32,
         u64  = alloy_primitives::U64,
         u128 = alloy_primitives::U128,
+    }
+
+    // Implment CovertRuint for non-primitive types as well
+    impl ConvertRuint for alloy_primitives::U256 {
+        type Ruint = ruint::Uint<256, 4>;
     }
 }
 


### PR DESCRIPTION
Adding the ConvertRuint trait to apply to the non-primitive type of U256,
this is a first step towards fixing [issue 85 in op-alloy](https://github.com/alloy-rs/op-alloy/issues/85)

This is my 1st contribution ever.. be gentle :)