### PR TITLE
Add edge case tests for `extract_value` and fix the newly discovered bug

### DIFF
--- a/crates/node-bindings/src/utils.rs
+++ b/crates/node-bindings/src/utils.rs
@@ -22,7 +22,7 @@ pub(crate) fn unused_port() -> u16 {
 }
 
 /// Extracts the value for the given key from the line of text.
-/// 
+///
 /// It supports keys that end with '=' or ': '.
 /// For keys end with '=', find value until ' ' is encountered or end of line
 /// For keys end with ':', find value until ',' is encountered or end of line
@@ -38,7 +38,6 @@ pub(crate) fn extract_value<'a>(key: &str, line: &'a str) -> Option<&'a str> {
         key_colon = format!("{}: ", key).into();
     }
 
-
     // Try to find the key with '='
     if let Some(pos) = line.find(key_equal.as_ref()) {
         let start = pos + key_equal.len();
@@ -51,7 +50,7 @@ pub(crate) fn extract_value<'a>(key: &str, line: &'a str) -> Option<&'a str> {
     // If not found, try to find the key with ': '
     if let Some(pos) = line.find(key_colon.as_ref()) {
         let start = pos + key_colon.len();
-        let end = line[start..].find(',').map(|i| start + i ).unwrap_or(line.len()); // Assuming comma or end of line
+        let end = line[start..].find(',').map(|i| start + i).unwrap_or(line.len()); // Assuming comma or end of line
         if start <= line.len() && end <= line.len() {
             return Some(line[start..end].trim());
         }
@@ -118,7 +117,7 @@ mod tests {
         let line = "INFO key=";
         assert_eq!(extract_value("key", line), Some(""))
     }
-    
+
     #[test]
     fn test_extract_value_colon_no_comma() {
         let line = "INFO key: value";

--- a/crates/node-bindings/src/utils.rs
+++ b/crates/node-bindings/src/utils.rs
@@ -22,7 +22,10 @@ pub(crate) fn unused_port() -> u16 {
 }
 
 /// Extracts the value for the given key from the line of text.
+/// 
 /// It supports keys that end with '=' or ': '.
+/// For keys end with '=', find value until ' ' is encountered or end of line
+/// For keys end with ':', find value until ',' is encountered or end of line
 pub(crate) fn extract_value<'a>(key: &str, line: &'a str) -> Option<&'a str> {
     let mut key_equal = Cow::from(key);
     let mut key_colon = Cow::from(key);

--- a/crates/node-bindings/src/utils.rs
+++ b/crates/node-bindings/src/utils.rs
@@ -35,6 +35,7 @@ pub(crate) fn extract_value<'a>(key: &str, line: &'a str) -> Option<&'a str> {
         key_colon = format!("{}: ", key).into();
     }
 
+
     // Try to find the key with '='
     if let Some(pos) = line.find(key_equal.as_ref()) {
         let start = pos + key_equal.len();
@@ -107,6 +108,18 @@ mod tests {
     fn test_extract_value_not_found() {
         let line = "unrelated text";
         assert_eq!(extract_value("key", line), None);
+    }
+
+    #[test]
+    fn test_extract_value_equals_no_space() {
+        let line = "INFO key=";
+        assert_eq!(extract_value("key", line), Some(""))
+    }
+    
+    #[test]
+    fn test_extract_value_colon_no_comma() {
+        let line = "INFO key: value";
+        assert_eq!(extract_value("key", line), Some("value"))
     }
 
     #[test]

--- a/crates/node-bindings/src/utils.rs
+++ b/crates/node-bindings/src/utils.rs
@@ -48,9 +48,9 @@ pub(crate) fn extract_value<'a>(key: &str, line: &'a str) -> Option<&'a str> {
     // If not found, try to find the key with ': '
     if let Some(pos) = line.find(key_colon.as_ref()) {
         let start = pos + key_colon.len();
-        let end = line[start..].find(',').unwrap_or(line.len()); // Assuming comma or end of line
-        if start <= line.len() && start + end <= line.len() {
-            return Some(line[start..start + end].trim());
+        let end = line[start..].find(',').map(|i| start + i ).unwrap_or(line.len()); // Assuming comma or end of line
+        if start <= line.len() && end <= line.len() {
+            return Some(line[start..end].trim());
         }
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Add two edge case tests for `extract_value` in https://github.com/alloy-rs/alloy/blob/main/crates/node-bindings/src/utils.rs#L26, which extract values given keys from the line of text. 
When there is no comma (like extract `value` from string `"key: value"`), the function will fail the test.
Also add doc to better explain this function.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

The code uses different patterns for finding values for keys ending with '=' and ': ', as shown below. By changing them into the same pattern, the issue is fixed. 10 tests in `utils.rs` are all passed.

```
    // Try to find the key with '='
    if let Some(pos) = line.find(key_equal.as_ref()) {
        let start = pos + key_equal.len();
        let end = line[start..].find(' ').map(|i| start + i).unwrap_or(line.len());
        if start <= line.len() && end <= line.len() {
            return Some(line[start..end].trim());
        }
    }

    // If not found, try to find the key with ': '
    if let Some(pos) = line.find(key_colon.as_ref()) {
        let start = pos + key_colon.len();
       // NOTE that there's no map here. If end of line is met, start + end will definited > line.len()
        let end = line[start..].find(',').unwrap_or(line.len()); // Assuming comma or end of line
        if start <= line.len() && start + end <= line.len() {
            return Some(line[start..start + end].trim());
        }
    }
```

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
