### PR TITLE
feat: impl `Encodable2718` for `ReceiptWithBloom`

### DIFF
--- a/crates/consensus-any/src/receipt/envelope.rs
+++ b/crates/consensus-any/src/receipt/envelope.rs
@@ -1,4 +1,4 @@
-use alloy_consensus::{Eip658Value, Receipt, ReceiptWithBloom, RlpReceipt, TxReceipt};
+use alloy_consensus::{Eip658Value, Receipt, ReceiptWithBloom, RlpEncodableReceipt, TxReceipt};
 use alloy_eips::eip2718::{Decodable2718, Eip2718Result, Encodable2718};
 use alloy_primitives::{bytes::BufMut, Bloom, Log};
 use alloy_rlp::{Decodable, Encodable};
@@ -32,7 +32,7 @@ impl<R> AnyReceiptEnvelope<R> {
     }
 }
 
-impl<R: RlpReceipt> AnyReceiptEnvelope<R> {
+impl<R: RlpEncodableReceipt> AnyReceiptEnvelope<R> {
     /// Calculate the length of the rlp payload of the network encoded receipt.
     pub fn rlp_payload_length(&self) -> usize {
         let length = self.inner.length();

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -20,8 +20,8 @@ pub use constants::{EMPTY_OMMER_ROOT_HASH, EMPTY_ROOT_HASH};
 
 mod receipt;
 pub use receipt::{
-    Eip658Value, Receipt, ReceiptEnvelope, ReceiptWithBloom, Receipts, RlpDecodableReceipt,
-    RlpEncodableReceipt, TxReceipt,
+    Eip2718EncodableReceipt, Eip658Value, Receipt, ReceiptEnvelope, ReceiptWithBloom, Receipts,
+    RlpDecodableReceipt, RlpEncodableReceipt, TxReceipt,
 };
 
 pub mod proofs;

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -20,7 +20,8 @@ pub use constants::{EMPTY_OMMER_ROOT_HASH, EMPTY_ROOT_HASH};
 
 mod receipt;
 pub use receipt::{
-    Eip658Value, Receipt, ReceiptEnvelope, ReceiptWithBloom, Receipts, RlpReceipt, TxReceipt,
+    Eip658Value, Receipt, ReceiptEnvelope, ReceiptWithBloom, Receipts, RlpDecodableReceipt,
+    RlpEncodableReceipt, TxReceipt,
 };
 
 pub mod proofs;

--- a/crates/consensus/src/receipt/mod.rs
+++ b/crates/consensus/src/receipt/mod.rs
@@ -1,5 +1,5 @@
 use alloy_primitives::Bloom;
-use alloy_rlp::{Buf, BufMut, Header};
+use alloy_rlp::BufMut;
 use core::fmt;
 
 mod envelope;
@@ -10,6 +10,8 @@ pub use receipts::{Receipt, ReceiptWithBloom, Receipts};
 
 mod status;
 pub use status::Eip658Value;
+
+use crate::Typed2718;
 
 /// Receipt is the result of a transaction execution.
 #[doc(alias = "TransactionReceipt")]
@@ -64,64 +66,30 @@ pub trait TxReceipt: Clone + fmt::Debug + PartialEq + Eq + Send + Sync {
 /// Receipt type that knows how to encode itself with a [`Bloom`] value.
 #[auto_impl::auto_impl(&)]
 pub trait RlpEncodableReceipt {
-    /// Returns the length of the RLP encoded receipt fields with the provided bloom filter, without
-    /// RLP header.
-    fn rlp_encoded_fields_length_with_bloom(&self, bloom: &Bloom) -> usize;
-
-    /// RLP encodes the receipt fields with the provided bloom filter, without RLP header.
-    fn rlp_encode_fields_with_bloom(&self, bloom: &Bloom, out: &mut dyn BufMut);
-
-    /// Returns the RLP header for the receipt payload with the provided bloom filter.
-    fn rlp_header_with_bloom(&self, bloom: &Bloom) -> alloy_rlp::Header {
-        alloy_rlp::Header {
-            list: true,
-            payload_length: self.rlp_encoded_fields_length_with_bloom(bloom),
-        }
-    }
-
     /// Returns the length of the receipt payload with the provided bloom filter.
-    fn rlp_encoded_length_with_bloom(&self, bloom: &Bloom) -> usize {
-        self.rlp_header_with_bloom(bloom).length_with_payload()
-    }
+    fn rlp_encoded_length_with_bloom(&self, bloom: &Bloom) -> usize;
 
     /// RLP encodes the receipt with the provided bloom filter.
-    fn rlp_encode_with_bloom(&self, bloom: &Bloom, out: &mut dyn BufMut) {
-        self.rlp_header_with_bloom(bloom).encode(out);
-        self.rlp_encode_fields_with_bloom(bloom, out);
-    }
+    fn rlp_encode_with_bloom(&self, bloom: &Bloom, out: &mut dyn BufMut);
 }
 
 /// Receipt type that knows how to decode itself with a [`Bloom`] value.
 pub trait RlpDecodableReceipt: Sized {
-    /// RLP decodes receipt's fields and [`Bloom`] into [`ReceiptWithBloom`] instance.
-    ///
-    /// Note: this should not decode an RLP header.
-    fn rlp_decode_fields_with_bloom(buf: &mut &[u8]) -> alloy_rlp::Result<ReceiptWithBloom<Self>>;
-
     /// RLP decodes receipt and [`Bloom`] into [`ReceiptWithBloom`] instance.
-    fn rlp_decode_with_bloom(buf: &mut &[u8]) -> alloy_rlp::Result<ReceiptWithBloom<Self>> {
-        let header = Header::decode(buf)?;
-        if !header.list {
-            return Err(alloy_rlp::Error::UnexpectedString);
-        }
+    fn rlp_decode_with_bloom(buf: &mut &[u8]) -> alloy_rlp::Result<ReceiptWithBloom<Self>>;
+}
 
-        if header.payload_length > buf.len() {
-            return Err(alloy_rlp::Error::InputTooShort);
-        }
+/// Receipt type that knows its EIP-2718 encoding.
+///
+/// Main consumer of this trait is [`ReceiptWithBloom`]. It is expected that [`RlpEncodableReceipt`]
+/// implementation for this type produces network encoding whcih is used by [`alloy_rlp::Encodable`]
+/// implementation for [`ReceiptWithBloom`].
+pub trait Eip2718EncodableReceipt: RlpEncodableReceipt + Typed2718 {
+    /// EIP-2718 encoded length with the provided bloom filter.
+    fn eip2718_encoded_length_with_bloom(&self, bloom: &Bloom) -> usize;
 
-        // Note: we pass a new slice to `Self::rlp_decode_fields_with_bloom` so that it knows the
-        // length of the payload specified in header.
-        let mut fields_buf = &buf[..header.payload_length];
-        let this = Self::rlp_decode_fields_with_bloom(&mut fields_buf)?;
-
-        if !fields_buf.is_empty() {
-            return Err(alloy_rlp::Error::UnexpectedLength);
-        }
-
-        buf.advance(header.payload_length);
-
-        Ok(this)
-    }
+    /// EIP-2718 encodes the receipt with the provided bloom filter.
+    fn eip2718_encode_with_bloom(&self, bloom: &Bloom, out: &mut dyn BufMut);
 }
 
 #[cfg(test)]

--- a/crates/consensus/src/receipt/mod.rs
+++ b/crates/consensus/src/receipt/mod.rs
@@ -234,10 +234,15 @@ mod tests {
 
     #[test]
     fn can_encode_by_reference() {
-        let receipt: Receipt = Receipt { cumulative_gas_used: 16747627, status: true.into(), logs: vec![] };
+        let receipt: Receipt =
+            Receipt { cumulative_gas_used: 16747627, status: true.into(), logs: vec![] };
 
-        let encoded_ref = alloy_rlp::encode(&ReceiptWithBloom { receipt: &receipt, logs_bloom: receipt.bloom_slow() });
-        let encoded = alloy_rlp::encode(&ReceiptWithBloom { logs_bloom: receipt.bloom_slow(), receipt  });
+        let encoded_ref = alloy_rlp::encode(&ReceiptWithBloom {
+            receipt: &receipt,
+            logs_bloom: receipt.bloom_slow(),
+        });
+        let encoded =
+            alloy_rlp::encode(&ReceiptWithBloom { logs_bloom: receipt.bloom_slow(), receipt });
 
         assert_eq!(encoded, encoded_ref);
     }

--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -129,30 +129,6 @@ impl Typed2718 for TxType {
     fn ty(&self) -> u8 {
         (*self).into()
     }
-
-    fn is_type(&self, ty: u8) -> bool {
-        *self == ty
-    }
-
-    fn is_legacy(&self) -> bool {
-        matches!(self, Self::Legacy)
-    }
-
-    fn is_eip2930(&self) -> bool {
-        matches!(self, Self::Eip2930)
-    }
-
-    fn is_eip1559(&self) -> bool {
-        matches!(self, Self::Eip1559)
-    }
-
-    fn is_eip4844(&self) -> bool {
-        matches!(self, Self::Eip4844)
-    }
-
-    fn is_eip7702(&self) -> bool {
-        matches!(self, Self::Eip7702)
-    }
 }
 
 /// The Ethereum [EIP-2718] Transaction Envelope.

--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -126,6 +126,10 @@ impl Decodable for TxType {
 }
 
 impl Typed2718 for TxType {
+    fn ty(&self) -> u8 {
+        (*self).into()
+    }
+
     fn is_type(&self, ty: u8) -> bool {
         *self == ty
     }

--- a/crates/consensus/src/transaction/mod.rs
+++ b/crates/consensus/src/transaction/mod.rs
@@ -342,20 +342,32 @@ pub trait Typed2718 {
     fn ty(&self) -> u8;
 
     /// Returns true if the type matches the given type.
-    fn is_type(&self, ty: u8) -> bool;
+    fn is_type(&self, ty: u8) -> bool {
+        self.ty() == ty
+    }
 
     /// Returns true if the type is a legacy transaction.
-    fn is_legacy(&self) -> bool;
+    fn is_legacy(&self) -> bool {
+        self.ty() == 0
+    }
 
     /// Returns true if the type is an EIP-2930 transaction.
-    fn is_eip2930(&self) -> bool;
+    fn is_eip2930(&self) -> bool {
+        self.ty() == 1
+    }
 
     /// Returns true if the type is an EIP-1559 transaction.
-    fn is_eip1559(&self) -> bool;
+    fn is_eip1559(&self) -> bool {
+        self.ty() == 2
+    }
 
     /// Returns true if the type is an EIP-4844 transaction.
-    fn is_eip4844(&self) -> bool;
+    fn is_eip4844(&self) -> bool {
+        self.ty() == 3
+    }
 
     /// Returns true if the type is an EIP-7702 transaction.
-    fn is_eip7702(&self) -> bool;
+    fn is_eip7702(&self) -> bool {
+        self.ty() == 4
+    }
 }

--- a/crates/consensus/src/transaction/mod.rs
+++ b/crates/consensus/src/transaction/mod.rs
@@ -336,7 +336,11 @@ impl<T: Transaction> Transaction for alloy_serde::WithOtherFields<T> {
 }
 
 /// A trait that helps to determine the type of the transaction.
+#[auto_impl::auto_impl(&)]
 pub trait Typed2718 {
+    /// Returns the EIP-2718 type flag.
+    fn ty(&self) -> u8;
+
     /// Returns true if the type matches the given type.
     fn is_type(&self, ty: u8) -> bool;
 

--- a/crates/eips/src/eip2718.rs
+++ b/crates/eips/src/eip2718.rs
@@ -173,7 +173,7 @@ pub trait Decodable2718: Sized {
 /// over the accepted transaction types.
 ///
 /// [EIP-2718]: https://eips.ethereum.org/EIPS/eip-2718
-pub trait Encodable2718: Sized + Send + Sync + 'static {
+pub trait Encodable2718: Sized + Send + Sync {
     /// Return the type flag (if any).
     ///
     /// This should return `None` for the default (legacy) variant of the


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

Divides `RlpReceipt` into `RlpEncodableReceipt` and `RlpDecodableReceipt`, implementing `RlpEncodableReceipt` for references.

Provides `impl Encodable2718 for ReceiptWithBloom` when inner receipt knows its type.
 
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
