### PR TITLE
chore(eips): Add super trait `Typed2718` to `Encodable2718`

### DIFF
--- a/crates/consensus-any/src/receipt/envelope.rs
+++ b/crates/consensus-any/src/receipt/envelope.rs
@@ -1,5 +1,8 @@
 use alloy_consensus::{Eip658Value, Receipt, ReceiptWithBloom, TxReceipt};
-use alloy_eips::eip2718::{Decodable2718, Eip2718Result, Encodable2718};
+use alloy_eips::{
+    eip2718::{Decodable2718, Eip2718Result, Encodable2718},
+    Typed2718,
+};
 use alloy_primitives::{bytes::BufMut, Bloom, Log};
 use alloy_rlp::{Decodable, Encodable};
 use core::fmt;
@@ -113,14 +116,13 @@ where
     }
 }
 
-impl Encodable2718 for AnyReceiptEnvelope {
-    fn type_flag(&self) -> Option<u8> {
-        match self.r#type {
-            0 => None,
-            ty => Some(ty),
-        }
+impl Typed2718 for AnyReceiptEnvelope {
+    fn ty(&self) -> u8 {
+        self.r#type
     }
+}
 
+impl Encodable2718 for AnyReceiptEnvelope {
     fn encode_2718_len(&self) -> usize {
         self.inner.length() + !self.is_legacy() as usize
     }

--- a/crates/consensus/src/block/mod.rs
+++ b/crates/consensus/src/block/mod.rs
@@ -6,9 +6,9 @@ pub use header::{BlockHeader, Header};
 #[cfg(all(feature = "serde", feature = "serde-bincode-compat"))]
 pub(crate) use header::serde_bincode_compat;
 
-use crate::{Transaction, Typed2718};
+use crate::Transaction;
 use alloc::vec::Vec;
-use alloy_eips::eip4895::Withdrawals;
+use alloy_eips::{eip4895::Withdrawals, Typed2718};
 use alloy_primitives::B256;
 use alloy_rlp::{Decodable, Encodable, RlpDecodable, RlpEncodable};
 

--- a/crates/consensus/src/constants.rs
+++ b/crates/consensus/src/constants.rs
@@ -1,6 +1,10 @@
 //! Ethereum protocol-related constants
 use alloy_primitives::{b256, B256};
 
+pub use alloy_eips::eip2718::{
+    EIP1559_TX_TYPE_ID, EIP2930_TX_TYPE_ID, EIP4844_TX_TYPE_ID, EIP7702_TX_TYPE_ID,
+    LEGACY_TX_TYPE_ID,
+};
 pub use alloy_trie::{EMPTY_ROOT_HASH, KECCAK_EMPTY};
 
 /// The first four bytes of the call data for a function call specifies the function to be called.

--- a/crates/consensus/src/constants.rs
+++ b/crates/consensus/src/constants.rs
@@ -61,19 +61,3 @@ pub const EMPTY_TRANSACTIONS: B256 = EMPTY_ROOT_HASH;
 
 /// Withdrawals root of empty withdrawals set.
 pub const EMPTY_WITHDRAWALS: B256 = EMPTY_ROOT_HASH;
-
-/// Identifier for legacy transaction, however a legacy tx is technically not
-/// typed.
-pub const LEGACY_TX_TYPE_ID: u8 = 0;
-
-/// Identifier for an EIP2930 transaction.
-pub const EIP2930_TX_TYPE_ID: u8 = 1;
-
-/// Identifier for an EIP1559 transaction.
-pub const EIP1559_TX_TYPE_ID: u8 = 2;
-
-/// Identifier for an EIP4844 transaction.
-pub const EIP4844_TX_TYPE_ID: u8 = 3;
-
-/// Identifier for an EIP7702 transaction.
-pub const EIP7702_TX_TYPE_ID: u8 = 4;

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -37,12 +37,15 @@ pub mod transaction;
 pub use transaction::BlobTransactionValidationError;
 pub use transaction::{
     SignableTransaction, Transaction, TxEip1559, TxEip2930, TxEip4844, TxEip4844Variant,
-    TxEip4844WithSidecar, TxEip7702, TxEnvelope, TxLegacy, TxType, Typed2718, TypedTransaction,
+    TxEip4844WithSidecar, TxEip7702, TxEnvelope, TxLegacy, TxType, TypedTransaction,
 };
 
-pub use alloy_eips::eip4844::{
-    builder::{SidecarBuilder, SidecarCoder, SimpleCoder},
-    utils, Blob, BlobTransactionSidecar, Bytes48,
+pub use alloy_eips::{
+    eip4844::{
+        builder::{SidecarBuilder, SidecarCoder, SimpleCoder},
+        utils, Blob, BlobTransactionSidecar, Bytes48,
+    },
+    Typed2718,
 };
 
 #[cfg(feature = "kzg")]

--- a/crates/consensus/src/receipt/envelope.rs
+++ b/crates/consensus/src/receipt/envelope.rs
@@ -1,7 +1,13 @@
 use core::fmt;
 
 use crate::{Eip658Value, Receipt, ReceiptWithBloom, TxReceipt, TxType};
-use alloy_eips::eip2718::{Decodable2718, Eip2718Error, Eip2718Result, Encodable2718};
+use alloy_eips::{
+    eip2718::{
+        Decodable2718, Eip2718Error, Eip2718Result, Encodable2718, EIP1559_TX_TYPE_ID,
+        EIP2930_TX_TYPE_ID, EIP4844_TX_TYPE_ID, EIP7702_TX_TYPE_ID, LEGACY_TX_TYPE_ID,
+    },
+    Typed2718,
+};
 use alloy_primitives::{Bloom, Log};
 use alloy_rlp::{BufMut, Decodable, Encodable};
 
@@ -175,17 +181,19 @@ impl Decodable for ReceiptEnvelope {
     }
 }
 
-impl Encodable2718 for ReceiptEnvelope {
-    fn type_flag(&self) -> Option<u8> {
+impl Typed2718 for ReceiptEnvelope {
+    fn ty(&self) -> u8 {
         match self {
-            Self::Legacy(_) => None,
-            Self::Eip2930(_) => Some(TxType::Eip2930 as u8),
-            Self::Eip1559(_) => Some(TxType::Eip1559 as u8),
-            Self::Eip4844(_) => Some(TxType::Eip4844 as u8),
-            Self::Eip7702(_) => Some(TxType::Eip7702 as u8),
+            Self::Legacy(_) => LEGACY_TX_TYPE_ID,
+            Self::Eip2930(_) => EIP2930_TX_TYPE_ID,
+            Self::Eip1559(_) => EIP1559_TX_TYPE_ID,
+            Self::Eip4844(_) => EIP4844_TX_TYPE_ID,
+            Self::Eip7702(_) => EIP7702_TX_TYPE_ID,
         }
     }
+}
 
+impl Encodable2718 for ReceiptEnvelope {
     fn encode_2718_len(&self) -> usize {
         self.inner_length() + !self.is_legacy() as usize
     }

--- a/crates/consensus/src/receipt/mod.rs
+++ b/crates/consensus/src/receipt/mod.rs
@@ -11,7 +11,7 @@ pub use receipts::{Receipt, ReceiptWithBloom, Receipts};
 mod status;
 pub use status::Eip658Value;
 
-use crate::Typed2718;
+use alloy_eips::Typed2718;
 
 /// Receipt is the result of a transaction execution.
 #[doc(alias = "TransactionReceipt")]

--- a/crates/consensus/src/receipt/receipts.rs
+++ b/crates/consensus/src/receipt/receipts.rs
@@ -2,7 +2,7 @@ use crate::receipt::{
     Eip2718EncodableReceipt, Eip658Value, RlpDecodableReceipt, RlpEncodableReceipt, TxReceipt,
 };
 use alloc::{vec, vec::Vec};
-use alloy_eips::eip2718::Encodable2718;
+use alloy_eips::{eip2718::Encodable2718, Typed2718};
 use alloy_primitives::{Bloom, Log};
 use alloy_rlp::{BufMut, Decodable, Encodable, Header};
 use core::fmt;
@@ -287,14 +287,16 @@ impl<R: RlpDecodableReceipt> Decodable for ReceiptWithBloom<R> {
     }
 }
 
+impl<R: Typed2718> Typed2718 for ReceiptWithBloom<R> {
+    fn ty(&self) -> u8 {
+        self.receipt.ty()
+    }
+}
+
 impl<R> Encodable2718 for ReceiptWithBloom<R>
 where
     R: Eip2718EncodableReceipt + Send + Sync,
 {
-    fn type_flag(&self) -> Option<u8> {
-        (!self.receipt.is_legacy()).then_some(self.receipt.ty())
-    }
-
     fn encode_2718_len(&self) -> usize {
         self.receipt.eip2718_encoded_length_with_bloom(&self.logs_bloom)
     }

--- a/crates/consensus/src/transaction/eip1559.rs
+++ b/crates/consensus/src/transaction/eip1559.rs
@@ -1,5 +1,5 @@
-use crate::{transaction::RlpEcdsaTx, SignableTransaction, Signed, Transaction, TxType, Typed2718};
-use alloy_eips::{eip2930::AccessList, eip7702::SignedAuthorization};
+use crate::{transaction::RlpEcdsaTx, SignableTransaction, Signed, Transaction, TxType};
+use alloy_eips::{eip2930::AccessList, eip7702::SignedAuthorization, Typed2718};
 use alloy_primitives::{Bytes, ChainId, PrimitiveSignature as Signature, TxKind, B256, U256};
 use alloy_rlp::{BufMut, Decodable, Encodable};
 use core::mem;

--- a/crates/consensus/src/transaction/eip2930.rs
+++ b/crates/consensus/src/transaction/eip2930.rs
@@ -1,10 +1,8 @@
-use crate::{SignableTransaction, Signed, Transaction, TxType};
-use alloy_eips::{eip2930::AccessList, eip7702::SignedAuthorization};
+use crate::{transaction::RlpEcdsaTx, SignableTransaction, Signed, Transaction, TxType};
+use alloy_eips::{eip2930::AccessList, eip7702::SignedAuthorization, Typed2718};
 use alloy_primitives::{Bytes, ChainId, PrimitiveSignature as Signature, TxKind, B256, U256};
 use alloy_rlp::{BufMut, Decodable, Encodable};
 use core::mem;
-
-use super::{RlpEcdsaTx, Typed2718};
 
 /// Transaction with an [`AccessList`] ([EIP-2930](https://eips.ethereum.org/EIPS/eip-2930)).
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]

--- a/crates/consensus/src/transaction/eip4844.rs
+++ b/crates/consensus/src/transaction/eip4844.rs
@@ -1,7 +1,9 @@
-use crate::{SignableTransaction, Signed, Transaction, TxType, Typed2718};
+use crate::{SignableTransaction, Signed, Transaction, TxType};
 
 use alloc::vec::Vec;
-use alloy_eips::{eip2930::AccessList, eip4844::DATA_GAS_PER_BLOB, eip7702::SignedAuthorization};
+use alloy_eips::{
+    eip2930::AccessList, eip4844::DATA_GAS_PER_BLOB, eip7702::SignedAuthorization, Typed2718,
+};
 use alloy_primitives::{
     Address, Bytes, ChainId, PrimitiveSignature as Signature, TxKind, B256, U256,
 };

--- a/crates/consensus/src/transaction/eip7702.rs
+++ b/crates/consensus/src/transaction/eip7702.rs
@@ -1,8 +1,9 @@
-use crate::{SignableTransaction, Signed, Transaction, TxType, Typed2718};
+use crate::{SignableTransaction, Signed, Transaction, TxType};
 use alloc::vec::Vec;
 use alloy_eips::{
     eip2930::AccessList,
     eip7702::{constants::EIP7702_TX_TYPE_ID, SignedAuthorization},
+    Typed2718,
 };
 use alloy_primitives::{
     Address, Bytes, ChainId, PrimitiveSignature as Signature, TxKind, B256, U256,

--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -1,13 +1,14 @@
 use crate::{
     transaction::{
         eip4844::{TxEip4844, TxEip4844Variant, TxEip4844WithSidecar},
-        RlpEcdsaTx, Typed2718,
+        RlpEcdsaTx,
     },
     Signed, Transaction, TxEip1559, TxEip2930, TxEip7702, TxLegacy,
 };
 use alloy_eips::{
     eip2718::{Decodable2718, Eip2718Error, Eip2718Result, Encodable2718},
     eip2930::AccessList,
+    Typed2718,
 };
 use alloy_primitives::{
     Bytes, ChainId, PrimitiveSignature as Signature, TxKind, B256, U256, U64, U8,
@@ -415,16 +416,6 @@ impl Decodable2718 for TxEnvelope {
 }
 
 impl Encodable2718 for TxEnvelope {
-    fn type_flag(&self) -> Option<u8> {
-        match self {
-            Self::Legacy(_) => None,
-            Self::Eip2930(_) => Some(TxType::Eip2930.into()),
-            Self::Eip1559(_) => Some(TxType::Eip1559.into()),
-            Self::Eip4844(_) => Some(TxType::Eip4844.into()),
-            Self::Eip7702(_) => Some(TxType::Eip7702.into()),
-        }
-    }
-
     fn encode_2718_len(&self) -> usize {
         self.eip2718_encoded_length()
     }

--- a/crates/consensus/src/transaction/legacy.rs
+++ b/crates/consensus/src/transaction/legacy.rs
@@ -1,13 +1,11 @@
 use crate::{transaction::RlpEcdsaTx, SignableTransaction, Signed, Transaction, TxType};
 use alloc::vec::Vec;
-use alloy_eips::{eip2930::AccessList, eip7702::SignedAuthorization};
+use alloy_eips::{eip2930::AccessList, eip7702::SignedAuthorization, Typed2718};
 use alloy_primitives::{
     keccak256, Bytes, ChainId, PrimitiveSignature as Signature, TxKind, B256, U256,
 };
 use alloy_rlp::{length_of_length, BufMut, Decodable, Encodable, Header, Result};
 use core::mem;
-
-use super::Typed2718;
 
 /// Legacy transaction.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]

--- a/crates/consensus/src/transaction/mod.rs
+++ b/crates/consensus/src/transaction/mod.rs
@@ -1,12 +1,6 @@
 //! Transaction types.
 
-use crate::{
-    constants::{
-        EIP1559_TX_TYPE_ID, EIP2930_TX_TYPE_ID, EIP4844_TX_TYPE_ID, EIP7702_TX_TYPE_ID,
-        LEGACY_TX_TYPE_ID,
-    },
-    Signed,
-};
+use crate::Signed;
 use alloc::vec::Vec;
 use alloy_eips::{eip2930::AccessList, eip7702::SignedAuthorization};
 use alloy_primitives::{keccak256, Address, Bytes, ChainId, TxKind, B256, U256};
@@ -65,6 +59,8 @@ pub mod serde_bincode_compat {
         eip7702::serde_bincode_compat::*, legacy::serde_bincode_compat::*,
     };
 }
+
+use alloy_eips::Typed2718;
 
 /// Represents a minimal EVM transaction.
 #[doc(alias = "Tx")]
@@ -255,14 +251,6 @@ impl<S: 'static> dyn SignableTransaction<S> {
 }
 
 #[cfg(feature = "serde")]
-impl<T: Typed2718> Typed2718 for alloy_serde::WithOtherFields<T> {
-    #[inline]
-    fn ty(&self) -> u8 {
-        self.inner.ty()
-    }
-}
-
-#[cfg(feature = "serde")]
 impl<T: Transaction> Transaction for alloy_serde::WithOtherFields<T> {
     #[inline]
     fn chain_id(&self) -> Option<ChainId> {
@@ -346,42 +334,5 @@ impl<T: Transaction> Transaction for alloy_serde::WithOtherFields<T> {
     #[inline]
     fn authorization_list(&self) -> Option<&[SignedAuthorization]> {
         self.inner.authorization_list()
-    }
-}
-
-/// A trait that helps to determine the type of the transaction.
-#[auto_impl::auto_impl(&)]
-pub trait Typed2718 {
-    /// Returns the EIP-2718 type flag.
-    fn ty(&self) -> u8;
-
-    /// Returns true if the type matches the given type.
-    fn is_type(&self, ty: u8) -> bool {
-        self.ty() == ty
-    }
-
-    /// Returns true if the type is a legacy transaction.
-    fn is_legacy(&self) -> bool {
-        self.ty() == LEGACY_TX_TYPE_ID
-    }
-
-    /// Returns true if the type is an EIP-2930 transaction.
-    fn is_eip2930(&self) -> bool {
-        self.ty() == EIP2930_TX_TYPE_ID
-    }
-
-    /// Returns true if the type is an EIP-1559 transaction.
-    fn is_eip1559(&self) -> bool {
-        self.ty() == EIP1559_TX_TYPE_ID
-    }
-
-    /// Returns true if the type is an EIP-4844 transaction.
-    fn is_eip4844(&self) -> bool {
-        self.ty() == EIP4844_TX_TYPE_ID
-    }
-
-    /// Returns true if the type is an EIP-7702 transaction.
-    fn is_eip7702(&self) -> bool {
-        self.ty() == EIP7702_TX_TYPE_ID
     }
 }

--- a/crates/consensus/src/transaction/pooled.rs
+++ b/crates/consensus/src/transaction/pooled.rs
@@ -4,12 +4,12 @@
 use crate::{
     transaction::{RlpEcdsaTx, TxEip1559, TxEip2930, TxEip4844, TxLegacy},
     SignableTransaction, Signed, Transaction, TxEip4844WithSidecar, TxEip7702, TxEnvelope, TxType,
-    Typed2718,
 };
 use alloy_eips::{
     eip2718::{Decodable2718, Eip2718Error, Eip2718Result, Encodable2718},
     eip2930::AccessList,
     eip7702::SignedAuthorization,
+    Typed2718,
 };
 use alloy_primitives::{
     bytes, Bytes, ChainId, PrimitiveSignature as Signature, TxHash, TxKind, B256, U256,
@@ -79,7 +79,7 @@ impl PooledTransaction {
     /// length of the header + the length of the type flag and inner encoding.
     fn network_len(&self) -> usize {
         let mut payload_length = self.encode_2718_len();
-        if !Encodable2718::is_legacy(self) {
+        if !self.is_legacy() {
             payload_length += Header { list: false, payload_length }.length();
         }
 
@@ -282,16 +282,6 @@ impl Decodable for PooledTransaction {
 }
 
 impl Encodable2718 for PooledTransaction {
-    fn type_flag(&self) -> Option<u8> {
-        match self {
-            Self::Legacy(_) => None,
-            Self::Eip2930(_) => Some(0x01),
-            Self::Eip1559(_) => Some(0x02),
-            Self::Eip4844(_) => Some(0x03),
-            Self::Eip7702(_) => Some(0x04),
-        }
-    }
-
     fn encode_2718_len(&self) -> usize {
         match self {
             Self::Legacy(tx) => tx.eip2718_encoded_length(),

--- a/crates/consensus/src/transaction/recovered.rs
+++ b/crates/consensus/src/transaction/recovered.rs
@@ -1,4 +1,4 @@
-use alloy_eips::eip2718::Encodable2718;
+use alloy_eips::{eip2718::Encodable2718, Typed2718};
 use alloy_primitives::{bytes, Address, B256};
 use alloy_rlp::{Decodable, Encodable};
 use derive_more::{AsRef, Deref};
@@ -91,11 +91,13 @@ impl<T: Decodable + SignerRecoverable> Decodable for Recovered<T> {
     }
 }
 
-impl<T: Encodable2718> Encodable2718 for Recovered<T> {
-    fn type_flag(&self) -> Option<u8> {
-        self.tx.type_flag()
+impl<T: Typed2718> Typed2718 for Recovered<T> {
+    fn ty(&self) -> u8 {
+        self.tx.ty()
     }
+}
 
+impl<T: Encodable2718> Encodable2718 for Recovered<T> {
     fn encode_2718_len(&self) -> usize {
         self.tx.encode_2718_len()
     }

--- a/crates/consensus/src/transaction/typed.rs
+++ b/crates/consensus/src/transaction/typed.rs
@@ -1,9 +1,9 @@
-use alloy_eips::{eip2930::AccessList, eip7702::SignedAuthorization};
+use alloy_eips::{eip2930::AccessList, eip7702::SignedAuthorization, Typed2718};
 use alloy_primitives::{Bytes, ChainId, TxKind, B256, U256};
 
 use crate::{
     transaction::eip4844::{TxEip4844, TxEip4844Variant, TxEip4844WithSidecar},
-    Transaction, TxEip1559, TxEip2930, TxEip7702, TxEnvelope, TxLegacy, TxType, Typed2718,
+    Transaction, TxEip1559, TxEip2930, TxEip7702, TxEnvelope, TxLegacy, TxType,
 };
 
 /// The TypedTransaction enum represents all Ethereum transaction request types.

--- a/crates/eips/Cargo.toml
+++ b/crates/eips/Cargo.toml
@@ -54,6 +54,9 @@ ethereum_ssz = { workspace = true, optional = true }
 # arbitrary
 arbitrary = { workspace = true, features = ["derive"], optional = true }
 
+# misc
+auto_impl.workspace = true
+
 [dev-dependencies]
 alloy-primitives = { workspace = true, features = [
     "rand",

--- a/crates/eips/src/eip2718.rs
+++ b/crates/eips/src/eip2718.rs
@@ -10,6 +10,22 @@ use core::fmt;
 // https://eips.ethereum.org/EIPS/eip-2718#transactiontype-only-goes-up-to-0x7f
 const TX_TYPE_BYTE_MAX: u8 = 0x7f;
 
+/// Identifier for legacy transaction, however a legacy tx is technically not
+/// typed.
+pub const LEGACY_TX_TYPE_ID: u8 = 0;
+
+/// Identifier for an EIP2930 transaction.
+pub const EIP2930_TX_TYPE_ID: u8 = 1;
+
+/// Identifier for an EIP1559 transaction.
+pub const EIP1559_TX_TYPE_ID: u8 = 2;
+
+/// Identifier for an EIP4844 transaction.
+pub const EIP4844_TX_TYPE_ID: u8 = 3;
+
+/// Identifier for an EIP7702 transaction.
+pub const EIP7702_TX_TYPE_ID: u8 = 4;
+
 /// [EIP-2718] decoding errors.
 ///
 /// [EIP-2718]: https://eips.ethereum.org/EIPS/eip-2718
@@ -162,16 +178,16 @@ pub trait Decodable2718: Sized {
 /// over the accepted transaction types.
 ///
 /// [EIP-2718]: https://eips.ethereum.org/EIPS/eip-2718
-pub trait Encodable2718: Sized + Send + Sync {
+pub trait Encodable2718: Typed2718 + Sized + Send + Sync {
     /// Return the type flag (if any).
     ///
     /// This should return `None` for the default (legacy) variant of the
     /// envelope.
-    fn type_flag(&self) -> Option<u8>;
-
-    /// True if the envelope is the legacy variant.
-    fn is_legacy(&self) -> bool {
-        matches!(self.type_flag(), None | Some(0))
+    fn type_flag(&self) -> Option<u8> {
+        match self.ty() {
+            LEGACY_TX_TYPE_ID => None,
+            ty => Some(ty),
+        }
     }
 
     /// The length of the 2718 encoded envelope. This is the length of the type
@@ -248,3 +264,48 @@ pub trait Encodable2718: Sized + Send + Sync {
 /// [EIP-2718]: https://eips.ethereum.org/EIPS/eip-2718
 pub trait Eip2718Envelope: Decodable2718 + Encodable2718 {}
 impl<T> Eip2718Envelope for T where T: Decodable2718 + Encodable2718 {}
+
+/// A trait that helps to determine the type of the transaction.
+#[auto_impl::auto_impl(&)]
+pub trait Typed2718 {
+    /// Returns the EIP-2718 type flag.
+    fn ty(&self) -> u8;
+
+    /// Returns true if the type matches the given type.
+    fn is_type(&self, ty: u8) -> bool {
+        self.ty() == ty
+    }
+
+    /// Returns true if the type is a legacy transaction.
+    fn is_legacy(&self) -> bool {
+        self.ty() == LEGACY_TX_TYPE_ID
+    }
+
+    /// Returns true if the type is an EIP-2930 transaction.
+    fn is_eip2930(&self) -> bool {
+        self.ty() == EIP2930_TX_TYPE_ID
+    }
+
+    /// Returns true if the type is an EIP-1559 transaction.
+    fn is_eip1559(&self) -> bool {
+        self.ty() == EIP1559_TX_TYPE_ID
+    }
+
+    /// Returns true if the type is an EIP-4844 transaction.
+    fn is_eip4844(&self) -> bool {
+        self.ty() == EIP4844_TX_TYPE_ID
+    }
+
+    /// Returns true if the type is an EIP-7702 transaction.
+    fn is_eip7702(&self) -> bool {
+        self.ty() == EIP7702_TX_TYPE_ID
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<T: Typed2718> Typed2718 for alloy_serde::WithOtherFields<T> {
+    #[inline]
+    fn ty(&self) -> u8 {
+        self.inner.ty()
+    }
+}

--- a/crates/eips/src/lib.rs
+++ b/crates/eips/src/lib.rs
@@ -23,6 +23,7 @@ pub use eip1898::{
 pub mod eip2124;
 
 pub mod eip2718;
+pub use eip2718::{Decodable2718, Encodable2718, Typed2718};
 
 pub mod eip2930;
 

--- a/crates/network/src/any/either.rs
+++ b/crates/network/src/any/either.rs
@@ -283,13 +283,6 @@ impl Typed2718 for AnyTxEnvelope {
 }
 
 impl Encodable2718 for AnyTxEnvelope {
-    fn type_flag(&self) -> Option<u8> {
-        match self {
-            Self::Ethereum(t) => t.type_flag(),
-            Self::Unknown(inner) => Some(inner.ty()),
-        }
-    }
-
     fn encode_2718_len(&self) -> usize {
         match self {
             Self::Ethereum(t) => t.encode_2718_len(),


### PR DESCRIPTION
Adds `Typed2718` as super trait to `Encodable2718` to remove redundancy