### PR TITLE
feat: port reth pooled tx type

### DIFF
--- a/crates/consensus/src/transaction/eip4844.rs
+++ b/crates/consensus/src/transaction/eip4844.rs
@@ -139,6 +139,15 @@ impl TxEip4844Variant {
             Self::TxEip4844WithSidecar(tx) => tx.size(),
         }
     }
+
+    /// Tries to unwrap the [`TxEip4844WithSidecar`] returns the transaction as error if it is not a
+    /// [`TxEip4844WithSidecar`]
+    pub fn try_into_4844_with_sidecar(self) -> Result<TxEip4844WithSidecar, Self> {
+        match self {
+            Self::TxEip4844WithSidecar(tx) => Ok(tx),
+            _ => Err(self),
+        }
+    }
 }
 
 impl Transaction for TxEip4844Variant {

--- a/crates/consensus/src/transaction/mod.rs
+++ b/crates/consensus/src/transaction/mod.rs
@@ -17,6 +17,8 @@ pub use eip7702::TxEip7702;
 
 /// [EIP-4844] constants, helpers, and types.
 pub mod eip4844;
+pub mod pooled;
+pub use pooled::PooledTransaction;
 
 use alloy_eips::eip4844::DATA_GAS_PER_BLOB;
 pub use alloy_eips::eip4844::{

--- a/crates/consensus/src/transaction/pooled.rs
+++ b/crates/consensus/src/transaction/pooled.rs
@@ -1,0 +1,530 @@
+//! Defines the exact transaction variant that are allowed to be propagated over the eth p2p protocol.
+
+use crate::{transaction::{TxEip1559, TxEip2930, TxEip4844, TxLegacy}, SignableTransaction, Signed, TxEip4844WithSidecar, TxEnvelope};
+use crate::{Transaction, TxEip7702};
+use alloy_eips::{
+    eip2718::{Decodable2718, Eip2718Result, Encodable2718},
+    eip2930::AccessList,
+    eip7702::SignedAuthorization,
+};
+use alloy_primitives::bytes;
+use alloy_primitives::{
+    Address, Bytes, ChainId, PrimitiveSignature as Signature, TxHash, TxKind, B256, U256,
+};
+use alloy_rlp::{Decodable, Encodable, Header};
+use core::hash::{Hash, Hasher};
+
+/// All possible transactions that can be included in a response to `GetPooledTransactions`.
+/// A response to `GetPooledTransactions`. This can include either a blob transaction, or a
+/// non-4844 signed transaction.
+///
+/// The difference between this and the [`TxEnvelope`] is that this type always requires the [`TxEip4844WithSidecar`] variant, because EIP-4844 transaction can only be propagated with the sidecar over p2p.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(all(any(test, feature = "arbitrary"), feature = "k256"), derive(arbitrary::Arbitrary))]
+pub enum PooledTransaction {
+    /// An untagged [`TxLegacy`].
+    Legacy(Signed<TxLegacy>),
+    /// A [`TxEip2930`] tagged with type 1.
+    Eip2930(Signed<TxEip2930>),
+    /// A [`TxEip1559`] tagged with type 2.
+    Eip1559(Signed<TxEip1559>),
+    /// A [`TxEip7702`] tagged with type 4.
+    Eip7702(Signed<TxEip7702>),
+    /// A EIP-4844 transaction, which includes the transaction, blob data, commitments, and proofs.
+    Eip4844(Signed<TxEip4844WithSidecar>),
+}
+
+impl PooledTransaction {
+
+    /// Heavy operation that return signature hash over rlp encoded transaction.
+    /// It is only for signature signing or signer recovery.
+    pub fn signature_hash(&self) -> B256 {
+        match self {
+            Self::Legacy(tx) => tx.signature_hash(),
+            Self::Eip2930(tx) => tx.signature_hash(),
+            Self::Eip1559(tx) => tx.signature_hash(),
+            Self::Eip7702(tx) => tx.signature_hash(),
+            Self::Eip4844(tx) => tx.signature_hash(),
+        }
+    }
+
+    /// Reference to transaction hash. Used to identify transaction.
+    pub const fn hash(&self) -> &TxHash {
+        match self {
+            Self::Legacy(tx) => tx.hash(),
+            Self::Eip2930(tx) => tx.hash(),
+            Self::Eip1559(tx) => tx.hash(),
+            Self::Eip7702(tx) => tx.hash(),
+            Self::Eip4844(tx) => tx.hash(),
+        }
+    }
+
+    /// Returns the signature of the transaction.
+    pub const fn signature(&self) -> &Signature {
+        match self {
+            Self::Legacy(tx) => tx.signature(),
+            Self::Eip2930(tx) => tx.signature(),
+            Self::Eip1559(tx) => tx.signature(),
+            Self::Eip7702(tx) => tx.signature(),
+            Self::Eip4844(tx) => tx.signature(),
+        }
+    }
+
+    /// The length of the 2718 encoded envelope in network format. This is the
+    /// length of the header + the length of the type flag and inner encoding.
+    fn network_len(&self) -> usize {
+        let mut payload_length = self.encode_2718_len();
+        if !self.is_legacy() {
+            payload_length += Header { list: false, payload_length }.length();
+        }
+
+        payload_length
+    }
+
+    /// Recover the signer of the transaction.
+    #[cfg(feature = "k256")]
+    pub fn recover_signer(
+        &self,
+    ) -> Result<Address, alloy_primitives::SignatureError> {
+        match self {
+            Self::Legacy(tx) => tx.recover_signer(),
+            Self::Eip2930(tx) => tx.recover_signer(),
+            Self::Eip1559(tx) => tx.recover_signer(),
+            Self::Eip4844(tx) => tx.recover_signer(),
+            Self::Eip7702(tx) => tx.recover_signer(),
+        }
+    }
+
+    /// This encodes the transaction _without_ the signature, and is only suitable for creating a
+    /// hash intended for signing.
+    pub fn encode_for_signing(&self, out: &mut dyn bytes::BufMut) {
+        match self {
+            Self::Legacy(tx) => tx.tx().encode_for_signing(out),
+            Self::Eip2930(tx) => tx.tx().encode_for_signing(out),
+            Self::Eip1559(tx) => tx.tx().encode_for_signing(out),
+            Self::Eip4844(tx) => tx.tx().encode_for_signing(out),
+            Self::Eip7702(tx) => tx.tx().encode_for_signing(out),
+        }
+    }
+
+    /// Converts the transaction into [`TxEnvelope`].
+    pub fn into_envelope(self) -> TxEnvelope {
+        match self {
+            Self::Legacy(tx) => tx.into(),
+            Self::Eip2930(tx) => tx.into(),
+            Self::Eip1559(tx) => tx.into(),
+            Self::Eip7702(tx) => tx.into(),
+            Self::Eip4844(tx) => tx.into(),
+        }
+    }
+
+    /// Returns the [`TxLegacy`] variant if the transaction is a legacy transaction.
+    pub const fn as_legacy(&self) -> Option<&TxLegacy> {
+        match self {
+            Self::Legacy(tx) => Some(tx.tx()),
+            _ => None,
+        }
+    }
+
+    /// Returns the [`TxEip2930`] variant if the transaction is an EIP-2930 transaction.
+    pub const fn as_eip2930(&self) -> Option<&TxEip2930> {
+        match self {
+            Self::Eip2930(tx) => Some(tx.tx()),
+            _ => None,
+        }
+    }
+
+    /// Returns the [`TxEip1559`] variant if the transaction is an EIP-1559 transaction.
+    pub const fn as_eip1559(&self) -> Option<&TxEip1559> {
+        match self {
+            Self::Eip1559(tx) => Some(tx.tx()),
+            _ => None,
+        }
+    }
+
+    /// Returns the [`TxEip4844WithSidecar`] variant if the transaction is an EIP-4844 transaction.
+    pub const fn as_eip4844_with_sidecar(&self) -> Option<&TxEip4844WithSidecar> {
+        match self {
+            Self::Eip4844(tx) => Some(tx.tx()),
+            _ => None,
+        }
+    }
+
+    /// Returns the [`TxEip4844`] variant if the transaction is an EIP-4844 transaction.
+    pub const fn as_eip4844(&self) -> Option<&TxEip4844> {
+        match self {
+            Self::Eip4844(tx) => Some(tx.tx().tx()),
+            _ => None,
+        }
+    }
+
+    /// Returns the [`TxEip7702`] variant if the transaction is an EIP-7702 transaction.
+    pub const fn as_eip7702(&self) -> Option<&TxEip7702> {
+        match self {
+            Self::Eip7702(tx) => Some(tx.tx()),
+            _ => None,
+        }
+    }
+}
+
+impl Hash for PooledTransaction {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.trie_hash().hash(state);
+    }
+}
+
+impl Encodable for PooledTransaction {
+    /// This encodes the transaction _with_ the signature, and an rlp header.
+    ///
+    /// For legacy transactions, it encodes the transaction data:
+    /// `rlp(tx-data)`
+    ///
+    /// For EIP-2718 typed transactions, it encodes the transaction type followed by the rlp of the
+    /// transaction:
+    /// `rlp(tx-type || rlp(tx-data))`
+    fn encode(&self, out: &mut dyn bytes::BufMut) {
+        self.network_encode(out);
+    }
+
+    fn length(&self) -> usize {
+       self.network_len()
+    }
+}
+
+impl Decodable for PooledTransaction {
+    /// Decodes an enveloped post EIP-4844 [`PooledTransaction`].
+    ///
+    /// CAUTION: this expects that `buf` is `rlp(tx_type || rlp(tx-data))`
+    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        todo!()
+    }
+}
+
+impl Encodable2718 for PooledTransaction {
+    fn type_flag(&self) -> Option<u8> {
+        match self {
+            Self::Legacy(_) => None,
+            Self::Eip2930(_) => Some(0x01),
+            Self::Eip1559(_) => Some(0x02),
+            Self::Eip4844(_) => Some(0x03),
+            Self::Eip7702(_) => Some(0x04),
+        }
+    }
+
+    fn encode_2718_len(&self) -> usize {
+        match self {
+            Self::Legacy(tx) => tx.eip2718_encoded_length(),
+            Self::Eip2930(tx) => tx.eip2718_encoded_length(),
+            Self::Eip1559(tx) => tx.eip2718_encoded_length(),
+            Self::Eip7702(tx) => tx.eip2718_encoded_length(),
+            Self::Eip4844(tx) => tx.eip2718_encoded_length(),
+        }
+    }
+
+    fn encode_2718(&self, out: &mut dyn alloy_rlp::BufMut) {
+        match self {
+            Self::Legacy(tx) => tx.eip2718_encode(out),
+            Self::Eip2930(tx) => tx.eip2718_encode(out),
+            Self::Eip1559(tx) => tx.eip2718_encode(out),
+            Self::Eip7702(tx) => tx.eip2718_encode(out),
+            Self::Eip4844(tx) => tx.eip2718_encode(out),
+        }
+    }
+
+    fn trie_hash(&self) -> B256 {
+        *self.hash()
+    }
+}
+
+impl Decodable2718 for PooledTransaction {
+    fn typed_decode(ty: u8, buf: &mut &[u8]) -> Eip2718Result<Self> {
+       todo!()
+    }
+
+    fn fallback_decode(buf: &mut &[u8]) -> Eip2718Result<Self> {
+       todo!()
+    }
+}
+
+impl Transaction for PooledTransaction {
+    fn chain_id(&self) -> Option<ChainId> {
+        match self {
+            Self::Legacy(tx) => tx.tx().chain_id(),
+            Self::Eip2930(tx) => tx.tx().chain_id(),
+            Self::Eip1559(tx) => tx.tx().chain_id(),
+            Self::Eip7702(tx) => tx.tx().chain_id(),
+            Self::Eip4844(tx) => tx.tx().chain_id(),
+        }
+    }
+
+    fn nonce(&self) -> u64 {
+        match self {
+            Self::Legacy(tx) => tx.tx().nonce(),
+            Self::Eip2930(tx) => tx.tx().nonce(),
+            Self::Eip1559(tx) => tx.tx().nonce(),
+            Self::Eip7702(tx) => tx.tx().nonce(),
+            Self::Eip4844(tx) => tx.tx().nonce(),
+        }
+    }
+
+    fn gas_limit(&self) -> u64 {
+        match self {
+            Self::Legacy(tx) => tx.tx().gas_limit(),
+            Self::Eip2930(tx) => tx.tx().gas_limit(),
+            Self::Eip1559(tx) => tx.tx().gas_limit(),
+            Self::Eip7702(tx) => tx.tx().gas_limit(),
+            Self::Eip4844(tx) => tx.tx().gas_limit(),
+        }
+    }
+
+    fn gas_price(&self) -> Option<u128> {
+        match self {
+            Self::Legacy(tx) => tx.tx().gas_price(),
+            Self::Eip2930(tx) => tx.tx().gas_price(),
+            Self::Eip1559(tx) => tx.tx().gas_price(),
+            Self::Eip7702(tx) => tx.tx().gas_price(),
+            Self::Eip4844(tx) => tx.tx().gas_price(),
+        }
+    }
+
+    fn max_fee_per_gas(&self) -> u128 {
+        match self {
+            Self::Legacy(tx) => tx.tx().max_fee_per_gas(),
+            Self::Eip2930(tx) => tx.tx().max_fee_per_gas(),
+            Self::Eip1559(tx) => tx.tx().max_fee_per_gas(),
+            Self::Eip7702(tx) => tx.tx().max_fee_per_gas(),
+            Self::Eip4844(tx) => tx.tx().max_fee_per_gas(),
+        }
+    }
+
+    fn max_priority_fee_per_gas(&self) -> Option<u128> {
+        match self {
+            Self::Legacy(tx) => tx.tx().max_priority_fee_per_gas(),
+            Self::Eip2930(tx) => tx.tx().max_priority_fee_per_gas(),
+            Self::Eip1559(tx) => tx.tx().max_priority_fee_per_gas(),
+            Self::Eip7702(tx) => tx.tx().max_priority_fee_per_gas(),
+            Self::Eip4844(tx) => tx.tx().max_priority_fee_per_gas(),
+        }
+    }
+
+    fn max_fee_per_blob_gas(&self) -> Option<u128> {
+        match self {
+            Self::Legacy(tx) => tx.tx().max_fee_per_blob_gas(),
+            Self::Eip2930(tx) => tx.tx().max_fee_per_blob_gas(),
+            Self::Eip1559(tx) => tx.tx().max_fee_per_blob_gas(),
+            Self::Eip7702(tx) => tx.tx().max_fee_per_blob_gas(),
+            Self::Eip4844(tx) => tx.tx().max_fee_per_blob_gas(),
+        }
+    }
+
+    fn priority_fee_or_price(&self) -> u128 {
+        match self {
+            Self::Legacy(tx) => tx.tx().priority_fee_or_price(),
+            Self::Eip2930(tx) => tx.tx().priority_fee_or_price(),
+            Self::Eip1559(tx) => tx.tx().priority_fee_or_price(),
+            Self::Eip7702(tx) => tx.tx().priority_fee_or_price(),
+            Self::Eip4844(tx) => tx.tx().priority_fee_or_price(),
+        }
+    }
+
+    fn effective_gas_price(&self, base_fee: Option<u64>) -> u128 {
+        match self {
+            Self::Legacy(tx) => tx.tx().effective_gas_price(base_fee),
+            Self::Eip2930(tx) => tx.tx().effective_gas_price(base_fee),
+            Self::Eip1559(tx) => tx.tx().effective_gas_price(base_fee),
+            Self::Eip7702(tx) => tx.tx().effective_gas_price(base_fee),
+            Self::Eip4844(tx) => tx.tx().effective_gas_price(base_fee),
+        }
+    }
+
+    fn is_dynamic_fee(&self) -> bool {
+        match self {
+            Self::Legacy(tx) => tx.tx().is_dynamic_fee(),
+            Self::Eip2930(tx) => tx.tx().is_dynamic_fee(),
+            Self::Eip1559(tx) => tx.tx().is_dynamic_fee(),
+            Self::Eip7702(tx) => tx.tx().is_dynamic_fee(),
+            Self::Eip4844(tx) => tx.tx().is_dynamic_fee(),
+        }
+    }
+
+    fn kind(&self) -> TxKind {
+        match self {
+            Self::Legacy(tx) => tx.tx().kind(),
+            Self::Eip2930(tx) => tx.tx().kind(),
+            Self::Eip1559(tx) => tx.tx().kind(),
+            Self::Eip7702(tx) => tx.tx().kind(),
+            Self::Eip4844(tx) => tx.tx().kind(),
+        }
+    }
+
+    fn is_create(&self) -> bool {
+        match self {
+            Self::Legacy(tx) => tx.tx().is_create(),
+            Self::Eip2930(tx) => tx.tx().is_create(),
+            Self::Eip1559(tx) => tx.tx().is_create(),
+            Self::Eip7702(tx) => tx.tx().is_create(),
+            Self::Eip4844(tx) => tx.tx().is_create(),
+        }
+    }
+
+    fn value(&self) -> U256 {
+        match self {
+            Self::Legacy(tx) => tx.tx().value(),
+            Self::Eip2930(tx) => tx.tx().value(),
+            Self::Eip1559(tx) => tx.tx().value(),
+            Self::Eip7702(tx) => tx.tx().value(),
+            Self::Eip4844(tx) => tx.tx().value(),
+        }
+    }
+
+    fn input(&self) -> &Bytes {
+        match self {
+            Self::Legacy(tx) => tx.tx().input(),
+            Self::Eip2930(tx) => tx.tx().input(),
+            Self::Eip1559(tx) => tx.tx().input(),
+            Self::Eip7702(tx) => tx.tx().input(),
+            Self::Eip4844(tx) => tx.tx().input(),
+        }
+    }
+
+    fn ty(&self) -> u8 {
+        match self {
+            Self::Legacy(tx) => tx.tx().ty(),
+            Self::Eip2930(tx) => tx.tx().ty(),
+            Self::Eip1559(tx) => tx.tx().ty(),
+            Self::Eip7702(tx) => tx.tx().ty(),
+            Self::Eip4844(tx) => tx.tx().ty(),
+        }
+    }
+
+    fn access_list(&self) -> Option<&AccessList> {
+        match self {
+            Self::Legacy(tx) => tx.tx().access_list(),
+            Self::Eip2930(tx) => tx.tx().access_list(),
+            Self::Eip1559(tx) => tx.tx().access_list(),
+            Self::Eip7702(tx) => tx.tx().access_list(),
+            Self::Eip4844(tx) => tx.tx().access_list(),
+        }
+    }
+
+    fn blob_versioned_hashes(&self) -> Option<&[B256]> {
+        match self {
+            Self::Legacy(tx) => tx.tx().blob_versioned_hashes(),
+            Self::Eip2930(tx) => tx.tx().blob_versioned_hashes(),
+            Self::Eip1559(tx) => tx.tx().blob_versioned_hashes(),
+            Self::Eip7702(tx) => tx.tx().blob_versioned_hashes(),
+            Self::Eip4844(tx) => tx.tx().blob_versioned_hashes(),
+        }
+    }
+
+    fn authorization_list(&self) -> Option<&[SignedAuthorization]> {
+        match self {
+            Self::Legacy(tx) => tx.tx().authorization_list(),
+            Self::Eip2930(tx) => tx.tx().authorization_list(),
+            Self::Eip1559(tx) => tx.tx().authorization_list(),
+            Self::Eip7702(tx) => tx.tx().authorization_list(),
+            Self::Eip4844(tx) => tx.tx().authorization_list(),
+        }
+    }
+}
+
+
+impl From<PooledTransaction> for TxEnvelope {
+    fn from(tx: PooledTransaction) -> Self {
+        tx.into_envelope()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_consensus::Transaction as _;
+    use alloy_primitives::{address, hex};
+    use assert_matches::assert_matches;
+    use bytes::Bytes;
+
+    #[test]
+    fn invalid_legacy_pooled_decoding_input_too_short() {
+        let input_too_short = [
+            // this should fail because the payload length is longer than expected
+            &hex!("d90b0280808bc5cd028083c5cdfd9e407c56565656")[..],
+            // these should fail decoding
+            //
+            // The `c1` at the beginning is a list header, and the rest is a valid legacy
+            // transaction, BUT the payload length of the list header is 1, and the payload is
+            // obviously longer than one byte.
+            &hex!("c10b02808083c5cd028883c5cdfd9e407c56565656"),
+            &hex!("c10b0280808bc5cd028083c5cdfd9e407c56565656"),
+            // this one is 19 bytes, and the buf is long enough, but the transaction will not
+            // consume that many bytes.
+            &hex!("d40b02808083c5cdeb8783c5acfd9e407c5656565656"),
+            &hex!("d30102808083c5cd02887dc5cdfd9e64fd9e407c56"),
+        ];
+
+        for hex_data in &input_too_short {
+            let input_rlp = &mut &hex_data[..];
+            let res = PooledTransaction::decode(input_rlp);
+
+            assert!(
+                res.is_err(),
+                "expected err after decoding rlp input: {:x?}",
+                Bytes::copy_from_slice(hex_data)
+            );
+
+            // this is a legacy tx so we can attempt the same test with decode_enveloped
+            let input_rlp = &mut &hex_data[..];
+            let res = PooledTransaction::decode_2718(input_rlp);
+
+            assert!(
+                res.is_err(),
+                "expected err after decoding enveloped rlp input: {:x?}",
+                Bytes::copy_from_slice(hex_data)
+            );
+        }
+    }
+
+    // <https://holesky.etherscan.io/tx/0x7f60faf8a410a80d95f7ffda301d5ab983545913d3d789615df3346579f6c849>
+    #[test]
+    fn decode_eip1559_enveloped() {
+        let data = hex!("02f903d382426882ba09832dc6c0848674742682ed9694714b6a4ea9b94a8a7d9fd362ed72630688c8898c80b90364492d24749189822d8512430d3f3ff7a2ede675ac08265c08e2c56ff6fdaa66dae1cdbe4a5d1d7809f3e99272d067364e597542ac0c369d69e22a6399c3e9bee5da4b07e3f3fdc34c32c3d88aa2268785f3e3f8086df0934b10ef92cfffc2e7f3d90f5e83302e31382e302d64657600000000000000000000000000000000000000000000569e75fc77c1a856f6daaf9e69d8a9566ca34aa47f9133711ce065a571af0cfd000000000000000000000000e1e210594771824dad216568b91c9cb4ceed361c00000000000000000000000000000000000000000000000000000000000546e00000000000000000000000000000000000000000000000000000000000e4e1c00000000000000000000000000000000000000000000000000000000065d6750c00000000000000000000000000000000000000000000000000000000000f288000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002cf600000000000000000000000000000000000000000000000000000000000000640000000000000000000000000000000000000000000000000000000000000000f1628e56fa6d8c50e5b984a58c0df14de31c7b857ce7ba499945b99252976a93d06dcda6776fc42167fbe71cb59f978f5ef5b12577a90b132d14d9c6efa528076f0161d7bf03643cfc5490ec5084f4a041db7f06c50bd97efa08907ba79ddcac8b890f24d12d8db31abbaaf18985d54f400449ee0559a4452afe53de5853ce090000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000028000000000000000000000000000000000000000000000000000000000000003e800000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000064ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000c080a01428023fc54a27544abc421d5d017b9a7c5936ad501cbdecd0d9d12d04c1a033a0753104bbf1c87634d6ff3f0ffa0982710612306003eb022363b57994bdef445a"
+);
+
+        let res = PooledTransaction::decode_2718(&mut &data[..]).unwrap();
+        assert_eq!(
+            res.into_transaction().to(),
+            Some(address!("714b6a4ea9b94a8a7d9fd362ed72630688c8898c"))
+        );
+    }
+
+    #[test]
+    fn legacy_valid_pooled_decoding() {
+        // d3 <- payload length, d3 - c0 = 0x13 = 19
+        // 0b <- nonce
+        // 02 <- gas_price
+        // 80 <- gas_limit
+        // 80 <- to (Create)
+        // 83 c5cdeb <- value
+        // 87 83c5acfd9e407c <- input
+        // 56 <- v (eip155, so modified with a chain id)
+        // 56 <- r
+        // 56 <- s
+        let data = &hex!("d30b02808083c5cdeb8783c5acfd9e407c565656")[..];
+
+        let input_rlp = &mut &data[..];
+        let res = PooledTransaction::decode(input_rlp);
+        assert_matches!(res, Ok(_tx));
+        assert!(input_rlp.is_empty());
+
+        // this is a legacy tx so we can attempt the same test with
+        // decode_rlp_legacy_transaction_tuple
+        let input_rlp = &mut &data[..];
+        let res = TransactionSigned::decode_rlp_legacy_transaction_tuple(input_rlp);
+        assert_matches!(res, Ok(_tx));
+        assert!(input_rlp.is_empty());
+
+        // we can also decode_enveloped
+        let res = PooledTransaction::decode_2718(&mut &data[..]);
+        assert_matches!(res, Ok(_tx));
+    }
+}

--- a/crates/consensus/src/transaction/pooled.rs
+++ b/crates/consensus/src/transaction/pooled.rs
@@ -33,10 +33,10 @@ pub enum PooledTransaction {
     Eip2930(Signed<TxEip2930>),
     /// A [`TxEip1559`] tagged with type 2.
     Eip1559(Signed<TxEip1559>),
+     /// A EIP-4844 transaction, which includes the transaction, blob data, commitments, and proofs.
+    Eip4844(Signed<TxEip4844WithSidecar>),
     /// A [`TxEip7702`] tagged with type 4.
     Eip7702(Signed<TxEip7702>),
-    /// A EIP-4844 transaction, which includes the transaction, blob data, commitments, and proofs.
-    Eip4844(Signed<TxEip4844WithSidecar>),
 }
 
 impl PooledTransaction {

--- a/crates/consensus/src/transaction/pooled.rs
+++ b/crates/consensus/src/transaction/pooled.rs
@@ -33,7 +33,7 @@ pub enum PooledTransaction {
     Eip2930(Signed<TxEip2930>),
     /// A [`TxEip1559`] tagged with type 2.
     Eip1559(Signed<TxEip1559>),
-     /// A EIP-4844 transaction, which includes the transaction, blob data, commitments, and proofs.
+    /// A EIP-4844 transaction, which includes the transaction, blob data, commitments, and proofs.
     Eip4844(Signed<TxEip4844WithSidecar>),
     /// A [`TxEip7702`] tagged with type 4.
     Eip7702(Signed<TxEip7702>),


### PR DESCRIPTION
migrates the reth `PooledTransactionElement` type and renames it to just `PooledTransaction`.

@klkvr I assume we can simplify the decode/encode impls now