### PR TITLE
feat(consensus): require typed2718 for transaction

### DIFF
--- a/crates/consensus/src/transaction/eip1559.rs
+++ b/crates/consensus/src/transaction/eip1559.rs
@@ -1,4 +1,4 @@
-use crate::{transaction::RlpEcdsaTx, SignableTransaction, Signed, Transaction, TxType};
+use crate::{transaction::RlpEcdsaTx, SignableTransaction, Signed, Transaction, TxType, Typed2718};
 use alloy_eips::{eip2930::AccessList, eip7702::SignedAuthorization};
 use alloy_primitives::{Bytes, ChainId, PrimitiveSignature as Signature, TxKind, B256, U256};
 use alloy_rlp::{BufMut, Decodable, Encodable};
@@ -235,11 +235,6 @@ impl Transaction for TxEip1559 {
     }
 
     #[inline]
-    fn ty(&self) -> u8 {
-        TxType::Eip1559 as u8
-    }
-
-    #[inline]
     fn access_list(&self) -> Option<&AccessList> {
         Some(&self.access_list)
     }
@@ -252,6 +247,39 @@ impl Transaction for TxEip1559 {
     #[inline]
     fn authorization_list(&self) -> Option<&[SignedAuthorization]> {
         None
+    }
+}
+
+impl Typed2718 for TxEip1559 {
+    fn ty(&self) -> u8 {
+        TxType::Eip1559 as u8
+    }
+    fn is_type(&self, ty: u8) -> bool {
+        self.ty() == ty
+    }
+
+    /// Returns true if the type is a legacy transaction.
+    fn is_legacy(&self) -> bool {
+        self.ty() == 0
+    }
+    /// Returns true if the type is an EIP-2930 transaction.
+    fn is_eip2930(&self) -> bool {
+        self.ty() == 1
+    }
+
+    /// Returns true if the type is an EIP-1559 transaction.
+    fn is_eip1559(&self) -> bool {
+        self.ty() == 2
+    }
+
+    /// Returns true if the type is an EIP-4844 transaction.
+    fn is_eip4844(&self) -> bool {
+        self.ty() == 3
+    }
+
+    /// Returns true if the type is an EIP-7702 transaction.
+    fn is_eip7702(&self) -> bool {
+        self.ty() == 4
     }
 }
 

