### PR TITLE
chore: introduce recovered and recoverable

### DIFF
--- a/crates/consensus/src/transaction/mod.rs
+++ b/crates/consensus/src/transaction/mod.rs
@@ -40,6 +40,9 @@ pub use rlp::RlpEcdsaTx;
 mod typed;
 pub use typed::TypedTransaction;
 
+mod recovered;
+pub use recovered::{Recovered, SignerRecoverable};
+
 #[cfg(feature = "serde")]
 pub use legacy::signed_legacy_serde;
 

--- a/crates/consensus/src/transaction/recovered.rs
+++ b/crates/consensus/src/transaction/recovered.rs
@@ -38,8 +38,8 @@ impl<T> Recovered<T> {
     }
 
     /// Dissolve Self to its component
-    pub fn to_components(self) -> (T, Address) {
-        (self.signed_transaction, self.signer)
+    pub fn into_parts(self) -> (T, Address) {
+        (self.tx, self.signer)
     }
 
     /// Create [`Recovered`] from the given transaction and [`Address`] of the signer.

--- a/crates/consensus/src/transaction/recovered.rs
+++ b/crates/consensus/src/transaction/recovered.rs
@@ -1,0 +1,123 @@
+use alloy_eips::eip2718::Encodable2718;
+use alloy_primitives::{bytes, Address, B256};
+use alloy_rlp::{Decodable, Encodable};
+use derive_more::{AsRef, Deref};
+
+/// Signed transaction with recovered signer.
+#[derive(Debug, Clone, PartialEq, Hash, Eq, AsRef, Deref)]
+pub struct Recovered<T> {
+    /// Signer of the transaction
+    signer: Address,
+    /// Signed transaction
+    #[deref]
+    #[as_ref]
+    signed_transaction: T,
+}
+
+// === impl RecoveredTx ===
+
+impl<T> Recovered<T> {
+    /// Signer of transaction recovered from signature
+    pub const fn signer(&self) -> Address {
+        self.signer
+    }
+
+    /// Reference to the signer of transaction recovered from signature
+    pub const fn signer_ref(&self) -> &Address {
+        &self.signer
+    }
+
+    /// Returns a reference to [`TransactionSigned`]
+    pub const fn as_signed(&self) -> &T {
+        &self.signed_transaction
+    }
+
+    /// Transform back to [`TransactionSigned`]
+    pub fn into_signed(self) -> T {
+        self.signed_transaction
+    }
+
+    /// Dissolve Self to its component
+    pub fn to_components(self) -> (T, Address) {
+        (self.signed_transaction, self.signer)
+    }
+
+    /// Create [`Recovered`] from the given transaction and [`Address`] of the signer.
+    ///
+    /// Note: This does not check if the signer is the actual signer of the transaction.
+    #[inline]
+    pub const fn new_unchecked(signed_transaction: T, signer: Address) -> Self {
+        Self { signed_transaction, signer }
+    }
+
+    /// Applies the given closure to the inner transactions.
+    pub fn map_transaction<Tx>(self, f: impl FnOnce(T) -> Tx) -> Recovered<Tx> {
+        Recovered::new_unchecked(f(self.signed_transaction), self.signer)
+    }
+}
+
+impl<T: Encodable> Encodable for Recovered<T> {
+    /// This encodes the transaction _with_ the signature, and an rlp header.
+    ///
+    /// Refer to docs for [`TransactionSigned::encode`] for details on the exact format.
+    fn encode(&self, out: &mut dyn bytes::BufMut) {
+        self.signed_transaction.encode(out)
+    }
+
+    fn length(&self) -> usize {
+        self.signed_transaction.length()
+    }
+}
+
+impl<T: Decodable + SignerRecoverable> Decodable for Recovered<T> {
+    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        let signed_transaction = T::decode(buf)?;
+        let signer = signed_transaction.recover_signer().map_err(|_| {
+            alloy_rlp::Error::Custom("Unable to recover decoded transaction signer.")
+        })?;
+        Ok(Self::new_unchecked(signed_transaction, signer))
+    }
+}
+
+impl<T: Encodable2718> Encodable2718 for Recovered<T> {
+    fn type_flag(&self) -> Option<u8> {
+        self.signed_transaction.type_flag()
+    }
+
+    fn encode_2718_len(&self) -> usize {
+        self.signed_transaction.encode_2718_len()
+    }
+
+    fn encode_2718(&self, out: &mut dyn alloy_rlp::BufMut) {
+        self.signed_transaction.encode_2718(out)
+    }
+
+    fn trie_hash(&self) -> B256 {
+        self.signed_transaction.trie_hash()
+    }
+}
+
+/// A type that can recover the signer of a transaction.
+///
+/// This is a helper trait that only provides the ability to recover the signer (address) of a
+/// transaction.
+///
+/// This
+pub trait SignerRecoverable {
+    /// Recover signer from signature and hash.
+    ///
+    /// Returns an error if the transaction's signature is invalid following [EIP-2](https://eips.ethereum.org/EIPS/eip-2).
+    ///
+    /// Note:
+    ///
+    /// This can fail for some early ethereum mainnet transactions pre EIP-2, use
+    /// [`Self::recover_signer_unchecked`] if you want to recover the signer without ensuring that
+    /// the signature has a low `s` value.
+    fn recover_signer(&self) -> Result<Address, alloy_primitives::SignatureError>;
+
+    /// Recover signer from signature and hash _without ensuring that the signature has a low `s`
+    /// value_.
+    ///
+    /// Returns an error if the transaction's signature is invalid.
+    fn recover_signer_unchecked(&self) -> Result<Address, alloy_primitives::SignatureError>;
+}

