### PR TITLE
chore: rm non exhaustive for envelope

### DIFF
--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -160,7 +160,6 @@ impl Typed2718 for TxType {
 )]
 #[cfg_attr(all(any(test, feature = "arbitrary"), feature = "k256"), derive(arbitrary::Arbitrary))]
 #[doc(alias = "TransactionEnvelope")]
-#[non_exhaustive]
 pub enum TxEnvelope {
     /// An untagged [`TxLegacy`].
     Legacy(Signed<TxLegacy>),

--- a/crates/rpc-types-eth/src/transaction/request.rs
+++ b/crates/rpc-types-eth/src/transaction/request.rs
@@ -992,7 +992,6 @@ impl From<TxEnvelope> for TransactionRequest {
                     tx.strip_signature().into()
                 }
             }
-            _ => Default::default(),
         }
     }
 }


### PR DESCRIPTION
this is a footgun because this forces users to add a _ => unreachable on a match missing new tx types