### PR TITLE
fix: pass slice to RlpReceipt::rlp_decode_fields

### DIFF
--- a/crates/consensus/src/receipt/mod.rs
+++ b/crates/consensus/src/receipt/mod.rs
@@ -1,5 +1,5 @@
 use alloy_primitives::Bloom;
-use alloy_rlp::{BufMut, Header};
+use alloy_rlp::{Buf, BufMut, Header};
 use core::fmt;
 
 mod envelope;
@@ -100,17 +100,19 @@ pub trait RlpReceipt: Sized {
         if !header.list {
             return Err(alloy_rlp::Error::UnexpectedString);
         }
-        let remaining = buf.len();
 
-        if header.payload_length > remaining {
+        if header.payload_length > buf.len() {
             return Err(alloy_rlp::Error::InputTooShort);
         }
 
-        let this = Self::rlp_decode_fields_with_bloom(buf)?;
+        let mut fields_buf = &buf[..header.payload_length];
+        let this = Self::rlp_decode_fields_with_bloom(&mut fields_buf)?;
 
-        if buf.len() + header.payload_length != remaining {
+        if !fields_buf.is_empty() {
             return Err(alloy_rlp::Error::UnexpectedLength);
         }
+
+        buf.advance(header.payload_length);
 
         Ok(this)
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

For OP we need to know the length of available payload to correctly handle optional fields on receipt. This PR changes the `RlpReceipt` trait so that fields decoding method accepts a slice of the same length as specified in header and can use it to determine where to stop decoding

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
