### PR TITLE
fix: remove `Borrow` impl for RPC receipt

### DIFF
--- a/crates/rpc-types-any/Cargo.toml
+++ b/crates/rpc-types-any/Cargo.toml
@@ -19,7 +19,6 @@ rustdoc-args = ["--cfg", "docsrs"]
 workspace = true
 
 [dependencies]
-alloy-consensus = { workspace = true, features = ["serde"] }
 alloy-consensus-any = { workspace = true, features = ["serde"] }
 alloy-rpc-types-eth.workspace = true
 alloy-serde.workspace = true

--- a/crates/rpc-types-any/src/transaction/receipt.rs
+++ b/crates/rpc-types-any/src/transaction/receipt.rs
@@ -1,12 +1,10 @@
-use alloy_consensus::Receipt;
 use alloy_consensus_any::AnyReceiptEnvelope;
 use alloy_rpc_types_eth::{Log, TransactionReceipt};
 use alloy_serde::WithOtherFields;
 
 /// Alias for a catch-all receipt type.
 #[doc(alias = "AnyTxReceipt")]
-pub type AnyTransactionReceipt =
-    WithOtherFields<TransactionReceipt<AnyReceiptEnvelope<Receipt<Log>>>>;
+pub type AnyTransactionReceipt = WithOtherFields<TransactionReceipt<AnyReceiptEnvelope<Log>>>;
 
 #[cfg(test)]
 mod test {

--- a/crates/rpc-types-eth/src/log.rs
+++ b/crates/rpc-types-eth/src/log.rs
@@ -1,5 +1,3 @@
-use core::borrow::Borrow;
-
 use alloy_primitives::{Address, BlockHash, LogData, TxHash, B256};
 
 /// Ethereum Log emitted by a transaction
@@ -150,12 +148,6 @@ impl<T> AsRef<T> for Log<T> {
 impl<T> AsMut<T> for Log<T> {
     fn as_mut(&mut self) -> &mut T {
         &mut self.inner.data
-    }
-}
-
-impl<T> Borrow<alloy_primitives::Log<T>> for Log<T> {
-    fn borrow(&self) -> &alloy_primitives::Log<T> {
-        &self.inner
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Based on #1719 

I've added this impl to support a more generic `AnyReceiptEnvelope` https://github.com/alloy-rs/alloy/blob/67576f9f6e70026116443851a43e4c805902c3b3/crates/rpc-types-eth/src/log.rs#L156-L160

However, it is in fact incorrect as `Borrow` shouldn't be implemented in this case

## Solution

This PR reverts changes including this impl and changes `AnyReceiptEnvelope` back to always holding a `Receipt<T>`

If we want to still support `AnyReceiptEnvelope` being generic over arbitrary receipt types, we'd need to either add `AsRef<Self> for alloy_primitives::Log` and use it instead or introduce a separate `Log` trait to replace such bounds with: https://github.com/alloy-rs/alloy/blob/67576f9f6e70026116443851a43e4c805902c3b3/crates/consensus/src/receipt/receipts.rs#L27-L29

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
