### PR TITLE
fix(`signer`): export PrimitiveSignature instead of deprecated sig

### DIFF
--- a/crates/signer/src/lib.rs
+++ b/crates/signer/src/lib.rs
@@ -14,7 +14,7 @@ pub use signer::{Signer, SignerSync};
 
 pub mod utils;
 
-pub use alloy_primitives::Signature;
+pub use alloy_primitives::PrimitiveSignature;
 pub use k256;
 
 /// Utility to get and set the chain ID on a transaction and the resulting signature within a

--- a/crates/signer/src/lib.rs
+++ b/crates/signer/src/lib.rs
@@ -14,7 +14,7 @@ pub use signer::{Signer, SignerSync};
 
 pub mod utils;
 
-pub use alloy_primitives::PrimitiveSignature;
+pub use alloy_primitives::PrimitiveSignature as Signature;
 pub use k256;
 
 /// Utility to get and set the chain ID on a transaction and the resulting signature within a


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Currently we are still re-exporting deprecated `Signature` from `alloy-signer`

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Export `PrimitiveSignature` instead

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
