### PR TITLE
docs: Fix `SignableTransaction` docs to use `PrimitiveSignature`

### DIFF
--- a/crates/consensus/src/transaction/mod.rs
+++ b/crates/consensus/src/transaction/mod.rs
@@ -177,7 +177,7 @@ pub trait Transaction: fmt::Debug + any::Any + Send + Sync + 'static {
 /// A signable transaction.
 ///
 /// A transaction can have multiple signature types. This is usually
-/// [`alloy_primitives::Signature`], however, it may be different for future EIP-2718 transaction
+/// [`alloy_primitives::PrimitiveSignature`], however, it may be different for future EIP-2718 transaction
 /// types, or in other networks. For example, in Optimism, the deposit transaction signature is the
 /// unit type `()`.
 #[doc(alias = "SignableTx", alias = "TxSignable")]

--- a/crates/consensus/src/transaction/mod.rs
+++ b/crates/consensus/src/transaction/mod.rs
@@ -177,9 +177,9 @@ pub trait Transaction: fmt::Debug + any::Any + Send + Sync + 'static {
 /// A signable transaction.
 ///
 /// A transaction can have multiple signature types. This is usually
-/// [`alloy_primitives::PrimitiveSignature`], however, it may be different for future EIP-2718 transaction
-/// types, or in other networks. For example, in Optimism, the deposit transaction signature is the
-/// unit type `()`.
+/// [`alloy_primitives::PrimitiveSignature`], however, it may be different for future EIP-2718
+/// transaction types, or in other networks. For example, in Optimism, the deposit transaction
+/// signature is the unit type `()`.
 #[doc(alias = "SignableTx", alias = "TxSignable")]
 pub trait SignableTransaction<Signature>: Transaction {
     /// Sets `chain_id`.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

`Signature` is being migrated to `PrimitiveSignature` and all alloy code now uses the latter
from: https://github.com/alloy-rs/core/issues/788

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
