### PR TITLE
feat: make ReadJsonStream generic to allow reuse

### DIFF
--- a/crates/transport-ipc/Cargo.toml
+++ b/crates/transport-ipc/Cargo.toml
@@ -33,10 +33,10 @@ serde_json.workspace = true
 tokio.workspace = true
 tokio-util = { workspace = true, features = ["io"] }
 tracing.workspace = true
+serde = { workspace = true }
 
 bytes = "1.5.0"
 interprocess = { version = "2", features = ["tokio"] }
-serde = { workspace = true, optional = true }
 tempfile = { workspace = true, optional = true }
 
 [dev-dependencies]
@@ -44,4 +44,4 @@ tokio-test.workspace = true
 
 [features]
 default = []
-mock = ["dep:serde", "dep:tempfile"]
+mock = ["dep:tempfile"]

--- a/crates/transport-ipc/Cargo.toml
+++ b/crates/transport-ipc/Cargo.toml
@@ -33,7 +33,7 @@ serde_json.workspace = true
 tokio.workspace = true
 tokio-util = { workspace = true, features = ["io"] }
 tracing.workspace = true
-serde = { workspace = true }
+serde.workspace = true
 
 bytes = "1.5.0"
 interprocess = { version = "2", features = ["tokio"] }

--- a/crates/transport-ipc/src/lib.rs
+++ b/crates/transport-ipc/src/lib.rs
@@ -126,7 +126,7 @@ impl<T: AsyncRead, U> ReadJsonStream<T, U> {
     }
 }
 
-impl<T: AsyncRead> From<T> for ReadJsonStream<T> {
+impl<T: AsyncRead, U> From<T> for ReadJsonStream<T, U> {
     fn from(reader: T) -> Self {
         Self::new(reader)
     }

--- a/crates/transport-ipc/src/lib.rs
+++ b/crates/transport-ipc/src/lib.rs
@@ -215,6 +215,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy_json_rpc::PubSubItem;
     use std::future::poll_fn;
 
     #[tokio::test]
@@ -228,7 +229,7 @@ mod tests {
             .read(r#", "params": {"subscription": "0xcd0c3e8af590364c09d0fa6a1210faf5", "result": {"difficulty": "0xd9263f42a87", "uncles": []}} }"#.as_bytes())
             .build();
 
-        let mut reader = ReadJsonStream::new(mock);
+        let mut reader = ReadJsonStream::<_, PubSubItem>::new(mock);
         poll_fn(|cx| {
             let res = reader.poll_next_unpin(cx);
             assert!(res.is_pending());
@@ -249,7 +250,7 @@ mod tests {
             .read(vec![b'a'; CAPACITY].as_ref())
             .build();
 
-        let mut reader = ReadJsonStream::new(mock);
+        let mut reader = ReadJsonStream::<_, PubSubItem>::new(mock);
         poll_fn(|cx| {
             let res = reader.poll_next_unpin(cx);
             assert!(res.is_pending());
@@ -281,7 +282,7 @@ mod tests {
             .read(second_page)
             .build();
 
-        let mut reader = ReadJsonStream::new(mock);
+        let mut reader = ReadJsonStream::<_, PubSubItem>::new(mock);
         poll_fn(|cx| {
             let res = reader.poll_next_unpin(cx);
             assert!(res.is_pending());


### PR DESCRIPTION

## Motivation

Right now this only reads a specific Json item, but it's trivial to make it read any json item. This would allow the logic to be reused for a server

## Solution

Make the stream generic over `T: DeserializeOwned`, have the stream yield `Item`, set a default item to `PubSubItem` to avoid any breaking changes.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
