### PR TITLE
feat: add rlp length helper

### DIFF
--- a/crates/consensus/src/block/mod.rs
+++ b/crates/consensus/src/block/mod.rs
@@ -95,6 +95,21 @@ impl<T, H> Block<T, H> {
             },
         })
     }
+
+    /// Returns the RLP encoded length of the block's header and body.
+    pub fn rlp_length_for(header: &H, body: &BlockBody<T>) -> usize
+    where
+        H: Encodable,
+        T: Encodable,
+    {
+        block_rlp::HelperRef {
+            header,
+            transactions: &body.transactions,
+            ommers: &body.ommers,
+            withdrawals: body.withdrawals.as_ref(),
+        }
+        .length()
+    }
 }
 
 impl<T, H> Default for Block<T, H>
@@ -214,11 +229,11 @@ mod block_rlp {
 
     #[derive(RlpEncodable)]
     #[rlp(trailing)]
-    struct HelperRef<'a, T, H> {
-        header: &'a H,
-        transactions: &'a Vec<T>,
-        ommers: &'a Vec<Header>,
-        withdrawals: Option<&'a Withdrawals>,
+    pub(crate) struct HelperRef<'a, T, H> {
+        pub(crate) header: &'a H,
+        pub(crate) transactions: &'a Vec<T>,
+        pub(crate) ommers: &'a Vec<Header>,
+        pub(crate) withdrawals: Option<&'a Withdrawals>,
     }
 
     impl<'a, T, H> From<&'a Block<T, H>> for HelperRef<'a, T, H> {


### PR DESCRIPTION
adds a helper that provides the rlp length for the standalone header + body