### PR TITLE
Remove wrapper BlobsBundleV1Ssz

### DIFF
--- a/crates/rpc-types-engine/src/payload.rs
+++ b/crates/rpc-types-engine/src/payload.rs
@@ -446,6 +446,7 @@ impl ssz::Encode for ExecutionPayloadV3 {
 /// This includes all bundled blob related data of an executed payload.
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ssz", derive(ssz_derive::Encode, ssz_derive::Decode))]
 pub struct BlobsBundleV1 {
     /// All commitments in the bundle.
     pub commitments: Vec<alloy_consensus::Bytes48>,
@@ -453,66 +454,6 @@ pub struct BlobsBundleV1 {
     pub proofs: Vec<alloy_consensus::Bytes48>,
     /// All blobs in the bundle.
     pub blobs: Vec<alloy_consensus::Blob>,
-}
-
-#[cfg(feature = "ssz")]
-#[derive(ssz_derive::Encode, ssz_derive::Decode)]
-struct BlobsBundleV1Ssz {
-    commitments: Vec<alloy_primitives::FixedBytes<48>>,
-    proofs: Vec<alloy_primitives::FixedBytes<48>>,
-    blobs: Vec<alloy_primitives::FixedBytes<{ alloy_eips::eip4844::BYTES_PER_BLOB }>>,
-}
-
-#[cfg(feature = "ssz")]
-impl BlobsBundleV1Ssz {
-    const _ASSERT: [(); std::mem::size_of::<BlobsBundleV1>()] = [(); std::mem::size_of::<Self>()];
-
-    const fn wrap_ref(other: &BlobsBundleV1) -> &Self {
-        // SAFETY: Same repr and size
-        unsafe { &*(other as *const BlobsBundleV1 as *const Self) }
-    }
-
-    fn unwrap(self) -> BlobsBundleV1 {
-        BlobsBundleV1 { commitments: self.commitments, proofs: self.proofs, blobs: self.blobs }
-    }
-}
-
-#[cfg(feature = "ssz")]
-impl ssz::Encode for BlobsBundleV1 {
-    fn is_ssz_fixed_len() -> bool {
-        <BlobsBundleV1Ssz as ssz::Encode>::is_ssz_fixed_len()
-    }
-
-    fn ssz_append(&self, buf: &mut Vec<u8>) {
-        BlobsBundleV1Ssz::wrap_ref(self).ssz_append(buf)
-    }
-
-    fn ssz_fixed_len() -> usize {
-        <BlobsBundleV1Ssz as ssz::Encode>::ssz_fixed_len()
-    }
-
-    fn ssz_bytes_len(&self) -> usize {
-        BlobsBundleV1Ssz::wrap_ref(self).ssz_bytes_len()
-    }
-
-    fn as_ssz_bytes(&self) -> Vec<u8> {
-        BlobsBundleV1Ssz::wrap_ref(self).as_ssz_bytes()
-    }
-}
-
-#[cfg(feature = "ssz")]
-impl ssz::Decode for BlobsBundleV1 {
-    fn is_ssz_fixed_len() -> bool {
-        <BlobsBundleV1Ssz as ssz::Decode>::is_ssz_fixed_len()
-    }
-
-    fn ssz_fixed_len() -> usize {
-        <BlobsBundleV1Ssz as ssz::Decode>::ssz_fixed_len()
-    }
-
-    fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, ssz::DecodeError> {
-        BlobsBundleV1Ssz::from_ssz_bytes(bytes).map(BlobsBundleV1Ssz::unwrap)
-    }
 }
 
 impl BlobsBundleV1 {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
Remove wrapper as it ssz decode could be used on the main type
Closes issue https://github.com/alloy-rs/alloy/issues/1722

## Solution
Removed private wrapper type and derived ssz directly on the main type
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
