### PR TITLE
chore: add consensus helper methods to BlockHeader

### DIFF
--- a/crates/consensus/src/block/header.rs
+++ b/crates/consensus/src/block/header.rs
@@ -353,28 +353,6 @@ impl Header {
         BlockWithParent::new(self.parent_hash, self.num_hash_slow())
     }
 
-    /// Checks if the block's difficulty is set to zero, indicating a Proof-of-Stake header.
-    ///
-    /// This function is linked to EIP-3675, proposing the consensus upgrade to Proof-of-Stake:
-    /// [EIP-3675](https://eips.ethereum.org/EIPS/eip-3675#replacing-difficulty-with-0)
-    ///
-    /// Verifies whether, as per the EIP, the block's difficulty is updated to zero,
-    /// signifying the transition to a Proof-of-Stake mechanism.
-    ///
-    /// Returns `true` if the block's difficulty matches the constant zero set by the EIP.
-    pub fn is_zero_difficulty(&self) -> bool {
-        self.difficulty.is_zero()
-    }
-
-    /// Checks if the block's timestamp is in the future based on the present timestamp.
-    ///
-    /// Clock can drift but this can be consensus issue.
-    ///
-    /// Note: This check is relevant only pre-merge.
-    pub const fn exceeds_allowed_future_timestamp(&self, present_timestamp: u64) -> bool {
-        self.timestamp > present_timestamp + ALLOWED_FUTURE_BLOCK_TIME_SECONDS
-    }
-
     /// Seal the header with a known hash.
     ///
     /// WARNING: This method does not perform validation whether the hash is correct.
@@ -730,6 +708,35 @@ pub trait BlockHeader {
         self.withdrawals_root().map_or(txs_and_ommers_empty, |withdrawals_root| {
             txs_and_ommers_empty && withdrawals_root == EMPTY_ROOT_HASH
         })
+    }
+
+    /// Checks if the block's difficulty is set to zero, indicating a Proof-of-Stake header.
+    ///
+    /// This function is linked to EIP-3675, proposing the consensus upgrade to Proof-of-Stake:
+    /// [EIP-3675](https://eips.ethereum.org/EIPS/eip-3675#replacing-difficulty-with-0)
+    ///
+    /// Verifies whether, as per the EIP, the block's difficulty is updated to zero,
+    /// signifying the transition to a Proof-of-Stake mechanism.
+    ///
+    /// Returns `true` if the block's difficulty matches the constant zero set by the EIP.
+    fn is_zero_difficulty(&self) -> bool {
+        self.difficulty().is_zero()
+    }
+
+    /// Checks if the block's timestamp is in the future based on the present timestamp.
+    ///
+    /// Clock can drift but this can be consensus issue.
+    ///
+    /// Note: This check is relevant only pre-merge.
+    fn exceeds_allowed_future_timestamp(&self, present_timestamp: u64) -> bool {
+        self.timestamp() > present_timestamp + ALLOWED_FUTURE_BLOCK_TIME_SECONDS
+    }
+
+    /// Checks if the nonce exists, and if it exists, if it's zero.
+    ///
+    /// If the nonce is `None`, then this returns `false`.
+    fn is_nonce_zero(&self) -> bool {
+        self.nonce().is_some_and(|nonce| nonce.is_zero())
     }
 }
 


### PR DESCRIPTION
## Motivation

These helpers are useful in reth consensus methods for example, and had to be reimplemented.

## Solution

Added these methods to the `BlockHeader` trait. Removes the methods from the concrete `Header`, making it breaking unless the trait is already imported.

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [x] Breaking changes
