### PR TITLE
feat: get_block_transaction_count_by_hash in Provider trait

### DIFF
--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -343,6 +343,7 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
         Ok(block)
     }
 
+    /// Returns the number of transactions in a block from a block matching the given block hash.
     async fn get_block_transaction_count_by_hash(
         &self,
         hash: BlockHash,
@@ -1703,11 +1704,13 @@ mod tests {
     #[tokio::test]
     async fn gets_block_transaction_count_by_hash() {
         let provider = ProviderBuilder::new().on_anvil();
-        let block =
-            provider.get_block(BlockId::latest(), BlockTransactionsKind::Hashes).await.unwrap().unwrap();
+        let block = provider
+            .get_block(BlockId::latest(), BlockTransactionsKind::Hashes)
+            .await
+            .unwrap()
+            .unwrap();
         let hash = block.header.hash;
-        let tx_count =
-            provider.get_block_transaction_count_by_hash(hash).await.unwrap();
+        let tx_count = provider.get_block_transaction_count_by_hash(hash).await.unwrap();
         assert!(tx_count.is_some());
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

Related: #1681.

## Motivation

Right now cannot call `get_block_transaction_count_by_hash` JSON-RPC method without using `raw_request` which is not ideal.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Adds a new `get_block_transaction_count_by_hash` method to `Provider` trait.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
