### PR TITLE
chore: Display instead of Debug the response JSON

### DIFF
--- a/crates/json-rpc/src/result.rs
+++ b/crates/json-rpc/src/result.rs
@@ -62,7 +62,7 @@ where
 {
     let json = result?;
     let json = json.borrow().get();
-    trace!(ty=%std::any::type_name::<T>(), json, "deserializing response");
+    trace!(ty=%std::any::type_name::<T>(), %json, "deserializing response");
     serde_json::from_str(json)
         .inspect(|response| trace!(?response, "deserialized response"))
         .inspect_err(|err| trace!(?err, "failed to deserialize response"))


### PR DESCRIPTION
Using Debug (used by tracing::Value for str) escapes strings which makes it really hard to copy paste or extract to format it or whatever when debugging