### PR TITLE
feat: add deref for block

### DIFF
--- a/crates/consensus/src/block/mod.rs
+++ b/crates/consensus/src/block/mod.rs
@@ -19,10 +19,11 @@ use alloy_rlp::{Decodable, Encodable, RlpDecodable, RlpEncodable};
 /// Taken from [reth-primitives](https://github.com/paradigmxyz/reth)
 ///
 /// See p2p block encoding reference: <https://github.com/ethereum/devp2p/blob/master/caps/eth.md#block-encoding-and-validity>
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, derive_more::Deref)]
 #[cfg_attr(any(test, feature = "serde"), derive(serde::Serialize, serde::Deserialize))]
 pub struct Block<T, H = Header> {
     /// Block header.
+    #[deref]
     pub header: H,
     /// Block body.
     pub body: BlockBody<T>,


### PR DESCRIPTION
we have this in reth's block type,

this seems reasonable, to prevent a ton of updates, but I'm not actually convinced