### PR TITLE
ci: add ignored advisory back

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,7 +1,10 @@
 [advisories]
 version = 2
 yanked = "warn"
-ignore = []
+ignore = [
+    # https://rustsec.org/advisories/RUSTSEC-2024-0388 used by ssz, will be removed https://github.com/sigp/ethereum_ssz/pull/34
+    "RUSTSEC-2024-0388"
+]
 
 [bans]
 multiple-versions = "warn"


### PR DESCRIPTION
this is still present until ssz released

unclear why the ci passed earlier @DaniPopes 

ah it didn't but not a blocker for auto merge -.-