### PR TITLE
fix(provider): use `BoxTransport` in `on_anvil_*`

### DIFF
--- a/crates/contract/src/call.rs
+++ b/crates/contract/src/call.rs
@@ -574,8 +574,6 @@ mod tests {
     };
     use alloy_rpc_types_eth::AccessListItem;
     use alloy_sol_types::sol;
-    use alloy_transport_http::Http;
-    use reqwest::Client;
 
     #[test]
     fn empty_constructor() {
@@ -624,8 +622,8 @@ mod tests {
     /// Creates a new call_builder to test field modifications, taken from [call_encoding]
     #[allow(clippy::type_complexity)]
     fn build_call_builder() -> CallBuilder<
-        Http<Client>,
-        AnvilProvider<RootProvider<Http<Client>>, Http<Client>>,
+        alloy_transport::BoxTransport,
+        AnvilProvider<RootProvider<alloy_transport::BoxTransport>, alloy_transport::BoxTransport>,
         PhantomData<MyContract::doStuffCall>,
     > {
         let provider = ProviderBuilder::new().on_anvil();

--- a/crates/provider/src/builder.rs
+++ b/crates/provider/src/builder.rs
@@ -376,13 +376,10 @@ impl<L, F> ProviderBuilder<L, F, Ethereum> {
     /// Build this provider with anvil, using an Reqwest HTTP transport.
     pub fn on_anvil(self) -> F::Provider
     where
-        F: TxFiller<Ethereum> + ProviderLayer<L::Provider, alloy_transport::BoxTransport, Ethereum>,
+        F: TxFiller<Ethereum> + ProviderLayer<L::Provider, BoxTransport, Ethereum>,
         L: crate::builder::ProviderLayer<
-            crate::layers::AnvilProvider<
-                crate::provider::RootProvider<alloy_transport::BoxTransport>,
-                alloy_transport::BoxTransport,
-            >,
-            alloy_transport::BoxTransport,
+            crate::layers::AnvilProvider<crate::provider::RootProvider<BoxTransport>, BoxTransport>,
+            BoxTransport,
         >,
     {
         self.on_anvil_with_config(std::convert::identity)
@@ -393,19 +390,12 @@ impl<L, F> ProviderBuilder<L, F, Ethereum> {
     /// use in tests.
     pub fn on_anvil_with_wallet(
         self,
-    ) -> <JoinedEthereumWalletFiller<F> as ProviderLayer<
-        L::Provider,
-        alloy_transport_http::Http<reqwest::Client>,
-    >>::Provider
+    ) -> <JoinedEthereumWalletFiller<F> as ProviderLayer<L::Provider, BoxTransport>>::Provider
     where
-        F: TxFiller<Ethereum>
-            + ProviderLayer<L::Provider, alloy_transport_http::Http<reqwest::Client>, Ethereum>,
+        F: TxFiller<Ethereum> + ProviderLayer<L::Provider, BoxTransport, Ethereum>,
         L: crate::builder::ProviderLayer<
-            crate::layers::AnvilProvider<
-                crate::provider::RootProvider<alloy_transport_http::Http<reqwest::Client>>,
-                alloy_transport_http::Http<reqwest::Client>,
-            >,
-            alloy_transport_http::Http<reqwest::Client>,
+            crate::layers::AnvilProvider<crate::provider::RootProvider<BoxTransport>, BoxTransport>,
+            BoxTransport,
         >,
     {
         self.on_anvil_with_wallet_and_config(std::convert::identity)
@@ -418,13 +408,10 @@ impl<L, F> ProviderBuilder<L, F, Ethereum> {
         f: impl FnOnce(alloy_node_bindings::Anvil) -> alloy_node_bindings::Anvil,
     ) -> F::Provider
     where
-        F: TxFiller<Ethereum> + ProviderLayer<L::Provider, alloy_transport::BoxTransport, Ethereum>,
+        F: TxFiller<Ethereum> + ProviderLayer<L::Provider, BoxTransport, Ethereum>,
         L: crate::builder::ProviderLayer<
-            crate::layers::AnvilProvider<
-                crate::provider::RootProvider<alloy_transport::BoxTransport>,
-                alloy_transport::BoxTransport,
-            >,
-            alloy_transport::BoxTransport,
+            crate::layers::AnvilProvider<crate::provider::RootProvider<BoxTransport>, BoxTransport>,
+            BoxTransport,
         >,
     {
         let anvil_layer = crate::layers::AnvilLayer::from(f(Default::default()));
@@ -440,19 +427,12 @@ impl<L, F> ProviderBuilder<L, F, Ethereum> {
     pub fn on_anvil_with_wallet_and_config(
         self,
         f: impl FnOnce(alloy_node_bindings::Anvil) -> alloy_node_bindings::Anvil,
-    ) -> <JoinedEthereumWalletFiller<F> as ProviderLayer<
-        L::Provider,
-        alloy_transport_http::Http<reqwest::Client>,
-    >>::Provider
+    ) -> <JoinedEthereumWalletFiller<F> as ProviderLayer<L::Provider, BoxTransport>>::Provider
     where
-        F: TxFiller<Ethereum>
-            + ProviderLayer<L::Provider, alloy_transport_http::Http<reqwest::Client>, Ethereum>,
+        F: TxFiller<Ethereum> + ProviderLayer<L::Provider, BoxTransport, Ethereum>,
         L: crate::builder::ProviderLayer<
-            crate::layers::AnvilProvider<
-                crate::provider::RootProvider<alloy_transport_http::Http<reqwest::Client>>,
-                alloy_transport_http::Http<reqwest::Client>,
-            >,
-            alloy_transport_http::Http<reqwest::Client>,
+            crate::layers::AnvilProvider<crate::provider::RootProvider<BoxTransport>, BoxTransport>,
+            BoxTransport,
         >,
     {
         self.try_on_anvil_with_wallet_and_config(f).unwrap()
@@ -466,20 +446,13 @@ impl<L, F> ProviderBuilder<L, F, Ethereum> {
         self,
         f: impl FnOnce(alloy_node_bindings::Anvil) -> alloy_node_bindings::Anvil,
     ) -> AnvilProviderResult<
-        <JoinedEthereumWalletFiller<F> as ProviderLayer<
-            L::Provider,
-            alloy_transport_http::Http<reqwest::Client>,
-        >>::Provider,
+        <JoinedEthereumWalletFiller<F> as ProviderLayer<L::Provider, BoxTransport>>::Provider,
     >
     where
-        F: TxFiller<Ethereum>
-            + ProviderLayer<L::Provider, alloy_transport_http::Http<reqwest::Client>, Ethereum>,
+        F: TxFiller<Ethereum> + ProviderLayer<L::Provider, BoxTransport, Ethereum>,
         L: crate::builder::ProviderLayer<
-            crate::layers::AnvilProvider<
-                crate::provider::RootProvider<alloy_transport_http::Http<reqwest::Client>>,
-                alloy_transport_http::Http<reqwest::Client>,
-            >,
-            alloy_transport_http::Http<reqwest::Client>,
+            crate::layers::AnvilProvider<crate::provider::RootProvider<BoxTransport>, BoxTransport>,
+            BoxTransport,
         >,
     {
         use alloy_signer::Signer;
@@ -499,7 +472,9 @@ impl<L, F> ProviderBuilder<L, F, Ethereum> {
             wallet.register_signer(alloy_signer_local::LocalSigner::from(key.clone()))
         }
 
-        Ok(self.wallet(wallet).layer(anvil_layer).on_http(url))
+        let rpc_client = ClientBuilder::default().http(url).boxed();
+
+        Ok(self.wallet(wallet).layer(anvil_layer).on_client(rpc_client))
     }
 }
 

--- a/crates/provider/src/builder.rs
+++ b/crates/provider/src/builder.rs
@@ -373,7 +373,7 @@ type AnvilProviderResult<T> = Result<T, alloy_node_bindings::NodeError>;
 // `reqwest` feature is enabled.
 #[cfg(any(test, feature = "anvil-node"))]
 impl<L, F> ProviderBuilder<L, F, Ethereum> {
-    /// Build this provider with anvil, using an Reqwest HTTP transport.
+    /// Build this provider with anvil, using the BoxTransport.
     pub fn on_anvil(self) -> F::Provider
     where
         F: TxFiller<Ethereum> + ProviderLayer<L::Provider, BoxTransport, Ethereum>,
@@ -385,7 +385,7 @@ impl<L, F> ProviderBuilder<L, F, Ethereum> {
         self.on_anvil_with_config(std::convert::identity)
     }
 
-    /// Build this provider with anvil, using an Reqwest HTTP transport. This
+    /// Build this provider with anvil, using the BoxTransport. This
     /// function configures a wallet backed by anvil keys, and is intended for
     /// use in tests.
     pub fn on_anvil_with_wallet(
@@ -401,7 +401,7 @@ impl<L, F> ProviderBuilder<L, F, Ethereum> {
         self.on_anvil_with_wallet_and_config(std::convert::identity)
     }
 
-    /// Build this provider with anvil, using an Reqwest HTTP transport. The
+    /// Build this provider with anvil, using the BoxTransport. The
     /// given function is used to configure the anvil instance.
     pub fn on_anvil_with_config(
         self,
@@ -422,7 +422,7 @@ impl<L, F> ProviderBuilder<L, F, Ethereum> {
         self.layer(anvil_layer).on_client(rpc_client)
     }
 
-    /// Build this provider with anvil, using an Reqwest HTTP transport.
+    /// Build this provider with anvil, using the BoxTransport.
     /// This calls `try_on_anvil_with_wallet_and_config` and panics on error.
     pub fn on_anvil_with_wallet_and_config(
         self,
@@ -438,7 +438,7 @@ impl<L, F> ProviderBuilder<L, F, Ethereum> {
         self.try_on_anvil_with_wallet_and_config(f).unwrap()
     }
 
-    /// Build this provider with anvil, using an Reqwest HTTP transport. The
+    /// Build this provider with anvil, using the BoxTransport. The
     /// given function is used to configure the anvil instance. This
     /// function configures a wallet backed by anvil keys, and is intended for
     /// use in tests.

--- a/crates/provider/src/builder.rs
+++ b/crates/provider/src/builder.rs
@@ -376,14 +376,13 @@ impl<L, F> ProviderBuilder<L, F, Ethereum> {
     /// Build this provider with anvil, using an Reqwest HTTP transport.
     pub fn on_anvil(self) -> F::Provider
     where
-        F: TxFiller<Ethereum>
-            + ProviderLayer<L::Provider, alloy_transport_http::Http<reqwest::Client>, Ethereum>,
+        F: TxFiller<Ethereum> + ProviderLayer<L::Provider, alloy_transport::BoxTransport, Ethereum>,
         L: crate::builder::ProviderLayer<
             crate::layers::AnvilProvider<
-                crate::provider::RootProvider<alloy_transport_http::Http<reqwest::Client>>,
-                alloy_transport_http::Http<reqwest::Client>,
+                crate::provider::RootProvider<alloy_transport::BoxTransport>,
+                alloy_transport::BoxTransport,
             >,
-            alloy_transport_http::Http<reqwest::Client>,
+            alloy_transport::BoxTransport,
         >,
     {
         self.on_anvil_with_config(std::convert::identity)
@@ -419,20 +418,21 @@ impl<L, F> ProviderBuilder<L, F, Ethereum> {
         f: impl FnOnce(alloy_node_bindings::Anvil) -> alloy_node_bindings::Anvil,
     ) -> F::Provider
     where
-        F: TxFiller<Ethereum>
-            + ProviderLayer<L::Provider, alloy_transport_http::Http<reqwest::Client>, Ethereum>,
+        F: TxFiller<Ethereum> + ProviderLayer<L::Provider, alloy_transport::BoxTransport, Ethereum>,
         L: crate::builder::ProviderLayer<
             crate::layers::AnvilProvider<
-                crate::provider::RootProvider<alloy_transport_http::Http<reqwest::Client>>,
-                alloy_transport_http::Http<reqwest::Client>,
+                crate::provider::RootProvider<alloy_transport::BoxTransport>,
+                alloy_transport::BoxTransport,
             >,
-            alloy_transport_http::Http<reqwest::Client>,
+            alloy_transport::BoxTransport,
         >,
     {
         let anvil_layer = crate::layers::AnvilLayer::from(f(Default::default()));
         let url = anvil_layer.endpoint_url();
 
-        self.layer(anvil_layer).on_http(url)
+        let rpc_client = ClientBuilder::default().http(url).boxed();
+
+        self.layer(anvil_layer).on_client(rpc_client)
     }
 
     /// Build this provider with anvil, using an Reqwest HTTP transport.

--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -1318,7 +1318,7 @@ mod tests {
 
         // These blocks are not necessary.
         {
-            let refdyn = &provider as &dyn Provider<alloy_transport_http::Http<reqwest::Client>, _>;
+            let refdyn = &provider as &dyn Provider<alloy_transport::BoxTransport, _>;
             let num = refdyn.get_block_number().await.unwrap();
             assert_eq!(0, num);
         }
@@ -1332,7 +1332,7 @@ mod tests {
 
         // Note the `Http` arg, vs no arg (defaulting to `BoxedTransport`) below.
         {
-            let refdyn = &provider as &dyn Provider<alloy_transport_http::Http<reqwest::Client>, _>;
+            let refdyn = &provider as &dyn Provider<alloy_transport::BoxTransport, _>;
             let num = refdyn.get_block_number().await.unwrap();
             assert_eq!(0, num);
         }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Currently, the `on_anvil_*`  methods on the provider builder return a provider based on `Http<Client>` transport client. 

Since, the default transport in `Provider` is `BoxTransport`, there exists friction when working with types that wrap a Provider. It becomes necessary to add the `T: Transport` generic to `Foo<P: Provider<T>, T: Transport + Clone>>.

The following (cleaner) way isn't possible:
```rust
struct Foo<P: Provider> {
    provider: P,
}

impl<P: Provider> Foo<P> { // default transport is BoxTransport
    pub fn new(provider: P) -> Self {
        Self { provider }
    }

    pub async fn get_block_number(&self) -> TransportResult<u64> {
        self.provider.get_block_number().await
    }
}

#[tokio::main]
async fn main() -> Result<()> {
    let provider = ProviderBuilder::new().on_anvil(); // provider based on Http<Client>

    let foo = Foo::new(provider); // Won't compile

}
```

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Box the transport after instantiating `RpcClient` using `.boxed`

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
