### PR TITLE
feat: add tryfrom payloadv1 for block

### DIFF
--- a/crates/consensus/src/proofs.rs
+++ b/crates/consensus/src/proofs.rs
@@ -5,12 +5,12 @@ use alloc::vec::Vec;
 use alloy_eips::{eip2718::Encodable2718, eip4895::Withdrawal};
 use alloy_primitives::{keccak256, B256};
 use alloy_rlp::Encodable;
-use alloy_trie::root::{ordered_trie_root, ordered_trie_root_with_encoder};
 
 #[doc(inline)]
 pub use alloy_trie::root::{
-    state_root, state_root_ref_unhashed, state_root_unhashed, state_root_unsorted, storage_root,
-    storage_root_unhashed, storage_root_unsorted,
+    ordered_trie_root, ordered_trie_root_with_encoder, state_root, state_root_ref_unhashed,
+    state_root_unhashed, state_root_unsorted, storage_root, storage_root_unhashed,
+    storage_root_unsorted,
 };
 
 /// Calculate a transaction root.


### PR DESCRIPTION
ports reth's standalone fn 1:1

https://github.com/paradigmxyz/reth/blob/d644900a8078db976cdbfb310a19df5df9b33125/crates/rpc/rpc-types-compat/src/engine/payload.rs#L23-L93

additional V2.. conversions will follow to keep diffs low

this is additional simplification that will be unlocked by https://github.com/paradigmxyz/reth/pull/13518