### PR TITLE
feat: add conversions from rpc block to consensus

### DIFF
--- a/crates/network-primitives/src/block.rs
+++ b/crates/network-primitives/src/block.rs
@@ -109,7 +109,7 @@ impl<T> BlockTransactions<T> {
     /// Consumes the type and returns the transactions as a vector.
     ///
     /// Note: if this is an uncle or hashes, this will return an empty vector.
-    pub fn into_vec(self) -> Vec<T> {
+    pub fn into_transactions_vec(self) -> Vec<T> {
         match self {
             Self::Full(txs) => txs,
             _ => vec![],

--- a/crates/network-primitives/src/block.rs
+++ b/crates/network-primitives/src/block.rs
@@ -106,6 +106,16 @@ impl<T> BlockTransactions<T> {
         }
     }
 
+    /// Consumes the type and returns the transactions as a vector.
+    ///
+    /// Note: if this is an uncle or hashes, this will return an empty vector.
+    pub fn into_vec(self) -> Vec<T> {
+        match self {
+            Self::Full(txs) => txs,
+            _ => vec![],
+        }
+    }
+
     /// Returns an instance of BlockTransactions with the Uncle special case.
     #[inline]
     pub const fn uncle() -> Self {

--- a/crates/rpc-types-eth/src/block.rs
+++ b/crates/rpc-types-eth/src/block.rs
@@ -198,7 +198,7 @@ impl<T> Block<T> {
     pub fn into_consensus(self) -> alloy_consensus::Block<T> {
         let Self { header, transactions, withdrawals, .. } = self;
         alloy_consensus::BlockBody {
-            transactions: transactions.into_vec(),
+            transactions: transactions.into_transactions_vec(),
             ommers: vec![],
             withdrawals,
         }


### PR DESCRIPTION
these conversions were missing.

the rpc block to consensus has some caveats, but should be fine