### PR TITLE
feat!: remove T: Transport from public APIs

### DIFF
--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -9,6 +9,9 @@
 
 extern crate alloc;
 
+#[cfg(feature = "arbitrary")]
+use rand as _;
+
 pub use alloy_trie::TrieAccount;
 
 #[deprecated(since = "0.7.3", note = "use TrieAccount instead")]

--- a/crates/contract/src/call.rs
+++ b/crates/contract/src/call.rs
@@ -532,8 +532,9 @@ impl<T, P: Clone, D, N: Network> CallBuilder<T, &P, D, N> {
 /// the associated future type, the returned future, must be a concrete type (`Box<dyn Future ...>`)
 /// and cannot be an opaque type (`impl Future ...`) because `impl Trait` in this position is not
 /// stable yet. See [rust-lang/rust#63063](https://github.com/rust-lang/rust/issues/63063).
-impl<T: Send + Sync, P, D, N> IntoFuture for CallBuilder<T, P, D, N>
+impl<T, P, D, N> IntoFuture for CallBuilder<T, P, D, N>
 where
+    T: Send + Sync,
     P: Provider<N>,
     D: CallDecoder + Send + Sync + Unpin,
     N: Network,

--- a/crates/contract/src/eth_call.rs
+++ b/crates/contract/src/eth_call.rs
@@ -6,7 +6,6 @@ use alloy_network::Network;
 use alloy_primitives::Bytes;
 use alloy_rpc_types_eth::{state::StateOverride, BlockId};
 use alloy_sol_types::SolCall;
-use alloy_transport::Transport;
 
 use crate::{Error, Result};
 
@@ -24,46 +23,39 @@ mod private {
 /// An [`alloy_provider::EthCall`] with an abi decoder.
 #[must_use = "EthCall must be awaited to execute the call"]
 #[derive(Clone, Debug)]
-pub struct EthCall<'req, 'coder, D, T, N>
+pub struct EthCall<'req, 'coder, D, N>
 where
-    T: Transport + Clone,
     N: Network,
     D: CallDecoder,
 {
-    inner: alloy_provider::EthCall<'req, T, N, Bytes>,
+    inner: alloy_provider::EthCall<'req, N, Bytes>,
 
     decoder: &'coder D,
 }
 
-impl<'req, 'coder, D, T, N> EthCall<'req, 'coder, D, T, N>
+impl<'req, 'coder, D, N> EthCall<'req, 'coder, D, N>
 where
-    T: Transport + Clone,
     N: Network,
     D: CallDecoder,
 {
     /// Create a new [`EthCall`].
-    pub const fn new(
-        inner: alloy_provider::EthCall<'req, T, N, Bytes>,
-        decoder: &'coder D,
-    ) -> Self {
+    pub const fn new(inner: alloy_provider::EthCall<'req, N, Bytes>, decoder: &'coder D) -> Self {
         Self { inner, decoder }
     }
 }
 
-impl<'req, T, N> EthCall<'req, 'static, (), T, N>
+impl<'req, N> EthCall<'req, 'static, (), N>
 where
-    T: Transport + Clone,
     N: Network,
 {
     /// Create a new [`EthCall`].
-    pub const fn new_raw(inner: alloy_provider::EthCall<'req, T, N, Bytes>) -> Self {
+    pub const fn new_raw(inner: alloy_provider::EthCall<'req, N, Bytes>) -> Self {
         Self::new(inner, &RAW_CODER)
     }
 }
 
-impl<'req, D, T, N> EthCall<'req, '_, D, T, N>
+impl<'req, D, N> EthCall<'req, '_, D, N>
 where
-    T: Transport + Clone,
     N: Network,
     D: CallDecoder,
 {
@@ -71,7 +63,7 @@ where
     pub fn with_decoder<'new_coder, E>(
         self,
         decoder: &'new_coder E,
-    ) -> EthCall<'req, 'new_coder, E, T, N>
+    ) -> EthCall<'req, 'new_coder, E, N>
     where
         E: CallDecoder,
     {
@@ -91,26 +83,23 @@ where
     }
 }
 
-impl<'req, T, N> From<alloy_provider::EthCall<'req, T, N, Bytes>>
-    for EthCall<'req, 'static, (), T, N>
+impl<'req, N> From<alloy_provider::EthCall<'req, N, Bytes>> for EthCall<'req, 'static, (), N>
 where
-    T: Transport + Clone,
     N: Network,
 {
-    fn from(inner: alloy_provider::EthCall<'req, T, N, Bytes>) -> Self {
+    fn from(inner: alloy_provider::EthCall<'req, N, Bytes>) -> Self {
         Self { inner, decoder: &RAW_CODER }
     }
 }
 
-impl<'req, 'coder, D, T, N> std::future::IntoFuture for EthCall<'req, 'coder, D, T, N>
+impl<'req, 'coder, D, N> std::future::IntoFuture for EthCall<'req, 'coder, D, N>
 where
     D: CallDecoder + Unpin,
-    T: Transport + Clone,
     N: Network,
 {
     type Output = Result<D::CallOutput>;
 
-    type IntoFuture = EthCallFut<'req, 'coder, D, T, N>;
+    type IntoFuture = EthCallFut<'req, 'coder, D, N>;
 
     fn into_future(self) -> Self::IntoFuture {
         EthCallFut { inner: self.inner.into_future(), decoder: self.decoder }
@@ -122,20 +111,18 @@ where
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 #[derive(Debug)]
 #[allow(unnameable_types)]
-pub struct EthCallFut<'req, 'coder, D, T, N>
+pub struct EthCallFut<'req, 'coder, D, N>
 where
-    T: Transport + Clone,
     N: Network,
     D: CallDecoder,
 {
-    inner: <alloy_provider::EthCall<'req, T, N, Bytes> as IntoFuture>::IntoFuture,
+    inner: <alloy_provider::EthCall<'req, N, Bytes> as IntoFuture>::IntoFuture,
     decoder: &'coder D,
 }
 
-impl<D, T, N> std::future::Future for EthCallFut<'_, '_, D, T, N>
+impl<D, N> std::future::Future for EthCallFut<'_, '_, D, N>
 where
     D: CallDecoder + Unpin,
-    T: Transport + Clone,
     N: Network,
 {
     type Output = Result<D::CallOutput>;

--- a/crates/contract/src/instance.rs
+++ b/crates/contract/src/instance.rs
@@ -6,7 +6,6 @@ use alloy_primitives::{Address, Selector};
 use alloy_provider::Provider;
 use alloy_rpc_types_eth::Filter;
 use alloy_sol_types::SolEvent;
-use alloy_transport::Transport;
 use std::marker::PhantomData;
 
 /// A handle to an Ethereum contract at a specific address.
@@ -14,19 +13,18 @@ use std::marker::PhantomData;
 /// A contract is an abstraction of an executable program on Ethereum. Every deployed contract has
 /// an address, which is used to connect to it so that it may receive messages (transactions).
 #[derive(Clone)]
-pub struct ContractInstance<T, P, N = Ethereum> {
+pub struct ContractInstance<P, N = Ethereum> {
     address: Address,
     provider: P,
     interface: Interface,
-    transport: PhantomData<T>,
     network: PhantomData<N>,
 }
 
-impl<T, P, N> ContractInstance<T, P, N> {
+impl<P, N> ContractInstance<P, N> {
     /// Creates a new contract from the provided address, provider, and interface.
     #[inline]
     pub const fn new(address: Address, provider: P, interface: Interface) -> Self {
-        Self { address, provider, interface, transport: PhantomData, network: PhantomData }
+        Self { address, provider, interface, network: PhantomData }
     }
 
     /// Returns a reference to the contract's address.
@@ -61,21 +59,20 @@ impl<T, P, N> ContractInstance<T, P, N> {
     }
 }
 
-impl<T, P: Clone, N> ContractInstance<T, &P, N> {
+impl<P: Clone, N> ContractInstance<&P, N> {
     /// Clones the provider and returns a new contract instance with the cloned provider.
     #[inline]
-    pub fn with_cloned_provider(self) -> ContractInstance<T, P, N> {
+    pub fn with_cloned_provider(self) -> ContractInstance<P, N> {
         ContractInstance {
             address: self.address,
             provider: self.provider.clone(),
             interface: self.interface,
-            transport: PhantomData,
             network: PhantomData,
         }
     }
 }
 
-impl<T: Transport + Clone, P: Provider<T, N>, N: Network> ContractInstance<T, P, N> {
+impl<P: Provider<N>, N: Network> ContractInstance<P, N> {
     /// Returns a transaction builder for the provided function name.
     ///
     /// If there are multiple functions with the same name due to overloading, consider using
@@ -85,7 +82,7 @@ impl<T: Transport + Clone, P: Provider<T, N>, N: Network> ContractInstance<T, P,
         &self,
         name: &str,
         args: &[DynSolValue],
-    ) -> Result<CallBuilder<T, &P, Function, N>> {
+    ) -> Result<CallBuilder<&P, Function, N>> {
         let function = self.interface.get_from_name(name)?;
         CallBuilder::new_dyn(&self.provider, &self.address, function, args)
     }
@@ -95,18 +92,18 @@ impl<T: Transport + Clone, P: Provider<T, N>, N: Network> ContractInstance<T, P,
         &self,
         selector: &Selector,
         args: &[DynSolValue],
-    ) -> Result<CallBuilder<T, &P, Function, N>> {
+    ) -> Result<CallBuilder<&P, Function, N>> {
         let function = self.interface.get_from_selector(selector)?;
         CallBuilder::new_dyn(&self.provider, &self.address, function, args)
     }
 
     /// Returns an [`Event`] builder with the provided filter.
-    pub const fn event<E: SolEvent>(&self, filter: Filter) -> Event<T, &P, E, N> {
+    pub const fn event<E: SolEvent>(&self, filter: Filter) -> Event<&P, E, N> {
         Event::new(&self.provider, filter)
     }
 }
 
-impl<T, P, N> std::ops::Deref for ContractInstance<T, P, N> {
+impl<P, N> std::ops::Deref for ContractInstance<P, N> {
     type Target = Interface;
 
     fn deref(&self) -> &Self::Target {
@@ -114,7 +111,7 @@ impl<T, P, N> std::ops::Deref for ContractInstance<T, P, N> {
     }
 }
 
-impl<T, P, N> std::fmt::Debug for ContractInstance<T, P, N> {
+impl<P, N> std::fmt::Debug for ContractInstance<P, N> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ContractInstance").field("address", &self.address).finish()
     }

--- a/crates/contract/src/instance.rs
+++ b/crates/contract/src/instance.rs
@@ -82,7 +82,7 @@ impl<P: Provider<N>, N: Network> ContractInstance<P, N> {
         &self,
         name: &str,
         args: &[DynSolValue],
-    ) -> Result<CallBuilder<&P, Function, N>> {
+    ) -> Result<CallBuilder<(), &P, Function, N>> {
         let function = self.interface.get_from_name(name)?;
         CallBuilder::new_dyn(&self.provider, &self.address, function, args)
     }
@@ -92,13 +92,13 @@ impl<P: Provider<N>, N: Network> ContractInstance<P, N> {
         &self,
         selector: &Selector,
         args: &[DynSolValue],
-    ) -> Result<CallBuilder<&P, Function, N>> {
+    ) -> Result<CallBuilder<(), &P, Function, N>> {
         let function = self.interface.get_from_selector(selector)?;
         CallBuilder::new_dyn(&self.provider, &self.address, function, args)
     }
 
     /// Returns an [`Event`] builder with the provided filter.
-    pub const fn event<E: SolEvent>(&self, filter: Filter) -> Event<&P, E, N> {
+    pub const fn event<E: SolEvent>(&self, filter: Filter) -> Event<(), &P, E, N> {
         Event::new(&self.provider, filter)
     }
 }

--- a/crates/contract/src/interface.rs
+++ b/crates/contract/src/interface.rs
@@ -119,11 +119,7 @@ impl Interface {
     }
 
     /// Create a [`ContractInstance`] from this ABI for a contract at the given address.
-    pub const fn connect<T, P, N>(
-        self,
-        address: Address,
-        provider: P,
-    ) -> ContractInstance<T, P, N> {
+    pub const fn connect<P, N>(self, address: Address, provider: P) -> ContractInstance<P, N> {
         ContractInstance::new(address, provider, self)
     }
 }

--- a/crates/contract/src/lib.rs
+++ b/crates/contract/src/lib.rs
@@ -36,9 +36,12 @@ pub use call::*;
 pub mod private {
     pub use alloy_network::{Ethereum, Network};
 
+    // Fake traits to mitigate `sol!` macro breaking changes.
     pub trait Provider<T, N: Network>: alloy_provider::Provider<N> {}
     impl<N: Network, P: alloy_provider::Provider<N>> Provider<(), N> for P {}
 
+    // This is done so that the compiler can infer the `T` type to be `()`, which is the only type
+    // that implements this fake `Transport` trait.
     pub trait Transport {}
     impl Transport for () {}
 }

--- a/crates/contract/src/lib.rs
+++ b/crates/contract/src/lib.rs
@@ -7,7 +7,6 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 #[cfg(test)]
-#[cfg(TODO)]
 extern crate self as alloy_contract;
 
 mod eth_call;
@@ -36,6 +35,10 @@ pub use call::*;
 #[doc(hidden)]
 pub mod private {
     pub use alloy_network::{Ethereum, Network};
-    pub use alloy_provider::Provider;
-    pub use alloy_transport::Transport;
+
+    pub trait Provider<T, N: Network>: alloy_provider::Provider<N> {}
+    impl<N: Network, P: alloy_provider::Provider<N>> Provider<(), N> for P {}
+
+    pub trait Transport {}
+    impl Transport for () {}
 }

--- a/crates/contract/src/lib.rs
+++ b/crates/contract/src/lib.rs
@@ -7,6 +7,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 #[cfg(test)]
+#[cfg(TODO)]
 extern crate self as alloy_contract;
 
 mod eth_call;

--- a/crates/provider/src/blocks.rs
+++ b/crates/provider/src/blocks.rs
@@ -1,7 +1,7 @@
 use alloy_network::{Ethereum, Network};
 use alloy_primitives::{BlockNumber, U64};
 use alloy_rpc_client::{NoParams, PollerBuilder, WeakClient};
-use alloy_transport::{RpcError, Transport};
+use alloy_transport::RpcError;
 use async_stream::stream;
 use futures::{Stream, StreamExt};
 use lru::LruCache;
@@ -20,8 +20,8 @@ const MAX_RETRIES: usize = 3;
 const NO_BLOCK_NUMBER: BlockNumber = BlockNumber::MAX;
 
 /// Streams new blocks from the client.
-pub(crate) struct NewBlocks<T, N: Network = Ethereum> {
-    client: WeakClient<T>,
+pub(crate) struct NewBlocks<N: Network = Ethereum> {
+    client: WeakClient,
     /// The next block to yield.
     /// [`NO_BLOCK_NUMBER`] indicates that it will be updated on the first poll.
     /// Only used by the polling task.
@@ -31,8 +31,8 @@ pub(crate) struct NewBlocks<T, N: Network = Ethereum> {
     _phantom: PhantomData<N>,
 }
 
-impl<T: Transport + Clone, N: Network> NewBlocks<T, N> {
-    pub(crate) fn new(client: WeakClient<T>) -> Self {
+impl<N: Network> NewBlocks<N> {
+    pub(crate) fn new(client: WeakClient) -> Self {
         Self {
             client,
             next_yield: NO_BLOCK_NUMBER,
@@ -99,7 +99,7 @@ impl<T: Transport + Clone, N: Network> NewBlocks<T, N> {
     fn into_poll_stream(mut self) -> impl Stream<Item = N::BlockResponse> + 'static {
         stream! {
         // Spawned lazily on the first `poll`.
-        let poll_task_builder: PollerBuilder<T, NoParams, U64> =
+        let poll_task_builder: PollerBuilder<NoParams, U64> =
             PollerBuilder::new(self.client.clone(), "eth_blockNumber", []);
         let mut poll_task = poll_task_builder.spawn().into_stream_raw();
         'task: loop {
@@ -208,7 +208,7 @@ mod tests {
         let url = if ws { anvil.ws_endpoint() } else { anvil.endpoint() };
         let provider = ProviderBuilder::new().on_builtin(&url).await.unwrap();
 
-        let new_blocks = NewBlocks::<_, Ethereum>::new(provider.weak_client()).with_next_yield(1);
+        let new_blocks = NewBlocks::<Ethereum>::new(provider.weak_client()).with_next_yield(1);
         let mut stream = Box::pin(new_blocks.into_stream());
         if ws {
             let _ = try_timeout(stream.next()).await; // Subscribe to newHeads.
@@ -239,7 +239,7 @@ mod tests {
         let url = if ws { anvil.ws_endpoint() } else { anvil.endpoint() };
         let provider = ProviderBuilder::new().on_builtin(&url).await.unwrap();
 
-        let new_blocks = NewBlocks::<_, Ethereum>::new(provider.weak_client()).with_next_yield(1);
+        let new_blocks = NewBlocks::<Ethereum>::new(provider.weak_client()).with_next_yield(1);
         let mut stream = Box::pin(new_blocks.into_stream());
         if ws {
             let _ = try_timeout(stream.next()).await; // Subscribe to newHeads.

--- a/crates/provider/src/builder.rs
+++ b/crates/provider/src/builder.rs
@@ -9,7 +9,7 @@ use crate::{
 use alloy_chains::NamedChain;
 use alloy_network::{Ethereum, Network};
 use alloy_primitives::ChainId;
-use alloy_rpc_client::{BuiltInConnectionString, ClientBuilder, RpcClient};
+use alloy_rpc_client::{ClientBuilder, RpcClient};
 use alloy_transport::{TransportError, TransportResult};
 use std::marker::PhantomData;
 
@@ -262,7 +262,7 @@ impl<L, F, N> ProviderBuilder<L, F, N> {
         P: Provider<N>,
         N: Network,
     {
-        let Self { layer, filler, .. } = self;
+        let Self { layer, filler, network: PhantomData } = self;
         let stack = Stack::new(layer, filler);
         stack.layer(provider)
     }
@@ -290,8 +290,7 @@ impl<L, F, N> ProviderBuilder<L, F, N> {
         F: TxFiller<N> + ProviderLayer<L::Provider, N>,
         N: Network,
     {
-        let connect: BuiltInConnectionString = s.parse()?;
-        let client = ClientBuilder::default().connect_boxed(connect).await?;
+        let client = ClientBuilder::default().connect(s).await?;
         Ok(self.on_client(client))
     }
 

--- a/crates/provider/src/builder.rs
+++ b/crates/provider/src/builder.rs
@@ -329,7 +329,7 @@ impl<L, F, N> ProviderBuilder<L, F, N> {
     #[cfg(any(test, feature = "reqwest"))]
     pub fn on_http(self, url: reqwest::Url) -> F::Provider
     where
-        L: ProviderLayer<crate::ReqwestProvider<N>, N>,
+        L: ProviderLayer<crate::RootProvider<N>, N>,
         F: TxFiller<N> + ProviderLayer<L::Provider, N>,
         N: Network,
     {
@@ -341,7 +341,7 @@ impl<L, F, N> ProviderBuilder<L, F, N> {
     #[cfg(feature = "hyper")]
     pub fn on_hyper_http(self, url: url::Url) -> F::Provider
     where
-        L: ProviderLayer<crate::HyperProvider<N>, N>,
+        L: ProviderLayer<crate::RootProvider<N>, N>,
         F: TxFiller<N> + ProviderLayer<L::Provider, N>,
         N: Network,
     {

--- a/crates/provider/src/ext/admin.rs
+++ b/crates/provider/src/ext/admin.rs
@@ -2,12 +2,12 @@
 use crate::Provider;
 use alloy_network::Network;
 use alloy_rpc_types_admin::{NodeInfo, PeerInfo};
-use alloy_transport::{Transport, TransportResult};
+use alloy_transport::TransportResult;
 
 /// Admin namespace rpc interface that gives access to several non-standard RPC methods.
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
-pub trait AdminApi<N, T>: Send + Sync {
+pub trait AdminApi<N>: Send + Sync {
     /// Requests adding the given peer, returning a boolean representing
     /// whether or not the peer was accepted for tracking.
     async fn add_peer(&self, record: &str) -> TransportResult<bool>;
@@ -41,11 +41,10 @@ pub trait AdminApi<N, T>: Send + Sync {
 
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
-impl<N, T, P> AdminApi<N, T> for P
+impl<N, P> AdminApi<N> for P
 where
     N: Network,
-    T: Transport + Clone,
-    P: Provider<T, N>,
+    P: Provider<N>,
 {
     async fn add_peer(&self, record: &str) -> TransportResult<bool> {
         self.client().request("admin_addPeer", (record,)).await

--- a/crates/provider/src/ext/anvil.rs
+++ b/crates/provider/src/ext/anvil.rs
@@ -5,12 +5,12 @@ use alloy_network::Network;
 use alloy_primitives::{Address, Bytes, TxHash, B256, U256};
 use alloy_rpc_types_anvil::{Forking, Metadata, MineOptions, NodeInfo, ReorgOptions};
 use alloy_rpc_types_eth::Block;
-use alloy_transport::{Transport, TransportResult};
+use alloy_transport::TransportResult;
 
 /// Anvil namespace rpc interface that gives access to several non-standard RPC methods.
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
-pub trait AnvilApi<N: Network, T>: Send + Sync {
+pub trait AnvilApi<N: Network>: Send + Sync {
     // Not implemented:
     // - anvil_enable_traces: Not implemented in the Anvil RPC API.
     // - anvil_set_block: Not implemented / wired correctly in the Anvil RPC API.
@@ -150,11 +150,10 @@ pub trait AnvilApi<N: Network, T>: Send + Sync {
 
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
-impl<N, T, P> AnvilApi<N, T> for P
+impl<N, P> AnvilApi<N> for P
 where
     N: Network,
-    T: Transport + Clone,
-    P: Provider<T, N>,
+    P: Provider<N>,
 {
     async fn anvil_impersonate_account(&self, address: Address) -> TransportResult<()> {
         self.client().request("anvil_impersonateAccount", (address,)).await

--- a/crates/provider/src/ext/debug.rs
+++ b/crates/provider/src/ext/debug.rs
@@ -11,12 +11,12 @@ use alloy_rpc_types_trace::geth::{
     BlockTraceResult, CallFrame, GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace,
     TraceResult,
 };
-use alloy_transport::{Transport, TransportResult};
+use alloy_transport::TransportResult;
 
 /// Debug namespace rpc interface that gives access to several non-standard RPC methods.
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
-pub trait DebugApi<N, T>: Send + Sync {
+pub trait DebugApi<N>: Send + Sync {
     /// Returns an RLP-encoded header.
     async fn debug_get_raw_header(&self, block: BlockId) -> TransportResult<Bytes>;
 
@@ -253,11 +253,10 @@ pub trait DebugApi<N, T>: Send + Sync {
 
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
-impl<N, T, P> DebugApi<N, T> for P
+impl<N, P> DebugApi<N> for P
 where
     N: Network,
-    T: Transport + Clone,
-    P: Provider<T, N>,
+    P: Provider<N>,
 {
     async fn debug_get_raw_header(&self, block: BlockId) -> TransportResult<Bytes> {
         self.client().request("debug_getRawHeader", (block,)).await

--- a/crates/provider/src/ext/engine.rs
+++ b/crates/provider/src/ext/engine.rs
@@ -7,7 +7,7 @@ use alloy_rpc_types_engine::{
     ExecutionPayloadV1, ExecutionPayloadV3, ForkchoiceState, ForkchoiceUpdated, PayloadAttributes,
     PayloadId, PayloadStatus,
 };
-use alloy_transport::{Transport, TransportResult};
+use alloy_transport::TransportResult;
 
 /// Extension trait that gives access to engine API RPC methods.
 ///
@@ -15,7 +15,7 @@ use alloy_transport::{Transport, TransportResult};
 /// > The provider should use a JWT authentication layer.
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
-pub trait EngineApi<N, T>: Send + Sync {
+pub trait EngineApi<N>: Send + Sync {
     /// Sends the given payload to the execution layer client, as specified for the Paris fork.
     ///
     /// Caution: This should not accept the `withdrawals` field
@@ -181,11 +181,10 @@ pub trait EngineApi<N, T>: Send + Sync {
 
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
-impl<N, T, P> EngineApi<N, T> for P
+impl<N, P> EngineApi<N> for P
 where
     N: Network,
-    T: Transport + Clone,
-    P: Provider<T, N>,
+    P: Provider<N>,
 {
     async fn new_payload_v1(&self, payload: ExecutionPayloadV1) -> TransportResult<PayloadStatus> {
         self.client().request("engine_newPayloadV1", (payload,)).await

--- a/crates/provider/src/ext/erc4337.rs
+++ b/crates/provider/src/ext/erc4337.rs
@@ -4,7 +4,7 @@ use alloy_primitives::{Address, Bytes};
 use alloy_rpc_types_eth::erc4337::{
     SendUserOperation, SendUserOperationResponse, UserOperationGasEstimation, UserOperationReceipt,
 };
-use alloy_transport::{Transport, TransportResult};
+use alloy_transport::TransportResult;
 
 /// ERC-4337 Account Abstraction API
 ///
@@ -12,7 +12,7 @@ use alloy_transport::{Transport, TransportResult};
 /// as defined in ERC-4337.
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
-pub trait Erc4337Api<N, T>: Send + Sync {
+pub trait Erc4337Api<N>: Send + Sync {
     /// Sends a user operation to the bundler, as defined in ERC-4337.
     ///
     /// Entry point changes based on the user operation type.
@@ -45,11 +45,10 @@ pub trait Erc4337Api<N, T>: Send + Sync {
 
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
-impl<N, T, P> Erc4337Api<N, T> for P
+impl<N, P> Erc4337Api<N> for P
 where
     N: Network,
-    T: Transport + Clone,
-    P: Provider<T, N>,
+    P: Provider<N>,
 {
     async fn send_user_operation(
         &self,

--- a/crates/provider/src/ext/net.rs
+++ b/crates/provider/src/ext/net.rs
@@ -1,12 +1,12 @@
 //! This module extends the Ethereum JSON-RPC provider with the Net namespace's RPC methods.
 use crate::Provider;
 use alloy_network::Network;
-use alloy_transport::{Transport, TransportResult};
+use alloy_transport::TransportResult;
 
 /// Net namespace rpc interface that provides access to network information of the node.
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
-pub trait NetApi<N, T>: Send + Sync {
+pub trait NetApi<N>: Send + Sync {
     /// Returns a `bool` indicating whether or not the node is listening for network connections.
     async fn net_listening(&self) -> TransportResult<bool>;
     /// Returns the number of peers connected to the node.
@@ -17,11 +17,10 @@ pub trait NetApi<N, T>: Send + Sync {
 
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
-impl<N, T, P> NetApi<N, T> for P
+impl<N, P> NetApi<N> for P
 where
     N: Network,
-    T: Transport + Clone,
-    P: Provider<T, N>,
+    P: Provider<N>,
 {
     async fn net_listening(&self) -> TransportResult<bool> {
         self.client().request_noparams("net_listening").await

--- a/crates/provider/src/ext/rpc.rs
+++ b/crates/provider/src/ext/rpc.rs
@@ -2,24 +2,23 @@
 use crate::Provider;
 use alloy_network::Network;
 use alloy_rpc_types::RpcModules;
-use alloy_transport::{Transport, TransportResult};
+use alloy_transport::TransportResult;
 
 /// The rpc API provides methods to get information about the RPC server itself, such as the enabled
 /// namespaces.
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
-pub trait RpcApi<N, T>: Send + Sync {
+pub trait RpcApi<N>: Send + Sync {
     /// Lists the enabled RPC namespaces and the versions of each.
     async fn rpc_modules(&self) -> TransportResult<RpcModules>;
 }
 
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
-impl<N, T, P> RpcApi<N, T> for P
+impl<N, P> RpcApi<N> for P
 where
     N: Network,
-    T: Transport + Clone,
-    P: Provider<T, N>,
+    P: Provider<N>,
 {
     async fn rpc_modules(&self) -> TransportResult<RpcModules> {
         self.client().request_noparams("rpc_modules").await

--- a/crates/provider/src/ext/trace.rs
+++ b/crates/provider/src/ext/trace.rs
@@ -8,7 +8,7 @@ use alloy_rpc_types_trace::{
     filter::TraceFilter,
     parity::{LocalizedTransactionTrace, TraceResults, TraceResultsWithTransactionHash, TraceType},
 };
-use alloy_transport::{Transport, TransportResult};
+use alloy_transport::TransportResult;
 
 /// List of trace calls for use with [`TraceApi::trace_call_many`]
 pub type TraceCallList<'a, N> = &'a [(<N as Network>::TransactionRequest, &'a [TraceType])];
@@ -16,10 +16,9 @@ pub type TraceCallList<'a, N> = &'a [(<N as Network>::TransactionRequest, &'a [T
 /// Trace namespace rpc interface that gives access to several non-standard RPC methods.
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
-pub trait TraceApi<N, T>: Send + Sync
+pub trait TraceApi<N>: Send + Sync
 where
     N: Network,
-    T: Transport + Clone,
 {
     /// Executes the given transaction and returns a number of possible traces.
     ///
@@ -30,7 +29,7 @@ where
         &self,
         request: &'a N::TransactionRequest,
         trace_type: &'b [TraceType],
-    ) -> RpcWithBlock<T, (&'a N::TransactionRequest, &'b [TraceType]), TraceResults>;
+    ) -> RpcWithBlock<(&'a N::TransactionRequest, &'b [TraceType]), TraceResults>;
 
     /// Traces multiple transactions on top of the same block, i.e. transaction `n` will be executed
     /// on top of the given block with all `n - 1` transaction applied first.
@@ -43,7 +42,7 @@ where
     fn trace_call_many<'a>(
         &self,
         request: TraceCallList<'a, N>,
-    ) -> RpcWithBlock<T, (TraceCallList<'a, N>,), Vec<TraceResults>>;
+    ) -> RpcWithBlock<(TraceCallList<'a, N>,), Vec<TraceResults>>;
 
     /// Parity trace transaction.
     async fn trace_transaction(
@@ -100,25 +99,23 @@ where
 
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
-impl<N, T, P> TraceApi<N, T> for P
+impl<N, P> TraceApi<N> for P
 where
     N: Network,
-    T: Transport + Clone,
-    P: Provider<T, N>,
+    P: Provider<N>,
 {
     fn trace_call<'a, 'b>(
         &self,
         request: &'a <N as Network>::TransactionRequest,
         trace_types: &'b [TraceType],
-    ) -> RpcWithBlock<T, (&'a <N as Network>::TransactionRequest, &'b [TraceType]), TraceResults>
-    {
+    ) -> RpcWithBlock<(&'a <N as Network>::TransactionRequest, &'b [TraceType]), TraceResults> {
         self.client().request("trace_call", (request, trace_types)).into()
     }
 
     fn trace_call_many<'a>(
         &self,
         request: TraceCallList<'a, N>,
-    ) -> RpcWithBlock<T, (TraceCallList<'a, N>,), Vec<TraceResults>> {
+    ) -> RpcWithBlock<(TraceCallList<'a, N>,), Vec<TraceResults>> {
         self.client().request("trace_callMany", (request,)).into()
     }
 

--- a/crates/provider/src/ext/txpool.rs
+++ b/crates/provider/src/ext/txpool.rs
@@ -3,13 +3,13 @@ use crate::Provider;
 use alloy_network::{Ethereum, Network};
 use alloy_primitives::Address;
 use alloy_rpc_types_txpool::{TxpoolContent, TxpoolContentFrom, TxpoolInspect, TxpoolStatus};
-use alloy_transport::{Transport, TransportResult};
+use alloy_transport::TransportResult;
 
 /// Txpool namespace rpc interface.
 #[allow(unused, unreachable_pub)]
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
-pub trait TxPoolApi<T, N: Network = Ethereum>: Send + Sync {
+pub trait TxPoolApi<N: Network = Ethereum>: Send + Sync {
     /// Returns the content of the transaction pool.
     ///
     /// Lists the exact details of all the transactions currently pending for inclusion in the next
@@ -47,10 +47,9 @@ pub trait TxPoolApi<T, N: Network = Ethereum>: Send + Sync {
 
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
-impl<P, T, N> TxPoolApi<T, N> for P
+impl<P, N> TxPoolApi<N> for P
 where
-    P: Provider<T, N>,
-    T: Transport + Clone,
+    P: Provider<N>,
     N: Network,
 {
     async fn txpool_content(&self) -> TransportResult<TxpoolContent<N::TransactionResponse>> {

--- a/crates/provider/src/fillers/chain_id.rs
+++ b/crates/provider/src/fillers/chain_id.rs
@@ -74,14 +74,13 @@ impl<N: Network> TxFiller<N> for ChainIdFiller {
         }
     }
 
-    async fn prepare<P, T>(
+    async fn prepare<P>(
         &self,
         provider: &P,
         _tx: &N::TransactionRequest,
     ) -> TransportResult<Self::Fillable>
     where
-        P: crate::Provider<T, N>,
-        T: alloy_transport::Transport + Clone,
+        P: crate::Provider<N>,
     {
         match self.0.get().copied() {
             Some(chain_id) => Ok(chain_id),

--- a/crates/provider/src/fillers/chain_id.rs
+++ b/crates/provider/src/fillers/chain_id.rs
@@ -70,7 +70,7 @@ impl<N: Network> TxFiller<N> for ChainIdFiller {
                 if builder.chain_id().is_none() {
                     builder.set_chain_id(*chain_id)
                 }
-            };
+            }
         }
     }
 

--- a/crates/provider/src/fillers/gas.rs
+++ b/crates/provider/src/fillers/gas.rs
@@ -10,7 +10,7 @@ use alloy_eips::eip4844::BLOB_TX_MIN_BLOB_GASPRICE;
 use alloy_json_rpc::RpcError;
 use alloy_network::{Network, TransactionBuilder, TransactionBuilder4844};
 use alloy_rpc_types_eth::BlockNumberOrTag;
-use alloy_transport::{Transport, TransportResult};
+use alloy_transport::TransportResult;
 use futures::FutureExt;
 
 /// An enum over the different types of gas fillable.
@@ -65,14 +65,13 @@ pub enum GasFillable {
 pub struct GasFiller;
 
 impl GasFiller {
-    async fn prepare_legacy<P, T, N>(
+    async fn prepare_legacy<P, N>(
         &self,
         provider: &P,
         tx: &N::TransactionRequest,
     ) -> TransportResult<GasFillable>
     where
-        P: Provider<T, N>,
-        T: Transport + Clone,
+        P: Provider<N>,
         N: Network,
     {
         let gas_price_fut = tx.gas_price().map_or_else(
@@ -90,14 +89,13 @@ impl GasFiller {
         Ok(GasFillable::Legacy { gas_limit, gas_price })
     }
 
-    async fn prepare_1559<P, T, N>(
+    async fn prepare_1559<P, N>(
         &self,
         provider: &P,
         tx: &N::TransactionRequest,
     ) -> TransportResult<GasFillable>
     where
-        P: Provider<T, N>,
-        T: Transport + Clone,
+        P: Provider<N>,
         N: Network,
     {
         let gas_limit_fut = tx.gas_limit().map_or_else(
@@ -142,14 +140,13 @@ impl<N: Network> TxFiller<N> for GasFiller {
 
     fn fill_sync(&self, _tx: &mut SendableTx<N>) {}
 
-    async fn prepare<P, T>(
+    async fn prepare<P>(
         &self,
         provider: &P,
         tx: &<N as Network>::TransactionRequest,
     ) -> TransportResult<Self::Fillable>
     where
-        P: Provider<T, N>,
-        T: Transport + Clone,
+        P: Provider<N>,
     {
         if tx.gas_price().is_some() {
             self.prepare_legacy(provider, tx).await
@@ -209,14 +206,13 @@ where
 
     fn fill_sync(&self, _tx: &mut SendableTx<N>) {}
 
-    async fn prepare<P, T>(
+    async fn prepare<P>(
         &self,
         provider: &P,
         tx: &<N as Network>::TransactionRequest,
     ) -> TransportResult<Self::Fillable>
     where
-        P: Provider<T, N>,
-        T: Transport + Clone,
+        P: Provider<N>,
     {
         if let Some(max_fee_per_blob_gas) = tx.max_fee_per_blob_gas() {
             if max_fee_per_blob_gas >= BLOB_TX_MIN_BLOB_GASPRICE {

--- a/crates/provider/src/fillers/join_fill.rs
+++ b/crates/provider/src/fillers/join_fill.rs
@@ -4,7 +4,7 @@ use crate::{
     Provider, ProviderLayer,
 };
 use alloy_network::Network;
-use alloy_transport::{Transport, TransportResult};
+use alloy_transport::TransportResult;
 use futures::try_join;
 
 /// A layer that can fill in a [`TransactionRequest`] with additional information by joining two
@@ -45,14 +45,13 @@ impl<L, R> JoinFill<L, R> {
 
 impl<L, R> JoinFill<L, R> {
     /// Get a request for the left filler, if the left filler is ready.
-    async fn prepare_left<P, T, N>(
+    async fn prepare_left<P, N>(
         &self,
         provider: &P,
         tx: &N::TransactionRequest,
     ) -> TransportResult<Option<L::Fillable>>
     where
-        P: Provider<T, N>,
-        T: Transport + Clone,
+        P: Provider<N>,
         L: TxFiller<N>,
         N: Network,
     {
@@ -64,14 +63,13 @@ impl<L, R> JoinFill<L, R> {
     }
 
     /// Get a prepare for the right filler, if the right filler is ready.
-    async fn prepare_right<P, T, N>(
+    async fn prepare_right<P, N>(
         &self,
         provider: &P,
         tx: &N::TransactionRequest,
     ) -> TransportResult<Option<R::Fillable>>
     where
-        P: Provider<T, N>,
-        T: Transport + Clone,
+        P: Provider<N>,
         R: TxFiller<N>,
         N: Network,
     {
@@ -100,14 +98,13 @@ where
         self.right.fill_sync(tx);
     }
 
-    async fn prepare<P, T>(
+    async fn prepare<P>(
         &self,
         provider: &P,
         tx: &N::TransactionRequest,
     ) -> TransportResult<Self::Fillable>
     where
-        P: Provider<T, N>,
-        T: Transport + Clone,
+        P: Provider<N>,
     {
         try_join!(self.prepare_left(provider, tx), self.prepare_right(provider, tx))
     }
@@ -127,15 +124,14 @@ where
     }
 }
 
-impl<L, R, P, T, N> ProviderLayer<P, T, N> for JoinFill<L, R>
+impl<L, R, P, N> ProviderLayer<P, N> for JoinFill<L, R>
 where
     L: TxFiller<N>,
     R: TxFiller<N>,
-    P: Provider<T, N>,
-    T: alloy_transport::Transport + Clone,
+    P: Provider<N>,
     N: Network,
 {
-    type Provider = FillProvider<Self, P, T, N>;
+    type Provider = FillProvider<Self, P, N>;
     fn layer(&self, inner: P) -> Self::Provider {
         FillProvider::new(inner, self.clone())
     }

--- a/crates/provider/src/fillers/join_fill.rs
+++ b/crates/provider/src/fillers/join_fill.rs
@@ -13,7 +13,7 @@ use futures::try_join;
 /// This struct is itself a [`TxFiller`], and can be nested to compose any number of fill layers.
 ///
 /// [`TransactionRequest`]: alloy_rpc_types_eth::TransactionRequest
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct JoinFill<L, R> {
     left: L,
     right: R,

--- a/crates/provider/src/fillers/mod.rs
+++ b/crates/provider/src/fillers/mod.rs
@@ -28,7 +28,7 @@ use crate::{
 };
 use alloy_json_rpc::RpcError;
 use alloy_network::{AnyNetwork, Ethereum, Network};
-use alloy_transport::{Transport, TransportResult};
+use alloy_transport::TransportResult;
 use async_trait::async_trait;
 use futures_utils_wasm::impl_future;
 use std::marker::PhantomData;
@@ -167,14 +167,11 @@ pub trait TxFiller<N: Network = Ethereum>: Clone + Send + Sync + std::fmt::Debug
     fn fill_sync(&self, tx: &mut SendableTx<N>);
 
     /// Prepares fillable properties, potentially by making an RPC request.
-    fn prepare<P, T>(
+    fn prepare<P: Provider<N>>(
         &self,
         provider: &P,
         tx: &N::TransactionRequest,
-    ) -> impl_future!(<Output = TransportResult<Self::Fillable>>)
-    where
-        P: Provider<T, N>,
-        T: Transport + Clone;
+    ) -> impl_future!(<Output = TransportResult<Self::Fillable>>);
 
     /// Fills in the transaction request with the fillable properties.
     fn fill(
@@ -184,14 +181,13 @@ pub trait TxFiller<N: Network = Ethereum>: Clone + Send + Sync + std::fmt::Debug
     ) -> impl_future!(<Output = TransportResult<SendableTx<N>>>);
 
     /// Prepares and fills the transaction request with the fillable properties.
-    fn prepare_and_fill<P, T>(
+    fn prepare_and_fill<P>(
         &self,
         provider: &P,
         tx: SendableTx<N>,
     ) -> impl_future!(<Output = TransportResult<SendableTx<N>>>)
     where
-        P: Provider<T, N>,
-        T: Transport + Clone,
+        P: Provider<N>,
     {
         async move {
             if tx.is_envelope() {
@@ -218,23 +214,21 @@ pub trait TxFiller<N: Network = Ethereum>: Clone + Send + Sync + std::fmt::Debug
 ///
 /// [`ProviderBuilder::filler`]: crate::ProviderBuilder::filler
 #[derive(Clone, Debug)]
-pub struct FillProvider<F, P, T, N>
+pub struct FillProvider<F, P, N>
 where
     F: TxFiller<N>,
-    P: Provider<T, N>,
-    T: Transport + Clone,
+    P: Provider<N>,
     N: Network,
 {
     pub(crate) inner: P,
     pub(crate) filler: F,
-    _pd: PhantomData<fn() -> (T, N)>,
+    _pd: PhantomData<fn() -> N>,
 }
 
-impl<F, P, T, N> FillProvider<F, P, T, N>
+impl<F, P, N> FillProvider<F, P, N>
 where
     F: TxFiller<N>,
-    P: Provider<T, N>,
-    T: Transport + Clone,
+    P: Provider<N>,
     N: Network,
 {
     /// Creates a new `FillProvider` with the given filler and inner provider.
@@ -246,7 +240,7 @@ where
     pub fn join_with<Other: TxFiller<N>>(
         self,
         other: Other,
-    ) -> FillProvider<JoinFill<F, Other>, P, T, N> {
+    ) -> FillProvider<JoinFill<F, Other>, P, N> {
         self.filler.join_with(other).layer(self.inner)
     }
 
@@ -278,21 +272,20 @@ where
 
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-impl<F, P, T, N> Provider<T, N> for FillProvider<F, P, T, N>
+impl<F, P, N> Provider<N> for FillProvider<F, P, N>
 where
     F: TxFiller<N>,
-    P: Provider<T, N>,
-    T: Transport + Clone,
+    P: Provider<N>,
     N: Network,
 {
-    fn root(&self) -> &RootProvider<T, N> {
+    fn root(&self) -> &RootProvider<N> {
         self.inner.root()
     }
 
     async fn send_transaction_internal(
         &self,
         mut tx: SendableTx<N>,
-    ) -> TransportResult<PendingTransactionBuilder<T, N>> {
+    ) -> TransportResult<PendingTransactionBuilder<N>> {
         tx = self.fill_inner(tx).await?;
 
         if let Some(builder) = tx.as_builder() {

--- a/crates/provider/src/fillers/mod.rs
+++ b/crates/provider/src/fillers/mod.rs
@@ -316,13 +316,7 @@ impl RecommendedFillers for Ethereum {
         JoinFill<GasFiller, JoinFill<BlobGasFiller, JoinFill<NonceFiller, ChainIdFiller>>>;
 
     fn recommended_fillers() -> Self::RecommendedFillers {
-        JoinFill::new(
-            GasFiller,
-            JoinFill::new(
-                BlobGasFiller,
-                JoinFill::new(NonceFiller::default(), ChainIdFiller::default()),
-            ),
-        )
+        Default::default()
     }
 }
 
@@ -331,12 +325,6 @@ impl RecommendedFillers for AnyNetwork {
         JoinFill<GasFiller, JoinFill<BlobGasFiller, JoinFill<NonceFiller, ChainIdFiller>>>;
 
     fn recommended_fillers() -> Self::RecommendedFillers {
-        JoinFill::new(
-            GasFiller,
-            JoinFill::new(
-                BlobGasFiller,
-                JoinFill::new(NonceFiller::default(), ChainIdFiller::default()),
-            ),
-        )
+        Default::default()
     }
 }

--- a/crates/provider/src/fillers/nonce.rs
+++ b/crates/provider/src/fillers/nonce.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use alloy_network::{Network, TransactionBuilder};
 use alloy_primitives::Address;
-use alloy_transport::{Transport, TransportResult};
+use alloy_transport::TransportResult;
 use async_trait::async_trait;
 use dashmap::DashMap;
 use futures::lock::Mutex;
@@ -16,11 +16,10 @@ use std::sync::Arc;
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait NonceManager: Clone + Send + Sync + std::fmt::Debug {
     /// Get the next nonce for the given account.
-    async fn get_next_nonce<P, T, N>(&self, provider: &P, address: Address) -> TransportResult<u64>
+    async fn get_next_nonce<P, N>(&self, provider: &P, address: Address) -> TransportResult<u64>
     where
-        P: Provider<T, N>,
-        N: Network,
-        T: Transport + Clone;
+        P: Provider<N>,
+        N: Network;
 }
 
 /// This [`NonceManager`] implementation will fetch the transaction count for any new account it
@@ -36,11 +35,10 @@ pub struct SimpleNonceManager;
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl NonceManager for SimpleNonceManager {
-    async fn get_next_nonce<P, T, N>(&self, provider: &P, address: Address) -> TransportResult<u64>
+    async fn get_next_nonce<P, N>(&self, provider: &P, address: Address) -> TransportResult<u64>
     where
-        P: Provider<T, N>,
+        P: Provider<N>,
         N: Network,
-        T: Transport + Clone,
     {
         provider.get_transaction_count(address).pending().await
     }
@@ -62,11 +60,10 @@ pub struct CachedNonceManager {
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl NonceManager for CachedNonceManager {
-    async fn get_next_nonce<P, T, N>(&self, provider: &P, address: Address) -> TransportResult<u64>
+    async fn get_next_nonce<P, N>(&self, provider: &P, address: Address) -> TransportResult<u64>
     where
-        P: Provider<T, N>,
+        P: Provider<N>,
         N: Network,
-        T: Transport + Clone,
     {
         // Use `u64::MAX` as a sentinel value to indicate that the nonce has not been fetched yet.
         const NONE: u64 = u64::MAX;
@@ -143,14 +140,13 @@ impl<M: NonceManager, N: Network> TxFiller<N> for NonceFiller<M> {
 
     fn fill_sync(&self, _tx: &mut SendableTx<N>) {}
 
-    async fn prepare<P, T>(
+    async fn prepare<P>(
         &self,
         provider: &P,
         tx: &N::TransactionRequest,
     ) -> TransportResult<Self::Fillable>
     where
-        P: Provider<T, N>,
-        T: Transport + Clone,
+        P: Provider<N>,
     {
         let from = tx.from().expect("checked by 'ready()'");
         self.nonce_manager.get_next_nonce(provider, from).await
@@ -176,15 +172,14 @@ mod tests {
     use alloy_primitives::{address, U256};
     use alloy_rpc_types_eth::TransactionRequest;
 
-    async fn check_nonces<P, T, N, M>(
+    async fn check_nonces<P, N, M>(
         filler: &NonceFiller<M>,
         provider: &P,
         address: Address,
         start: u64,
     ) where
-        P: Provider<T, N>,
+        P: Provider<N>,
         N: Network,
-        T: Transport + Clone,
         M: NonceManager,
     {
         for i in start..start + 5 {

--- a/crates/provider/src/fillers/wallet.rs
+++ b/crates/provider/src/fillers/wallet.rs
@@ -1,7 +1,7 @@
 use crate::{provider::SendableTx, Provider};
 use alloy_json_rpc::RpcError;
 use alloy_network::{Network, NetworkWallet, TransactionBuilder};
-use alloy_transport::{Transport, TransportResult};
+use alloy_transport::TransportResult;
 
 use super::{FillerControlFlow, TxFiller};
 
@@ -76,14 +76,13 @@ where
         }
     }
 
-    async fn prepare<P, T>(
+    async fn prepare<P>(
         &self,
         _provider: &P,
         _tx: &<N as Network>::TransactionRequest,
     ) -> TransportResult<Self::Fillable>
     where
-        P: Provider<T, N>,
-        T: Transport + Clone,
+        P: Provider<N>,
     {
         Ok(())
     }

--- a/crates/provider/src/heart.rs
+++ b/crates/provider/src/heart.rs
@@ -8,7 +8,7 @@ use alloy_primitives::{
     map::{B256HashMap, B256HashSet},
     TxHash, B256,
 };
-use alloy_transport::{utils::Spawnable, Transport, TransportError};
+use alloy_transport::{utils::Spawnable, TransportError};
 use futures::{stream::StreamExt, FutureExt, Stream};
 use std::{
     collections::{BTreeMap, VecDeque},
@@ -83,22 +83,19 @@ pub enum PendingTransactionError {
 #[must_use = "this type does nothing unless you call `register`, `watch` or `get_receipt`"]
 #[derive(Debug)]
 #[doc(alias = "PendingTxBuilder")]
-pub struct PendingTransactionBuilder<T, N: Network> {
+pub struct PendingTransactionBuilder<N: Network> {
     config: PendingTransactionConfig,
-    provider: RootProvider<T, N>,
+    provider: RootProvider<N>,
 }
 
-impl<T: Transport + Clone, N: Network> PendingTransactionBuilder<T, N> {
+impl<N: Network> PendingTransactionBuilder<N> {
     /// Creates a new pending transaction builder.
-    pub const fn new(provider: RootProvider<T, N>, tx_hash: TxHash) -> Self {
+    pub const fn new(provider: RootProvider<N>, tx_hash: TxHash) -> Self {
         Self::from_config(provider, PendingTransactionConfig::new(tx_hash))
     }
 
     /// Creates a new pending transaction builder from the given configuration.
-    pub const fn from_config(
-        provider: RootProvider<T, N>,
-        config: PendingTransactionConfig,
-    ) -> Self {
+    pub const fn from_config(provider: RootProvider<N>, config: PendingTransactionConfig) -> Self {
         Self { config, provider }
     }
 
@@ -113,12 +110,12 @@ impl<T: Transport + Clone, N: Network> PendingTransactionBuilder<T, N> {
     }
 
     /// Returns the provider.
-    pub const fn provider(&self) -> &RootProvider<T, N> {
+    pub const fn provider(&self) -> &RootProvider<N> {
         &self.provider
     }
 
     /// Consumes this builder, returning the provider and the configuration.
-    pub fn split(self) -> (RootProvider<T, N>, PendingTransactionConfig) {
+    pub fn split(self) -> (RootProvider<N>, PendingTransactionConfig) {
         (self.provider, self.config)
     }
 
@@ -324,10 +321,10 @@ impl PendingTransactionConfig {
     }
 
     /// Wraps this configuration with a provider to expose watching methods.
-    pub const fn with_provider<T: Transport + Clone, N: Network>(
+    pub const fn with_provider<N: Network>(
         self,
-        provider: RootProvider<T, N>,
-    ) -> PendingTransactionBuilder<T, N> {
+        provider: RootProvider<N>,
+    ) -> PendingTransactionBuilder<N> {
         PendingTransactionBuilder::from_config(provider, self)
     }
 }

--- a/crates/provider/src/layers/anvil.rs
+++ b/crates/provider/src/layers/anvil.rs
@@ -1,11 +1,7 @@
 use alloy_network::Ethereum;
 use alloy_node_bindings::{Anvil, AnvilInstance};
-use alloy_transport::Transport;
 use reqwest::Url;
-use std::{
-    marker::PhantomData,
-    sync::{Arc, OnceLock},
-};
+use std::sync::{Arc, OnceLock};
 
 use crate::{Provider, ProviderLayer, RootProvider};
 
@@ -44,12 +40,11 @@ impl From<Anvil> for AnvilLayer {
     }
 }
 
-impl<P, T> ProviderLayer<P, T, Ethereum> for AnvilLayer
+impl<P> ProviderLayer<P, Ethereum> for AnvilLayer
 where
-    P: Provider<T>,
-    T: Transport + Clone,
+    P: Provider,
 {
-    type Provider = AnvilProvider<P, T>;
+    type Provider = AnvilProvider<P>;
 
     fn layer(&self, inner: P) -> Self::Provider {
         let anvil = self.instance();
@@ -60,31 +55,29 @@ where
 /// A provider that wraps an [`AnvilInstance`], preventing the instance from
 /// being dropped while the provider is in use.
 #[derive(Clone, Debug)]
-pub struct AnvilProvider<P, T> {
+pub struct AnvilProvider<P> {
     inner: P,
     _anvil: Arc<AnvilInstance>,
-    _pd: PhantomData<fn() -> T>,
 }
 
-impl<P, T> AnvilProvider<P, T>
+impl<P> AnvilProvider<P>
 where
-    P: Provider<T>,
-    T: Transport + Clone,
+    P: Provider,
 {
     /// Creates a new `AnvilProvider` with the given inner provider and anvil
     /// instance.
+    #[allow(clippy::missing_const_for_fn)]
     pub fn new(inner: P, _anvil: Arc<AnvilInstance>) -> Self {
-        Self { inner, _anvil, _pd: PhantomData }
+        Self { inner, _anvil }
     }
 }
 
-impl<P, T> Provider<T> for AnvilProvider<P, T>
+impl<P> Provider for AnvilProvider<P>
 where
-    P: Provider<T>,
-    T: Transport + Clone,
+    P: Provider,
 {
     #[inline(always)]
-    fn root(&self) -> &RootProvider<T> {
+    fn root(&self) -> &RootProvider {
         self.inner.root()
     }
 }

--- a/crates/provider/src/layers/chain.rs
+++ b/crates/provider/src/layers/chain.rs
@@ -1,6 +1,5 @@
 use alloy_chains::NamedChain;
 use alloy_network::Ethereum;
-use alloy_transport::Transport;
 use std::time::Duration;
 
 use crate::{Provider, ProviderLayer};
@@ -25,10 +24,9 @@ impl From<NamedChain> for ChainLayer {
     }
 }
 
-impl<P, T> ProviderLayer<P, T, Ethereum> for ChainLayer
+impl<P> ProviderLayer<P, Ethereum> for ChainLayer
 where
-    P: Provider<T>,
-    T: Transport + Clone,
+    P: Provider,
 {
     type Provider = P;
 

--- a/crates/provider/src/lib.rs
+++ b/crates/provider/src/lib.rs
@@ -15,6 +15,7 @@ use alloy_transport_http as _;
 ///
 /// [`Http`]: alloy_transport_http::Http
 #[cfg(any(test, feature = "reqwest"))]
+#[deprecated(since = "0.9.0", note = "use `RootProvider` instead")]
 pub type ReqwestProvider<N = alloy_network::Ethereum> = crate::RootProvider<N>;
 
 /// Type alias for a [`RootProvider`] using the [`Http`] transport and a hyper
@@ -22,6 +23,7 @@ pub type ReqwestProvider<N = alloy_network::Ethereum> = crate::RootProvider<N>;
 ///
 /// [`Http`]: alloy_transport_http::Http
 #[cfg(feature = "hyper")]
+#[deprecated(since = "0.9.0", note = "use `RootProvider` instead")]
 pub type HyperProvider<N = alloy_network::Ethereum> = crate::RootProvider<N>;
 
 #[macro_use]

--- a/crates/provider/src/lib.rs
+++ b/crates/provider/src/lib.rs
@@ -6,21 +6,23 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
+// For features.
+#[cfg(any(feature = "reqwest", feature = "hyper"))]
+use alloy_transport_http as _;
+
 /// Type alias for a [`RootProvider`] using the [`Http`] transport and a
 /// reqwest client.
 ///
 /// [`Http`]: alloy_transport_http::Http
 #[cfg(any(test, feature = "reqwest"))]
-pub type ReqwestProvider<N = alloy_network::Ethereum> =
-    crate::RootProvider<alloy_transport_http::Http<reqwest::Client>, N>;
+pub type ReqwestProvider<N = alloy_network::Ethereum> = crate::RootProvider<N>;
 
 /// Type alias for a [`RootProvider`] using the [`Http`] transport and a hyper
 /// client.
 ///
 /// [`Http`]: alloy_transport_http::Http
 #[cfg(feature = "hyper")]
-pub type HyperProvider<N = alloy_network::Ethereum> =
-    crate::RootProvider<alloy_transport_http::HyperTransport, N>;
+pub type HyperProvider<N = alloy_network::Ethereum> = crate::RootProvider<N>;
 
 #[macro_use]
 extern crate tracing;

--- a/crates/provider/src/provider/prov_call.rs
+++ b/crates/provider/src/provider/prov_call.rs
@@ -1,6 +1,6 @@
 use alloy_json_rpc::{RpcParam, RpcReturn};
 use alloy_rpc_client::{RpcCall, Waiter};
-use alloy_transport::{Transport, TransportResult};
+use alloy_transport::TransportResult;
 use futures::FutureExt;
 use pin_project::pin_project;
 use serde_json::value::RawValue;
@@ -22,15 +22,14 @@ use tokio::sync::oneshot;
 ///
 /// [`Provider`]: crate::Provider
 #[pin_project(project = ProviderCallProj)]
-pub enum ProviderCall<Conn, Params, Resp, Output = Resp, Map = fn(Resp) -> Output>
+pub enum ProviderCall<Params, Resp, Output = Resp, Map = fn(Resp) -> Output>
 where
-    Conn: Transport + Clone,
     Params: RpcParam,
     Resp: RpcReturn,
     Map: Fn(Resp) -> Output,
 {
     /// An underlying call to an RPC server.
-    RpcCall(RpcCall<Conn, Params, Resp, Output, Map>),
+    RpcCall(RpcCall<Params, Resp, Output, Map>),
     /// A waiter for a batched call to a remote RPC server.
     Waiter(Waiter<Resp, Output, Map>),
     /// A boxed future.
@@ -39,9 +38,8 @@ where
     Ready(Option<TransportResult<Output>>),
 }
 
-impl<Conn, Params, Resp, Output, Map> ProviderCall<Conn, Params, Resp, Output, Map>
+impl<Params, Resp, Output, Map> ProviderCall<Params, Resp, Output, Map>
 where
-    Conn: Transport + Clone,
     Params: RpcParam,
     Resp: RpcReturn,
     Map: Fn(Resp) -> Output,
@@ -57,7 +55,7 @@ where
     }
 
     /// Fallible cast to [`RpcCall`]
-    pub const fn as_rpc_call(&self) -> Option<&RpcCall<Conn, Params, Resp, Output, Map>> {
+    pub const fn as_rpc_call(&self) -> Option<&RpcCall<Params, Resp, Output, Map>> {
         match self {
             Self::RpcCall(call) => Some(call),
             _ => None,
@@ -65,7 +63,7 @@ where
     }
 
     /// Fallible cast to mutable [`RpcCall`]
-    pub fn as_mut_rpc_call(&mut self) -> Option<&mut RpcCall<Conn, Params, Resp, Output, Map>> {
+    pub fn as_mut_rpc_call(&mut self) -> Option<&mut RpcCall<Params, Resp, Output, Map>> {
         match self {
             Self::RpcCall(call) => Some(call),
             _ => None,
@@ -144,7 +142,7 @@ where
     pub fn map_resp<NewOutput, NewMap>(
         self,
         map: NewMap,
-    ) -> Result<ProviderCall<Conn, Params, Resp, NewOutput, NewMap>, Self>
+    ) -> Result<ProviderCall<Params, Resp, NewOutput, NewMap>, Self>
     where
         NewMap: Fn(Resp) -> NewOutput + Clone,
     {
@@ -156,9 +154,8 @@ where
     }
 }
 
-impl<Conn, Params, Resp, Output, Map> ProviderCall<Conn, &Params, Resp, Output, Map>
+impl<Params, Resp, Output, Map> ProviderCall<&Params, Resp, Output, Map>
 where
-    Conn: Transport + Clone,
     Params: RpcParam + ToOwned,
     Params::Owned: RpcParam,
     Resp: RpcReturn,
@@ -169,7 +166,7 @@ where
     /// # Panics
     ///
     /// Panics if called after the request has been polled.
-    pub fn into_owned_params(self) -> ProviderCall<Conn, Params::Owned, Resp, Output, Map> {
+    pub fn into_owned_params(self) -> ProviderCall<Params::Owned, Resp, Output, Map> {
         match self {
             Self::RpcCall(call) => ProviderCall::RpcCall(call.into_owned_params()),
             _ => panic!(),
@@ -177,9 +174,8 @@ where
     }
 }
 
-impl<Conn, Params, Resp> std::fmt::Debug for ProviderCall<Conn, Params, Resp>
+impl<Params, Resp> std::fmt::Debug for ProviderCall<Params, Resp>
 where
-    Conn: Transport + Clone,
     Params: RpcParam,
     Resp: RpcReturn,
 {
@@ -193,23 +189,20 @@ where
     }
 }
 
-impl<Conn, Params, Resp, Output, Map> From<RpcCall<Conn, Params, Resp, Output, Map>>
-    for ProviderCall<Conn, Params, Resp, Output, Map>
+impl<Params, Resp, Output, Map> From<RpcCall<Params, Resp, Output, Map>>
+    for ProviderCall<Params, Resp, Output, Map>
 where
-    Conn: Transport + Clone,
     Params: RpcParam,
     Resp: RpcReturn,
     Map: Fn(Resp) -> Output,
 {
-    fn from(call: RpcCall<Conn, Params, Resp, Output, Map>) -> Self {
+    fn from(call: RpcCall<Params, Resp, Output, Map>) -> Self {
         Self::RpcCall(call)
     }
 }
 
-impl<Conn, Params, Resp> From<Waiter<Resp>>
-    for ProviderCall<Conn, Params, Resp, Resp, fn(Resp) -> Resp>
+impl<Params, Resp> From<Waiter<Resp>> for ProviderCall<Params, Resp, Resp, fn(Resp) -> Resp>
 where
-    Conn: Transport + Clone,
     Params: RpcParam,
     Resp: RpcReturn,
 {
@@ -218,11 +211,9 @@ where
     }
 }
 
-impl<Conn, Params, Resp, Output, Map>
-    From<Pin<Box<dyn Future<Output = TransportResult<Output>> + Send>>>
-    for ProviderCall<Conn, Params, Resp, Output, Map>
+impl<Params, Resp, Output, Map> From<Pin<Box<dyn Future<Output = TransportResult<Output>> + Send>>>
+    for ProviderCall<Params, Resp, Output, Map>
 where
-    Conn: Transport + Clone,
     Params: RpcParam,
     Resp: RpcReturn,
     Map: Fn(Resp) -> Output,
@@ -232,10 +223,9 @@ where
     }
 }
 
-impl<Conn, Params, Resp> From<oneshot::Receiver<TransportResult<Box<RawValue>>>>
-    for ProviderCall<Conn, Params, Resp>
+impl<Params, Resp> From<oneshot::Receiver<TransportResult<Box<RawValue>>>>
+    for ProviderCall<Params, Resp>
 where
-    Conn: Transport + Clone,
     Params: RpcParam,
     Resp: RpcReturn,
 {
@@ -244,9 +234,8 @@ where
     }
 }
 
-impl<Conn, Params, Resp, Output, Map> Future for ProviderCall<Conn, Params, Resp, Output, Map>
+impl<Params, Resp, Output, Map> Future for ProviderCall<Params, Resp, Output, Map>
 where
-    Conn: Transport + Clone,
     Params: RpcParam,
     Resp: RpcReturn,
     Output: 'static,

--- a/crates/provider/src/provider/root.rs
+++ b/crates/provider/src/provider/root.rs
@@ -73,7 +73,7 @@ impl<N: Network> RootProvider<N> {
     /// Connects to a boxed transport with the given connector.
     #[deprecated(
         since = "0.9.0",
-        note = "RootProvider is now always boxed, use `connect_with` instead"
+        note = "`RootProvider` is now always boxed, use `connect_with` instead"
     )]
     pub async fn connect_boxed<C: TransportConnect>(conn: C) -> Result<Self, TransportError> {
         Self::connect_with(conn).await
@@ -82,7 +82,7 @@ impl<N: Network> RootProvider<N> {
 
 impl<N: Network> RootProvider<N> {
     /// Boxes the inner client.
-    #[deprecated(since = "0.9.0", note = "RootProvider is now always boxed")]
+    #[deprecated(since = "0.9.0", note = "`RootProvider` is now always boxed")]
     #[allow(clippy::missing_const_for_fn)]
     pub fn boxed(self) -> Self {
         self

--- a/crates/provider/src/provider/root.rs
+++ b/crates/provider/src/provider/root.rs
@@ -5,33 +5,30 @@ use crate::{
 };
 use alloy_network::{Ethereum, Network};
 use alloy_rpc_client::{BuiltInConnectionString, ClientBuilder, ClientRef, RpcClient, WeakClient};
-use alloy_transport::{BoxTransport, BoxTransportConnect, Transport, TransportError};
+use alloy_transport::{BoxTransportConnect, TransportError};
 use std::{
     fmt,
     marker::PhantomData,
     sync::{Arc, OnceLock},
 };
 
-#[cfg(feature = "reqwest")]
-use alloy_transport_http::Http;
-
 #[cfg(feature = "pubsub")]
 use alloy_pubsub::{PubSubFrontend, Subscription};
 
 /// The root provider manages the RPC client and the heartbeat. It is at the
 /// base of every provider stack.
-pub struct RootProvider<T, N: Network = Ethereum> {
+pub struct RootProvider<N: Network = Ethereum> {
     /// The inner state of the root provider.
-    pub(crate) inner: Arc<RootProviderInner<T, N>>,
+    pub(crate) inner: Arc<RootProviderInner<N>>,
 }
 
-impl<T, N: Network> Clone for RootProvider<T, N> {
+impl<N: Network> Clone for RootProvider<N> {
     fn clone(&self) -> Self {
         Self { inner: self.inner.clone() }
     }
 }
 
-impl<T: fmt::Debug, N: Network> fmt::Debug for RootProvider<T, N> {
+impl<N: Network> fmt::Debug for RootProvider<N> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("RootProvider").field("client", &self.inner.client).finish_non_exhaustive()
     }
@@ -43,22 +40,18 @@ pub fn builder<N: Network>() -> ProviderBuilder<Identity, Identity, N> {
     ProviderBuilder::default()
 }
 
-#[cfg(feature = "reqwest")]
-impl<N: Network> RootProvider<Http<reqwest::Client>, N> {
+impl<N: Network> RootProvider<N> {
     /// Creates a new HTTP root provider from the given URL.
+    #[cfg(feature = "reqwest")]
     pub fn new_http(url: url::Url) -> Self {
         Self::new(RpcClient::new_http(url))
     }
-}
 
-impl<T: Transport + Clone, N: Network> RootProvider<T, N> {
     /// Creates a new root provider from the given RPC client.
-    pub fn new(client: RpcClient<T>) -> Self {
+    pub fn new(client: RpcClient) -> Self {
         Self { inner: Arc::new(RootProviderInner::new(client)) }
     }
-}
 
-impl<N: Network> RootProvider<BoxTransport, N> {
     /// Connects to a boxed transport with the given connector.
     pub async fn connect_boxed<C: BoxTransportConnect>(conn: C) -> Result<Self, TransportError> {
         let client = ClientBuilder::default().connect_boxed(conn).await?;
@@ -74,14 +67,13 @@ impl<N: Network> RootProvider<BoxTransport, N> {
     }
 }
 
-impl<T: Transport + Clone, N: Network> RootProvider<T, N> {
+impl<N: Network> RootProvider<N> {
     /// Boxes the inner client.
-    ///
-    /// This will create a new provider if this instance is not the only reference to the inner
-    /// client.
-    pub fn boxed(self) -> RootProvider<BoxTransport, N> {
-        let inner = Arc::unwrap_or_clone(self.inner);
-        RootProvider { inner: Arc::new(inner.boxed()) }
+    #[doc(hidden)]
+    #[deprecated(since = "0.9.0", note = "RootProvider is now always boxed")]
+    #[allow(clippy::missing_const_for_fn)]
+    pub fn boxed(self) -> Self {
+        self
     }
 
     /// Gets the subscription corresponding to the given RPC subscription ID.
@@ -110,7 +102,7 @@ impl<T: Transport + Clone, N: Network> RootProvider<T, N> {
     #[inline]
     pub(crate) fn get_heart(&self) -> &HeartbeatHandle<N> {
         self.inner.heart.get_or_init(|| {
-            let new_blocks = NewBlocks::<T, N>::new(self.inner.weak_client());
+            let new_blocks = NewBlocks::<N>::new(self.inner.weak_client());
             let stream = new_blocks.into_stream();
             Heartbeat::new(Box::pin(stream)).spawn()
         })
@@ -119,34 +111,28 @@ impl<T: Transport + Clone, N: Network> RootProvider<T, N> {
 
 /// The root provider manages the RPC client and the heartbeat. It is at the
 /// base of every provider stack.
-pub(crate) struct RootProviderInner<T, N: Network = Ethereum> {
-    client: RpcClient<T>,
+pub(crate) struct RootProviderInner<N: Network = Ethereum> {
+    client: RpcClient,
     heart: OnceLock<HeartbeatHandle<N>>,
     _network: PhantomData<N>,
 }
 
-impl<T, N: Network> Clone for RootProviderInner<T, N> {
+impl<N: Network> Clone for RootProviderInner<N> {
     fn clone(&self) -> Self {
         Self { client: self.client.clone(), heart: self.heart.clone(), _network: PhantomData }
     }
 }
 
-impl<T: Transport + Clone, N: Network> RootProviderInner<T, N> {
-    pub(crate) fn new(client: RpcClient<T>) -> Self {
+impl<N: Network> RootProviderInner<N> {
+    pub(crate) fn new(client: RpcClient) -> Self {
         Self { client, heart: Default::default(), _network: PhantomData }
     }
 
-    pub(crate) fn weak_client(&self) -> WeakClient<T> {
+    pub(crate) fn weak_client(&self) -> WeakClient {
         self.client.get_weak()
     }
 
-    pub(crate) fn client_ref(&self) -> ClientRef<'_, T> {
+    pub(crate) fn client_ref(&self) -> ClientRef<'_> {
         self.client.get_ref()
-    }
-}
-
-impl<T: Transport + Clone, N: Network> RootProviderInner<T, N> {
-    fn boxed(self) -> RootProviderInner<BoxTransport, N> {
-        RootProviderInner { client: self.client.boxed(), heart: self.heart, _network: PhantomData }
     }
 }

--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -137,7 +137,7 @@ pub trait Provider<N: Network = Ethereum>: Send + Sync {
     /// # use alloy_eips::BlockId;
     /// # use alloy_rpc_types_eth::state::StateOverride;
     /// # use alloy_transport::BoxTransport;
-    /// # async fn example<P: Provider<BoxTransport>>(
+    /// # async fn example<P: Provider>(
     /// #    provider: P,
     /// #    my_overrides: StateOverride
     /// # ) -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -23,14 +23,14 @@ use alloy_rpc_types_eth::{
     AccessListResult, BlockId, BlockNumberOrTag, EIP1186AccountProofResponse, FeeHistory, Filter,
     FilterChanges, Index, Log, SyncStatus,
 };
-use alloy_transport::{BoxTransport, Transport, TransportResult};
+use alloy_transport::TransportResult;
 use serde_json::value::RawValue;
 use std::borrow::Cow;
 
 /// A task that polls the provider with `eth_getFilterChanges`, returning a list of `R`.
 ///
 /// See [`PollerBuilder`] for more details.
-pub type FilterPollerBuilder<T, R> = PollerBuilder<T, (U256,), Vec<R>>;
+pub type FilterPollerBuilder<R> = PollerBuilder<(U256,), Vec<R>>;
 
 // todo: adjust docs
 // todo: reorder
@@ -70,11 +70,9 @@ pub type FilterPollerBuilder<T, R> = PollerBuilder<T, (U256,), Vec<R>>;
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 #[auto_impl::auto_impl(&, &mut, Rc, Arc, Box)]
-pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
-    Send + Sync
-{
+pub trait Provider<N: Network = Ethereum>: Send + Sync {
     /// Returns the root provider.
-    fn root(&self) -> &RootProvider<T, N>;
+    fn root(&self) -> &RootProvider<N>;
 
     /// Returns the [`ProviderBuilder`](crate::ProviderBuilder) to build on.
     fn builder() -> ProviderBuilder<Identity, Identity, N>
@@ -88,7 +86,7 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
     ///
     /// NOTE: this method should not be overridden.
     #[inline]
-    fn client(&self) -> ClientRef<'_, T> {
+    fn client(&self) -> ClientRef<'_> {
         self.root().client()
     }
 
@@ -96,18 +94,18 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
     ///
     /// NOTE: this method should not be overridden.
     #[inline]
-    fn weak_client(&self) -> WeakClient<T> {
+    fn weak_client(&self) -> WeakClient {
         self.root().weak_client()
     }
 
     /// Gets the accounts in the remote node. This is usually empty unless you're using a local
     /// node.
-    fn get_accounts(&self) -> ProviderCall<T, NoParams, Vec<Address>> {
+    fn get_accounts(&self) -> ProviderCall<NoParams, Vec<Address>> {
         self.client().request_noparams("eth_accounts").into()
     }
 
     /// Returns the base fee per blob gas (blob gas price) in wei.
-    fn get_blob_base_fee(&self) -> ProviderCall<T, NoParams, U128, u128> {
+    fn get_blob_base_fee(&self) -> ProviderCall<NoParams, U128, u128> {
         self.client()
             .request_noparams("eth_blobBaseFee")
             .map_resp(utils::convert_u128 as fn(U128) -> u128)
@@ -115,7 +113,7 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
     }
 
     /// Get the last block number available.
-    fn get_block_number(&self) -> ProviderCall<T, NoParams, U64, BlockNumber> {
+    fn get_block_number(&self) -> ProviderCall<NoParams, U64, BlockNumber> {
         self.client()
             .request_noparams("eth_blockNumber")
             .map_resp(utils::convert_u64 as fn(U64) -> u64)
@@ -151,7 +149,7 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
     /// ```
     #[doc(alias = "eth_call")]
     #[doc(alias = "call_with_overrides")]
-    fn call<'req>(&self, tx: &'req N::TransactionRequest) -> EthCall<'req, T, N, Bytes> {
+    fn call<'req>(&self, tx: &'req N::TransactionRequest) -> EthCall<'req, N, Bytes> {
         EthCall::new(self.weak_client(), tx).block(BlockNumberOrTag::Pending.into())
     }
 
@@ -162,12 +160,12 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
     fn simulate<'req>(
         &self,
         payload: &'req SimulatePayload,
-    ) -> RpcWithBlock<T, &'req SimulatePayload, Vec<SimulatedBlock<N::BlockResponse>>> {
+    ) -> RpcWithBlock<&'req SimulatePayload, Vec<SimulatedBlock<N::BlockResponse>>> {
         self.client().request("eth_simulateV1", payload).into()
     }
 
     /// Gets the chain ID.
-    fn get_chain_id(&self) -> ProviderCall<T, NoParams, U64, u64> {
+    fn get_chain_id(&self) -> ProviderCall<NoParams, U64, u64> {
         self.client()
             .request_noparams("eth_chainId")
             .map_resp(utils::convert_u64 as fn(U64) -> u64)
@@ -180,7 +178,7 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
     fn create_access_list<'a>(
         &self,
         request: &'a N::TransactionRequest,
-    ) -> RpcWithBlock<T, &'a N::TransactionRequest, AccessListResult> {
+    ) -> RpcWithBlock<&'a N::TransactionRequest, AccessListResult> {
         self.client().request("eth_createAccessList", request).into()
     }
 
@@ -197,7 +195,7 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
     /// # Note
     ///
     /// Not all client implementations support state overrides for eth_estimateGas.
-    fn estimate_gas<'req>(&self, tx: &'req N::TransactionRequest) -> EthCall<'req, T, N, U64, u64> {
+    fn estimate_gas<'req>(&self, tx: &'req N::TransactionRequest) -> EthCall<'req, N, U64, u64> {
         EthCall::gas_estimate(self.weak_client(), tx)
             .block(BlockNumberOrTag::Pending.into())
             .map_resp(utils::convert_u64)
@@ -257,7 +255,7 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
     }
 
     /// Gets the current gas price in wei.
-    fn get_gas_price(&self) -> ProviderCall<T, NoParams, U128, u128> {
+    fn get_gas_price(&self) -> ProviderCall<NoParams, U128, u128> {
         self.client()
             .request_noparams("eth_gasPrice")
             .map_resp(utils::convert_u128 as fn(U128) -> u128)
@@ -266,14 +264,14 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
 
     /// Retrieves account information ([Account](alloy_consensus::Account)) for the given [Address]
     /// at the particular [BlockId].
-    fn get_account(&self, address: Address) -> RpcWithBlock<T, Address, alloy_consensus::Account> {
+    fn get_account(&self, address: Address) -> RpcWithBlock<Address, alloy_consensus::Account> {
         self.client().request("eth_getAccount", address).into()
     }
 
     /// Gets the balance of the account.
     ///
     /// Defaults to the latest block. See also [`RpcWithBlock::block_id`].
-    fn get_balance(&self, address: Address) -> RpcWithBlock<T, Address, U256, U256> {
+    fn get_balance(&self, address: Address) -> RpcWithBlock<Address, U256, U256> {
         self.client().request("eth_getBalance", address).into()
     }
 
@@ -369,12 +367,12 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
     fn get_block_receipts(
         &self,
         block: BlockId,
-    ) -> ProviderCall<T, (BlockId,), Option<Vec<N::ReceiptResponse>>> {
+    ) -> ProviderCall<(BlockId,), Option<Vec<N::ReceiptResponse>>> {
         self.client().request("eth_getBlockReceipts", (block,)).into()
     }
 
     /// Gets the bytecode located at the corresponding [Address].
-    fn get_code_at(&self, address: Address) -> RpcWithBlock<T, Address, Bytes> {
+    fn get_code_at(&self, address: Address) -> RpcWithBlock<Address, Bytes> {
         self.client().request("eth_getCode", address).into()
     }
 
@@ -400,7 +398,7 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
     /// # Ok(())
     /// # }
     /// ```
-    async fn watch_blocks(&self) -> TransportResult<FilterPollerBuilder<T, B256>> {
+    async fn watch_blocks(&self) -> TransportResult<FilterPollerBuilder<B256>> {
         let id = self.new_block_filter().await?;
         Ok(PollerBuilder::new(self.weak_client(), "eth_getFilterChanges", (id,)))
     }
@@ -427,7 +425,7 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
     /// # Ok(())
     /// # }
     /// ```
-    async fn watch_pending_transactions(&self) -> TransportResult<FilterPollerBuilder<T, B256>> {
+    async fn watch_pending_transactions(&self) -> TransportResult<FilterPollerBuilder<B256>> {
         let id = self.new_pending_transactions_filter(false).await?;
         Ok(PollerBuilder::new(self.weak_client(), "eth_getFilterChanges", (id,)))
     }
@@ -460,7 +458,7 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
     /// # Ok(())
     /// # }
     /// ```
-    async fn watch_logs(&self, filter: &Filter) -> TransportResult<FilterPollerBuilder<T, Log>> {
+    async fn watch_logs(&self, filter: &Filter) -> TransportResult<FilterPollerBuilder<Log>> {
         let id = self.new_filter(filter).await?;
         Ok(PollerBuilder::new(self.weak_client(), "eth_getFilterChanges", (id,)))
     }
@@ -493,7 +491,7 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
     /// ```
     async fn watch_full_pending_transactions(
         &self,
-    ) -> TransportResult<FilterPollerBuilder<T, N::TransactionResponse>> {
+    ) -> TransportResult<FilterPollerBuilder<N::TransactionResponse>> {
         let id = self.new_pending_transactions_filter(true).await?;
         Ok(PollerBuilder::new(self.weak_client(), "eth_getFilterChanges", (id,)))
     }
@@ -552,7 +550,7 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
         &self,
         address: Address,
         keys: Vec<StorageKey>,
-    ) -> RpcWithBlock<T, (Address, Vec<StorageKey>), EIP1186AccountProofResponse> {
+    ) -> RpcWithBlock<(Address, Vec<StorageKey>), EIP1186AccountProofResponse> {
         self.client().request("eth_getProof", (address, keys)).into()
     }
 
@@ -561,7 +559,7 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
         &self,
         address: Address,
         key: U256,
-    ) -> RpcWithBlock<T, (Address, U256), StorageValue> {
+    ) -> RpcWithBlock<(Address, U256), StorageValue> {
         self.client().request("eth_getStorageAt", (address, key)).into()
     }
 
@@ -569,7 +567,7 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
     fn get_transaction_by_hash(
         &self,
         hash: TxHash,
-    ) -> ProviderCall<T, (TxHash,), Option<N::TransactionResponse>> {
+    ) -> ProviderCall<(TxHash,), Option<N::TransactionResponse>> {
         self.client().request("eth_getTransactionByHash", (hash,)).into()
     }
 
@@ -578,7 +576,7 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
         &self,
         block_hash: B256,
         index: usize,
-    ) -> ProviderCall<T, (B256, Index), Option<N::TransactionResponse>> {
+    ) -> ProviderCall<(B256, Index), Option<N::TransactionResponse>> {
         self.client()
             .request("eth_getTransactionByBlockHashAndIndex", (block_hash, Index(index)))
             .into()
@@ -589,7 +587,7 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
         &self,
         block_hash: B256,
         index: usize,
-    ) -> ProviderCall<T, (B256, Index), Option<Bytes>> {
+    ) -> ProviderCall<(B256, Index), Option<Bytes>> {
         self.client()
             .request("eth_getRawTransactionByBlockHashAndIndex", (block_hash, Index(index)))
             .into()
@@ -600,7 +598,7 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
         &self,
         block_number: BlockNumberOrTag,
         index: usize,
-    ) -> ProviderCall<T, (BlockNumberOrTag, Index), Option<N::TransactionResponse>> {
+    ) -> ProviderCall<(BlockNumberOrTag, Index), Option<N::TransactionResponse>> {
         self.client()
             .request("eth_getTransactionByBlockNumberAndIndex", (block_number, Index(index)))
             .into()
@@ -611,7 +609,7 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
         &self,
         block_number: BlockNumberOrTag,
         index: usize,
-    ) -> ProviderCall<T, (BlockNumberOrTag, Index), Option<Bytes>> {
+    ) -> ProviderCall<(BlockNumberOrTag, Index), Option<Bytes>> {
         self.client()
             .request("eth_getRawTransactionByBlockNumberAndIndex", (block_number, Index(index)))
             .into()
@@ -625,10 +623,7 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
     /// [TxEip4844](alloy_consensus::transaction::eip4844::TxEip4844).
     ///
     /// This can be decoded into [TxEnvelope](alloy_consensus::transaction::TxEnvelope).
-    fn get_raw_transaction_by_hash(
-        &self,
-        hash: TxHash,
-    ) -> ProviderCall<T, (TxHash,), Option<Bytes>> {
+    fn get_raw_transaction_by_hash(&self, hash: TxHash) -> ProviderCall<(TxHash,), Option<Bytes>> {
         self.client().request("eth_getRawTransactionByHash", (hash,)).into()
     }
 
@@ -638,7 +633,7 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
     fn get_transaction_count(
         &self,
         address: Address,
-    ) -> RpcWithBlock<T, Address, U64, u64, fn(U64) -> u64> {
+    ) -> RpcWithBlock<Address, U64, u64, fn(U64) -> u64> {
         self.client()
             .request("eth_getTransactionCount", address)
             .map_resp(utils::convert_u64 as fn(U64) -> u64)
@@ -649,7 +644,7 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
     fn get_transaction_receipt(
         &self,
         hash: TxHash,
-    ) -> ProviderCall<T, (TxHash,), Option<N::ReceiptResponse>> {
+    ) -> ProviderCall<(TxHash,), Option<N::ReceiptResponse>> {
         self.client().request("eth_getTransactionReceipt", (hash,)).into()
     }
 
@@ -685,7 +680,7 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
     }
 
     /// Returns a suggestion for the current `maxPriorityFeePerGas` in wei.
-    fn get_max_priority_fee_per_gas(&self) -> ProviderCall<T, NoParams, U128, u128> {
+    fn get_max_priority_fee_per_gas(&self) -> ProviderCall<NoParams, U128, u128> {
         self.client()
             .request_noparams("eth_maxPriorityFeePerGas")
             .map_resp(utils::convert_u128 as fn(U128) -> u128)
@@ -731,7 +726,7 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
     async fn send_raw_transaction(
         &self,
         encoded_tx: &[u8],
-    ) -> TransportResult<PendingTransactionBuilder<T, N>> {
+    ) -> TransportResult<PendingTransactionBuilder<N>> {
         let rlp_hex = hex::encode_prefixed(encoded_tx);
         let tx_hash = self.client().request("eth_sendRawTransaction", (rlp_hex,)).await?;
         Ok(PendingTransactionBuilder::new(self.root().clone(), tx_hash))
@@ -760,7 +755,7 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
     async fn send_transaction(
         &self,
         tx: N::TransactionRequest,
-    ) -> TransportResult<PendingTransactionBuilder<T, N>> {
+    ) -> TransportResult<PendingTransactionBuilder<N>> {
         self.send_transaction_internal(SendableTx::Builder(tx)).await
     }
 
@@ -771,7 +766,7 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
     async fn send_tx_envelope(
         &self,
         tx: N::TxEnvelope,
-    ) -> TransportResult<PendingTransactionBuilder<T, N>> {
+    ) -> TransportResult<PendingTransactionBuilder<N>> {
         self.send_transaction_internal(SendableTx::Envelope(tx)).await
     }
 
@@ -786,7 +781,7 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
     async fn send_transaction_internal(
         &self,
         tx: SendableTx<N>,
-    ) -> TransportResult<PendingTransactionBuilder<T, N>> {
+    ) -> TransportResult<PendingTransactionBuilder<N>> {
         // Make sure to initialize heartbeat before we submit transaction, so that
         // we don't miss it if user will subscriber to it immediately after sending.
         let _handle = self.root().get_heart();
@@ -972,24 +967,24 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
     }
 
     /// Gets syncing info.
-    fn syncing(&self) -> ProviderCall<T, NoParams, SyncStatus> {
+    fn syncing(&self) -> ProviderCall<NoParams, SyncStatus> {
         self.client().request_noparams("eth_syncing").into()
     }
 
     /// Gets the client version.
     #[doc(alias = "web3_client_version")]
-    fn get_client_version(&self) -> ProviderCall<T, NoParams, String> {
+    fn get_client_version(&self) -> ProviderCall<NoParams, String> {
         self.client().request_noparams("web3_clientVersion").into()
     }
 
     /// Gets the `Keccak-256` hash of the given data.
     #[doc(alias = "web3_sha3")]
-    fn get_sha3(&self, data: &[u8]) -> ProviderCall<T, (String,), B256> {
+    fn get_sha3(&self, data: &[u8]) -> ProviderCall<(String,), B256> {
         self.client().request("web3_sha3", (hex::encode_prefixed(data),)).into()
     }
 
     /// Gets the network ID. Same as `eth_chainId`.
-    fn get_net_version(&self) -> ProviderCall<T, NoParams, U64, u64> {
+    fn get_net_version(&self) -> ProviderCall<NoParams, U64, u64> {
         self.client()
             .request_noparams("net_version")
             .map_resp(utils::convert_u64 as fn(U64) -> u64)
@@ -1068,19 +1063,19 @@ pub trait Provider<T: Transport + Clone = BoxTransport, N: Network = Ethereum>:
 
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
-impl<T: Transport + Clone, N: Network> Provider<T, N> for RootProvider<T, N> {
+impl<N: Network> Provider<N> for RootProvider<N> {
     #[inline]
     fn root(&self) -> &Self {
         self
     }
 
     #[inline]
-    fn client(&self) -> ClientRef<'_, T> {
+    fn client(&self) -> ClientRef<'_> {
         self.inner.client_ref()
     }
 
     #[inline]
-    fn weak_client(&self) -> WeakClient<T> {
+    fn weak_client(&self) -> WeakClient {
         self.inner.weak_client()
     }
 
@@ -1141,8 +1136,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_provider_builder() {
-        let provider =
-            RootProvider::<BoxTransport, Ethereum>::builder().with_recommended_fillers().on_anvil();
+        let provider = RootProvider::builder().with_recommended_fillers().on_anvil();
         let num = provider.get_block_number().await.unwrap();
         assert_eq!(0, num);
     }
@@ -1162,7 +1156,7 @@ mod tests {
 
         let rpc_client = alloy_rpc_client::RpcClient::new(hyper_t, true);
 
-        let provider = RootProvider::<_, Ethereum>::new(rpc_client);
+        let provider = RootProvider::<Ethereum>::new(rpc_client);
         let num = provider.get_block_number().await.unwrap();
         assert_eq!(0, num);
     }
@@ -1247,7 +1241,7 @@ mod tests {
 
         let rpc_client = alloy_rpc_client::RpcClient::new(http_hyper, true);
 
-        let provider = RootProvider::<_, Ethereum>::new(rpc_client);
+        let provider = RootProvider::<Ethereum>::new(rpc_client);
         let num = provider.get_block_number().await.unwrap();
         assert_eq!(0, num);
 
@@ -1256,7 +1250,7 @@ mod tests {
 
         let rpc_client = alloy_rpc_client::RpcClient::new(cloned_t, true);
 
-        let provider = RootProvider::<_, Ethereum>::new(rpc_client);
+        let provider = RootProvider::<Ethereum>::new(rpc_client);
         let num = provider.get_block_number().await.unwrap();
         assert_eq!(0, num);
     }
@@ -1294,7 +1288,7 @@ mod tests {
 
             let rpc_client = alloy_rpc_client::RpcClient::new(http_hyper, true);
 
-            let provider = RootProvider::<_, Ethereum>::new(rpc_client);
+            let provider = RootProvider::<Ethereum>::new(rpc_client);
 
             let num = provider.get_block_number().await.unwrap();
             assert_eq!(0, num);
@@ -1316,33 +1310,8 @@ mod tests {
     async fn object_safety() {
         let provider = ProviderBuilder::new().on_anvil();
 
-        // These blocks are not necessary.
-        {
-            let refdyn = &provider as &dyn Provider<alloy_transport::BoxTransport, _>;
-            let num = refdyn.get_block_number().await.unwrap();
-            assert_eq!(0, num);
-        }
-
-        // Clones the underlying provider too.
-        {
-            let clone_boxed = provider.root().clone().boxed();
-            let num = clone_boxed.get_block_number().await.unwrap();
-            assert_eq!(0, num);
-        }
-
-        // Note the `Http` arg, vs no arg (defaulting to `BoxedTransport`) below.
-        {
-            let refdyn = &provider as &dyn Provider<alloy_transport::BoxTransport, _>;
-            let num = refdyn.get_block_number().await.unwrap();
-            assert_eq!(0, num);
-        }
-
-        let boxed = provider.root().clone().boxed();
-        let num = boxed.get_block_number().await.unwrap();
-        assert_eq!(0, num);
-
-        let boxed_boxdyn = Box::new(boxed) as Box<dyn Provider<_>>;
-        let num = boxed_boxdyn.get_block_number().await.unwrap();
+        let refdyn = &provider as &dyn Provider<_>;
+        let num = refdyn.get_block_number().await.unwrap();
         assert_eq!(0, num);
     }
 
@@ -1380,27 +1349,7 @@ mod tests {
         let anvil = Anvil::new().block_time(1).spawn();
         let ws = alloy_rpc_client::WsConnect::new(anvil.ws_endpoint());
         let client = alloy_rpc_client::RpcClient::connect_pubsub(ws).await.unwrap();
-        let provider = RootProvider::<_, Ethereum>::new(client);
-
-        let sub = provider.subscribe_blocks().await.unwrap();
-        let mut stream = sub.into_stream().take(2);
-        let mut n = 1;
-        while let Some(header) = stream.next().await {
-            assert_eq!(header.number, n);
-            n += 1;
-        }
-    }
-
-    #[cfg(all(feature = "ws", not(windows)))]
-    #[tokio::test]
-    async fn subscribe_blocks_ws_boxed() {
-        use futures::stream::StreamExt;
-
-        let anvil = Anvil::new().block_time(1).spawn();
-        let ws = alloy_rpc_client::WsConnect::new(anvil.ws_endpoint());
-        let client = alloy_rpc_client::RpcClient::connect_pubsub(ws).await.unwrap();
-        let provider = RootProvider::<_, Ethereum>::new(client);
-        let provider = provider.boxed();
+        let provider = RootProvider::<Ethereum>::new(client);
 
         let sub = provider.subscribe_blocks().await.unwrap();
         let mut stream = sub.into_stream().take(2);
@@ -1419,7 +1368,7 @@ mod tests {
         let url = "wss://eth-mainnet.g.alchemy.com/v2/viFmeVzhg6bWKVMIWWS8MhmzREB-D4f7";
         let ws = alloy_rpc_client::WsConnect::new(url);
         let Ok(client) = alloy_rpc_client::RpcClient::connect_pubsub(ws).await else { return };
-        let provider = RootProvider::<_, Ethereum>::new(client);
+        let provider = RootProvider::<Ethereum>::new(client);
         let sub = provider.subscribe_blocks().await.unwrap();
         let mut stream = sub.into_stream().take(1);
         while let Some(header) = stream.next().await {
@@ -1449,7 +1398,7 @@ mod tests {
         let anvil = Anvil::new().spawn();
         let client = RpcClient::builder().layer(retry_layer).http(anvil.endpoint_url());
 
-        let provider = RootProvider::<_, Ethereum>::new(client);
+        let provider = RootProvider::<Ethereum>::new(client);
         let num = provider.get_block_number().await.unwrap();
         assert_eq!(0, num);
     }
@@ -1791,9 +1740,7 @@ mod tests {
     async fn connect_boxed() {
         let anvil = Anvil::new().spawn();
 
-        let provider =
-            RootProvider::<BoxTransport, Ethereum>::connect_builtin(anvil.endpoint().as_str())
-                .await;
+        let provider = RootProvider::<Ethereum>::connect_builtin(anvil.endpoint().as_str()).await;
 
         match provider {
             Ok(provider) => {
@@ -1844,7 +1791,7 @@ mod tests {
 
         let client = alloy_rpc_client::RpcClient::new(transport, true);
 
-        let provider = RootProvider::<BoxTransport, Ethereum>::new(client);
+        let provider = RootProvider::<Ethereum>::new(client);
 
         let num = provider.get_block_number().await.unwrap();
         assert_eq!(0, num);

--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -1740,7 +1740,7 @@ mod tests {
     async fn connect_boxed() {
         let anvil = Anvil::new().spawn();
 
-        let provider = RootProvider::<Ethereum>::connect_builtin(anvil.endpoint().as_str()).await;
+        let provider = RootProvider::<Ethereum>::connect(anvil.endpoint().as_str()).await;
 
         match provider {
             Ok(provider) => {

--- a/crates/provider/src/provider/wallet.rs
+++ b/crates/provider/src/provider/wallet.rs
@@ -4,7 +4,6 @@ use crate::{
 };
 use alloy_network::{Ethereum, Network, NetworkWallet};
 use alloy_primitives::Address;
-use alloy_transport::Transport;
 
 /// Trait for Providers, Fill stacks, etc, which contain [`NetworkWallet`].
 pub trait WalletProvider<N: Network = Ethereum> {
@@ -71,11 +70,10 @@ where
     }
 }
 
-impl<F, P, T, N> WalletProvider<N> for FillProvider<F, P, T, N>
+impl<F, P, N> WalletProvider<N> for FillProvider<F, P, N>
 where
     F: TxFiller<N> + WalletProvider<N>,
-    P: Provider<T, N>,
-    T: Transport + Clone,
+    P: Provider<N>,
     N: Network,
 {
     type Wallet = F::Wallet;

--- a/crates/rpc-client/README.md
+++ b/crates/rpc-client/README.md
@@ -4,7 +4,7 @@ Low-level Ethereum JSON-RPC client implementation.
 
 ## Usage
 
-Usage of this crate typically means instantiating an `RpcClient<T>` over some
+Usage of this crate typically means instantiating an `RpcClient` over some
 `Transport`. The RPC client can then be used to make requests to the RPC
 server. Requests are captured as `RpcCall` futures, which can then be polled to
 completion.

--- a/crates/rpc-client/src/builder.rs
+++ b/crates/rpc-client/src/builder.rs
@@ -1,6 +1,6 @@
 use crate::RpcClient;
 use alloy_transport::{
-    BoxTransport, BoxTransportConnect, Transport, TransportConnect, TransportResult,
+    BoxTransport, BoxTransportConnect, IntoBoxTransport, TransportConnect, TransportResult,
 };
 use tower::{
     layer::util::{Identity, Stack},
@@ -37,11 +37,11 @@ impl<L> ClientBuilder<L> {
 
     /// Create a new [`RpcClient`] with the given transport and the configured
     /// layers.
-    pub fn transport<T>(self, transport: T, is_local: bool) -> RpcClient<L::Service>
+    pub fn transport<T>(self, transport: T, is_local: bool) -> RpcClient
     where
         L: Layer<T>,
-        T: Transport,
-        L::Service: Transport,
+        T: IntoBoxTransport,
+        L::Service: IntoBoxTransport,
     {
         RpcClient::new(self.builder.service(transport), is_local)
     }
@@ -49,10 +49,10 @@ impl<L> ClientBuilder<L> {
     /// Convenience function to create a new [`RpcClient`] with a [`reqwest`]
     /// HTTP transport.
     #[cfg(feature = "reqwest")]
-    pub fn http(self, url: url::Url) -> RpcClient<L::Service>
+    pub fn http(self, url: url::Url) -> RpcClient
     where
         L: Layer<alloy_transport_http::Http<reqwest::Client>>,
-        L::Service: Transport,
+        L::Service: IntoBoxTransport,
     {
         let transport = alloy_transport_http::Http::new(url);
         let is_local = transport.guess_local();
@@ -62,10 +62,10 @@ impl<L> ClientBuilder<L> {
 
     /// Convenience function to create a new [`RpcClient`] with a `hyper` HTTP transport.
     #[cfg(all(not(target_arch = "wasm32"), feature = "hyper"))]
-    pub fn hyper_http(self, url: url::Url) -> RpcClient<L::Service>
+    pub fn hyper_http(self, url: url::Url) -> RpcClient
     where
         L: Layer<alloy_transport_http::HyperTransport>,
-        L::Service: Transport,
+        L::Service: IntoBoxTransport,
     {
         let transport = alloy_transport_http::HyperTransport::new_hyper(url);
         let is_local = transport.guess_local();
@@ -76,11 +76,11 @@ impl<L> ClientBuilder<L> {
     /// Connect a pubsub transport, producing an [`RpcClient`] with the provided
     /// connection.
     #[cfg(feature = "pubsub")]
-    pub async fn pubsub<C>(self, pubsub_connect: C) -> TransportResult<RpcClient<L::Service>>
+    pub async fn pubsub<C>(self, pubsub_connect: C) -> TransportResult<RpcClient>
     where
         C: alloy_pubsub::PubSubConnect,
         L: Layer<alloy_pubsub::PubSubFrontend>,
-        L::Service: Transport,
+        L::Service: IntoBoxTransport,
     {
         let is_local = pubsub_connect.is_local();
         let transport = pubsub_connect.into_service().await?;
@@ -90,13 +90,10 @@ impl<L> ClientBuilder<L> {
     /// Connect a WS transport, producing an [`RpcClient`] with the provided
     /// connection
     #[cfg(feature = "ws")]
-    pub async fn ws(
-        self,
-        ws_connect: alloy_transport_ws::WsConnect,
-    ) -> TransportResult<RpcClient<L::Service>>
+    pub async fn ws(self, ws_connect: alloy_transport_ws::WsConnect) -> TransportResult<RpcClient>
     where
         L: Layer<alloy_pubsub::PubSubFrontend>,
-        L::Service: Transport,
+        L::Service: IntoBoxTransport,
     {
         self.pubsub(ws_connect).await
     }
@@ -107,22 +104,22 @@ impl<L> ClientBuilder<L> {
     pub async fn ipc<T>(
         self,
         ipc_connect: alloy_transport_ipc::IpcConnect<T>,
-    ) -> TransportResult<RpcClient<L::Service>>
+    ) -> TransportResult<RpcClient>
     where
         alloy_transport_ipc::IpcConnect<T>: alloy_pubsub::PubSubConnect,
         L: Layer<alloy_pubsub::PubSubFrontend>,
-        L::Service: Transport,
+        L::Service: IntoBoxTransport,
     {
         self.pubsub(ipc_connect).await
     }
 
     /// Connect a transport, producing an [`RpcClient`] with the provided
     /// connection.
-    pub async fn connect<C>(self, connect: C) -> TransportResult<RpcClient<L::Service>>
+    pub async fn connect<C>(self, connect: C) -> TransportResult<RpcClient>
     where
         C: TransportConnect,
         L: Layer<C::Transport>,
-        L::Service: Transport,
+        L::Service: IntoBoxTransport,
     {
         let transport = connect.get_transport().await?;
         Ok(self.transport(transport, connect.is_local()))
@@ -130,11 +127,11 @@ impl<L> ClientBuilder<L> {
 
     /// Connect a transport, producing an [`RpcClient`] with a [`BoxTransport`]
     /// connection.
-    pub async fn connect_boxed<C>(self, connect: C) -> TransportResult<RpcClient<L::Service>>
+    pub async fn connect_boxed<C>(self, connect: C) -> TransportResult<RpcClient>
     where
         C: BoxTransportConnect,
         L: Layer<BoxTransport>,
-        L::Service: Transport,
+        L::Service: IntoBoxTransport,
     {
         let transport = connect.get_boxed_transport().await?;
         Ok(self.transport(transport, connect.is_local()))

--- a/crates/rpc-client/src/builtin.rs
+++ b/crates/rpc-client/src/builtin.rs
@@ -1,5 +1,5 @@
 use alloy_json_rpc::RpcError;
-use alloy_transport::{BoxTransport, BoxTransportConnect, TransportError, TransportErrorKind};
+use alloy_transport::{BoxTransport, TransportConnect, TransportError, TransportErrorKind};
 use std::str::FromStr;
 
 #[cfg(any(feature = "ws", feature = "ipc"))]
@@ -20,7 +20,7 @@ pub enum BuiltInConnectionString {
     Ipc(std::path::PathBuf),
 }
 
-impl BoxTransportConnect for BuiltInConnectionString {
+impl TransportConnect for BuiltInConnectionString {
     fn is_local(&self) -> bool {
         match self {
             #[cfg(any(feature = "reqwest", feature = "hyper"))]
@@ -39,10 +39,8 @@ impl BoxTransportConnect for BuiltInConnectionString {
         }
     }
 
-    fn get_boxed_transport<'a: 'b, 'b>(
-        &'a self,
-    ) -> alloy_transport::Pbf<'b, BoxTransport, TransportError> {
-        Box::pin(self.connect_boxed())
+    async fn get_transport(&self) -> Result<BoxTransport, TransportError> {
+        self.connect_boxed().await
     }
 }
 

--- a/crates/rpc-client/src/call.rs
+++ b/crates/rpc-client/src/call.rs
@@ -2,7 +2,7 @@ use alloy_json_rpc::{
     transform_response, try_deserialize_ok, Request, RequestPacket, ResponsePacket, RpcParam,
     RpcResult, RpcReturn,
 };
-use alloy_transport::{RpcFut, Transport, TransportError, TransportResult};
+use alloy_transport::{BoxTransport, IntoBoxTransport, RpcFut, TransportError, TransportResult};
 use core::panic;
 use futures::FutureExt;
 use serde_json::value::RawValue;
@@ -18,26 +18,24 @@ use tower::Service;
 /// The states of the [`RpcCall`] future.
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 #[pin_project::pin_project(project = CallStateProj)]
-enum CallState<Params, Conn>
+enum CallState<Params>
 where
     Params: RpcParam,
-    Conn: Transport + Clone,
 {
     Prepared {
         request: Option<Request<Params>>,
-        connection: Conn,
+        connection: BoxTransport,
     },
     AwaitingResponse {
         #[pin]
-        fut: <Conn as Service<RequestPacket>>::Future,
+        fut: <BoxTransport as Service<RequestPacket>>::Future,
     },
     Complete,
 }
 
-impl<Params, Conn> Clone for CallState<Params, Conn>
+impl<Params> Clone for CallState<Params>
 where
     Params: RpcParam,
-    Conn: Transport + Clone,
 {
     fn clone(&self) -> Self {
         match self {
@@ -49,10 +47,9 @@ where
     }
 }
 
-impl<Params, Conn> fmt::Debug for CallState<Params, Conn>
+impl<Params> fmt::Debug for CallState<Params>
 where
     Params: RpcParam,
-    Conn: Transport + Clone,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(match self {
@@ -63,9 +60,8 @@ where
     }
 }
 
-impl<Params, Conn> Future for CallState<Params, Conn>
+impl<Params> Future for CallState<Params>
 where
-    Conn: Transport + Clone,
     Params: RpcParam,
 {
     type Output = TransportResult<Box<RawValue>>;
@@ -136,21 +132,19 @@ where
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 #[pin_project::pin_project]
 #[derive(Clone)]
-pub struct RpcCall<Conn, Params, Resp, Output = Resp, Map = fn(Resp) -> Output>
+pub struct RpcCall<Params, Resp, Output = Resp, Map = fn(Resp) -> Output>
 where
-    Conn: Transport + Clone,
     Params: RpcParam,
     Map: FnOnce(Resp) -> Output,
 {
     #[pin]
-    state: CallState<Params, Conn>,
+    state: CallState<Params>,
     map: Option<Map>,
     _pd: core::marker::PhantomData<fn() -> (Resp, Output)>,
 }
 
-impl<Conn, Params, Resp, Output, Map> core::fmt::Debug for RpcCall<Conn, Params, Resp, Output, Map>
+impl<Params, Resp, Output, Map> core::fmt::Debug for RpcCall<Params, Resp, Output, Map>
 where
-    Conn: Transport + Clone,
     Params: RpcParam,
     Map: FnOnce(Resp) -> Output,
 {
@@ -159,24 +153,25 @@ where
     }
 }
 
-impl<Conn, Params, Resp> RpcCall<Conn, Params, Resp>
+impl<Params, Resp> RpcCall<Params, Resp>
 where
-    Conn: Transport + Clone,
     Params: RpcParam,
 {
     #[doc(hidden)]
-    pub fn new(req: Request<Params>, connection: Conn) -> Self {
+    pub fn new(req: Request<Params>, connection: impl IntoBoxTransport) -> Self {
         Self {
-            state: CallState::Prepared { request: Some(req), connection },
+            state: CallState::Prepared {
+                request: Some(req),
+                connection: connection.into_box_transport(),
+            },
             map: Some(std::convert::identity),
             _pd: PhantomData,
         }
     }
 }
 
-impl<Conn, Params, Resp, Output, Map> RpcCall<Conn, Params, Resp, Output, Map>
+impl<Params, Resp, Output, Map> RpcCall<Params, Resp, Output, Map>
 where
-    Conn: Transport + Clone,
     Params: RpcParam,
     Map: FnOnce(Resp) -> Output,
 {
@@ -194,7 +189,7 @@ where
     pub fn map_resp<NewOutput, NewMap>(
         self,
         map: NewMap,
-    ) -> RpcCall<Conn, Params, Resp, NewOutput, NewMap>
+    ) -> RpcCall<Params, Resp, NewOutput, NewMap>
     where
         NewMap: FnOnce(Resp) -> NewOutput,
     {
@@ -265,7 +260,7 @@ where
     pub fn map_params<NewParams: RpcParam>(
         self,
         map: impl Fn(Params) -> NewParams,
-    ) -> RpcCall<Conn, NewParams, Resp, Output, Map> {
+    ) -> RpcCall<NewParams, Resp, Output, Map> {
         let CallState::Prepared { request, connection } = self.state else {
             panic!("Cannot get request after request has been sent");
         };
@@ -278,9 +273,8 @@ where
     }
 }
 
-impl<Conn, Params, Resp, Output, Map> RpcCall<Conn, &Params, Resp, Output, Map>
+impl<Params, Resp, Output, Map> RpcCall<&Params, Resp, Output, Map>
 where
-    Conn: Transport + Clone,
     Params: RpcParam + ToOwned,
     Params::Owned: RpcParam,
     Map: FnOnce(Resp) -> Output,
@@ -290,7 +284,7 @@ where
     /// # Panics
     ///
     /// Panics if called after the request has been polled.
-    pub fn into_owned_params(self) -> RpcCall<Conn, Params::Owned, Resp, Output, Map> {
+    pub fn into_owned_params(self) -> RpcCall<Params::Owned, Resp, Output, Map> {
         let CallState::Prepared { request, connection } = self.state else {
             panic!("Cannot get params after request has been sent");
         };
@@ -304,9 +298,8 @@ where
     }
 }
 
-impl<'a, Conn, Params, Resp, Output, Map> RpcCall<Conn, Params, Resp, Output, Map>
+impl<'a, Params, Resp, Output, Map> RpcCall<Params, Resp, Output, Map>
 where
-    Conn: Transport + Clone,
     Params: RpcParam + 'a,
     Resp: RpcReturn,
     Output: 'static,
@@ -318,9 +311,8 @@ where
     }
 }
 
-impl<Conn, Params, Resp, Output, Map> Future for RpcCall<Conn, Params, Resp, Output, Map>
+impl<Params, Resp, Output, Map> Future for RpcCall<Params, Resp, Output, Map>
 where
-    Conn: Transport + Clone,
     Params: RpcParam,
     Resp: RpcReturn,
     Output: 'static,

--- a/crates/rpc-client/src/call.rs
+++ b/crates/rpc-client/src/call.rs
@@ -114,7 +114,7 @@ where
 /// A prepared, but unsent, RPC call.
 ///
 /// This is a future that will send the request when polled. It contains a
-/// [`Request`], a [`Transport`], and knowledge of its expected response
+/// [`Request`], a [`BoxTransport`], and knowledge of its expected response
 /// type. Upon awaiting, it will send the request and wait for the response. It
 /// will then deserialize the response into the expected type.
 ///

--- a/crates/rpc-client/src/client.rs
+++ b/crates/rpc-client/src/client.rs
@@ -108,7 +108,7 @@ impl RpcClient {
     }
 
     /// Boxes the transport.
-    #[deprecated(since = "0.9.0", note = "RpcClient is now always boxed")]
+    #[deprecated(since = "0.9.0", note = "`RpcClient` is now always boxed")]
     #[allow(clippy::missing_const_for_fn)]
     pub fn boxed(self) -> Self {
         self
@@ -299,7 +299,7 @@ impl RpcClientInner {
 
     /// Type erase the service in the transport, allowing it to be used in a
     /// generic context.
-    #[deprecated(since = "0.9.0", note = "RpcClientInner is now always boxed")]
+    #[deprecated(since = "0.9.0", note = "`RpcClientInner` is now always boxed")]
     #[allow(clippy::missing_const_for_fn)]
     pub fn boxed(self) -> Self {
         self

--- a/crates/rpc-client/src/client.rs
+++ b/crates/rpc-client/src/client.rs
@@ -132,7 +132,7 @@ impl Deref for RpcClient {
 
 /// A JSON-RPC client.
 ///
-/// This struct manages a [`Transport`] and a request ID counter. It is used to
+/// This struct manages a [`BoxTransport`] and a request ID counter. It is used to
 /// build [`RpcCall`] and [`BatchRequest`] objects. The client delegates
 /// transport access to the calls.
 ///

--- a/crates/rpc-client/src/client.rs
+++ b/crates/rpc-client/src/client.rs
@@ -1,6 +1,6 @@
 use crate::{poller::PollerBuilder, BatchRequest, ClientBuilder, RpcCall};
 use alloy_json_rpc::{Id, Request, RpcParam, RpcReturn};
-use alloy_transport::{BoxTransport, Transport};
+use alloy_transport::{BoxTransport, IntoBoxTransport};
 use alloy_transport_http::Http;
 use std::{
     borrow::Cow,
@@ -14,10 +14,10 @@ use std::{
 use tower::{layer::util::Identity, ServiceBuilder};
 
 /// An [`RpcClient`] in a [`Weak`] reference.
-pub type WeakClient<T> = Weak<RpcClientInner<T>>;
+pub type WeakClient = Weak<RpcClientInner>;
 
 /// A borrowed [`RpcClient`].
-pub type ClientRef<'a, T> = &'a RpcClientInner<T>;
+pub type ClientRef<'a> = &'a RpcClientInner;
 
 /// Parameter type of a JSON-RPC request with no parameters.
 pub type NoParams = [(); 0];
@@ -29,59 +29,57 @@ pub type NoParams = [(); 0];
 ///
 /// [`ClientBuilder`]: crate::ClientBuilder
 #[derive(Debug)]
-pub struct RpcClient<T>(Arc<RpcClientInner<T>>);
+pub struct RpcClient(Arc<RpcClientInner>);
 
-impl<T> Clone for RpcClient<T> {
+impl Clone for RpcClient {
     fn clone(&self) -> Self {
         Self(Arc::clone(&self.0))
     }
 }
 
-impl RpcClient<Identity> {
+impl RpcClient {
     /// Create a new [`ClientBuilder`].
     pub const fn builder() -> ClientBuilder<Identity> {
         ClientBuilder { builder: ServiceBuilder::new() }
     }
 }
 
-#[cfg(feature = "reqwest")]
-impl RpcClient<Http<reqwest::Client>> {
+impl RpcClient {
     /// Create a new [`RpcClient`] with an HTTP transport.
+    #[cfg(feature = "reqwest")]
     pub fn new_http(url: reqwest::Url) -> Self {
         let http = Http::new(url);
         let is_local = http.guess_local();
         Self::new(http, is_local)
     }
-}
 
-impl<T> RpcClient<T> {
     /// Creates a new [`RpcClient`] with the given transport.
-    pub fn new(t: T, is_local: bool) -> Self {
+    pub fn new(t: impl IntoBoxTransport, is_local: bool) -> Self {
         Self(Arc::new(RpcClientInner::new(t, is_local)))
     }
 
     /// Creates a new [`RpcClient`] with the given inner client.
-    pub fn from_inner(inner: RpcClientInner<T>) -> Self {
+    pub fn from_inner(inner: RpcClientInner) -> Self {
         Self(Arc::new(inner))
     }
 
     /// Get a reference to the client.
-    pub const fn inner(&self) -> &Arc<RpcClientInner<T>> {
+    pub const fn inner(&self) -> &Arc<RpcClientInner> {
         &self.0
     }
 
     /// Convert the client into its inner type.
-    pub fn into_inner(self) -> Arc<RpcClientInner<T>> {
+    pub fn into_inner(self) -> Arc<RpcClientInner> {
         self.0
     }
 
     /// Get a [`Weak`] reference to the client.
-    pub fn get_weak(&self) -> WeakClient<T> {
+    pub fn get_weak(&self) -> WeakClient {
         Arc::downgrade(&self.0)
     }
 
     /// Borrow the client.
-    pub fn get_ref(&self) -> ClientRef<'_, T> {
+    pub fn get_ref(&self) -> ClientRef<'_> {
         &self.0
     }
 
@@ -93,9 +91,7 @@ impl<T> RpcClient<T> {
         self.inner().set_poll_interval(poll_interval);
         self
     }
-}
 
-impl<T: Transport> RpcClient<T> {
     /// Build a poller that polls a method with the given parameters.
     ///
     /// See [`PollerBuilder`] for examples and more details.
@@ -103,41 +99,32 @@ impl<T: Transport> RpcClient<T> {
         &self,
         method: impl Into<Cow<'static, str>>,
         params: Params,
-    ) -> PollerBuilder<T, Params, Resp>
+    ) -> PollerBuilder<Params, Resp>
     where
-        T: Clone,
         Params: RpcParam + 'static,
         Resp: RpcReturn + Clone,
     {
         PollerBuilder::new(self.get_weak(), method, params)
     }
-}
 
-impl<T: Transport + Clone> RpcClient<T> {
     /// Boxes the transport.
-    ///
-    /// This will create a new client if this instance is not the only reference to the inner
-    /// client.
-    pub fn boxed(self) -> RpcClient<BoxTransport> {
-        let inner = Arc::try_unwrap(self.0).unwrap_or_else(|inner| {
-            RpcClientInner::new(inner.transport.clone(), inner.is_local)
-                .with_id(inner.id.load(Ordering::Relaxed))
-        });
-        RpcClient::from_inner(inner.boxed())
+    #[deprecated(since = "0.9.0", note = "RpcClient is now always boxed")]
+    #[allow(clippy::missing_const_for_fn)]
+    pub fn boxed(self) -> Self {
+        self
     }
-}
 
-impl<T> RpcClient<Http<T>> {
     /// Create a new [`BatchRequest`] builder.
     #[inline]
-    pub fn new_batch(&self) -> BatchRequest<'_, Http<T>> {
+    pub fn new_batch(&self) -> BatchRequest<'_> {
         BatchRequest::new(&self.0)
     }
 }
 
-impl<T> Deref for RpcClient<T> {
-    type Target = RpcClientInner<T>;
+impl Deref for RpcClient {
+    type Target = RpcClientInner;
 
+    #[inline]
     fn deref(&self) -> &Self::Target {
         &self.0
     }
@@ -156,9 +143,9 @@ impl<T> Deref for RpcClient<T> {
 /// is no guarantee that a prepared [`RpcCall`] will be sent, or that a sent
 /// call will receive a response.
 #[derive(Debug)]
-pub struct RpcClientInner<T> {
+pub struct RpcClientInner {
     /// The underlying transport.
-    pub(crate) transport: T,
+    pub(crate) transport: BoxTransport,
     /// `true` if the transport is local.
     pub(crate) is_local: bool,
     /// The next request ID to use.
@@ -167,15 +154,15 @@ pub struct RpcClientInner<T> {
     pub(crate) poll_interval: AtomicU64,
 }
 
-impl<T> RpcClientInner<T> {
+impl RpcClientInner {
     /// Create a new [`RpcClient`] with the given transport.
     ///
     /// Note: Sets the poll interval to 250ms for local transports and 7s for remote transports by
     /// default.
     #[inline]
-    pub const fn new(t: T, is_local: bool) -> Self {
+    pub fn new(t: impl IntoBoxTransport, is_local: bool) -> Self {
         Self {
-            transport: t,
+            transport: t.into_box_transport(),
             is_local,
             id: AtomicU64::new(0),
             poll_interval: if is_local { AtomicU64::new(250) } else { AtomicU64::new(7000) },
@@ -201,33 +188,40 @@ impl<T> RpcClientInner<T> {
 
     /// Returns a reference to the underlying transport.
     #[inline]
-    pub const fn transport(&self) -> &T {
+    pub const fn transport(&self) -> &BoxTransport {
         &self.transport
     }
 
     /// Returns a mutable reference to the underlying transport.
     #[inline]
-    pub fn transport_mut(&mut self) -> &mut T {
+    pub fn transport_mut(&mut self) -> &mut BoxTransport {
         &mut self.transport
     }
 
     /// Consumes the client and returns the underlying transport.
     #[inline]
-    pub fn into_transport(self) -> T {
+    pub fn into_transport(self) -> BoxTransport {
         self.transport
     }
 
     /// Returns a reference to the pubsub frontend if the transport supports it.
     #[cfg(feature = "pubsub")]
-    pub fn pubsub_frontend(&self) -> Option<&alloy_pubsub::PubSubFrontend>
-    where
-        T: std::any::Any,
-    {
-        let t = self.transport() as &dyn std::any::Any;
-        t.downcast_ref::<alloy_pubsub::PubSubFrontend>().or_else(|| {
-            t.downcast_ref::<BoxTransport>()
-                .and_then(|t| t.as_any().downcast_ref::<alloy_pubsub::PubSubFrontend>())
-        })
+    #[inline]
+    #[track_caller]
+    pub fn pubsub_frontend(&self) -> Option<&alloy_pubsub::PubSubFrontend> {
+        self.transport.as_any().downcast_ref::<alloy_pubsub::PubSubFrontend>()
+    }
+
+    /// Returns a reference to the pubsub frontend if the transport supports it.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the transport does not support pubsub.
+    #[cfg(feature = "pubsub")]
+    #[inline]
+    #[track_caller]
+    pub fn expect_pubsub_frontend(&self) -> &alloy_pubsub::PubSubFrontend {
+        self.pubsub_frontend().expect("called pubsub_frontend on a non-pubsub transport")
     }
 
     /// Build a `JsonRpcRequest` with the given method and params.
@@ -272,9 +266,7 @@ impl<T> RpcClientInner<T> {
     pub fn next_id(&self) -> Id {
         self.increment_id().into()
     }
-}
 
-impl<T: Transport + Clone> RpcClientInner<T> {
     /// Prepares an [`RpcCall`].
     ///
     /// This function reserves an ID for the request, however the request is not sent.
@@ -290,7 +282,7 @@ impl<T: Transport + Clone> RpcClientInner<T> {
         &self,
         method: impl Into<Cow<'static, str>>,
         params: Params,
-    ) -> RpcCall<T, Params, Resp> {
+    ) -> RpcCall<Params, Resp> {
         let request = self.make_request(method, params);
         RpcCall::new(request, self.transport.clone())
     }
@@ -301,41 +293,41 @@ impl<T: Transport + Clone> RpcClientInner<T> {
     pub fn request_noparams<Resp: RpcReturn>(
         &self,
         method: impl Into<Cow<'static, str>>,
-    ) -> RpcCall<T, NoParams, Resp> {
+    ) -> RpcCall<NoParams, Resp> {
         self.request(method, [])
     }
 
     /// Type erase the service in the transport, allowing it to be used in a
     /// generic context.
-    ///
-    /// ## Note:
-    ///
-    /// This is for abstracting over `RpcClient<T>` for multiple `T` by
-    /// erasing each type. E.g. if you have `RpcClient<Http>` and
-    /// `RpcClient<Ws>` you can put both into a `Vec<RpcClient<BoxTransport>>`.
-    pub fn boxed(self) -> RpcClientInner<BoxTransport> {
-        RpcClientInner {
-            transport: self.transport.boxed(),
-            is_local: self.is_local,
-            id: self.id,
-            poll_interval: self.poll_interval,
-        }
+    #[doc(hidden)]
+    #[deprecated(since = "0.9.0", note = "RpcClientInner is now always boxed")]
+    #[allow(clippy::missing_const_for_fn)]
+    pub fn boxed(self) -> Self {
+        self
     }
 }
 
 #[cfg(feature = "pubsub")]
 mod pubsub_impl {
     use super::*;
-    use alloy_pubsub::{PubSubConnect, PubSubFrontend, RawSubscription, Subscription};
+    use alloy_pubsub::{PubSubConnect, RawSubscription, Subscription};
     use alloy_transport::TransportResult;
 
-    impl RpcClientInner<PubSubFrontend> {
+    impl RpcClientInner {
         /// Get a [`RawSubscription`] for the given subscription ID.
+        ///
+        /// # Panics
+        ///
+        /// Panics if the transport does not support pubsub.
         pub async fn get_raw_subscription(&self, id: alloy_primitives::B256) -> RawSubscription {
-            self.transport.get_subscription(id).await.unwrap()
+            self.expect_pubsub_frontend().get_subscription(id).await.unwrap()
         }
 
         /// Get a [`Subscription`] for the given subscription ID.
+        ///
+        /// # Panics
+        ///
+        /// Panics if the transport does not support pubsub.
         pub async fn get_subscription<T: serde::de::DeserializeOwned>(
             &self,
             id: alloy_primitives::B256,
@@ -344,12 +336,9 @@ mod pubsub_impl {
         }
     }
 
-    impl RpcClient<PubSubFrontend> {
+    impl RpcClient {
         /// Connect to a transport via a [`PubSubConnect`] implementor.
-        pub async fn connect_pubsub<C>(connect: C) -> TransportResult<Self>
-        where
-            C: PubSubConnect,
-        {
+        pub async fn connect_pubsub<C: PubSubConnect>(connect: C) -> TransportResult<Self> {
             ClientBuilder::default().pubsub(connect).await
         }
 
@@ -359,13 +348,23 @@ mod pubsub_impl {
         /// behavior.
         ///
         /// [`tokio::sync::broadcast`]: https://docs.rs/tokio/latest/tokio/sync/broadcast/index.html
+        ///
+        /// # Panics
+        ///
+        /// Panics if the transport does not support pubsub.
+        #[track_caller]
         pub fn channel_size(&self) -> usize {
-            self.transport.channel_size()
+            self.expect_pubsub_frontend().channel_size()
         }
 
         /// Set the channel size.
+        ///
+        /// # Panics
+        ///
+        /// Panics if the transport does not support pubsub.
+        #[track_caller]
         pub fn set_channel_size(&self, size: usize) {
-            self.transport.set_channel_size(size)
+            self.expect_pubsub_frontend().set_channel_size(size)
         }
     }
 }

--- a/crates/rpc-client/src/client.rs
+++ b/crates/rpc-client/src/client.rs
@@ -299,7 +299,6 @@ impl RpcClientInner {
 
     /// Type erase the service in the transport, allowing it to be used in a
     /// generic context.
-    #[doc(hidden)]
     #[deprecated(since = "0.9.0", note = "RpcClientInner is now always boxed")]
     #[allow(clippy::missing_const_for_fn)]
     pub fn boxed(self) -> Self {

--- a/crates/rpc-client/src/lib.rs
+++ b/crates/rpc-client/src/lib.rs
@@ -35,4 +35,4 @@ pub use alloy_transport_ipc::IpcConnect;
 
 /// A client using a [`reqwest`] HTTP transport.
 #[cfg(feature = "reqwest")]
-pub type ReqwestClient = RpcClient<alloy_transport_http::ReqwestTransport>;
+pub type ReqwestClient = RpcClient;

--- a/crates/rpc-client/src/poller.rs
+++ b/crates/rpc-client/src/poller.rs
@@ -50,8 +50,8 @@ const MAX_RETRIES: usize = 3;
 /// use alloy_rpc_client::PollerBuilder;
 /// use futures_util::StreamExt;
 ///
-/// let poller: PollerBuilder<_, (), U64> = client
-///     .prepare_static_poller("eth_blockNumber", ())
+/// let poller: PollerBuilder<alloy_rpc_client::NoParams, U64> = client
+///     .prepare_static_poller("eth_blockNumber", [])
 ///     .with_poll_interval(std::time::Duration::from_secs(5));
 /// let mut stream = poller.into_stream();
 /// while let Some(block_number) = stream.next().await {

--- a/crates/rpc-client/src/poller.rs
+++ b/crates/rpc-client/src/poller.rs
@@ -1,6 +1,6 @@
 use crate::WeakClient;
 use alloy_json_rpc::{RpcError, RpcParam, RpcReturn};
-use alloy_transport::{utils::Spawnable, Transport};
+use alloy_transport::utils::Spawnable;
 use futures::{Stream, StreamExt};
 use serde::Serialize;
 use serde_json::value::RawValue;
@@ -45,7 +45,7 @@ const MAX_RETRIES: usize = 3;
 /// Poll `eth_blockNumber` every 5 seconds:
 ///
 /// ```no_run
-/// # async fn example<T: alloy_transport::Transport + Clone>(client: alloy_rpc_client::RpcClient<T>) -> Result<(), Box<dyn std::error::Error>> {
+/// # async fn example(client: alloy_rpc_client::RpcClient) -> Result<(), Box<dyn std::error::Error>> {
 /// use alloy_primitives::U64;
 /// use alloy_rpc_client::PollerBuilder;
 /// use futures_util::StreamExt;
@@ -63,9 +63,9 @@ const MAX_RETRIES: usize = 3;
 // TODO: make this be able to be spawned on the current thread instead of forcing a task.
 #[derive(Debug)]
 #[must_use = "this builder does nothing unless you call `spawn` or `into_stream`"]
-pub struct PollerBuilder<Conn, Params, Resp> {
+pub struct PollerBuilder<Params, Resp> {
     /// The client to poll with.
-    client: WeakClient<Conn>,
+    client: WeakClient,
 
     /// Request Method
     method: Cow<'static, str>,
@@ -79,18 +79,13 @@ pub struct PollerBuilder<Conn, Params, Resp> {
     _pd: PhantomData<fn() -> Resp>,
 }
 
-impl<Conn, Params, Resp> PollerBuilder<Conn, Params, Resp>
+impl<Params, Resp> PollerBuilder<Params, Resp>
 where
-    Conn: Transport + Clone,
     Params: RpcParam + 'static,
     Resp: RpcReturn + Clone,
 {
     /// Create a new poller task.
-    pub fn new(
-        client: WeakClient<Conn>,
-        method: impl Into<Cow<'static, str>>,
-        params: Params,
-    ) -> Self {
+    pub fn new(client: WeakClient, method: impl Into<Cow<'static, str>>, params: Params) -> Self {
         let poll_interval =
             client.upgrade().map_or_else(|| Duration::from_secs(7), |c| c.poll_interval());
         Self {

--- a/crates/rpc-types-admin/src/admin.rs
+++ b/crates/rpc-types-admin/src/admin.rs
@@ -75,7 +75,7 @@ pub struct EthProtocolInfo {
     /// * <https://github.com/ethereum/go-ethereum/blob/314e18193eeca3e47b627408da47e33132d72aa8/eth/protocols/eth/handler.go#L119-L126>
     #[deprecated(
         since = "0.8.2",
-        note = "The difficulty field of admin_nodeInfo is being removed from the response, see https://github.com/ethereum/go-ethereum/pull/30744"
+        note = "`difficulty` is being removed from `admin_nodeInfo`, see https://github.com/ethereum/go-ethereum/pull/30744"
     )]
     pub difficulty: Option<U256>,
     /// The Keccak hash of the host's genesis block.

--- a/crates/rpc-types-eth/src/erc4337.rs
+++ b/crates/rpc-types-eth/src/erc4337.rs
@@ -7,10 +7,7 @@ use alloy_primitives::{
 };
 
 /// Alias for backwards compat
-#[deprecated(
-    since = "0.8.4",
-    note = "Please use `TransactionConditional` instead of `ConditionalOptions`."
-)]
+#[deprecated(since = "0.8.4", note = "use `TransactionConditional` instead")]
 pub type ConditionalOptions = TransactionConditional;
 
 /// Options for conditional raw transaction submissions.

--- a/crates/transport-http/src/hyper_transport.rs
+++ b/crates/transport-http/src/hyper_transport.rs
@@ -1,3 +1,4 @@
+use crate::{Http, HttpConnect};
 use alloy_json_rpc::{RequestPacket, ResponsePacket};
 use alloy_transport::{
     utils::guess_local_url, BoxTransport, TransportConnect, TransportError, TransportErrorKind,
@@ -12,8 +13,6 @@ use hyper_util::client::legacy::Error;
 use std::{future::Future, marker::PhantomData, pin::Pin, task};
 use tower::Service;
 use tracing::{debug, debug_span, trace, Instrument};
-
-use crate::{Http, HttpConnect};
 
 type Hyper = hyper_util::client::legacy::Client<
     hyper_util::client::legacy::connect::HttpConnector,

--- a/crates/transport-http/src/reqwest_transport.rs
+++ b/crates/transport-http/src/reqwest_transport.rs
@@ -1,7 +1,8 @@
 use crate::{Http, HttpConnect};
 use alloy_json_rpc::{RequestPacket, ResponsePacket};
 use alloy_transport::{
-    utils::guess_local_url, TransportConnect, TransportError, TransportErrorKind, TransportFut,
+    utils::guess_local_url, BoxTransport, TransportConnect, TransportError, TransportErrorKind,
+    TransportFut,
 };
 use std::task;
 use tower::Service;
@@ -18,16 +19,12 @@ pub type ReqwestTransport = Http<Client>;
 pub type ReqwestConnect = HttpConnect<ReqwestTransport>;
 
 impl TransportConnect for ReqwestConnect {
-    type Transport = ReqwestTransport;
-
     fn is_local(&self) -> bool {
         guess_local_url(self.url.as_str())
     }
 
-    fn get_transport<'a: 'b, 'b>(
-        &'a self,
-    ) -> alloy_transport::Pbf<'b, Self::Transport, TransportError> {
-        Box::pin(async move { Ok(Http::with_client(Client::new(), self.url.clone())) })
+    async fn get_transport(&self) -> Result<BoxTransport, TransportError> {
+        Ok(BoxTransport::new(Http::with_client(Client::new(), self.url.clone())))
     }
 }
 

--- a/crates/transport/Cargo.toml
+++ b/crates/transport/Cargo.toml
@@ -22,7 +22,6 @@ workspace = true
 alloy-json-rpc.workspace = true
 
 base64.workspace = true
-futures-util.workspace = true
 futures-utils-wasm.workspace = true
 serde_json = { workspace = true, features = ["raw_value"] }
 serde.workspace = true

--- a/crates/transport/src/boxed.rs
+++ b/crates/transport/src/boxed.rs
@@ -3,6 +3,27 @@ use alloy_json_rpc::{RequestPacket, ResponsePacket};
 use std::fmt;
 use tower::Service;
 
+#[allow(unnameable_types)]
+mod private {
+    pub trait Sealed {}
+    impl<T: super::Transport + Clone> Sealed for T {}
+}
+
+/// Trait for converting a transport into a boxed transport.
+///
+/// This trait is sealed and implemented for all types that implement
+/// [`Transport`] + [`Clone`].
+pub trait IntoBoxTransport: Transport + Clone + private::Sealed {
+    /// Boxes the transport.
+    fn into_box_transport(self) -> BoxTransport;
+}
+
+impl<T: Transport + Clone> IntoBoxTransport for T {
+    fn into_box_transport(self) -> BoxTransport {
+        BoxTransport { inner: Box::new(self) }
+    }
+}
+
 /// A boxed, Clone-able [`Transport`] trait object.
 ///
 /// This type allows RPC clients to use a type-erased transport. It is
@@ -10,23 +31,23 @@ use tower::Service;
 /// allows for complex behavior abstracting across several different clients
 /// with different transport types.
 ///
-/// Most higher-level types will be generic over `T: Transport = BoxTransport`.
-/// This allows parameterization with a concrete type, while hiding this
-/// complexity from the library consumer.
+/// All higher-level types, such as [`RpcClient`], use this type internally
+/// rather than a generic [`Transport`] parameter.
 ///
 /// [`RpcClient`]: crate::client::RpcClient
-#[repr(transparent)]
 pub struct BoxTransport {
-    inner: Box<dyn CloneTransport + Send + Sync>,
+    inner: Box<dyn CloneTransport>,
 }
 
 impl BoxTransport {
     /// Instantiate a new box transport from a suitable transport.
+    #[inline]
     pub fn new<T: IntoBoxTransport>(transport: T) -> Self {
         transport.into_box_transport()
     }
 
     /// Returns a reference to the inner transport.
+    #[inline]
     pub fn as_any(&self) -> &dyn std::any::Any {
         self.inner.as_any()
     }
@@ -44,24 +65,6 @@ impl Clone for BoxTransport {
     }
 }
 
-#[allow(unnameable_types)]
-mod private {
-    pub trait Sealed {}
-    impl<T: super::Transport + Clone> Sealed for T {}
-}
-
-/// Trait for converting a transport into a boxed transport.
-pub trait IntoBoxTransport: Transport + Clone + private::Sealed {
-    /// Boxes the transport.
-    fn into_box_transport(self) -> BoxTransport;
-}
-
-impl<T: Transport + Clone> IntoBoxTransport for T {
-    fn into_box_transport(self) -> BoxTransport {
-        BoxTransport { inner: Box::new(self) }
-    }
-}
-
 /// Helper trait for constructing [`BoxTransport`].
 trait CloneTransport: Transport + std::any::Any {
     fn clone_box(&self) -> Box<dyn CloneTransport + Send + Sync>;
@@ -72,10 +75,12 @@ impl<T> CloneTransport for T
 where
     T: Transport + Clone + Send + Sync,
 {
+    #[inline]
     fn clone_box(&self) -> Box<dyn CloneTransport + Send + Sync> {
         Box::new(self.clone())
     }
 
+    #[inline]
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }
@@ -88,6 +93,7 @@ impl Service<RequestPacket> for BoxTransport {
 
     type Future = TransportFut<'static>;
 
+    #[inline]
     fn poll_ready(
         &mut self,
         cx: &mut std::task::Context<'_>,
@@ -95,6 +101,7 @@ impl Service<RequestPacket> for BoxTransport {
         self.inner.poll_ready(cx)
     }
 
+    #[inline]
     fn call(&mut self, req: RequestPacket) -> Self::Future {
         self.inner.call(req)
     }
@@ -105,10 +112,12 @@ mod test {
     use super::*;
 
     // checks trait + send + sync + 'static
-    fn __compile_check() {
-        fn inner<T: CloneTransport>(_: Option<T>) {}
-        fn inner_2<T: Transport>(_: Option<T>) {}
-        inner::<BoxTransport>(None);
-        inner::<BoxTransport>(None);
+    fn _compile_check() {
+        fn inner<T>()
+        where
+            T: Transport + CloneTransport + Send + Sync + Clone + IntoBoxTransport + 'static,
+        {
+        }
+        inner::<BoxTransport>();
     }
 }

--- a/crates/transport/src/boxed.rs
+++ b/crates/transport/src/boxed.rs
@@ -137,7 +137,7 @@ mod test {
     }
 
     // checks trait + send + sync + 'static
-    fn _compile_check() {
+    const fn _compile_check() {
         const fn inner<T>()
         where
             T: Transport + CloneTransport + Send + Sync + Clone + IntoBoxTransport + 'static,

--- a/crates/transport/src/boxed.rs
+++ b/crates/transport/src/boxed.rs
@@ -22,6 +22,8 @@ impl<T: Transport + Clone> IntoBoxTransport for T {
     fn into_box_transport(self) -> BoxTransport {
         // "specialization" to re-use `BoxTransport`.
         if TypeId::of::<T>() == TypeId::of::<BoxTransport>() {
+            // This is not `transmute` because it doesn't allow size mismatch at compile time.
+            // `transmute_copy` is a work-around for `transmute_unchecked` not being stable.
             // SAFETY: `self` is `BoxTransport`. This is a no-op.
             let this = std::mem::ManuallyDrop::new(self);
             return unsafe { std::mem::transmute_copy(&this) };

--- a/crates/transport/src/boxed.rs
+++ b/crates/transport/src/boxed.rs
@@ -160,12 +160,12 @@ mod test {
         eprintln!("{}", std::any::type_name::<T>());
 
         let t1 = BoxTransport::new(t);
-        let t1p = &raw const *t1.inner;
+        let t1p = std::ptr::addr_of!(*t1.inner);
         let t1id = t1.as_any().type_id();
 
         // This shouldn't wrap `t1` in another box (`BoxTransport<BoxTransport<_>>`).
         let t2 = BoxTransport::new(t1);
-        let t2p = &raw const *t2.inner;
+        let t2p = std::ptr::addr_of!(*t2.inner);
         let t2id = t2.as_any().type_id();
 
         assert_eq!(t1id, id);

--- a/crates/transport/src/boxed.rs
+++ b/crates/transport/src/boxed.rs
@@ -37,10 +37,8 @@ impl<T: Transport + Clone> IntoBoxTransport for T {
 /// allows for complex behavior abstracting across several different clients
 /// with different transport types.
 ///
-/// All higher-level types, such as [`RpcClient`], use this type internally
+/// All higher-level types, such as `RpcClient`, use this type internally
 /// rather than a generic [`Transport`] parameter.
-///
-/// [`RpcClient`]: crate::client::RpcClient
 pub struct BoxTransport {
     inner: Box<dyn CloneTransport>,
 }

--- a/crates/transport/src/boxed.rs
+++ b/crates/transport/src/boxed.rs
@@ -113,7 +113,7 @@ mod test {
 
     // checks trait + send + sync + 'static
     fn _compile_check() {
-        fn inner<T>()
+        const fn inner<T>()
         where
             T: Transport + CloneTransport + Send + Sync + Clone + IntoBoxTransport + 'static,
         {

--- a/crates/transport/src/connect.rs
+++ b/crates/transport/src/connect.rs
@@ -11,7 +11,7 @@ use futures_utils_wasm::impl_future;
 /// Users may want to implement transport-connect for the following reasons:
 /// - You want to customize a `reqwest::Client` before using it.
 /// - You need to provide special authentication information to a remote provider.
-/// - You have implemented a custom [`Transport`].
+/// - You have implemented a custom [`Transport`](crate::Transport).
 /// - You require a specific websocket reconnection strategy.
 pub trait TransportConnect: Sized + Send + Sync + 'static {
     /// Returns `true` if the transport connects to a local resource.

--- a/crates/transport/src/connect.rs
+++ b/crates/transport/src/connect.rs
@@ -1,5 +1,5 @@
-use crate::{BoxTransport, Pbf, Transport, TransportError};
-use futures_util::TryFutureExt;
+use crate::{BoxTransport, TransportError};
+use futures_utils_wasm::impl_future;
 
 /// Connection details for a transport.
 ///
@@ -14,43 +14,9 @@ use futures_util::TryFutureExt;
 /// - You have implemented a custom [`Transport`].
 /// - You require a specific websocket reconnection strategy.
 pub trait TransportConnect: Sized + Send + Sync + 'static {
-    /// The transport type that is returned by `connect`.
-    type Transport: Transport + Clone;
-
     /// Returns `true` if the transport connects to a local resource.
     fn is_local(&self) -> bool;
 
     /// Connect to the transport, returning a `Transport` instance.
-    fn get_transport<'a: 'b, 'b>(&'a self) -> Pbf<'b, Self::Transport, TransportError>;
+    fn get_transport(&self) -> impl_future!(<Output = Result<BoxTransport, TransportError>>);
 }
-
-/// Connection details for a transport that can be boxed.
-///
-/// This trait is implemented for [`TransportConnect`] implementors that
-/// produce a boxable transport. It can be used to create a boxed transport
-/// without knowing the exact type of the transport.
-///
-/// This trait is separate from `TransportConnect`` to hide the associated type
-/// in when this trait is a trait object. It is intended to allow creation of
-/// several unlike transports or clients at once. E.g.
-/// in something like `Vec<&dyn BoxTransportConnect>.
-pub trait BoxTransportConnect {
-    /// Returns `true` if the transport is a local transport.
-    fn is_local(&self) -> bool;
-
-    /// Connect to a transport, and box it.
-    fn get_boxed_transport<'a: 'b, 'b>(&'a self) -> Pbf<'b, BoxTransport, TransportError>;
-}
-
-impl<T: TransportConnect> BoxTransportConnect for T {
-    fn is_local(&self) -> bool {
-        TransportConnect::is_local(self)
-    }
-
-    fn get_boxed_transport<'a: 'b, 'b>(&'a self) -> Pbf<'b, BoxTransport, TransportError> {
-        Box::pin(self.get_transport().map_ok(Transport::boxed))
-    }
-}
-
-#[cfg(test)]
-fn _object_safe(_: Box<dyn BoxTransportConnect>) {}

--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -10,7 +10,7 @@ mod boxed;
 pub use boxed::{BoxTransport, IntoBoxTransport};
 
 mod connect;
-pub use connect::{BoxTransportConnect, TransportConnect};
+pub use connect::TransportConnect;
 
 mod common;
 pub use common::Authorization;

--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -7,7 +7,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 mod boxed;
-pub use boxed::BoxTransport;
+pub use boxed::{BoxTransport, IntoBoxTransport};
 
 mod connect;
 pub use connect::{BoxTransportConnect, TransportConnect};

--- a/crates/transport/src/trait.rs
+++ b/crates/transport/src/trait.rs
@@ -1,4 +1,4 @@
-use crate::{BoxTransport, TransportError, TransportFut};
+use crate::{BoxTransport, IntoBoxTransport, TransportError, TransportFut};
 use alloy_json_rpc::{RequestPacket, ResponsePacket};
 use tower::Service;
 
@@ -46,7 +46,7 @@ pub trait Transport:
     /// Convert this transport into a boxed trait object.
     fn boxed(self) -> BoxTransport
     where
-        Self: Sized + Clone,
+        Self: IntoBoxTransport,
     {
         BoxTransport::new(self)
     }
@@ -54,7 +54,7 @@ pub trait Transport:
     /// Make a boxed trait object by cloning this transport.
     fn as_boxed(&self) -> BoxTransport
     where
-        Self: Sized + Clone,
+        Self: IntoBoxTransport,
     {
         self.clone().boxed()
     }


### PR DESCRIPTION
Currently, every high-level type derived from RPC client contains a `T: Transport + Clone = BoxTransport` generic parameter.

However, there is, AFAICT, no benefit to exposing this generic in high-level types. The dynamic dispatch performance impact is negligible compared to what a transport actually does (many syscalls, network calls, etc.), and it only complicates generic bounds where any of those types are used.

- Remove `T: Transport (+ Clone)` generic parameters from almost every public API by always boxing the transport internally.
- Add a public `IntoBoxTransport` for where this generic is still needed, mainly the builder/layer types.
- Remove `BoxTransportConnect` and rename (with deprecation) `connect_boxed` methods to simpler names.
  - driveby: Rename (with deprecation) `connect_builtin` and similar to just `connect`
- Deprecate `.boxed()` methods, as they just return `self` now

Breaking changes have been adjusted to not require any changes in alloy-core (`sol!` macro); mainly, `CallBuilder` and `Event` will keep the `T` generic, but the trait bounds are replaced with a fake `Transport` trait only exposed to `sol!`, so that the compiler is able to infer the type to be `()`, the only implementer of that fake trait.