### PR TITLE
fix(`transport`): use `HttpsConnector` in `HyperTransport`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,7 @@ wasmtimer = "0.4.0"
 
 hyper = { version = "1.2", default-features = false }
 hyper-util = "0.1"
+hyper-tls = "0.6.0"
 http-body-util = "0.1"
 tokio = "1"
 tokio-util = "0.7"

--- a/crates/provider/Cargo.toml
+++ b/crates/provider/Cargo.toml
@@ -109,6 +109,7 @@ reqwest = [
     "alloy-rpc-client/reqwest",
 ]
 hyper = ["dep:alloy-transport-http", "dep:url", "alloy-rpc-client/hyper"]
+hyper-tls = ["hyper", "alloy-transport-http/hyper-tls"]
 ws = ["pubsub", "alloy-rpc-client/ws", "alloy-transport-ws"]
 ipc = ["pubsub", "alloy-rpc-client/ipc", "alloy-transport-ipc"]
 reqwest-default-tls = ["alloy-transport-http?/reqwest-default-tls"]

--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -1830,7 +1830,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg(feature = "hyper")]
+    #[cfg(feature = "hyper-tls")]
     async fn hyper_https() {
         let url = "https://eth-mainnet.alchemyapi.io/v2/jGiK5vwDfC3F4r0bqukm-W2GqgdrxdSr";
 

--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -1830,6 +1830,18 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(feature = "hyper")]
+    async fn hyper_https() {
+        let url = "https://eth-mainnet.alchemyapi.io/v2/jGiK5vwDfC3F4r0bqukm-W2GqgdrxdSr";
+
+        // With the `hyper` feature enabled .on_builtin builds the provider based on
+        // `HyperTransport`.
+        let provider = ProviderBuilder::new().on_builtin(url).await.unwrap();
+
+        let _num = provider.get_block_number().await.unwrap();
+    }
+
+    #[tokio::test]
     async fn test_empty_transactions() {
         let provider = ProviderBuilder::new().on_anvil();
 

--- a/crates/transport-http/Cargo.toml
+++ b/crates/transport-http/Cargo.toml
@@ -54,7 +54,6 @@ reqwest = [
 ]
 hyper = [
     "dep:hyper",
-    "dep:hyper-tls",
     "dep:hyper-util",
     "dep:http-body-util",
     "dep:alloy-json-rpc",
@@ -62,6 +61,7 @@ hyper = [
     "dep:tower",
     "dep:tracing",
 ]
+hyper-tls = ["hyper", "dep:hyper-tls"]
 jwt-auth = [
     "hyper",
     "dep:alloy-rpc-types-engine",

--- a/crates/transport-http/Cargo.toml
+++ b/crates/transport-http/Cargo.toml
@@ -37,6 +37,7 @@ tracing = { workspace = true, optional = true }
 http-body-util = { workspace = true, optional = true }
 hyper = { workspace = true, default-features = false, optional = true }
 hyper-util = { workspace = true, features = ["full"], optional = true }
+hyper-tls = { workspace = true, optional = true }
 
 # auth layer
 alloy-rpc-types-engine = { workspace = true, optional = true }
@@ -53,6 +54,7 @@ reqwest = [
 ]
 hyper = [
     "dep:hyper",
+    "dep:hyper-tls",
     "dep:hyper-util",
     "dep:http-body-util",
     "dep:alloy-json-rpc",

--- a/crates/transport-http/src/hyper_transport.rs
+++ b/crates/transport-http/src/hyper_transport.rs
@@ -15,7 +15,7 @@ use tower::Service;
 use tracing::{debug, debug_span, trace, Instrument};
 
 type Hyper = hyper_util::client::legacy::Client<
-    hyper_util::client::legacy::connect::HttpConnector,
+    hyper_tls::HttpsConnector<hyper_util::client::legacy::connect::HttpConnector>,
     http_body_util::Full<::hyper::body::Bytes>,
 >;
 
@@ -49,8 +49,8 @@ impl HyperClient {
     pub fn new() -> Self {
         let executor = hyper_util::rt::TokioExecutor::new();
 
-        let service =
-            hyper_util::client::legacy::Client::builder(executor).build_http::<Full<Bytes>>();
+        let service = hyper_util::client::legacy::Client::builder(executor)
+            .build(hyper_tls::HttpsConnector::new());
 
         Self { service, _pd: PhantomData }
     }

--- a/crates/transport-http/src/hyper_transport.rs
+++ b/crates/transport-http/src/hyper_transport.rs
@@ -14,8 +14,15 @@ use std::{future::Future, marker::PhantomData, pin::Pin, task};
 use tower::Service;
 use tracing::{debug, debug_span, trace, Instrument};
 
+#[cfg(feature = "hyper-tls")]
 type Hyper = hyper_util::client::legacy::Client<
     hyper_tls::HttpsConnector<hyper_util::client::legacy::connect::HttpConnector>,
+    http_body_util::Full<::hyper::body::Bytes>,
+>;
+
+#[cfg(not(feature = "hyper-tls"))]
+type Hyper = hyper_util::client::legacy::Client<
+    hyper_util::client::legacy::connect::HttpConnector,
     http_body_util::Full<::hyper::body::Bytes>,
 >;
 
@@ -49,9 +56,13 @@ impl HyperClient {
     pub fn new() -> Self {
         let executor = hyper_util::rt::TokioExecutor::new();
 
+        #[cfg(feature = "hyper-tls")]
         let service = hyper_util::client::legacy::Client::builder(executor)
             .build(hyper_tls::HttpsConnector::new());
 
+        #[cfg(not(feature = "hyper-tls"))]
+        let service =
+            hyper_util::client::legacy::Client::builder(executor).build_http::<Full<Bytes>>();
         Self { service, _pd: PhantomData }
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Currently the `HyperTransport` uses the `HttpConnector` as the default connector making it impossible to use: `ProviderBuilder::new().on_builtin("https://..")` when the `hyper` feature is enabled as it will always throw "invalid URL, scheme is not http".

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Use `HttpsConnector` from the `hyper_tls` lib as default in `HyperTransport`. 

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
