### PR TITLE
chore: port calc block gas limit

### DIFF
--- a/crates/eips/src/eip1559/constants.rs
+++ b/crates/eips/src/eip1559/constants.rs
@@ -3,6 +3,9 @@ use alloy_primitives::U256;
 /// The default Ethereum block gas limit.
 pub const ETHEREUM_BLOCK_GAS_LIMIT: u64 = 30_000_000;
 
+/// The bound divisor of the gas limit, used in update calculations.
+pub const GAS_LIMIT_BOUND_DIVISOR: u64 = 1024;
+
 /// The minimum tx fee below which the txpool will reject the transaction.
 ///
 /// Configured to `7` WEI which is the lowest possible value of base fee under mainnet EIP-1559

--- a/crates/eips/src/eip1559/helpers.rs
+++ b/crates/eips/src/eip1559/helpers.rs
@@ -1,4 +1,4 @@
-use crate::eip1559::BaseFeeParams;
+use crate::eip1559::{constants::GAS_LIMIT_BOUND_DIVISOR, BaseFeeParams};
 
 /// Calculate the base fee for the next block based on the EIP-1559 specification.
 ///
@@ -59,6 +59,15 @@ pub fn calc_next_block_base_fee(
             )
         }
     }
+}
+
+/// Calculate the gas limit for the next block based on parent and desired gas limits.
+/// Ref: <https://github.com/ethereum/go-ethereum/blob/88cbfab332c96edfbe99d161d9df6a40721bd786/core/block_validator.go#L166>
+pub fn calculate_block_gas_limit(parent_gas_limit: u64, desired_gas_limit: u64) -> u64 {
+    let delta = (parent_gas_limit / GAS_LIMIT_BOUND_DIVISOR).saturating_sub(1);
+    let min_gas_limit = parent_gas_limit - delta;
+    let max_gas_limit = parent_gas_limit + delta;
+    desired_gas_limit.clamp(min_gas_limit, max_gas_limit)
 }
 
 #[cfg(test)]

--- a/crates/eips/src/eip1559/mod.rs
+++ b/crates/eips/src/eip1559/mod.rs
@@ -8,8 +8,9 @@ pub use basefee::BaseFeeParams;
 mod constants;
 pub use constants::{
     DEFAULT_BASE_FEE_MAX_CHANGE_DENOMINATOR, DEFAULT_ELASTICITY_MULTIPLIER,
-    ETHEREUM_BLOCK_GAS_LIMIT, INITIAL_BASE_FEE, MIN_PROTOCOL_BASE_FEE, MIN_PROTOCOL_BASE_FEE_U256,
+    ETHEREUM_BLOCK_GAS_LIMIT, GAS_LIMIT_BOUND_DIVISOR, INITIAL_BASE_FEE, MIN_PROTOCOL_BASE_FEE,
+    MIN_PROTOCOL_BASE_FEE_U256,
 };
 
 mod helpers;
-pub use helpers::calc_next_block_base_fee;
+pub use helpers::{calc_next_block_base_fee, calculate_block_gas_limit};


### PR DESCRIPTION
port fn we added to reth

https://github.com/paradigmxyz/reth/blob/ca4095a6a807e4859f508bb9748b1608832f5b41/crates/ethereum/payload/src/config.rs#L40-L47

note: this doesn't really fit into the 1559 mod, but it's the closest and that's also where the gas limit const is defined