### PR TITLE
feat(`provider`): instantiate recommended fillers by default

### DIFF
--- a/crates/contract/Cargo.toml
+++ b/crates/contract/Cargo.toml
@@ -46,6 +46,7 @@ alloy-rpc-client = { workspace = true, features = ["pubsub", "ws"] }
 alloy-transport-http.workspace = true
 alloy-node-bindings.workspace = true
 alloy-provider = { workspace = true, features = ["anvil-node"] }
+alloy-signer-local.workspace = true
 
 reqwest.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/contract/README.md
+++ b/crates/contract/README.md
@@ -32,7 +32,7 @@ sol! {
 }
 
 // Build a provider.
-let provider = ProviderBuilder::new().with_recommended_fillers().on_builtin("http://localhost:8545").await?;
+let provider = ProviderBuilder::new().on_builtin("http://localhost:8545").await?;
 
 // If `#[sol(bytecode = "0x...")]` is provided, the contract can be deployed with `MyContract::deploy`,
 // and a new instance will be created.

--- a/crates/contract/src/call.rs
+++ b/crates/contract/src/call.rs
@@ -569,10 +569,7 @@ mod tests {
     use super::*;
     use alloy_consensus::Transaction;
     use alloy_primitives::{address, b256, bytes, hex, utils::parse_units, B256};
-    use alloy_provider::{
-        fillers::FillProvider, layers::AnvilProvider, utils::JoinedRecommendedFillers, Provider,
-        ProviderBuilder, RootProvider, WalletProvider,
-    };
+    use alloy_provider::{Provider, ProviderBuilder, WalletProvider};
     use alloy_rpc_types_eth::AccessListItem;
     use alloy_sol_types::sol;
 
@@ -620,12 +617,10 @@ mod tests {
         }
     }
 
-    type AnvilFillProvider =
-        FillProvider<JoinedRecommendedFillers, AnvilProvider<RootProvider>, Ethereum>;
     /// Creates a new call_builder to test field modifications, taken from [call_encoding]
     #[allow(clippy::type_complexity)]
