### PR TITLE
feat: Add more missing eth_callBundle arguments

### DIFF
--- a/crates/rpc-types-mev/src/eth_calls.rs
+++ b/crates/rpc-types-mev/src/eth_calls.rs
@@ -103,7 +103,7 @@ impl EthCallBundle {
     }
 
     /// Sets the coinbase for the bundle.
-    pub fn with_coinbase(mut self, coinbase: Address) -> Self {
+    pub const fn with_coinbase(mut self, coinbase: Address) -> Self {
         self.coinbase = Some(coinbase);
         self
     }
@@ -115,7 +115,7 @@ impl EthCallBundle {
     }
 
     /// Sets the timeout for the bundle.
-    pub fn with_timeout(mut self, timeout: u64) -> Self {
+    pub const fn with_timeout(mut self, timeout: u64) -> Self {
         self.timeout = Some(timeout);
         self
     }

--- a/crates/rpc-types-mev/src/eth_calls.rs
+++ b/crates/rpc-types-mev/src/eth_calls.rs
@@ -18,9 +18,15 @@ pub struct EthCallBundle {
     pub block_number: u64,
     /// Either a hex encoded number or a block tag for which state to base this simulation on
     pub state_block_number: BlockNumberOrTag,
+    /// the coinbase to use for this bundle simulation
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub coinbase: Option<Address>,
     /// the timestamp to use for this bundle simulation, in seconds since the unix epoch
     #[serde(default, with = "alloy_serde::quantity::opt", skip_serializing_if = "Option::is_none")]
     pub timestamp: Option<u64>,
+    /// the timeout to apply to execution of this bundle, in milliseconds
+    #[serde(default, with = "alloy_serde::quantity::opt", skip_serializing_if = "Option::is_none")]
+    pub timeout: Option<u64>,
     /// gas limit of the block to use for this simulation
     #[serde(default, with = "alloy_serde::quantity::opt", skip_serializing_if = "Option::is_none")]
     pub gas_limit: Option<u64>,
@@ -96,9 +102,21 @@ impl EthCallBundle {
         self
     }
 
+    /// Sets the coinbase for the bundle.
+    pub fn with_coinbase(mut self, coinbase: Address) -> Self {
+        self.coinbase = Some(coinbase);
+        self
+    }
+
     /// Sets the timestamp for the bundle.
     pub const fn with_timestamp(mut self, timestamp: u64) -> Self {
         self.timestamp = Some(timestamp);
+        self
+    }
+
+    /// Sets the timeout for the bundle.
+    pub fn with_timeout(mut self, timeout: u64) -> Self {
+        self.timeout = Some(timeout);
         self
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Previously https://github.com/alloy-rs/alloy/pull/978 missed `coinbase` and `timeout` when adding the additional undocumented fields available on the actual node.  I suspect this happened because the the initial versions of `rpc-types-mev` were based on Flashbots' public API docs for `eth_callBundle`, but the public options are actually only a subset of what's actually available on an actual node.  

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

This simply adds the missing fields and their builder methods. I'll also make a follow-on PR to add functionality for them in reth.

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
