### PR TITLE
feat: Remove duplicated `to` method in `TransactionResponse`

### DIFF
--- a/crates/network-primitives/src/traits.rs
+++ b/crates/network-primitives/src/traits.rs
@@ -80,11 +80,6 @@ pub trait TransactionResponse: Transaction {
     /// Sender of the transaction
     fn from(&self) -> Address;
 
-    /// Recipient of the transaction. Returns `None` if transaction is a contract creation.
-    fn to(&self) -> Option<Address> {
-        self.kind().to().copied()
-    }
-
     /// Gas Price, this is the RPC format for `max_fee_per_gas`, pre-eip-1559.
     fn gas_price(&self) -> Option<u128> {
         if self.ty() < 2 {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

`TransactionResponse`'s base trait `alloy_consensus::Transaction` already has `to` method with the exact same default implementation.
It causes the following error when using `TransactionResponse` along with `Transaction`, and the result is the same when `to()` is called with either of the above traits. It would be a bit confusing.

```rs
error[E0034]: multiple applicable items in scope
   --> crates/.../...
    |
216 |                 .to()
    |                  ^^ multiple `to` found
    |
    = note: candidate #1 is defined in an impl of the trait `TransactionResponse` for the type `alloy_rpc_types_eth::Transaction<T>`
    = note: candidate #2 is defined in an impl of the trait `TransactionTrait` for the type `alloy_rpc_types_eth::Transaction<T>`
help: disambiguate the method for candidate #1
    |
215 |             && TransactionResponse::to(&tx)
    |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
help: disambiguate the method for candidate #2
    |
215 |             && TransactionTrait::to(&tx)
    |                ~~~~~~~~~~~~~~~~~~~~~~~~~
```


<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