-    fn build_call_builder(
-    ) -> CallBuilder<(), AnvilFillProvider, PhantomData<MyContract::doStuffCall>> {
+    fn build_call_builder() -> CallBuilder<(), impl Provider, PhantomData<MyContract::doStuffCall>>
+    {
         let provider = ProviderBuilder::new().on_anvil();
         let contract = MyContract::new(Address::ZERO, provider);
         let call_builder = contract.doStuff(U256::ZERO, true).with_cloned_provider();

--- a/crates/contract/src/event.rs
+++ b/crates/contract/src/event.rs
@@ -280,8 +280,9 @@ pub(crate) mod subscription {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_primitives::U256;
+    use alloy_primitives::{address, U256};
     use alloy_sol_types::sol;
+    use MyContract::MyContractInstance;
 
     sol! {
         // solc v0.8.24; solc a.sol --via-ir --optimize --bin
@@ -309,9 +310,13 @@ mod tests {
         let _ = tracing_subscriber::fmt::try_init();
 
         let anvil = alloy_node_bindings::Anvil::new().spawn();
+
         let provider = alloy_provider::ProviderBuilder::new().on_http(anvil.endpoint_url());
 
-        let contract = MyContract::deploy(&provider).await.unwrap();
+        let from = address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+        let contract_addr =
+            MyContract::deploy_builder(&provider).from(from).deploy().await.unwrap();
+        let contract = MyContractInstance::new(contract_addr, &provider);
 
         let event: Event<(), _, MyContract::MyEvent, _> = Event::new(&provider, Filter::new());
         let all = event.query().await.unwrap();
@@ -322,8 +327,15 @@ mod tests {
 
         let poller = event.watch().await.unwrap();
 
-        let _receipt =
-            contract.doEmit().send().await.unwrap().get_receipt().await.expect("no receipt");
+        let _receipt = contract
+            .doEmit()
+            .from(from)
+            .send()
+            .await
+            .unwrap()
+            .get_receipt()
+            .await
+            .expect("no receipt");
 
         let expected_event = MyContract::MyEvent {
             _0: 42,
@@ -350,6 +362,7 @@ mod tests {
         // send the wrong event and make sure it is NOT picked up by the event filter
         let _wrong_receipt = contract
             .doEmitWrongEvent()
+            .from(from)
             .send()
             .await
             .unwrap()
@@ -374,7 +387,15 @@ mod tests {
 
             let sub = event.subscribe().await.unwrap();
 
-            contract.doEmit().send().await.unwrap().get_receipt().await.expect("no receipt");
+            contract
+                .doEmit()
+                .from(from)
+                .send()
+                .await
+                .unwrap()
+                .get_receipt()
+                .await
+                .expect("no receipt");
 
             let mut stream = sub.into_stream();
 
@@ -390,6 +411,7 @@ mod tests {
             // send the request to emit the wrong event
             contract
                 .doEmitWrongEvent()
+                .from(from)
                 .send()
                 .await
                 .unwrap()
@@ -412,7 +434,10 @@ mod tests {
         let anvil = alloy_node_bindings::Anvil::new().spawn();
         let provider = alloy_provider::ProviderBuilder::new().on_http(anvil.endpoint_url());
 
-        let contract = MyContract::deploy(&provider).await.unwrap();
+        let from = address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+        let contract_addr =
+            MyContract::deploy_builder(&provider).from(from).deploy().await.unwrap();
+        let contract = MyContractInstance::new(contract_addr, &provider);
 
         let event: Event<(), _, MyContract::MyEvent, _> = Event::new(&provider, Filter::new())
             .address(*contract.address())
@@ -422,8 +447,15 @@ mod tests {
 
         let poller = event.watch().await.unwrap();
 
-        let _receipt =
-            contract.doEmit().send().await.unwrap().get_receipt().await.expect("no receipt");
+        let _receipt = contract
+            .doEmit()
+            .from(from)
+            .send()
+            .await
+            .unwrap()
+            .get_receipt()
+            .await
+            .expect("no receipt");
 
         let expected_event = MyContract::MyEvent {
             _0: 42,
@@ -450,6 +482,7 @@ mod tests {
         // send the wrong event and make sure it is NOT picked up by the event filter
         let _wrong_receipt = contract
             .doEmitWrongEvent()
+            .from(from)
             .send()
             .await
             .unwrap()
@@ -476,7 +509,15 @@ mod tests {
 
             let sub = event.subscribe().await.unwrap();
 
-            contract.doEmit().send().await.unwrap().get_receipt().await.expect("no receipt");
+            contract
+                .doEmit()
+                .from(from)
+                .send()
+                .await
+                .unwrap()
+                .get_receipt()
+                .await
+                .expect("no receipt");
 
             let mut stream = sub.into_stream();
 
@@ -492,6 +533,7 @@ mod tests {
             // send the request to emit the wrong event
             contract
                 .doEmitWrongEvent()
+                .from(from)
                 .send()
                 .await
                 .unwrap()

--- a/crates/contract/src/instance.rs
+++ b/crates/contract/src/instance.rs
@@ -127,7 +127,7 @@ mod tests {
 
     #[tokio::test]
     async fn contract_interface() {
-        let provider = ProviderBuilder::new().on_anvil();
+        let provider = ProviderBuilder::new().on_anvil_with_wallet();
 
         let abi_str = r#"[{"inputs":[],"name":"counter","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"increment","outputs":[],"stateMutability":"nonpayable","type":"function"}]"#;
         let abi = serde_json::from_str::<JsonAbi>(abi_str).unwrap();

--- a/crates/provider/src/builder.rs
+++ b/crates/provider/src/builder.rs
@@ -131,18 +131,16 @@ impl
     pub fn new() -> Self {
         ProviderBuilder::default().with_recommended_fillers()
     }
+
+    /// Opt-out of the recommended fillers by reseting the fillers stack in the [`ProviderBuilder`].
+    pub fn disable_recommended_fillers(self) -> ProviderBuilder<Identity, Identity, Ethereum> {
+        ProviderBuilder { layer: self.layer, filler: Identity, network: self.network }
+    }
 }
 
 impl<N> Default for ProviderBuilder<Identity, Identity, N> {
     fn default() -> Self {
         Self { layer: Identity, filler: Identity, network: PhantomData }
-    }
-}
-
-impl<L, F, N> ProviderBuilder<L, F, N> {
-    /// Opt-out of the recommended fillers by reseting the fillers stack in the [`ProviderBuilder`].
-    pub fn disable_recommended_fillers(self) -> ProviderBuilder<L, Identity, N> {
-        ProviderBuilder { layer: self.layer, filler: Identity, network: self.network }
     }
 }
 

--- a/crates/provider/src/builder.rs
+++ b/crates/provider/src/builder.rs
@@ -140,6 +140,8 @@ impl
     }
 
     /// Opt-out of the recommended fillers by reseting the fillers stack in the [`ProviderBuilder`].
+    ///
+    /// This is equivalent to creating the builder using `ProviderBuilder::default()`.
     pub fn disable_recommended_fillers(self) -> ProviderBuilder<Identity, Identity, Ethereum> {
         ProviderBuilder { layer: self.layer, filler: Identity, network: self.network }
     }

--- a/crates/provider/src/builder.rs
+++ b/crates/provider/src/builder.rs
@@ -112,25 +112,6 @@ pub struct ProviderBuilder<L, F, N = Ethereum> {
     network: PhantomData<fn() -> N>,
 }
 
-// impl ProviderBuilder<Identity, Identity, Ethereum> {
-//     /// Create a new [`ProviderBuilder`] with recommended fillers enabled.
-//     pub const fn new() -> Self {
-//         let p: ProviderBuilder<
-//             Identity,
-//             JoinFill<
-//                 Identity,
-//                 JoinFill<
-//                     GasFiller,
-//                     JoinFill<crate::fillers::BlobGasFiller, JoinFill<NonceFiller,
-// ChainIdFiller>>,                 >,
-//             >,
-//         > = Self { layer: Identity, filler: Identity, network: PhantomData }
-//         > .with_recommended_fillers();
-
-//         p
-//     }
-// }
-
 impl
     ProviderBuilder<
         Identity,

--- a/crates/provider/src/builder.rs
+++ b/crates/provider/src/builder.rs
@@ -104,6 +104,13 @@ where
 /// This type is similar to [`tower::ServiceBuilder`], with extra complication
 /// around maintaining the network and transport types.
 ///
+/// The [`ProviderBuilder`] can be instantiated in two ways, using `ProviderBuilder::new()` or
+/// `ProviderBuilder::default()`.
+///
+/// `ProviderBuilder::new()` will create a new [`ProviderBuilder`] with the [`RecommendedFillers`]
+/// enabled, whereas `ProviderBuilder::default()` will instantiate it in its vanilla
+/// [`ProviderBuilder`] form i.e with no fillers enabled.
+///
 /// [`tower::ServiceBuilder`]: https://docs.rs/tower/latest/tower/struct.ServiceBuilder.html
 #[derive(Debug)]
 pub struct ProviderBuilder<L, F, N = Ethereum> {

--- a/crates/provider/src/ext/debug.rs
+++ b/crates/provider/src/ext/debug.rs
@@ -413,7 +413,7 @@ mod test {
     #[tokio::test]
     async fn test_debug_trace_transaction() {
         async_ci_only(|| async move {
-            let provider = ProviderBuilder::new().with_recommended_fillers().on_anvil_with_wallet();
+            let provider = ProviderBuilder::new().on_anvil_with_wallet();
             let from = provider.default_signer_address();
 
             let gas_price = provider.get_gas_price().await.unwrap();
@@ -542,8 +542,7 @@ mod test {
         async_ci_only(|| async move {
             run_with_tempdir("reth-test-", |temp_dir| async move {
                 let reth = Reth::new().dev().disable_discovery().data_dir(temp_dir).spawn();
-                let provider =
-                    ProviderBuilder::new().with_recommended_fillers().on_http(reth.endpoint_url());
+                let provider = ProviderBuilder::new().on_http(reth.endpoint_url());
 
                 let tx1 = TransactionRequest::default()
                     .with_from(address!("0000000000000000000000000000000000000123"))

--- a/crates/provider/src/fillers/chain_id.rs
+++ b/crates/provider/src/fillers/chain_id.rs
@@ -26,7 +26,7 @@ use crate::{
 /// # use alloy_rpc_types_eth::TransactionRequest;
 /// # use alloy_provider::{ProviderBuilder, RootProvider, Provider};
 /// # async fn test<W: NetworkWallet<Ethereum> + Clone>(url: url::Url, wallet: W) -> Result<(), Box<dyn std::error::Error>> {
-/// let provider = ProviderBuilder::new()
+/// let provider = ProviderBuilder::default()
 ///     .with_chain_id(1)
 ///     .wallet(wallet)
 ///     .on_http(url);

--- a/crates/provider/src/fillers/gas.rs
+++ b/crates/provider/src/fillers/gas.rs
@@ -52,7 +52,7 @@ pub enum GasFillable {
 /// # use alloy_rpc_types_eth::TransactionRequest;
 /// # use alloy_provider::{ProviderBuilder, RootProvider, Provider};
 /// # async fn test<W: NetworkWallet<Ethereum> + Clone>(url: url::Url, wallet: W) -> Result<(), Box<dyn std::error::Error>> {
-/// let provider = ProviderBuilder::new()
+/// let provider = ProviderBuilder::default()
 ///     .with_gas_estimation()
 ///     .wallet(wallet)
 ///     .on_http(url);

--- a/crates/provider/src/fillers/gas.rs
+++ b/crates/provider/src/fillers/gas.rs
@@ -253,7 +253,7 @@ mod tests {
 
     #[tokio::test]
     async fn no_gas_price_or_limit() {
-        let provider = ProviderBuilder::new().with_recommended_fillers().on_anvil_with_wallet();
+        let provider = ProviderBuilder::new().on_anvil_with_wallet();
 
         // GasEstimationLayer requires chain_id to be set to handle EIP-1559 tx
         let tx = TransactionRequest {
@@ -273,7 +273,7 @@ mod tests {
 
     #[tokio::test]
     async fn no_gas_limit() {
-        let provider = ProviderBuilder::new().with_recommended_fillers().on_anvil_with_wallet();
+        let provider = ProviderBuilder::new().on_anvil_with_wallet();
 
         let gas_price = provider.get_gas_price().await.unwrap();
         let tx = TransactionRequest {
@@ -292,7 +292,7 @@ mod tests {
 
     #[tokio::test]
     async fn no_max_fee_per_blob_gas() {
-        let provider = ProviderBuilder::new().with_recommended_fillers().on_anvil_with_wallet();
+        let provider = ProviderBuilder::new().on_anvil_with_wallet();
 
         let sidecar: SidecarBuilder<SimpleCoder> = SidecarBuilder::from_slice(b"Hello World");
         let sidecar = sidecar.build().unwrap();
@@ -319,7 +319,7 @@ mod tests {
 
     #[tokio::test]
     async fn zero_max_fee_per_blob_gas() {
-        let provider = ProviderBuilder::new().with_recommended_fillers().on_anvil_with_wallet();
+        let provider = ProviderBuilder::new().on_anvil_with_wallet();
 
         let sidecar: SidecarBuilder<SimpleCoder> = SidecarBuilder::from_slice(b"Hello World");
         let sidecar = sidecar.build().unwrap();

--- a/crates/provider/src/fillers/nonce.rs
+++ b/crates/provider/src/fillers/nonce.rs
@@ -104,7 +104,7 @@ impl NonceManager for CachedNonceManager {
 /// # use alloy_rpc_types_eth::TransactionRequest;
 /// # use alloy_provider::{ProviderBuilder, RootProvider, Provider};
 /// # async fn test<W: NetworkWallet<Ethereum> + Clone>(url: url::Url, wallet: W) -> Result<(), Box<dyn std::error::Error>> {
-/// let provider = ProviderBuilder::new()
+/// let provider = ProviderBuilder::default()
 ///     .with_simple_nonce_management()
 ///     .wallet(wallet)
 ///     .on_http(url);

--- a/crates/provider/src/fillers/nonce.rs
+++ b/crates/provider/src/fillers/nonce.rs
@@ -232,7 +232,10 @@ mod tests {
 
     #[tokio::test]
     async fn no_nonce_if_sender_unset() {
-        let provider = ProviderBuilder::new().with_cached_nonce_management().on_anvil();
+        let provider = ProviderBuilder::new()
+            .disable_recommended_fillers()
+            .with_cached_nonce_management()
+            .on_anvil();
 
         let tx = TransactionRequest {
             value: Some(U256::from(100)),
@@ -248,7 +251,10 @@ mod tests {
 
     #[tokio::test]
     async fn increments_nonce() {
-        let provider = ProviderBuilder::new().with_cached_nonce_management().on_anvil_with_wallet();
+        let provider = ProviderBuilder::new()
+            .disable_recommended_fillers()
+            .with_cached_nonce_management()
+            .on_anvil_with_wallet();
 
         let from = provider.default_signer_address();
         let tx = TransactionRequest {

--- a/crates/provider/src/layers/cache.rs
+++ b/crates/provider/src/layers/cache.rs
@@ -724,8 +724,7 @@ mod tests {
         run_with_tempdir("get-code", |dir| async move {
             let cache_layer = CacheLayer::new(100);
             let shared_cache = cache_layer.cache();
-            let anvil = Anvil::new().spawn();
-            let provider = ProviderBuilder::new().layer(cache_layer).on_http(anvil.endpoint_url());
+            let provider = ProviderBuilder::new().layer(cache_layer).on_anvil_with_wallet();
 
             let path = dir.join("rpc-cache-code.txt");
             shared_cache.load_cache(path.clone()).unwrap();

--- a/crates/provider/src/layers/cache.rs
+++ b/crates/provider/src/layers/cache.rs
@@ -656,7 +656,10 @@ mod tests {
             let cache_layer = CacheLayer::new(100);
             let shared_cache = cache_layer.cache();
             let anvil = Anvil::new().block_time_f64(0.3).spawn();
-            let provider = ProviderBuilder::new().layer(cache_layer).on_http(anvil.endpoint_url());
+            let provider = ProviderBuilder::new()
+                .disable_recommended_fillers()
+                .layer(cache_layer)
+                .on_http(anvil.endpoint_url());
 
             let path = dir.join("rpc-cache-tx.txt");
             shared_cache.load_cache(path.clone()).unwrap();
@@ -724,7 +727,7 @@ mod tests {
         run_with_tempdir("get-code", |dir| async move {
             let cache_layer = CacheLayer::new(100);
             let shared_cache = cache_layer.cache();
-            let provider = ProviderBuilder::new().layer(cache_layer).on_anvil_with_wallet();
+            let provider = ProviderBuilder::default().with_gas_estimation().layer(cache_layer).on_anvil_with_wallet();
 
             let path = dir.join("rpc-cache-code.txt");
             shared_cache.load_cache(path.clone()).unwrap();
@@ -733,7 +736,7 @@ mod tests {
                 // solc v0.8.26; solc Counter.sol --via-ir --optimize --bin
                 "6080806040523460135760df908160198239f35b600080fdfe6080806040526004361015601257600080fd5b60003560e01c9081633fb5c1cb1460925781638381f58a146079575063d09de08a14603c57600080fd5b3460745760003660031901126074576000546000198114605e57600101600055005b634e487b7160e01b600052601160045260246000fd5b600080fd5b3460745760003660031901126074576020906000548152f35b34607457602036600319011260745760043560005500fea2646970667358221220e978270883b7baed10810c4079c941512e93a7ba1cd1108c781d4bc738d9090564736f6c634300081a0033"
             ).unwrap();
-            let tx = TransactionRequest::default().with_deploy_code(bytecode);
+            let tx = TransactionRequest::default().with_nonce(0).with_deploy_code(bytecode).with_chain_id(31337);
 
             let receipt = provider.send_transaction(tx).await.unwrap().get_receipt().await.unwrap();
 

--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -1106,7 +1106,7 @@ impl<N: Network> Provider<N> for RootProvider<N> {
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
+    use std::{str::FromStr, time::Duration};
 
     use super::*;
     use crate::{builder, ProviderBuilder, WalletProvider};
@@ -1838,5 +1838,21 @@ mod tests {
             .unwrap()
             .unwrap();
         assert!(block.transactions.is_hashes());
+    }
+
+    #[tokio::test]
+    async fn disable_test() {
+        let provider = ProviderBuilder::new()
+            .disable_recommended_fillers()
+            .with_cached_nonce_management()
+            .on_anvil();
+
+        let tx = TransactionRequest::default()
+            .with_kind(alloy_primitives::TxKind::Create)
+            .value(U256::from(1235))
+            .with_input(Bytes::from_str("ffffffffffffff").unwrap());
+
+        let err = provider.send_transaction(tx).await.unwrap_err().to_string();
+        assert!(err.contains("missing properties: [(\"NonceManager\", [\"from\"])]"));
     }
 }

--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -1407,7 +1407,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_send_tx() {
-        let provider = ProviderBuilder::new().on_anvil();
+        let provider = ProviderBuilder::new().on_anvil_with_wallet();
         let tx = TransactionRequest {
             value: Some(U256::from(100)),
             to: Some(address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045").into()),
@@ -1430,7 +1430,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_watch_confirmed_tx() {
-        let provider = ProviderBuilder::new().on_anvil();
+        let provider = ProviderBuilder::new().on_anvil_with_wallet();
         let tx = TransactionRequest {
             value: Some(U256::from(100)),
             to: Some(address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045").into()),
@@ -1622,7 +1622,7 @@ mod tests {
 
     #[tokio::test]
     async fn gets_transaction_by_hash() {
-        let provider = ProviderBuilder::new().with_recommended_fillers().on_anvil_with_wallet();
+        let provider = ProviderBuilder::new().on_anvil_with_wallet();
 
         let req = TransactionRequest::default()
             .from(provider.default_signer_address())
@@ -1767,7 +1767,6 @@ mod tests {
         let wallet = EthereumWallet::from(signer);
 
         let provider = ProviderBuilder::new()
-            .with_recommended_fillers()
             .network::<AnyNetwork>()
             .wallet(wallet)
             .on_http(anvil.endpoint_url());

--- a/crates/provider/src/provider/wallet.rs
+++ b/crates/provider/src/provider/wallet.rs
@@ -97,14 +97,14 @@ mod test {
 
     #[test]
     fn basic_usage() {
-        let provider = ProviderBuilder::new().on_anvil_with_wallet();
+        let provider = ProviderBuilder::new().disable_recommended_fillers().on_anvil_with_wallet();
 
         assert!(provider.signer_addresses().contains(&provider.default_signer_address()));
     }
 
     #[test]
     fn bubbles_through_fillers() {
-        let provider = ProviderBuilder::new().with_recommended_fillers().on_anvil_with_wallet();
+        let provider = ProviderBuilder::new().on_anvil_with_wallet();
 
         assert!(provider.signer_addresses().contains(&provider.default_signer_address()));
     }

--- a/crates/provider/src/utils.rs
+++ b/crates/provider/src/utils.rs
@@ -2,6 +2,11 @@
 
 use alloy_primitives::{U128, U64};
 
+use crate::{
+    fillers::{BlobGasFiller, ChainIdFiller, GasFiller, JoinFill, NonceFiller},
+    Identity,
+};
+
 /// The number of blocks from the past for which the fee rewards are fetched for fee estimation.
 pub const EIP1559_FEE_ESTIMATION_PAST_BLOCKS: u64 = 10;
 /// Multiplier for the current base fee to estimate max base fee for the next block.
@@ -65,6 +70,13 @@ pub(crate) fn convert_u128(r: U128) -> u128 {
 pub(crate) fn convert_u64(r: U64) -> u64 {
     r.to::<u64>()
 }
+
+/// Helper type representing the joined recommended fillers i.e [`GasFiller`],
+/// [`BlobGasFiller`], [`NonceFiller`], and [`ChainIdFiller`].
+pub type JoinedRecommendedFillers = JoinFill<
+    Identity,
+    JoinFill<GasFiller, JoinFill<BlobGasFiller, JoinFill<NonceFiller, ChainIdFiller>>>,
+>;
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Instantiate `RecommendedFillers` by default. 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

- `RecommededFillers` are added when the `ProviderBuilder` is instantiated using `new()` i.e `ProviderBuilder::new()` will now return `FillProvider` with the recommended fillers instantiated.
- Users can opt-out of this behaviour using `.disable_recommended_fillers()`. 

For example, if a user want just wants `cached_nonce_management`. It can be achieved like so: 

```rust
let provider = ProviderBuilder::new()
            .disable_recommended_fillers()
            .with_cached_nonce_management()
            .on_anvil();
```

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [x] Breaking changes
