### PR TITLE
fix: use u64 for all gas values

### DIFF
--- a/crates/consensus-any/src/receipt/envelope.rs
+++ b/crates/consensus-any/src/receipt/envelope.rs
@@ -76,7 +76,7 @@ impl<T> AnyReceiptEnvelope<T> {
     }
 
     /// Returns the cumulative gas used at this receipt.
-    pub const fn cumulative_gas_used(&self) -> u128 {
+    pub const fn cumulative_gas_used(&self) -> u64 {
         self.inner.receipt.cumulative_gas_used
     }
 
@@ -104,7 +104,7 @@ where
         self.bloom()
     }
 
-    fn cumulative_gas_used(&self) -> u128 {
+    fn cumulative_gas_used(&self) -> u64 {
         self.cumulative_gas_used()
     }
 

--- a/crates/consensus/src/receipt/envelope.rs
+++ b/crates/consensus/src/receipt/envelope.rs
@@ -69,7 +69,7 @@ impl<T> ReceiptEnvelope<T> {
     }
 
     /// Returns the cumulative gas used at this receipt.
-    pub fn cumulative_gas_used(&self) -> u128 {
+    pub fn cumulative_gas_used(&self) -> u64 {
         self.as_receipt().unwrap().cumulative_gas_used
     }
 
@@ -132,7 +132,7 @@ where
     }
 
     /// Returns the cumulative gas used at this receipt.
-    fn cumulative_gas_used(&self) -> u128 {
+    fn cumulative_gas_used(&self) -> u64 {
         self.as_receipt().unwrap().cumulative_gas_used
     }
 

--- a/crates/consensus/src/receipt/mod.rs
+++ b/crates/consensus/src/receipt/mod.rs
@@ -71,7 +71,7 @@ pub trait TxReceipt: Clone + fmt::Debug + PartialEq + Eq + Send + Sync {
     }
 
     /// Returns the cumulative gas used in the block after this transaction was executed.
-    fn cumulative_gas_used(&self) -> u128;
+    fn cumulative_gas_used(&self) -> u64;
 
     /// Returns the logs emitted by this transaction.
     fn logs(&self) -> &[Self::Log];
@@ -123,7 +123,7 @@ mod tests {
         let receipt =
             ReceiptEnvelope::Legacy(ReceiptWithBloom {
                 receipt: Receipt {
-                    cumulative_gas_used: 0x1u128,
+                    cumulative_gas_used: 0x1,
                     logs: vec![Log {
                         address: address!("0000000000000000000000000000000000000011"),
                         data: LogData::new_unchecked(
@@ -155,7 +155,7 @@ mod tests {
         let expected =
             ReceiptWithBloom {
                 receipt: Receipt {
-                    cumulative_gas_used: 0x1u128,
+                    cumulative_gas_used: 0x1,
                     logs: vec![Log {
                         address: address!("0000000000000000000000000000000000000011"),
                         data: LogData::new_unchecked(

--- a/crates/consensus/src/receipt/receipts.rs
+++ b/crates/consensus/src/receipt/receipts.rs
@@ -22,7 +22,7 @@ pub struct Receipt<T = Log> {
     pub status: Eip658Value,
     /// Gas used
     #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
-    pub cumulative_gas_used: u128,
+    pub cumulative_gas_used: u64,
     /// Log send from contracts.
     pub logs: Vec<T>,
 }
@@ -62,7 +62,7 @@ where
         self.bloom_slow()
     }
 
-    fn cumulative_gas_used(&self) -> u128 {
+    fn cumulative_gas_used(&self) -> u64 {
         self.cumulative_gas_used
     }
 
@@ -240,7 +240,7 @@ where
         Some(self.logs_bloom)
     }
 
-    fn cumulative_gas_used(&self) -> u128 {
+    fn cumulative_gas_used(&self) -> u64 {
         self.receipt.cumulative_gas_used()
     }
 

--- a/crates/genesis/src/lib.rs
+++ b/crates/genesis/src/lib.rs
@@ -57,10 +57,10 @@ pub struct Genesis {
     pub base_fee_per_gas: Option<u128>,
     /// The genesis header excess blob gas
     #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
-    pub excess_blob_gas: Option<u128>,
+    pub excess_blob_gas: Option<u64>,
     /// The genesis header blob gas used
     #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
-    pub blob_gas_used: Option<u128>,
+    pub blob_gas_used: Option<u64>,
     /// The genesis block number
     #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
     pub number: Option<u64>,
@@ -170,13 +170,13 @@ impl Genesis {
     }
 
     /// Set the excess blob gas.
-    pub const fn with_excess_blob_gas(mut self, excess_blob_gas: Option<u128>) -> Self {
+    pub const fn with_excess_blob_gas(mut self, excess_blob_gas: Option<u64>) -> Self {
         self.excess_blob_gas = excess_blob_gas;
         self
     }
 
     /// Set the blob gas used.
-    pub const fn with_blob_gas_used(mut self, blob_gas_used: Option<u128>) -> Self {
+    pub const fn with_blob_gas_used(mut self, blob_gas_used: Option<u64>) -> Self {
         self.blob_gas_used = blob_gas_used;
         self
     }

--- a/crates/network-primitives/src/traits.rs
+++ b/crates/network-primitives/src/traits.rs
@@ -33,13 +33,13 @@ pub trait ReceiptResponse {
     fn transaction_index(&self) -> Option<u64>;
 
     /// Gas used by this transaction alone.
-    fn gas_used(&self) -> u128;
+    fn gas_used(&self) -> u64;
 
     /// Effective gas price.
     fn effective_gas_price(&self) -> u128;
 
     /// Blob gas used by the eip-4844 transaction.
-    fn blob_gas_used(&self) -> Option<u128>;
+    fn blob_gas_used(&self) -> Option<u64>;
 
     /// Blob gas price paid by the eip-4844 transaction.
     fn blob_gas_price(&self) -> Option<u128>;
@@ -54,7 +54,7 @@ pub trait ReceiptResponse {
     fn authorization_list(&self) -> Option<&[SignedAuthorization]>;
 
     /// Returns the cumulative gas used at this receipt.
-    fn cumulative_gas_used(&self) -> u128;
+    fn cumulative_gas_used(&self) -> u64;
 
     /// The post-transaction state root (pre Byzantium)
     ///
@@ -181,7 +181,7 @@ impl<T: ReceiptResponse> ReceiptResponse for WithOtherFields<T> {
         self.inner.transaction_index()
     }
 
-    fn gas_used(&self) -> u128 {
+    fn gas_used(&self) -> u64 {
         self.inner.gas_used()
     }
 
@@ -189,7 +189,7 @@ impl<T: ReceiptResponse> ReceiptResponse for WithOtherFields<T> {
         self.inner.effective_gas_price()
     }
 
-    fn blob_gas_used(&self) -> Option<u128> {
+    fn blob_gas_used(&self) -> Option<u64> {
         self.inner.blob_gas_used()
     }
 
@@ -209,7 +209,7 @@ impl<T: ReceiptResponse> ReceiptResponse for WithOtherFields<T> {
         self.inner.authorization_list()
     }
 
-    fn cumulative_gas_used(&self) -> u128 {
+    fn cumulative_gas_used(&self) -> u64 {
         self.inner.cumulative_gas_used()
     }
 

--- a/crates/provider/src/fillers/gas.rs
+++ b/crates/provider/src/fillers/gas.rs
@@ -317,7 +317,7 @@ mod tests {
         assert_eq!(receipt.gas_used, 21000);
         assert_eq!(
             receipt.blob_gas_used.expect("Expected to be EIP-4844 transaction"),
-            DATA_GAS_PER_BLOB as u128
+            DATA_GAS_PER_BLOB
         );
     }
 
@@ -345,7 +345,7 @@ mod tests {
         assert_eq!(receipt.gas_used, 21000);
         assert_eq!(
             receipt.blob_gas_used.expect("Expected to be EIP-4844 transaction"),
-            DATA_GAS_PER_BLOB as u128
+            DATA_GAS_PER_BLOB
         );
     }
 }

--- a/crates/rpc-types-eth/src/transaction/receipt.rs
+++ b/crates/rpc-types-eth/src/transaction/receipt.rs
@@ -33,7 +33,7 @@ pub struct TransactionReceipt<T = ReceiptEnvelope<Log>> {
     pub block_number: Option<u64>,
     /// Gas used by this transaction alone.
     #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
-    pub gas_used: u128,
+    pub gas_used: u64,
     /// The price paid post-execution by the transaction (i.e. base fee + priority fee). Both
     /// fields in 1559-style transactions are maximums (max fee + max priority fee), the amount
     /// that's actually paid by users can only be determined post-execution
@@ -50,7 +50,7 @@ pub struct TransactionReceipt<T = ReceiptEnvelope<Log>> {
             default
         )
     )]
-    pub blob_gas_used: Option<u128>,
+    pub blob_gas_used: Option<u64>,
     /// The price paid by the eip-4844 transaction per blob gas.
     #[cfg_attr(
         feature = "serde",
@@ -158,7 +158,7 @@ impl<T: TxReceipt<Log = Log>> ReceiptResponse for TransactionReceipt<T> {
         self.transaction_index
     }
 
-    fn gas_used(&self) -> u128 {
+    fn gas_used(&self) -> u64 {
         self.gas_used
     }
 
@@ -166,7 +166,7 @@ impl<T: TxReceipt<Log = Log>> ReceiptResponse for TransactionReceipt<T> {
         self.effective_gas_price
     }
 
-    fn blob_gas_used(&self) -> Option<u128> {
+    fn blob_gas_used(&self) -> Option<u64> {
         self.blob_gas_used
     }
 
@@ -186,7 +186,7 @@ impl<T: TxReceipt<Log = Log>> ReceiptResponse for TransactionReceipt<T> {
         self.authorization_list.as_deref()
     }
 
-    fn cumulative_gas_used(&self) -> u128 {
+    fn cumulative_gas_used(&self) -> u64 {
         self.inner.cumulative_gas_used()
     }
 
@@ -226,7 +226,7 @@ mod test {
         );
 
         const EXPECTED_BLOOM: Bloom = bloom!("00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000200000000000000000040000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000400000800000000000000000000000000000000004000000000000000000800000000100000020000000000000000000080000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000010000000000000000000000000000");
-        const EXPECTED_CGU: u128 = 0xa42aec;
+        const EXPECTED_CGU: u64 = 0xa42aec;
 
         assert!(matches!(
             receipt.inner,

--- a/crates/rpc-types-txpool/src/txpool.rs
+++ b/crates/rpc-types-txpool/src/txpool.rs
@@ -16,7 +16,7 @@ pub struct TxpoolInspectSummary {
     /// Transferred value
     pub value: U256,
     /// Gas amount
-    pub gas: u128,
+    pub gas: u64,
     /// Gas Price
     pub gas_price: u128,
 }
@@ -60,7 +60,7 @@ impl Visitor<'_> for TxpoolInspectSummaryVisitor {
             }
         };
         let value = U256::from_str(value_split[0]).map_err(de::Error::custom)?;
-        let gas = u128::from_str(gas_split[0]).map_err(de::Error::custom)?;
+        let gas = u64::from_str(gas_split[0]).map_err(de::Error::custom)?;
         let gas_price = u128::from_str(gas_price_split[0]).map_err(de::Error::custom)?;
 
         Ok(TxpoolInspectSummary { to, value, gas, gas_price })
@@ -423,7 +423,7 @@ mod tests {
             TxpoolInspectSummary {
                 to: Some(Address::from_str("000000000000000000000000000000000000007E").unwrap()),
                 value: U256::from(0u128),
-                gas: 100187u128,
+                gas: 100187,
                 gas_price: 20000000000u128,
             },
         );
@@ -437,7 +437,7 @@ mod tests {
             TxpoolInspectSummary {
                 to: Some(Address::from_str("d10e3Be2bc8f959Bc8C41CF65F60dE721cF89ADF").unwrap()),
                 value: U256::from(0u128),
-                gas: 65792u128,
+                gas: 65792,
                 gas_price: 2000000000u128,
             },
         );
@@ -446,7 +446,7 @@ mod tests {
             TxpoolInspectSummary {
                 to: Some(Address::from_str("d10e3Be2bc8f959Bc8C41CF65F60dE721cF89ADF").unwrap()),
                 value: U256::from(0u128),
-                gas: 65792u128,
+                gas: 65792,
                 gas_price: 2000000000u128,
             },
         );
@@ -455,7 +455,7 @@ mod tests {
             TxpoolInspectSummary {
                 to: Some(Address::from_str("d10e3Be2bc8f959Bc8C41CF65F60dE721cF89ADF").unwrap()),
                 value: U256::from(0u128),
-                gas: 65780u128,
+                gas: 65780,
                 gas_price: 2000000000u128,
             },
         );
@@ -464,7 +464,7 @@ mod tests {
             TxpoolInspectSummary {
                 to: Some(Address::from_str("d10e3Be2bc8f959Bc8C41CF65F60dE721cF89ADF").unwrap()),
                 value: U256::from(0u128),
-                gas: 65780u128,
+                gas: 65780,
                 gas_price: 2000000000u128,
             },
         );
@@ -478,7 +478,7 @@ mod tests {
             TxpoolInspectSummary {
                 to: None,
                 value: U256::from(0u128),
-                gas: 612412u128,
+                gas: 612412,
                 gas_price: 6000000000u128,
             },
         );
@@ -493,7 +493,7 @@ mod tests {
             TxpoolInspectSummary {
                 to: Some(Address::from_str("3479BE69e07E838D9738a301Bb0c89e8EA2Bef4a").unwrap()),
                 value: U256::from(1000000000000000u128),
-                gas: 21000u128,
+                gas: 21000,
                 gas_price: 10000000000u128,
             },
         );
@@ -502,7 +502,7 @@ mod tests {
             TxpoolInspectSummary {
                 to: Some(Address::from_str("73Aaf691bc33fe38f86260338EF88f9897eCaa4F").unwrap()),
                 value: U256::from(1000000000000000u128),
-                gas: 21000u128,
+                gas: 21000,
                 gas_price: 10000000000u128,
             },
         );
@@ -516,7 +516,7 @@ mod tests {
             TxpoolInspectSummary {
                 to: Some(Address::from_str("73Aaf691bc33fe38f86260338EF88f9897eCaa4F").unwrap()),
                 value: U256::from(10000000000000000u128),
-                gas: 21000u128,
+                gas: 21000,
                 gas_price: 10000000000u128,
             },
         );


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Some types are still using u128 for gas which is inconsistent. With this PR only gas price values are stored as u128

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
