### PR TITLE
feat(consensus-tx): enable fast `is_create`

### DIFF
--- a/crates/consensus/src/transaction/eip1559.rs
+++ b/crates/consensus/src/transaction/eip1559.rs
@@ -220,6 +220,11 @@ impl Transaction for TxEip1559 {
     }
 
     #[inline]
+    fn is_create(&self) -> bool {
+        self.to.is_create()
+    }
+
+    #[inline]
     fn value(&self) -> U256 {
         self.value
     }

--- a/crates/consensus/src/transaction/eip2930.rs
+++ b/crates/consensus/src/transaction/eip2930.rs
@@ -178,6 +178,11 @@ impl Transaction for TxEip2930 {
     }
 
     #[inline]
+    fn is_create(&self) -> bool {
+        self.to.is_create()
+    }
+
+    #[inline]
     fn value(&self) -> U256 {
         self.value
     }

--- a/crates/consensus/src/transaction/eip4844.rs
+++ b/crates/consensus/src/transaction/eip4844.rs
@@ -228,6 +228,11 @@ impl Transaction for TxEip4844Variant {
     }
 
     #[inline]
+    fn is_create(&self) -> bool {
+        false
+    }
+
+    #[inline]
     fn value(&self) -> U256 {
         match self {
             Self::TxEip4844(tx) => tx.value,
@@ -657,6 +662,11 @@ impl Transaction for TxEip4844 {
     }
 
     #[inline]
+    fn is_create(&self) -> bool {
+        false
+    }
+
+    #[inline]
     fn value(&self) -> U256 {
         self.value
     }
@@ -868,6 +878,11 @@ impl Transaction for TxEip4844WithSidecar {
     #[inline]
     fn kind(&self) -> TxKind {
         self.tx.kind()
+    }
+
+    #[inline]
+    fn is_create(&self) -> bool {
+        false
     }
 
     #[inline]

--- a/crates/consensus/src/transaction/eip7702.rs
+++ b/crates/consensus/src/transaction/eip7702.rs
@@ -218,6 +218,11 @@ impl Transaction for TxEip7702 {
     }
 
     #[inline]
+    fn is_create(&self) -> bool {
+        false
+    }
+
+    #[inline]
     fn value(&self) -> U256 {
         self.value
     }

--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -592,6 +592,17 @@ impl Transaction for TxEnvelope {
     }
 
     #[inline]
+    fn is_create(&self) -> bool {
+        match self {
+            Self::Legacy(tx) => tx.tx().is_create(),
+            Self::Eip2930(tx) => tx.tx().is_create(),
+            Self::Eip1559(tx) => tx.tx().is_create(),
+            Self::Eip4844(tx) => tx.tx().is_create(),
+            Self::Eip7702(tx) => tx.tx().is_create(),
+        }
+    }
+
+    #[inline]
     fn value(&self) -> U256 {
         match self {
             Self::Legacy(tx) => tx.tx().value(),

--- a/crates/consensus/src/transaction/legacy.rs
+++ b/crates/consensus/src/transaction/legacy.rs
@@ -287,6 +287,11 @@ impl Transaction for TxLegacy {
     }
 
     #[inline]
+    fn is_create(&self) -> bool {
+        self.to.is_create()
+    }
+
+    #[inline]
     fn value(&self) -> U256 {
         self.value
     }

--- a/crates/consensus/src/transaction/mod.rs
+++ b/crates/consensus/src/transaction/mod.rs
@@ -128,6 +128,11 @@ pub trait Transaction: fmt::Debug + any::Any + Send + Sync + 'static {
     /// Returns the transaction kind.
     fn kind(&self) -> TxKind;
 
+    /// Returns true if the transaction is a contract creation.
+    /// We don't provide a default implementation via `kind` as it copies the 21-byte
+    /// [`TxKind`] for this simple check. A proper implementation shouldn't allocate.
+    fn is_create(&self) -> bool;
+
     /// Get the transaction's address of the contract that will be called, or the address that will
     /// receive the transfer.
     ///
@@ -282,6 +287,11 @@ impl<T: Transaction> Transaction for alloy_serde::WithOtherFields<T> {
     #[inline]
     fn kind(&self) -> TxKind {
         self.inner.kind()
+    }
+
+    #[inline]
+    fn is_create(&self) -> bool {
+        self.inner.is_create()
     }
 
     #[inline]

--- a/crates/consensus/src/transaction/typed.rs
+++ b/crates/consensus/src/transaction/typed.rs
@@ -264,6 +264,17 @@ impl Transaction for TypedTransaction {
     }
 
     #[inline]
+    fn is_create(&self) -> bool {
+        match self {
+            Self::Legacy(tx) => tx.is_create(),
+            Self::Eip2930(tx) => tx.is_create(),
+            Self::Eip1559(tx) => tx.is_create(),
+            Self::Eip4844(tx) => tx.is_create(),
+            Self::Eip7702(tx) => tx.is_create(),
+        }
+    }
+
+    #[inline]
     fn value(&self) -> U256 {
         match self {
             Self::Legacy(tx) => tx.value(),

--- a/crates/network/src/any/either.rs
+++ b/crates/network/src/any/either.rs
@@ -143,6 +143,14 @@ impl TransactionTrait for AnyTypedTransaction {
     }
 
     #[inline]
+    fn is_create(&self) -> bool {
+        match self {
+            Self::Ethereum(inner) => inner.is_create(),
+            Self::Unknown(inner) => inner.is_create(),
+        }
+    }
+
+    #[inline]
     fn value(&self) -> U256 {
         match self {
             Self::Ethereum(inner) => inner.value(),
@@ -329,6 +337,14 @@ impl TransactionTrait for AnyTxEnvelope {
         match self {
             Self::Ethereum(inner) => inner.kind(),
             Self::Unknown(inner) => inner.kind(),
+        }
+    }
+
+    #[inline]
+    fn is_create(&self) -> bool {
+        match self {
+            Self::Ethereum(inner) => inner.is_create(),
+            Self::Unknown(inner) => inner.is_create(),
         }
     }
 

--- a/crates/network/src/any/unknowns.rs
+++ b/crates/network/src/any/unknowns.rs
@@ -199,6 +199,11 @@ impl alloy_consensus::Transaction for UnknownTypedTransaction {
     }
 
     #[inline]
+    fn is_create(&self) -> bool {
+        self.fields.get("to").map_or(true, |v| v.is_null())
+    }
+
+    #[inline]
     fn value(&self) -> U256 {
         self.fields.get_deserialized("value").and_then(Result::ok).unwrap_or_default()
     }
@@ -326,6 +331,11 @@ impl alloy_consensus::Transaction for UnknownTxEnvelope {
     #[inline]
     fn kind(&self) -> TxKind {
         self.inner.kind()
+    }
+
+    #[inline]
+    fn is_create(&self) -> bool {
+        self.inner.is_create()
     }
 
     #[inline]

--- a/crates/rpc-types-eth/src/transaction/mod.rs
+++ b/crates/rpc-types-eth/src/transaction/mod.rs
@@ -224,6 +224,10 @@ impl<T: TransactionTrait> TransactionTrait for Transaction<T> {
         self.inner.kind()
     }
 
+    fn is_create(&self) -> bool {
+        self.inner.is_create()
+    }
+
     fn value(&self) -> U256 {
         self.inner.value()
     }


### PR DESCRIPTION
## Motivation

`alloy-consensus::Transaction` implementors didn't have a cheap way to check if the transaction was a `Create`. They had to go through `kind` which copies the 21-byte `TxKind`. This may scale poorly for code that processes (hundreds of) thousands of transactions per second: https://github.com/paradigmxyz/reth/issues/12838.

## Solution

Add `is_create` to the trait that allows fast non-allocating implementation. I considered making `kind` returns `&TxKind` but transactions like EIP-4844, 7702, etc. only store an `Address` and it would be bad if we forced them to promote it to `TxKind`.

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
