### PR TITLE
fix: wasm compatibility for RetryBackoff

### DIFF
--- a/crates/transport/src/layers/retry.rs
+++ b/crates/transport/src/layers/retry.rs
@@ -113,11 +113,10 @@ impl<S> RetryBackoffService<S> {
 
 impl<S> Service<RequestPacket> for RetryBackoffService<S>
 where
-    S: Service<RequestPacket, Response = ResponsePacket, Error = TransportError>
+    S: Service<RequestPacket, Future = TransportFut<'static>, Error = TransportError>
         + Send
         + 'static
         + Clone,
-    S::Future: Send + 'static,
 {
     type Response = ResponsePacket;
     type Error = TransportError;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Closes https://github.com/alloy-rs/alloy/issues/1147

## Solution

Use `TransportFut` in the bound which adjusts when to require `Send`.

This is a bit more restrictive but should be fine as all transports are requried to produce `TransportFut`

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
