### PR TITLE
feat: get_filter_logs in Provider trait

### DIFF
--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -496,6 +496,11 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
         self.client().request("eth_getFilterChanges", (id,)).await
     }
 
+    /// Retrieves a [`Vec<Log>`] for the given filter ID.
+    async fn get_filter_logs(&self, id: U256) -> TransportResult<Vec<Log>> {
+        self.client().request("eth_getFilterLogs", (id,)).await
+    }
+
     /// Watch for the confirmation of a single pending transaction with the given configuration.
     ///
     /// Note that this is handled internally rather than calling any specific RPC method, and as


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

Related: #1681.

## Motivation

Right now cannot call `eth_getFilterLogs` JSON-RPC method without using `raw_request` which is not ideal.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Adds a new `get_filter_logs` method to `Provider` trait.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
