### PR TITLE
feat: get_block_transaction_count_by_number in Provider trait

### DIFF
--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -354,6 +354,17 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
             .map(|opt_count: Option<U64>| opt_count.map(|count| count.to::<u64>()))
     }
 
+    /// Returns the number of transactions in a block matching the given block number.
+    async fn get_block_transaction_count_by_number(
+        &self,
+        block_number: BlockNumberOrTag,
+    ) -> TransportResult<Option<u64>> {
+        self.client()
+            .request("eth_getBlockTransactionCountByNumber", (block_number,))
+            .await
+            .map(|opt_count: Option<U64>| opt_count.map(|count| count.to::<u64>()))
+    }
+
     /// Gets the selected block [BlockId] receipts.
     fn get_block_receipts(
         &self,
@@ -1711,6 +1722,14 @@ mod tests {
             .unwrap();
         let hash = block.header.hash;
         let tx_count = provider.get_block_transaction_count_by_hash(hash).await.unwrap();
+        assert!(tx_count.is_some());
+    }
+
+    #[tokio::test]
+    async fn gets_block_transaction_count_by_number() {
+        let provider = ProviderBuilder::new().on_anvil();
+        let tx_count =
+            provider.get_block_transaction_count_by_number(BlockNumberOrTag::Latest).await.unwrap();
         assert!(tx_count.is_some());
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

Related: #1681.

## Motivation

Right now cannot call `get_block_transaction_count_by_number` JSON-RPC method without using `raw_request` which is not ideal.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Adds a new `get_block_transaction_count_by_number` method to `Provider` trait.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
