### PR TITLE
chore: shift std::error impls to core

### DIFF
--- a/crates/eips/src/eip1898.rs
+++ b/crates/eips/src/eip1898.rs
@@ -247,8 +247,8 @@ pub enum ParseBlockNumberError {
 impl core::error::Error for ParseBlockNumberError {
     fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         match self {
-            Self::ParseIntErr(err) => core::error::Error::source(err),
-            Self::MissingPrefix(err) => core::error::Error::source(err),
+            Self::ParseIntErr(err) => Some(err),
+            Self::MissingPrefix(err) => Some(err),
             Self::ParseErr(_) => None,
         }
     }
@@ -598,13 +598,12 @@ impl fmt::Display for ParseBlockIdError {
     }
 }
 
-#[cfg(feature = "std")]
 impl core::error::Error for ParseBlockIdError {
     fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         match self {
-            Self::ParseIntError(err) => core::error::Error::source(err),
-            Self::FromHexError(err) => core::error::Error::source(err),
-            Self::ParseError(err) => core::error::Error::source(err),
+            Self::ParseIntError(err) => Some(err),
+            Self::FromHexError(err) => Some(err),
+            Self::ParseError(_) => None,
         }
     }
 }

--- a/crates/eips/src/eip1898.rs
+++ b/crates/eips/src/eip1898.rs
@@ -244,13 +244,12 @@ pub enum ParseBlockNumberError {
 }
 
 /// Error variants when parsing a [BlockNumberOrTag]
-#[cfg(feature = "std")]
-impl std::error::Error for ParseBlockNumberError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for ParseBlockNumberError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         match self {
-            Self::ParseIntErr(err) => std::error::Error::source(err),
-            Self::ParseErr(err) => std::error::Error::source(err),
-            Self::MissingPrefix(err) => std::error::Error::source(err),
+            Self::ParseIntErr(err) => core::error::Error::source(err),
+            Self::MissingPrefix(err) => core::error::Error::source(err),
+            Self::ParseErr(_) => None,
         }
     }
 }
@@ -600,12 +599,12 @@ impl fmt::Display for ParseBlockIdError {
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for ParseBlockIdError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for ParseBlockIdError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         match self {
-            Self::ParseIntError(err) => std::error::Error::source(err),
-            Self::FromHexError(err) => std::error::Error::source(err),
-            Self::ParseError(err) => std::error::Error::source(err),
+            Self::ParseIntError(err) => core::error::Error::source(err),
+            Self::FromHexError(err) => core::error::Error::source(err),
+            Self::ParseError(err) => core::error::Error::source(err),
         }
     }
 }

--- a/crates/eips/src/eip1898.rs
+++ b/crates/eips/src/eip1898.rs
@@ -824,7 +824,6 @@ impl FromStr for HashOrNumber {
     type Err = ParseBlockHashOrNumberError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        #[cfg(not(feature = "std"))]
         use alloc::string::ToString;
 
         match u64::from_str(s) {

--- a/crates/eips/src/eip2718.rs
+++ b/crates/eips/src/eip2718.rs
@@ -49,14 +49,7 @@ impl From<Eip2718Error> for alloy_rlp::Error {
     }
 }
 
-impl core::error::Error for Eip2718Error {
-    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
-        match self {
-            Self::RlpError(err) => Some(err),
-            Self::UnexpectedType(_) => None,
-        }
-    }
-}
+impl core::error::Error for Eip2718Error {}
 
 /// Decoding trait for [EIP-2718] envelopes. These envelopes wrap a transaction
 /// or a receipt with a type flag.

--- a/crates/eips/src/eip2718.rs
+++ b/crates/eips/src/eip2718.rs
@@ -49,9 +49,8 @@ impl From<Eip2718Error> for alloy_rlp::Error {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for Eip2718Error {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for Eip2718Error {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         match self {
             Self::RlpError(err) => Some(err),
             Self::UnexpectedType(_) => None,

--- a/crates/rpc-types-engine/src/error.rs
+++ b/crates/rpc-types-engine/src/error.rs
@@ -69,14 +69,7 @@ pub enum PayloadError {
     Decode(alloy_rlp::Error),
 }
 
-impl core::error::Error for PayloadError {
-    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
-        match self {
-            Self::Decode(err) => Some(err),
-            _ => None,
-        }
-    }
-}
+impl core::error::Error for PayloadError {}
 
 impl From<alloy_rlp::Error> for PayloadError {
     fn from(value: alloy_rlp::Error) -> Self {

--- a/crates/rpc-types-engine/src/error.rs
+++ b/crates/rpc-types-engine/src/error.rs
@@ -69,9 +69,8 @@ pub enum PayloadError {
     Decode(alloy_rlp::Error),
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for PayloadError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for PayloadError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         match self {
             Self::Decode(err) => Some(err),
             _ => None,


### PR DESCRIPTION
more core error impls

all of those could now use thiserror but I'd like to open a good first issue for this instead