### PR TITLE
feat: introduce Typed2718 trait

### DIFF
--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -1,7 +1,7 @@
 use crate::{
     transaction::{
         eip4844::{TxEip4844, TxEip4844Variant, TxEip4844WithSidecar},
-        RlpEcdsaTx,
+        RlpEcdsaTx, Typed2718,
     },
     Signed, Transaction, TxEip1559, TxEip2930, TxEip7702, TxLegacy,
 };
@@ -122,6 +122,32 @@ impl Decodable for TxType {
     fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
         let ty = u8::decode(buf)?;
         Self::try_from(ty).map_err(|_| alloy_rlp::Error::Custom("invalid transaction type"))
+    }
+}
+
+impl Typed2718 for TxType {
+    fn is_type(&self, ty: u8) -> bool {
+        *self == ty
+    }
+
+    fn is_legacy(&self) -> bool {
+        matches!(self, Self::Legacy)
+    }
+
+    fn is_eip2930(&self) -> bool {
+        matches!(self, Self::Eip2930)
+    }
+
+    fn is_eip1559(&self) -> bool {
+        matches!(self, Self::Eip1559)
+    }
+
+    fn is_eip4844(&self) -> bool {
+        matches!(self, Self::Eip4844)
+    }
+
+    fn is_eip7702(&self) -> bool {
+        matches!(self, Self::Eip7702)
     }
 }
 

--- a/crates/consensus/src/transaction/mod.rs
+++ b/crates/consensus/src/transaction/mod.rs
@@ -275,6 +275,11 @@ impl<T: Transaction> Transaction for alloy_serde::WithOtherFields<T> {
     }
 
     #[inline]
+    fn is_dynamic_fee(&self) -> bool {
+        self.inner.is_dynamic_fee()
+    }
+
+    #[inline]
     fn kind(&self) -> TxKind {
         self.inner.kind()
     }
@@ -308,9 +313,25 @@ impl<T: Transaction> Transaction for alloy_serde::WithOtherFields<T> {
     fn authorization_list(&self) -> Option<&[SignedAuthorization]> {
         self.inner.authorization_list()
     }
+}
 
-    #[inline]
-    fn is_dynamic_fee(&self) -> bool {
-        self.inner.is_dynamic_fee()
-    }
+/// A trait that helps to determine the type of the transaction.
+pub trait Typed2718 {
+    /// Returns true if the type matches the given type.
+    fn is_type(&self, ty: u8) -> bool;
+
+    /// Returns true if the type is a legacy transaction.
+    fn is_legacy(&self) -> bool;
+
+    /// Returns true if the type is an EIP-2930 transaction.
+    fn is_eip2930(&self) -> bool;
+
+    /// Returns true if the type is an EIP-1559 transaction.
+    fn is_eip1559(&self) -> bool;
+
+    /// Returns true if the type is an EIP-4844 transaction.
+    fn is_eip4844(&self) -> bool;
+
+    /// Returns true if the type is an EIP-7702 transaction.
+    fn is_eip7702(&self) -> bool;
 }


### PR DESCRIPTION
we need this often and this can be implemented on txtype and transaction itself.

this first introduces the trait and in a next step this can be added to `Transaction: Typed2718`