--- a/crates/consensus/src/transaction/recovered.rs
+++ b/crates/consensus/src/transaction/recovered.rs
@@ -56,8 +56,6 @@ impl<T> Recovered<T> {
 
 impl<T: Encodable> Encodable for Recovered<T> {
     /// This encodes the transaction _with_ the signature, and an rlp header.
-    ///
-    /// Refer to docs for [`TransactionSigned::encode`] for details on the exact format.
     fn encode(&self, out: &mut dyn bytes::BufMut) {
         self.tx.encode(out)
     }

--- a/crates/consensus/src/transaction/recovered.rs
+++ b/crates/consensus/src/transaction/recovered.rs
@@ -33,8 +33,8 @@ impl<T> Recovered<T> {
     }
 
     /// Transform back to [`TransactionSigned`]
-    pub fn into_signed(self) -> T {
-        self.signed_transaction
+    pub fn into_tx(self) -> T {
+        self.tx
     }
 
     /// Dissolve Self to its component

--- a/crates/consensus/src/transaction/recovered.rs
+++ b/crates/consensus/src/transaction/recovered.rs
@@ -46,8 +46,8 @@ impl<T> Recovered<T> {
     ///
     /// Note: This does not check if the signer is the actual signer of the transaction.
     #[inline]
-    pub const fn new_unchecked(signed_transaction: T, signer: Address) -> Self {
-        Self { signed_transaction, signer }
+    pub const fn new_unchecked(tx: T, signer: Address) -> Self {
+        Self { tx, signer }
     }
 
     /// Applies the given closure to the inner transactions.

--- a/crates/consensus/src/transaction/recovered.rs
+++ b/crates/consensus/src/transaction/recovered.rs
@@ -11,7 +11,7 @@ pub struct Recovered<T> {
     /// Signed transaction
     #[deref]
     #[as_ref]
-    signed_transaction: T,
+    tx: T,
 }
 
 // === impl RecoveredTx ===

--- a/crates/consensus/src/transaction/recovered.rs
+++ b/crates/consensus/src/transaction/recovered.rs
@@ -28,8 +28,8 @@ impl<T> Recovered<T> {
     }
 
     /// Returns a reference to [`TransactionSigned`]
-    pub const fn as_signed(&self) -> &T {
-        &self.signed_transaction
+    pub const fn tx(&self) -> &T {
+        &self.tx
     }
 
     /// Transform back to [`TransactionSigned`]

--- a/crates/consensus/src/transaction/recovered.rs
+++ b/crates/consensus/src/transaction/recovered.rs
@@ -14,8 +14,6 @@ pub struct Recovered<T> {
     tx: T,
 }
 
-// === impl RecoveredTx ===
-
 impl<T> Recovered<T> {
     /// Signer of transaction recovered from signature
     pub const fn signer(&self) -> Address {
@@ -27,12 +25,12 @@ impl<T> Recovered<T> {
         &self.signer
     }
 
-    /// Returns a reference to [`TransactionSigned`]
+    /// Returns a reference to the transaction.
     pub const fn tx(&self) -> &T {
         &self.tx
     }
 
-    /// Transform back to [`TransactionSigned`]
+    /// Transform back to the transaction.
     pub fn into_tx(self) -> T {
         self.tx
     }
@@ -101,8 +99,6 @@ impl<T: Encodable2718> Encodable2718 for Recovered<T> {
 ///
 /// This is a helper trait that only provides the ability to recover the signer (address) of a
 /// transaction.
-///
-/// This
 pub trait SignerRecoverable {
     /// Recover signer from signature and hash.
     ///

--- a/crates/consensus/src/transaction/recovered.rs
+++ b/crates/consensus/src/transaction/recovered.rs
@@ -52,7 +52,7 @@ impl<T> Recovered<T> {
 
     /// Applies the given closure to the inner transactions.
     pub fn map_transaction<Tx>(self, f: impl FnOnce(T) -> Tx) -> Recovered<Tx> {
-        Recovered::new_unchecked(f(self.signed_transaction), self.signer)
+        Recovered::new_unchecked(f(self.tx), self.signer)
     }
 }
 
@@ -61,39 +61,39 @@ impl<T: Encodable> Encodable for Recovered<T> {
     ///
     /// Refer to docs for [`TransactionSigned::encode`] for details on the exact format.
     fn encode(&self, out: &mut dyn bytes::BufMut) {
-        self.signed_transaction.encode(out)
+        self.tx.encode(out)
     }
 
     fn length(&self) -> usize {
-        self.signed_transaction.length()
+        self.tx.length()
     }
 }
 
 impl<T: Decodable + SignerRecoverable> Decodable for Recovered<T> {
     fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
-        let signed_transaction = T::decode(buf)?;
-        let signer = signed_transaction.recover_signer().map_err(|_| {
+        let tx = T::decode(buf)?;
+        let signer = tx.recover_signer().map_err(|_| {
             alloy_rlp::Error::Custom("Unable to recover decoded transaction signer.")
         })?;
-        Ok(Self::new_unchecked(signed_transaction, signer))
+        Ok(Self::new_unchecked(tx, signer))
     }
 }
 
 impl<T: Encodable2718> Encodable2718 for Recovered<T> {
     fn type_flag(&self) -> Option<u8> {
-        self.signed_transaction.type_flag()
+        self.tx.type_flag()
     }
 
     fn encode_2718_len(&self) -> usize {
-        self.signed_transaction.encode_2718_len()
+        self.tx.encode_2718_len()
     }
 
     fn encode_2718(&self, out: &mut dyn alloy_rlp::BufMut) {
-        self.signed_transaction.encode_2718(out)
+        self.tx.encode_2718(out)
     }
 
     fn trie_hash(&self) -> B256 {
-        self.signed_transaction.trie_hash()
+        self.tx.trie_hash()
     }
 }
 


### PR DESCRIPTION
ports the reth `RecoveredTx` to alloy as `Recovered`.

this is similar to `Signed`.

we don't have `recover_signer` as part of any API rn, so this introduces this as a new trait.

once we're happy with this we can integrate this like: `Signed -> Recovered<Signed>`

wdyt @Rjected @klkvr 