### PR TITLE
fix: skip empty request objects

### DIFF
--- a/crates/eips/src/eip7685.rs
+++ b/crates/eips/src/eip7685.rs
@@ -89,6 +89,11 @@ impl Requests {
         use sha2::{Digest, Sha256};
         let mut hash = Sha256::new();
         for req in self.0.iter() {
+            if req.is_empty() {
+                // Sanity check: empty requests are omitted from the hash calculation.
+                continue;
+            }
+
             let mut req_hash = Sha256::new();
             req_hash.update(req);
             hash.update(req_hash.finalize());


### PR DESCRIPTION
we can prevent this entirely if we enforce this during serde, but having this check also doesn't hurt