### PR TITLE
feat: EIP-7691

### DIFF
--- a/crates/eips/src/eip7691.rs
+++ b/crates/eips/src/eip7691.rs
@@ -1,0 +1,21 @@
+use crate::eip4844::BLOB_TX_MIN_BLOB_GASPRICE;
+
+/// CL-enforced target blobs per block after Pectra hardfork activation.
+pub const TARGET_BLOBS_PER_BLOCK_ELECTRA: u64 = 6;
+
+/// CL-enforced maximum blobs per block after Pectra hardfork activation.
+pub const MAX_BLOBS_PER_BLOCK_ELECTRA: u64 = 9;
+
+/// Determines the maximum rate of change for blob fee after Pectra hardfork activation.
+pub const BLOB_GASPRICE_UPDATE_FRACTION_PECTRA: u128 = 5007716;
+
+/// Same as [`crate::eip4844::calc_blob_gasprice`] but uses the
+/// [`BLOB_GASPRICE_UPDATE_FRACTION_PECTRA`].
+#[inline]
+pub fn calc_blob_gasprice(excess_blob_gas: u64) -> u128 {
+    fake_exponential(
+        BLOB_TX_MIN_BLOB_GASPRICE,
+        excess_blob_gas as u128,
+        BLOB_GASPRICE_UPDATE_FRACTION_PECTRA,
+    )
+}

--- a/crates/eips/src/eip7691.rs
+++ b/crates/eips/src/eip7691.rs
@@ -1,4 +1,6 @@
-use crate::eip4844::BLOB_TX_MIN_BLOB_GASPRICE;
+//! Contains constants and utility functions for [EIP-7691](https://eips.ethereum.org/EIPS/eip-7691)
+
+use crate::eip4844::{fake_exponential, BLOB_TX_MIN_BLOB_GASPRICE};
 
 /// CL-enforced target blobs per block after Pectra hardfork activation.
 pub const TARGET_BLOBS_PER_BLOCK_ELECTRA: u64 = 6;

--- a/crates/eips/src/lib.rs
+++ b/crates/eips/src/lib.rs
@@ -42,6 +42,8 @@ pub mod eip7251;
 
 pub mod eip7685;
 
+pub mod eip7691;
+
 pub mod eip7702;
 
 pub mod eip7742;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Closes #1712 
Implements https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7691.md

## Solution

The current API might be a bit confusing given that the fn has same signature as `eip4844::calc_blob_gasprice`. Unsure how we can make this nicer, something similar to `BaseFeeParams` could probably work but it's unclear how callers would set it

Also I don't not how we should handle this in `BlockHeader::next_block_blob_fee` and `BlobGasFiller`. Given variable update fraction we no longer can estimate the blob fee for next block without knowing the hardfork activation times

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
