### PR TITLE
feat: return tagged variant deserde error

### DIFF
--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -686,15 +686,14 @@ mod serde_from {
         Untagged(UntaggedLegacy),
     }
 
-    // Manually modified derived serde(untagged) to preserve the error of the [`TaggedTxEnvelope`] attempt.
-    // Note: This use private serde API
+    // Manually modified derived serde(untagged) to preserve the error of the [`TaggedTxEnvelope`]
+    // attempt. Note: This use private serde API
     impl<'de> serde::Deserialize<'de> for MaybeTaggedTxEnvelope {
         fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
         where
             D: serde::Deserializer<'de>,
         {
-            let content =
-                serde::__private::de::Content::deserialize(deserializer)?;
+            let content = serde::__private::de::Content::deserialize(deserializer)?;
             let deserializer =
                 serde::__private::de::ContentRefDeserializer::<D::Error>::new(&content);
 


### PR DESCRIPTION
modifies the derived untagged impl to return the tagged attempt error, which is more useful that the generated "data did not match any variant of untagged enum MaybeTaggedTxEnvelope".

this requires private serde API but this should be okay because this is what untagged expands to.
we could technically make this work if we handroll deserde entirely but would be more error prone


```rust
    impl<'de> _serde::Deserialize<'de> for MaybeTaggedTxEnvelope {
            fn deserialize<__D>(
                __deserializer: __D,
            ) -> _serde::__private::Result<Self, __D::Error>
            where
                __D: _serde::Deserializer<'de>,
            {
                let __content = <_serde::__private::de::Content as _serde::Deserialize>::deserialize(
                    __deserializer,
                )?;
                let __deserializer = _serde::__private::de::ContentRefDeserializer::<
                    __D::Error,
                >::new(&__content);
                if let _serde::__private::Ok(__ok)
                    = _serde::__private::Result::map(
                        <TaggedTxEnvelope as _serde::Deserialize>::deserialize(
                            __deserializer,
                        ),
                        MaybeTaggedTxEnvelope::Tagged,
                    ) {
                    return _serde::__private::Ok(__ok);
                }
                if let _serde::__private::Ok(__ok)
                    = _serde::__private::Result::map(
                        <UntaggedLegacy as _serde::Deserialize>::deserialize(
                            __deserializer,
                        ),
                        MaybeTaggedTxEnvelope::Untagged,
                    ) {
                    return _serde::__private::Ok(__ok);
                }
                _serde::__private::Err(
                    _serde::de::Error::custom(
                        "data did not match any variant of untagged enum MaybeTaggedTxEnvelope",
                    ),
                )
            }
        }
```