### PR TITLE
fix(`node-bindings`): reset `child.stdout` in `AnvilInstance`

### DIFF
--- a/crates/node-bindings/src/nodes/anvil.rs
+++ b/crates/node-bindings/src/nodes/anvil.rs
@@ -7,7 +7,7 @@ use std::{
     io::{BufRead, BufReader},
     net::SocketAddr,
     path::PathBuf,
-    process::{Child, Command},
+    process::{Child, ChildStdout, Command},
     str::FromStr,
     time::{Duration, Instant},
 };
@@ -28,6 +28,7 @@ pub struct AnvilInstance {
     addresses: Vec<Address>,
     port: u16,
     chain_id: Option<ChainId>,
+    reader: BufReader<ChildStdout>,
 }
 
 impl AnvilInstance {
@@ -39,6 +40,16 @@ impl AnvilInstance {
     /// Returns a mutable reference to the child process.
     pub fn child_mut(&mut self) -> &mut Child {
         &mut self.child
+    }
+
+    /// Returns a reference to the stdout reader of the child process.
+    pub fn read(&self) -> &BufReader<ChildStdout> {
+        &self.reader
+    }
+
+    /// Returns a mutable reference to the stdout reader of the child process.
+    pub fn read_mut(&mut self) -> &mut BufReader<ChildStdout> {
+        &mut self.reader
     }
 
     /// Returns the private keys used to instantiate this instance
@@ -340,6 +351,7 @@ impl Anvil {
             addresses,
             port,
             chain_id: self.chain_id.or(chain_id),
+            reader,
         })
     }
 }

--- a/crates/node-bindings/src/nodes/anvil.rs
+++ b/crates/node-bindings/src/nodes/anvil.rs
@@ -40,6 +40,7 @@ impl AnvilInstance {
     pub fn child_mut(&mut self) -> &mut Child {
         &mut self.child
     }
+
     /// Returns the private keys used to instantiate this instance
     pub fn keys(&self) -> &[K256SecretKey] {
         &self.private_keys

--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -1884,7 +1884,11 @@ mod tests {
         anvil.child_mut().kill().unwrap();
 
         let mut output = String::new();
-        anvil.read_mut().read_to_string(&mut output).unwrap();
+        anvil.child_mut().stdout.take().unwrap().read_to_string(&mut output).unwrap();
+
+        assert_eq!(anvil.chain_id(), 31337);
+        assert_eq!(anvil.addresses().len(), 10);
+        assert_eq!(anvil.keys().len(), 10);
 
         assert!(output.contains("eth_sendTransaction"));
         assert!(output.contains("Block Number: 1"))

--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -1106,7 +1106,7 @@ impl<N: Network> Provider<N> for RootProvider<N> {
 
 #[cfg(test)]
 mod tests {
-    use std::{str::FromStr, time::Duration};
+    use std::{io::Read, str::FromStr, time::Duration};
 
     use super::*;
     use crate::{builder, ProviderBuilder, WalletProvider};
@@ -1866,5 +1866,27 @@ mod tests {
 
         let err = provider.send_transaction(tx).await.unwrap_err().to_string();
         assert!(err.contains("missing properties: [(\"NonceManager\", [\"from\"])]"));
+    }
+
+    #[tokio::test]
+    async fn capture_anvil_logs() {
+        let mut anvil = Anvil::new().spawn();
+
+        let provider = ProviderBuilder::new().on_http(anvil.endpoint_url());
+
+        let tx = TransactionRequest::default()
+            .with_from(address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266"))
+            .with_to(address!("70997970C51812dc3A010C7d01b50e0d17dc79C8"))
+            .value(U256::from(100));
+
+        let _ = provider.send_transaction(tx).await.unwrap().get_receipt().await.unwrap();
+
+        anvil.child_mut().kill().unwrap();
+
+        let mut output = String::new();
+        anvil.read_mut().read_to_string(&mut output).unwrap();
+
+        assert!(output.contains("eth_sendTransaction"));
+        assert!(output.contains("Block Number: 1"))
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Currently, `AnvilInstance.child.stdout` is not being set again after initial parsing, resulting in `child.stdout` being always `None`. 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Set `child.stdout` after initial parsing has completed in `.spawn()`.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