--- a/crates/consensus/src/transaction/eip1559.rs
+++ b/crates/consensus/src/transaction/eip1559.rs
@@ -254,33 +254,6 @@ impl Typed2718 for TxEip1559 {
     fn ty(&self) -> u8 {
         TxType::Eip1559 as u8
     }
-    fn is_type(&self, ty: u8) -> bool {
-        self.ty() == ty
-    }
-
-    /// Returns true if the type is a legacy transaction.
-    fn is_legacy(&self) -> bool {
-        self.ty() == 0
-    }
-    /// Returns true if the type is an EIP-2930 transaction.
-    fn is_eip2930(&self) -> bool {
-        self.ty() == 1
-    }
-
-    /// Returns true if the type is an EIP-1559 transaction.
-    fn is_eip1559(&self) -> bool {
-        self.ty() == 2
-    }
-
-    /// Returns true if the type is an EIP-4844 transaction.
-    fn is_eip4844(&self) -> bool {
-        self.ty() == 3
-    }
-
-    /// Returns true if the type is an EIP-7702 transaction.
-    fn is_eip7702(&self) -> bool {
-        self.ty() == 4
-    }
 }
 
 impl SignableTransaction<Signature> for TxEip1559 {

--- a/crates/consensus/src/transaction/eip2930.rs
+++ b/crates/consensus/src/transaction/eip2930.rs
@@ -4,7 +4,7 @@ use alloy_primitives::{Bytes, ChainId, PrimitiveSignature as Signature, TxKind, 
 use alloy_rlp::{BufMut, Decodable, Encodable};
 use core::mem;
 
-use super::RlpEcdsaTx;
+use super::{RlpEcdsaTx, Typed2718};
 
 /// Transaction with an [`AccessList`] ([EIP-2930](https://eips.ethereum.org/EIPS/eip-2930)).
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
@@ -193,11 +193,6 @@ impl Transaction for TxEip2930 {
     }
 
     #[inline]
-    fn ty(&self) -> u8 {
-        TxType::Eip2930 as u8
-    }
-
-    #[inline]
     fn access_list(&self) -> Option<&AccessList> {
         Some(&self.access_list)
     }
@@ -210,6 +205,20 @@ impl Transaction for TxEip2930 {
     #[inline]
     fn authorization_list(&self) -> Option<&[SignedAuthorization]> {
         None
+    }
+}
+
+impl Typed2718 for TxEip2930 {
+    fn ty(&self) -> u8 {
+        TxType::Eip2930 as u8
+    }
+    fn is_type(&self, ty: u8) -> bool {
+        self.ty() == ty
+    }
+
+    /// Returns true if the type is an EIP-2930 transaction.
+    fn is_eip2930(&self) -> bool {
+        self.ty() == 1
     }
 }
 

--- a/crates/consensus/src/transaction/eip2930.rs
+++ b/crates/consensus/src/transaction/eip2930.rs
@@ -212,14 +212,6 @@ impl Typed2718 for TxEip2930 {
     fn ty(&self) -> u8 {
         TxType::Eip2930 as u8
     }
-    fn is_type(&self, ty: u8) -> bool {
-        self.ty() == ty
-    }
-
-    /// Returns true if the type is an EIP-2930 transaction.
-    fn is_eip2930(&self) -> bool {
-        self.ty() == 1
-    }
 }
 
 impl SignableTransaction<Signature> for TxEip2930 {

--- a/crates/consensus/src/transaction/eip4844.rs
+++ b/crates/consensus/src/transaction/eip4844.rs
@@ -273,33 +273,6 @@ impl Typed2718 for TxEip4844 {
     fn ty(&self) -> u8 {
         TxType::Eip4844 as u8
     }
-    fn is_type(&self, ty: u8) -> bool {
-        self.ty() == ty
-    }
-
-    /// Returns true if the type is a legacy transaction.
-    fn is_legacy(&self) -> bool {
-        self.ty() == 0
-    }
-    /// Returns true if the type is an EIP-2930 transaction.
-    fn is_eip2930(&self) -> bool {
-        self.ty() == 1
-    }
-
-    /// Returns true if the type is an EIP-1559 transaction.
-    fn is_eip1559(&self) -> bool {
-        self.ty() == 2
-    }
-
-    /// Returns true if the type is an EIP-4844 transaction.
-    fn is_eip4844(&self) -> bool {
-        self.ty() == 3
-    }
-
-    /// Returns true if the type is an EIP-7702 transaction.
-    fn is_eip7702(&self) -> bool {
-        self.ty() == 4
-    }
 }
 
 impl RlpEcdsaTx for TxEip4844Variant {
@@ -395,33 +368,6 @@ impl RlpEcdsaTx for TxEip4844Variant {
 impl Typed2718 for TxEip4844Variant {
     fn ty(&self) -> u8 {
         TxType::Eip4844 as u8
-    }
-    fn is_type(&self, ty: u8) -> bool {
-        self.ty() == ty
-    }
-
-    /// Returns true if the type is a legacy transaction.
-    fn is_legacy(&self) -> bool {
-        self.ty() == 0
-    }
-    /// Returns true if the type is an EIP-2930 transaction.
-    fn is_eip2930(&self) -> bool {
-        self.ty() == 1
-    }
-
-    /// Returns true if the type is an EIP-1559 transaction.
-    fn is_eip1559(&self) -> bool {
-        self.ty() == 2
-    }
-
-    /// Returns true if the type is an EIP-4844 transaction.
-    fn is_eip4844(&self) -> bool {
-        self.ty() == 3
-    }
-
-    /// Returns true if the type is an EIP-7702 transaction.
-    fn is_eip7702(&self) -> bool {
-        self.ty() == 4
     }
 }
 
@@ -969,33 +915,6 @@ impl Transaction for TxEip4844WithSidecar {
 impl Typed2718 for TxEip4844WithSidecar {
     fn ty(&self) -> u8 {
         TxType::Eip4844 as u8
-    }
-    fn is_type(&self, ty: u8) -> bool {
-        self.ty() == ty
-    }
-
-    /// Returns true if the type is a legacy transaction.
-    fn is_legacy(&self) -> bool {
-        self.ty() == 0
-    }
-    /// Returns true if the type is an EIP-2930 transaction.
-    fn is_eip2930(&self) -> bool {
-        self.ty() == 1
-    }
-
-    /// Returns true if the type is an EIP-1559 transaction.
-    fn is_eip1559(&self) -> bool {
-        self.ty() == 2
-    }
-
-    /// Returns true if the type is an EIP-4844 transaction.
-    fn is_eip4844(&self) -> bool {
-        self.ty() == 3
-    }
-
-    /// Returns true if the type is an EIP-7702 transaction.
-    fn is_eip7702(&self) -> bool {
-        self.ty() == 4
     }
 }
 

--- a/crates/consensus/src/transaction/eip4844.rs
+++ b/crates/consensus/src/transaction/eip4844.rs
@@ -1,4 +1,4 @@
-use crate::{SignableTransaction, Signed, Transaction, TxType};
+use crate::{SignableTransaction, Signed, Transaction, TxType, Typed2718};
 
 use alloc::vec::Vec;
 use alloy_eips::{eip2930::AccessList, eip4844::DATA_GAS_PER_BLOB, eip7702::SignedAuthorization};
@@ -249,11 +249,6 @@ impl Transaction for TxEip4844Variant {
     }
 
     #[inline]
-    fn ty(&self) -> u8 {
-        TxType::Eip4844 as u8
-    }
-
-    #[inline]
     fn access_list(&self) -> Option<&AccessList> {
         match self {
             Self::TxEip4844(tx) => tx.access_list(),
@@ -272,6 +267,38 @@ impl Transaction for TxEip4844Variant {
     #[inline]
     fn authorization_list(&self) -> Option<&[SignedAuthorization]> {
         None
+    }
+}
+impl Typed2718 for TxEip4844 {
+    fn ty(&self) -> u8 {
+        TxType::Eip4844 as u8
+    }
+    fn is_type(&self, ty: u8) -> bool {
+        self.ty() == ty
+    }
+
+    /// Returns true if the type is a legacy transaction.
+    fn is_legacy(&self) -> bool {
+        self.ty() == 0
+    }
+    /// Returns true if the type is an EIP-2930 transaction.
+    fn is_eip2930(&self) -> bool {
+        self.ty() == 1
+    }
+
+    /// Returns true if the type is an EIP-1559 transaction.
+    fn is_eip1559(&self) -> bool {
+        self.ty() == 2
+    }
+
+    /// Returns true if the type is an EIP-4844 transaction.
+    fn is_eip4844(&self) -> bool {
+        self.ty() == 3
+    }
+
+    /// Returns true if the type is an EIP-7702 transaction.
+    fn is_eip7702(&self) -> bool {
+        self.ty() == 4
     }
 }
 
@@ -362,6 +389,39 @@ impl RlpEcdsaTx for TxEip4844Variant {
             Self::TxEip4844(inner) => inner.tx_hash_with_type(signature, ty),
             Self::TxEip4844WithSidecar(inner) => inner.tx_hash_with_type(signature, ty),
         }
+    }
+}
+
+impl Typed2718 for TxEip4844Variant {
+    fn ty(&self) -> u8 {
+        TxType::Eip4844 as u8
+    }
+    fn is_type(&self, ty: u8) -> bool {
+        self.ty() == ty
+    }
+
+    /// Returns true if the type is a legacy transaction.
+    fn is_legacy(&self) -> bool {
+        self.ty() == 0
+    }
+    /// Returns true if the type is an EIP-2930 transaction.
+    fn is_eip2930(&self) -> bool {
+        self.ty() == 1
+    }
+
+    /// Returns true if the type is an EIP-1559 transaction.
+    fn is_eip1559(&self) -> bool {
+        self.ty() == 2
+    }
+
+    /// Returns true if the type is an EIP-4844 transaction.
+    fn is_eip4844(&self) -> bool {
+        self.ty() == 3
+    }
+
+    /// Returns true if the type is an EIP-7702 transaction.
+    fn is_eip7702(&self) -> bool {
+        self.ty() == 4
     }
 }
 
@@ -677,11 +737,6 @@ impl Transaction for TxEip4844 {
     }
 
     #[inline]
-    fn ty(&self) -> u8 {
-        TxType::Eip4844 as u8
-    }
-
-    #[inline]
     fn access_list(&self) -> Option<&AccessList> {
         Some(&self.access_list)
     }
@@ -896,11 +951,6 @@ impl Transaction for TxEip4844WithSidecar {
     }
 
     #[inline]
-    fn ty(&self) -> u8 {
-        TxType::Eip4844 as u8
-    }
-
-    #[inline]
     fn access_list(&self) -> Option<&AccessList> {
         Some(&self.tx.access_list)
     }
@@ -913,6 +963,39 @@ impl Transaction for TxEip4844WithSidecar {
     #[inline]
     fn authorization_list(&self) -> Option<&[SignedAuthorization]> {
         None
+    }
+}
+
+impl Typed2718 for TxEip4844WithSidecar {
+    fn ty(&self) -> u8 {
+        TxType::Eip4844 as u8
+    }
+    fn is_type(&self, ty: u8) -> bool {
+        self.ty() == ty
+    }
+
+    /// Returns true if the type is a legacy transaction.
+    fn is_legacy(&self) -> bool {
+        self.ty() == 0
+    }
+    /// Returns true if the type is an EIP-2930 transaction.
+    fn is_eip2930(&self) -> bool {
+        self.ty() == 1
+    }
+
+    /// Returns true if the type is an EIP-1559 transaction.
+    fn is_eip1559(&self) -> bool {
+        self.ty() == 2
+    }
+
+    /// Returns true if the type is an EIP-4844 transaction.
+    fn is_eip4844(&self) -> bool {
+        self.ty() == 3
+    }
+
+    /// Returns true if the type is an EIP-7702 transaction.
+    fn is_eip7702(&self) -> bool {
+        self.ty() == 4
     }
 }
 

--- a/crates/consensus/src/transaction/eip7702.rs
+++ b/crates/consensus/src/transaction/eip7702.rs
@@ -273,33 +273,6 @@ impl Typed2718 for TxEip7702 {
     fn ty(&self) -> u8 {
         TxType::Eip7702 as u8
     }
-    fn is_type(&self, ty: u8) -> bool {
-        self.ty() == ty
-    }
-
-    /// Returns true if the type is a legacy transaction.
-    fn is_legacy(&self) -> bool {
-        self.ty() == 0
-    }
-    /// Returns true if the type is an EIP-2930 transaction.
-    fn is_eip2930(&self) -> bool {
-        self.ty() == 1
-    }
-
-    /// Returns true if the type is an EIP-1559 transaction.
-    fn is_eip1559(&self) -> bool {
-        self.ty() == 2
-    }
-
-    /// Returns true if the type is an EIP-4844 transaction.
-    fn is_eip4844(&self) -> bool {
-        self.ty() == 3
-    }
-
-    /// Returns true if the type is an EIP-7702 transaction.
-    fn is_eip7702(&self) -> bool {
-        self.ty() == 4
-    }
 }
 
 impl Encodable for TxEip7702 {

--- a/crates/consensus/src/transaction/eip7702.rs
+++ b/crates/consensus/src/transaction/eip7702.rs
@@ -1,4 +1,4 @@
-use crate::{SignableTransaction, Signed, Transaction, TxType};
+use crate::{SignableTransaction, Signed, Transaction, TxType, Typed2718};
 use alloc::vec::Vec;
 use alloy_eips::{
     eip2930::AccessList,
@@ -233,11 +233,6 @@ impl Transaction for TxEip7702 {
     }
 
     #[inline]
-    fn ty(&self) -> u8 {
-        TxType::Eip7702 as u8
-    }
-
-    #[inline]
     fn access_list(&self) -> Option<&AccessList> {
         Some(&self.access_list)
     }
@@ -271,6 +266,39 @@ impl SignableTransaction<Signature> for TxEip7702 {
         let tx_hash = self.tx_hash(&signature);
 
         Signed::new_unchecked(self, signature, tx_hash)
+    }
+}
+
+impl Typed2718 for TxEip7702 {
+    fn ty(&self) -> u8 {
+        TxType::Eip7702 as u8
+    }
+    fn is_type(&self, ty: u8) -> bool {
+        self.ty() == ty
+    }
+
+    /// Returns true if the type is a legacy transaction.
+    fn is_legacy(&self) -> bool {
+        self.ty() == 0
+    }
+    /// Returns true if the type is an EIP-2930 transaction.
+    fn is_eip2930(&self) -> bool {
+        self.ty() == 1
+    }
+
+    /// Returns true if the type is an EIP-1559 transaction.
+    fn is_eip1559(&self) -> bool {
+        self.ty() == 2
+    }
+
+    /// Returns true if the type is an EIP-4844 transaction.
+    fn is_eip4844(&self) -> bool {
+        self.ty() == 3
+    }
+
+    /// Returns true if the type is an EIP-7702 transaction.
+    fn is_eip7702(&self) -> bool {
+        self.ty() == 4
     }
 }
 

--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -655,34 +655,6 @@ impl Typed2718 for TxEnvelope {
             Self::Eip7702(tx) => tx.tx().ty(),
         }
     }
-
-    fn is_type(&self, ty: u8) -> bool {
-        self.ty() == ty
-    }
-
-    /// Returns true if the type is a legacy transaction.
-    fn is_legacy(&self) -> bool {
-        self.ty() == 0
-    }
-    /// Returns true if the type is an EIP-2930 transaction.
-    fn is_eip2930(&self) -> bool {
-        self.ty() == 1
-    }
-
-    /// Returns true if the type is an EIP-1559 transaction.
-    fn is_eip1559(&self) -> bool {
-        self.ty() == 2
-    }
-
-    /// Returns true if the type is an EIP-4844 transaction.
-    fn is_eip4844(&self) -> bool {
-        self.ty() == 3
-    }
-
-    /// Returns true if the type is an EIP-7702 transaction.
-    fn is_eip7702(&self) -> bool {
-        self.ty() == 4
-    }
 }
 
 #[cfg(feature = "serde")]

--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -613,17 +613,6 @@ impl Transaction for TxEnvelope {
     }
 
     #[inline]
-    fn ty(&self) -> u8 {
-        match self {
-            Self::Legacy(tx) => tx.tx().ty(),
-            Self::Eip2930(tx) => tx.tx().ty(),
-            Self::Eip1559(tx) => tx.tx().ty(),
-            Self::Eip4844(tx) => tx.tx().ty(),
-            Self::Eip7702(tx) => tx.tx().ty(),
-        }
-    }
-
-    #[inline]
     fn access_list(&self) -> Option<&AccessList> {
         match self {
             Self::Legacy(tx) => tx.tx().access_list(),
@@ -653,6 +642,46 @@ impl Transaction for TxEnvelope {
             Self::Eip4844(tx) => tx.tx().authorization_list(),
             Self::Eip7702(tx) => tx.tx().authorization_list(),
         }
+    }
+}
+
+impl Typed2718 for TxEnvelope {
+    fn ty(&self) -> u8 {
+        match self {
+            Self::Legacy(tx) => tx.tx().ty(),
+            Self::Eip2930(tx) => tx.tx().ty(),
+            Self::Eip1559(tx) => tx.tx().ty(),
+            Self::Eip4844(tx) => tx.tx().ty(),
+            Self::Eip7702(tx) => tx.tx().ty(),
+        }
+    }
+
+    fn is_type(&self, ty: u8) -> bool {
+        self.ty() == ty
+    }
+
+    /// Returns true if the type is a legacy transaction.
+    fn is_legacy(&self) -> bool {
+        self.ty() == 0
+    }
+    /// Returns true if the type is an EIP-2930 transaction.
+    fn is_eip2930(&self) -> bool {
+        self.ty() == 1
+    }
+
+    /// Returns true if the type is an EIP-1559 transaction.
+    fn is_eip1559(&self) -> bool {
+        self.ty() == 2
+    }
+
+    /// Returns true if the type is an EIP-4844 transaction.
+    fn is_eip4844(&self) -> bool {
+        self.ty() == 3
+    }
+
+    /// Returns true if the type is an EIP-7702 transaction.
+    fn is_eip7702(&self) -> bool {
+        self.ty() == 4
     }
 }
 

--- a/crates/consensus/src/transaction/legacy.rs
+++ b/crates/consensus/src/transaction/legacy.rs
@@ -358,25 +358,6 @@ impl Typed2718 for TxLegacy {
     fn is_legacy(&self) -> bool {
         self.ty() == 0
     }
-    /// Returns true if the type is an EIP-2930 transaction.
-    fn is_eip2930(&self) -> bool {
-        self.ty() == 1
-    }
-
-    /// Returns true if the type is an EIP-1559 transaction.
-    fn is_eip1559(&self) -> bool {
-        self.ty() == 2
-    }
-
-    /// Returns true if the type is an EIP-4844 transaction.
-    fn is_eip4844(&self) -> bool {
-        self.ty() == 3
-    }
-
-    /// Returns true if the type is an EIP-7702 transaction.
-    fn is_eip7702(&self) -> bool {
-        self.ty() == 4
-    }
 }
 
 impl Encodable for TxLegacy {

--- a/crates/consensus/src/transaction/legacy.rs
+++ b/crates/consensus/src/transaction/legacy.rs
@@ -7,6 +7,8 @@ use alloy_primitives::{
 use alloy_rlp::{length_of_length, BufMut, Decodable, Encodable, Header, Result};
 use core::mem;
 
+use super::Typed2718;
+
 /// Legacy transaction.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
 #[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
@@ -302,11 +304,6 @@ impl Transaction for TxLegacy {
     }
 
     #[inline]
-    fn ty(&self) -> u8 {
-        TxType::Legacy as u8
-    }
-
-    #[inline]
     fn access_list(&self) -> Option<&AccessList> {
         None
     }
@@ -346,6 +343,39 @@ impl SignableTransaction<Signature> for TxLegacy {
     fn into_signed(self, signature: Signature) -> Signed<Self> {
         let hash = self.tx_hash(&signature);
         Signed::new_unchecked(self, signature, hash)
+    }
+}
+
+impl Typed2718 for TxLegacy {
+    fn ty(&self) -> u8 {
+        TxType::Legacy as u8
+    }
+    fn is_type(&self, ty: u8) -> bool {
+        self.ty() == ty
+    }
+
+    /// Returns true if the type is a legacy transaction.
+    fn is_legacy(&self) -> bool {
+        self.ty() == 0
+    }
+    /// Returns true if the type is an EIP-2930 transaction.
+    fn is_eip2930(&self) -> bool {
+        self.ty() == 1
+    }
+
+    /// Returns true if the type is an EIP-1559 transaction.
+    fn is_eip1559(&self) -> bool {
+        self.ty() == 2
+    }
+
+    /// Returns true if the type is an EIP-4844 transaction.
+    fn is_eip4844(&self) -> bool {
+        self.ty() == 3
+    }
+
+    /// Returns true if the type is an EIP-7702 transaction.
+    fn is_eip7702(&self) -> bool {
+        self.ty() == 4
     }
 }
 

--- a/crates/consensus/src/transaction/legacy.rs
+++ b/crates/consensus/src/transaction/legacy.rs
@@ -350,14 +350,6 @@ impl Typed2718 for TxLegacy {
     fn ty(&self) -> u8 {
         TxType::Legacy as u8
     }
-    fn is_type(&self, ty: u8) -> bool {
-        self.ty() == ty
-    }
-
-    /// Returns true if the type is a legacy transaction.
-    fn is_legacy(&self) -> bool {
-        self.ty() == 0
-    }
 }
 
 impl Encodable for TxLegacy {

--- a/crates/consensus/src/transaction/mod.rs
+++ b/crates/consensus/src/transaction/mod.rs
@@ -55,7 +55,7 @@ pub mod serde_bincode_compat {
 /// Represents a minimal EVM transaction.
 #[doc(alias = "Tx")]
 #[auto_impl::auto_impl(&, Arc)]
-pub trait Transaction: fmt::Debug + any::Any + Send + Sync + 'static {
+pub trait Transaction: fmt::Debug + any::Any + Send + Sync + 'static + Typed2718 {
     /// Get `chain_id`.
     fn chain_id(&self) -> Option<ChainId>;
 
@@ -147,9 +147,6 @@ pub trait Transaction: fmt::Debug + any::Any + Send + Sync + 'static {
 
     /// Get `data`.
     fn input(&self) -> &Bytes;
-
-    /// Returns the transaction type
-    fn ty(&self) -> u8;
 
     /// Returns the EIP-2930 `access_list` for the particular transaction type. Returns `None` for
     /// older transaction types.
@@ -244,6 +241,14 @@ impl<S: 'static> dyn SignableTransaction<S> {
 }
 
 #[cfg(feature = "serde")]
+impl<T: Typed2718> Typed2718 for alloy_serde::WithOtherFields<T> {
+    #[inline]
+    fn ty(&self) -> u8 {
+        self.inner.ty()
+    }
+}
+
+#[cfg(feature = "serde")]
 impl<T: Transaction> Transaction for alloy_serde::WithOtherFields<T> {
     #[inline]
     fn chain_id(&self) -> Option<ChainId> {
@@ -312,11 +317,6 @@ impl<T: Transaction> Transaction for alloy_serde::WithOtherFields<T> {
     #[inline]
     fn input(&self) -> &Bytes {
         self.inner.input()
-    }
-
-    #[inline]
-    fn ty(&self) -> u8 {
-        self.inner.ty()
     }
 
     #[inline]

--- a/crates/consensus/src/transaction/mod.rs
+++ b/crates/consensus/src/transaction/mod.rs
@@ -55,7 +55,7 @@ pub mod serde_bincode_compat {
 /// Represents a minimal EVM transaction.
 #[doc(alias = "Tx")]
 #[auto_impl::auto_impl(&, Arc)]
-pub trait Transaction: fmt::Debug + any::Any + Send + Sync + 'static + Typed2718 {
+pub trait Transaction: Typed2718 + fmt::Debug + any::Any + Send + Sync + 'static {
     /// Get `chain_id`.
     fn chain_id(&self) -> Option<ChainId>;
 

--- a/crates/consensus/src/transaction/typed.rs
+++ b/crates/consensus/src/transaction/typed.rs
@@ -3,7 +3,7 @@ use alloy_primitives::{Bytes, ChainId, TxKind, B256, U256};
 
 use crate::{
     transaction::eip4844::{TxEip4844, TxEip4844Variant, TxEip4844WithSidecar},
-    Transaction, TxEip1559, TxEip2930, TxEip7702, TxEnvelope, TxLegacy, TxType,
+    Transaction, TxEip1559, TxEip2930, TxEip7702, TxEnvelope, TxLegacy, TxType, Typed2718,
 };
 
 /// The TypedTransaction enum represents all Ethereum transaction request types.
@@ -297,17 +297,6 @@ impl Transaction for TypedTransaction {
     }
 
     #[inline]
-    fn ty(&self) -> u8 {
-        match self {
-            Self::Legacy(tx) => tx.ty(),
-            Self::Eip2930(tx) => tx.ty(),
-            Self::Eip1559(tx) => tx.ty(),
-            Self::Eip4844(tx) => tx.ty(),
-            Self::Eip7702(tx) => tx.ty(),
-        }
-    }
-
-    #[inline]
     fn access_list(&self) -> Option<&AccessList> {
         match self {
             Self::Legacy(tx) => tx.access_list(),
@@ -337,6 +326,18 @@ impl Transaction for TypedTransaction {
             Self::Eip1559(tx) => tx.authorization_list(),
             Self::Eip4844(tx) => tx.authorization_list(),
             Self::Eip7702(tx) => tx.authorization_list(),
+        }
+    }
+}
+
+impl Typed2718 for TypedTransaction {
+    fn ty(&self) -> u8 {
+        match self {
+            Self::Legacy(tx) => tx.ty(),
+            Self::Eip2930(tx) => tx.ty(),
+            Self::Eip1559(tx) => tx.ty(),
+            Self::Eip4844(tx) => tx.ty(),
+            Self::Eip7702(tx) => tx.ty(),
         }
     }
 }

--- a/crates/network/src/any/either.rs
+++ b/crates/network/src/any/either.rs
@@ -200,15 +200,6 @@ impl Typed2718 for AnyTypedTransaction {
     }
 }
 
-impl Typed2718 for AnyTxEnvelope {
-    fn ty(&self) -> u8 {
-        match self {
-            Self::Ethereum(inner) => inner.ty(),
-            Self::Unknown(inner) => inner.ty(),
-        }
-    }
-}
-
 /// Transaction envelope for a catch-all network.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(untagged)]
@@ -218,6 +209,15 @@ pub enum AnyTxEnvelope {
     Ethereum(TxEnvelope),
     /// A transaction with unknown type.
     Unknown(UnknownTxEnvelope),
+}
+
+impl Typed2718 for AnyTxEnvelope {
+    fn ty(&self) -> u8 {
+        match self {
+            Self::Ethereum(inner) => inner.ty(),
+            Self::Unknown(inner) => inner.ty(),
+        }
+    }
 }
 
 impl Encodable2718 for AnyTxEnvelope {

--- a/crates/network/src/any/either.rs
+++ b/crates/network/src/any/either.rs
@@ -1,5 +1,5 @@
 use crate::{UnknownTxEnvelope, UnknownTypedTransaction};
-use alloy_consensus::{Transaction as TransactionTrait, TxEnvelope, TypedTransaction};
+use alloy_consensus::{Transaction as TransactionTrait, TxEnvelope, Typed2718, TypedTransaction};
 use alloy_eips::{
     eip2718::{Decodable2718, Encodable2718},
     eip7702::SignedAuthorization,
@@ -167,14 +167,6 @@ impl TransactionTrait for AnyTypedTransaction {
     }
 
     #[inline]
-    fn ty(&self) -> u8 {
-        match self {
-            Self::Ethereum(inner) => inner.ty(),
-            Self::Unknown(inner) => inner.ty(),
-        }
-    }
-
-    #[inline]
     fn access_list(&self) -> Option<&AccessList> {
         match self {
             Self::Ethereum(inner) => inner.access_list(),
@@ -195,6 +187,24 @@ impl TransactionTrait for AnyTypedTransaction {
         match self {
             Self::Ethereum(inner) => inner.authorization_list(),
             Self::Unknown(inner) => inner.authorization_list(),
+        }
+    }
+}
+
+impl Typed2718 for AnyTypedTransaction {
+    fn ty(&self) -> u8 {
+        match self {
+            Self::Ethereum(inner) => inner.ty(),
+            Self::Unknown(inner) => inner.ty(),
+        }
+    }
+}
+
+impl Typed2718 for AnyTxEnvelope {
+    fn ty(&self) -> u8 {
+        match self {
+            Self::Ethereum(inner) => inner.ty(),
+            Self::Unknown(inner) => inner.ty(),
         }
     }
 }
@@ -361,14 +371,6 @@ impl TransactionTrait for AnyTxEnvelope {
         match self {
             Self::Ethereum(inner) => inner.input(),
             Self::Unknown(inner) => inner.input(),
-        }
-    }
-
-    #[inline]
-    fn ty(&self) -> u8 {
-        match self {
-            Self::Ethereum(inner) => inner.ty(),
-            Self::Unknown(inner) => inner.ty(),
         }
     }
 

--- a/crates/network/src/any/unknowns.rs
+++ b/crates/network/src/any/unknowns.rs
@@ -1,7 +1,7 @@
 use core::fmt;
 use std::sync::OnceLock;
 
-use alloy_consensus::TxType;
+use alloy_consensus::{TxType, Typed2718};
 use alloy_eips::{eip2718::Eip2718Error, eip7702::SignedAuthorization};
 use alloy_primitives::{Address, Bytes, ChainId, TxKind, B256, U128, U256, U64, U8};
 use alloy_rpc_types_eth::AccessList;
@@ -216,11 +216,6 @@ impl alloy_consensus::Transaction for UnknownTypedTransaction {
     }
 
     #[inline]
-    fn ty(&self) -> u8 {
-        self.ty.0
-    }
-
-    #[inline]
     fn access_list(&self) -> Option<&AccessList> {
         if self.fields.contains_key("accessList") {
             Some(self.memo.access_list.get_or_init(|| {
@@ -257,6 +252,18 @@ impl alloy_consensus::Transaction for UnknownTypedTransaction {
         } else {
             None
         }
+    }
+}
+
+impl Typed2718 for UnknownTxEnvelope {
+    fn ty(&self) -> u8 {
+        self.inner.ty.0
+    }
+}
+
+impl Typed2718 for UnknownTypedTransaction {
+    fn ty(&self) -> u8 {
+        self.ty.0
     }
 }
 
@@ -346,11 +353,6 @@ impl alloy_consensus::Transaction for UnknownTxEnvelope {
     #[inline]
     fn input(&self) -> &Bytes {
         self.inner.input()
-    }
-
-    #[inline]
-    fn ty(&self) -> u8 {
-        self.inner.ty()
     }
 
     #[inline]

--- a/crates/rpc-types-eth/src/transaction/mod.rs
+++ b/crates/rpc-types-eth/src/transaction/mod.rs
@@ -180,7 +180,7 @@ impl From<Transaction> for TxEnvelope {
     }
 }
 
-impl<T: TransactionTrait + Typed2718> TransactionTrait for Transaction<T> {
+impl<T: TransactionTrait> TransactionTrait for Transaction<T> {
     fn chain_id(&self) -> Option<ChainId> {
         self.inner.chain_id()
     }

--- a/crates/rpc-types-eth/src/transaction/mod.rs
+++ b/crates/rpc-types-eth/src/transaction/mod.rs
@@ -2,6 +2,7 @@
 
 use alloy_consensus::{
     Signed, TxEip1559, TxEip2930, TxEip4844, TxEip4844Variant, TxEip7702, TxEnvelope, TxLegacy,
+    Typed2718,
 };
 use alloy_eips::{eip2718::Encodable2718, eip7702::SignedAuthorization};
 use alloy_network_primitives::TransactionResponse;
@@ -179,7 +180,7 @@ impl From<Transaction> for TxEnvelope {
     }
 }
 
-impl<T: TransactionTrait> TransactionTrait for Transaction<T> {
+impl<T: TransactionTrait + Typed2718> TransactionTrait for Transaction<T> {
     fn chain_id(&self) -> Option<ChainId> {
         self.inner.chain_id()
     }
@@ -236,10 +237,6 @@ impl<T: TransactionTrait> TransactionTrait for Transaction<T> {
         self.inner.input()
     }
 
-    fn ty(&self) -> u8 {
-        self.inner.ty()
-    }
-
     fn access_list(&self) -> Option<&AccessList> {
         self.inner.access_list()
     }
@@ -272,6 +269,12 @@ impl<T: TransactionTrait + Encodable2718> TransactionResponse for Transaction<T>
 
     fn from(&self) -> Address {
         self.from
+    }
+}
+
+impl<T: Typed2718> Typed2718 for Transaction<T> {
+    fn ty(&self) -> u8 {
+        self.inner.ty()
     }
 }
 

--- a/crates/rpc-types-eth/src/transaction/request.rs
+++ b/crates/rpc-types-eth/src/transaction/request.rs
@@ -3,7 +3,7 @@
 use crate::{transaction::AccessList, BlobTransactionSidecar, Transaction, TransactionTrait};
 use alloy_consensus::{
     TxEip1559, TxEip2930, TxEip4844, TxEip4844Variant, TxEip4844WithSidecar, TxEip7702, TxEnvelope,
-    TxLegacy, TxType, TypedTransaction,
+    TxLegacy, TxType, Typed2718, TypedTransaction,
 };
 use alloy_eips::eip7702::SignedAuthorization;
 use alloy_network_primitives::{TransactionBuilder4844, TransactionBuilder7702};


### PR DESCRIPTION


## Motivation
Address #1735 ,  unifies tx types around eip2718

## Solution
Implements the Typed2718 for transaction types with `fn ty` 

## PR Checklist
- [X] cargo fmt
- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
