### PR TITLE
refactor: change json-rpc trait names, relax bounds

### DIFF
--- a/crates/json-rpc/src/error.rs
+++ b/crates/json-rpc/src/error.rs
@@ -1,4 +1,4 @@
-use crate::{ErrorPayload, RpcReturn};
+use crate::{ErrorPayload, RpcRecv};
 use serde_json::value::RawValue;
 
 /// An RPC error.
@@ -55,7 +55,7 @@ pub enum RpcError<E, ErrResp = Box<RawValue>> {
 
 impl<E, ErrResp> RpcError<E, ErrResp>
 where
-    ErrResp: RpcReturn,
+    ErrResp: RpcRecv,
 {
     /// Instantiate a new `ErrorResp` from an error response.
     pub const fn err_resp(err: ErrorPayload<ErrResp>) -> Self {

--- a/crates/json-rpc/src/response/error.rs
+++ b/crates/json-rpc/src/response/error.rs
@@ -14,7 +14,7 @@ use std::{
     marker::PhantomData,
 };
 
-use crate::RpcObject;
+use crate::RpcSend;
 
 const INTERNAL_ERROR: Cow<'static, str> = Cow::Borrowed("Internal error");
 
@@ -68,7 +68,7 @@ impl<E> ErrorPayload<E> {
     /// and additional data.
     pub const fn internal_error_with_obj(data: E) -> Self
     where
-        E: RpcObject,
+        E: RpcSend,
     {
         Self { code: -32603, message: INTERNAL_ERROR, data: Some(data) }
     }
@@ -76,7 +76,7 @@ impl<E> ErrorPayload<E> {
     /// Create a new error payload for an internal error with a custom message
     pub const fn internal_error_with_message_and_obj(message: Cow<'static, str>, data: E) -> Self
     where
-        E: RpcObject,
+        E: RpcSend,
     {
         Self { code: -32603, message, data: Some(data) }
     }
@@ -129,7 +129,7 @@ impl<E> ErrorPayload<E> {
 
 impl<T> From<T> for ErrorPayload<T>
 where
-    T: std::error::Error + RpcObject,
+    T: std::error::Error + RpcSend,
 {
     fn from(value: T) -> Self {
         Self { code: -32603, message: INTERNAL_ERROR, data: Some(value) }
@@ -138,7 +138,7 @@ where
 
 impl<E> ErrorPayload<E>
 where
-    E: RpcObject,
+    E: RpcSend,
 {
     /// Serialize the inner data into a [`RawValue`].
     pub fn serialize_payload(&self) -> serde_json::Result<ErrorPayload> {

--- a/crates/json-rpc/src/response/mod.rs
+++ b/crates/json-rpc/src/response/mod.rs
@@ -1,4 +1,4 @@
-use crate::{common::Id, RpcObject};
+use crate::{common::Id, RpcSend};
 use serde::{
     de::{DeserializeOwned, MapAccess, Visitor},
     ser::SerializeMap,
@@ -85,7 +85,7 @@ impl<Payload, ErrData> Response<Payload, ErrData> {
     /// Create a new error response for an internal error with additional data.
     pub const fn internal_error_with_obj(id: Id, data: ErrData) -> Self
     where
-        ErrData: RpcObject,
+        ErrData: RpcSend,
     {
         Self { id, payload: ResponsePayload::Failure(ErrorPayload::internal_error_with_obj(data)) }
     }
@@ -98,7 +98,7 @@ impl<Payload, ErrData> Response<Payload, ErrData> {
         data: ErrData,
     ) -> Self
     where
-        ErrData: RpcObject,
+        ErrData: RpcSend,
     {
         Self {
             id,
@@ -121,8 +121,8 @@ impl<Payload, ErrData> Response<Payload, ErrData> {
 
 impl<Payload, ErrData> Response<Payload, ErrData>
 where
-    Payload: RpcObject,
-    ErrData: RpcObject,
+    Payload: RpcSend,
+    ErrData: RpcSend,
 {
     /// Serialize the payload of this response.
     pub fn serialize_payload(&self) -> serde_json::Result<Response> {

--- a/crates/json-rpc/src/response/payload.rs
+++ b/crates/json-rpc/src/response/payload.rs
@@ -1,4 +1,4 @@
-use crate::{ErrorPayload, RpcObject};
+use crate::{ErrorPayload, RpcSend};
 use serde::{de::DeserializeOwned, Deserialize};
 use serde_json::value::{to_raw_value, RawValue};
 use std::borrow::{Borrow, Cow};
@@ -78,7 +78,7 @@ impl<Payload, ErrData> ResponsePayload<Payload, ErrData> {
     /// and additional data.
     pub const fn internal_error_with_obj(data: ErrData) -> Self
     where
-        ErrData: RpcObject,
+        ErrData: RpcSend,
     {
         Self::Failure(ErrorPayload::internal_error_with_obj(data))
     }
@@ -90,7 +90,7 @@ impl<Payload, ErrData> ResponsePayload<Payload, ErrData> {
         data: ErrData,
     ) -> Self
     where
-        ErrData: RpcObject,
+        ErrData: RpcSend,
     {
         Self::Failure(ErrorPayload::internal_error_with_message_and_obj(message, data))
     }
@@ -124,8 +124,8 @@ impl<Payload, ErrData> ResponsePayload<Payload, ErrData> {
 
 impl<Payload, ErrData> ResponsePayload<Payload, ErrData>
 where
-    Payload: RpcObject,
-    ErrData: RpcObject,
+    Payload: RpcSend,
+    ErrData: RpcSend,
 {
     /// Convert the inner types into a [`RawValue`] by serializing them.
     pub fn serialize_payload(&self) -> serde_json::Result<ResponsePayload> {

--- a/crates/json-rpc/src/result.rs
+++ b/crates/json-rpc/src/result.rs
@@ -1,4 +1,4 @@
-use crate::{Response, ResponsePayload, RpcError, RpcReturn};
+use crate::{Response, ResponsePayload, RpcError, RpcRecv};
 use serde_json::value::RawValue;
 use std::borrow::Borrow;
 
@@ -24,7 +24,7 @@ pub type BorrowedRpcResult<'a, E> = RpcResult<&'a RawValue, E, &'a RawValue>;
 /// [`Id`]: crate::Id
 pub fn transform_response<T, E, ErrResp>(response: Response<T, ErrResp>) -> RpcResult<T, E, ErrResp>
 where
-    ErrResp: RpcReturn,
+    ErrResp: RpcRecv,
 {
     match response {
         Response { payload: ResponsePayload::Failure(err_resp), .. } => {
@@ -41,7 +41,7 @@ pub fn transform_result<T, E, ErrResp>(
     response: Result<Response<T, ErrResp>, E>,
 ) -> Result<T, RpcError<E, ErrResp>>
 where
-    ErrResp: RpcReturn,
+    ErrResp: RpcRecv,
 {
     match response {
         Ok(resp) => transform_response(resp),
@@ -55,8 +55,8 @@ pub fn try_deserialize_ok<J, T, E, ErrResp>(
 ) -> RpcResult<T, E, ErrResp>
 where
     J: Borrow<RawValue>,
-    T: RpcReturn,
-    ErrResp: RpcReturn,
+    T: RpcRecv,
+    ErrResp: RpcRecv,
 {
     let json = result?;
     let json = json.borrow().get();

--- a/crates/provider/src/ext/debug.rs
+++ b/crates/provider/src/ext/debug.rs
@@ -1,6 +1,6 @@
 //! This module extends the Ethereum JSON-RPC provider with the Debug namespace's RPC methods.
 use crate::Provider;
-use alloy_json_rpc::RpcReturn;
+use alloy_json_rpc::RpcRecv;
 use alloy_network::Network;
 use alloy_primitives::{hex, Bytes, TxHash, B256};
 use alloy_rpc_types_debug::ExecutionWitness;
@@ -72,7 +72,7 @@ pub trait DebugApi<N>: Send + Sync {
 
     /// Reruns the transaction specified by the hash and returns the trace in a specified format.
     ///
-    /// This method allows for the trace to be returned as a type that implements `RpcReturn` and
+    /// This method allows for the trace to be returned as a type that implements `RpcRecv` and
     /// `serde::de::DeserializeOwned`.
     ///
     /// [GethDebugTracingOptions] can be used to specify the trace options.
@@ -86,7 +86,7 @@ pub trait DebugApi<N>: Send + Sync {
         trace_options: GethDebugTracingOptions,
     ) -> TransportResult<R>
     where
-        R: RpcReturn + serde::de::DeserializeOwned;
+        R: RpcRecv + serde::de::DeserializeOwned;
 
     /// Reruns the transaction specified by the hash and returns the trace as a JSON object.
     ///
@@ -122,7 +122,7 @@ pub trait DebugApi<N>: Send + Sync {
 
     /// Reruns the transaction specified by the hash and returns the trace in a specified format.
     ///
-    /// This method allows for the trace to be returned as a type that implements `RpcReturn` and
+    /// This method allows for the trace to be returned as a type that implements `RpcRecv` and
     /// `serde::de::DeserializeOwned`.
     ///
     /// [GethDebugTracingOptions] can be used to specify the trace options.
@@ -137,7 +137,7 @@ pub trait DebugApi<N>: Send + Sync {
         trace_options: GethDebugTracingCallOptions,
     ) -> TransportResult<R>
     where
-        R: RpcReturn + serde::de::DeserializeOwned;
+        R: RpcRecv + serde::de::DeserializeOwned;
 
     /// Reruns the transaction specified by the hash and returns the trace as a JSON object.
     ///
@@ -309,7 +309,7 @@ where
         trace_options: GethDebugTracingOptions,
     ) -> TransportResult<R>
     where
-        R: RpcReturn,
+        R: RpcRecv,
     {
         self.client().request("debug_traceTransaction", (hash, trace_options)).await
     }
@@ -337,7 +337,7 @@ where
         trace_options: GethDebugTracingCallOptions,
     ) -> TransportResult<R>
     where
-        R: RpcReturn,
+        R: RpcRecv,
     {
         self.client().request("debug_traceCall", (tx, block, trace_options)).await
     }

--- a/crates/provider/src/layers/cache.rs
+++ b/crates/provider/src/layers/cache.rs
@@ -1,6 +1,6 @@
 use crate::{ParamsWithBlock, Provider, ProviderCall, ProviderLayer, RootProvider, RpcWithBlock};
 use alloy_eips::BlockId;
-use alloy_json_rpc::{RpcError, RpcObject, RpcParam};
+use alloy_json_rpc::{RpcError, RpcObject, RpcSend};
 use alloy_network::Network;
 use alloy_primitives::{
     keccak256, Address, BlockHash, Bytes, StorageKey, StorageValue, TxHash, B256, U256, U64,
@@ -377,13 +377,13 @@ where
 }
 
 /// Internal type to handle different types of requests and generating their param hashes.
-struct RequestType<Params: RpcParam> {
+struct RequestType<Params: RpcSend> {
     method: &'static str,
     params: Params,
     block_id: Option<BlockId>,
 }
 
-impl<Params: RpcParam> RequestType<Params> {
+impl<Params: RpcSend> RequestType<Params> {
     const fn new(method: &'static str, params: Params) -> Self {
         Self { method, params, block_id: None }
     }
@@ -505,12 +505,14 @@ impl SharedCache {
     }
 }
 
-/// Attempts to fetch the response from the cache by using the hash of the request params.
+/// Attempts to fetch the response from the cache by using the hash of the
+/// request params.
 ///
-/// In case of a cache miss, fetches from the RPC and saves the response to the cache.
+/// In case of a cache miss, fetches from the RPC and saves the response to the
+/// cache.
 ///
 /// This helps overriding [`Provider`] methods that return [`TransportResult<T>`].
-async fn cache_get_or_fetch<Params: RpcParam, Resp: RpcObject>(
+async fn cache_get_or_fetch<Params: RpcSend, Resp: RpcObject>(
     cache: &SharedCache,
     req: RequestType<Params>,
     fetch_fn: impl std::future::Future<Output = TransportResult<Option<Resp>>>,

--- a/crates/provider/src/provider/caller.rs
+++ b/crates/provider/src/provider/caller.rs
@@ -1,6 +1,6 @@
 use super::EthCallParams;
 use crate::ProviderCall;
-use alloy_json_rpc::RpcReturn;
+use alloy_json_rpc::RpcRecv;
 use alloy_network::Network;
 use alloy_rpc_client::WeakClient;
 use alloy_transport::{TransportErrorKind, TransportResult};
@@ -9,7 +9,7 @@ use alloy_transport::{TransportErrorKind, TransportResult};
 pub trait Caller<N, Resp>: Send + Sync
 where
     N: Network,
-    Resp: RpcReturn,
+    Resp: RpcRecv,
 {
     /// Method that needs to be implemented to convert to a `ProviderCall`.
     ///
@@ -30,7 +30,7 @@ where
 impl<N, Resp> Caller<N, Resp> for WeakClient
 where
     N: Network,
-    Resp: RpcReturn,
+    Resp: RpcRecv,
 {
     fn call(
         &self,
@@ -47,7 +47,7 @@ where
     }
 }
 
-fn provider_rpc_call<N: Network, Resp: RpcReturn>(
+fn provider_rpc_call<N: Network, Resp: RpcRecv>(
     client: &WeakClient,
     method: &'static str,
     params: EthCallParams<'_, N>,

--- a/crates/provider/src/provider/eth_call.rs
+++ b/crates/provider/src/provider/eth_call.rs
@@ -1,5 +1,5 @@
 use alloy_eips::BlockId;
-use alloy_json_rpc::RpcReturn;
+use alloy_json_rpc::RpcRecv;
 use alloy_network::Network;
 use alloy_rpc_types_eth::state::StateOverride;
 use alloy_transport::TransportResult;
@@ -89,7 +89,7 @@ impl<N: Network> serde::Serialize for EthCallParams<'_, N> {
 pub struct EthCallFut<'req, N, Resp, Output, Map>
 where
     N: Network,
-    Resp: RpcReturn,
+    Resp: RpcRecv,
     Output: 'static,
     Map: Fn(Resp) -> Output,
 {
@@ -99,7 +99,7 @@ where
 enum EthCallFutInner<'req, N, Resp, Output, Map>
 where
     N: Network,
-    Resp: RpcReturn,
+    Resp: RpcRecv,
     Map: Fn(Resp) -> Output,
 {
     Preparing {
@@ -118,7 +118,7 @@ where
 impl<N, Resp, Output, Map> core::fmt::Debug for EthCallFutInner<'_, N, Resp, Output, Map>
 where
     N: Network,
-    Resp: RpcReturn,
+    Resp: RpcRecv,
     Output: 'static,
     Map: Fn(Resp) -> Output,
 {
@@ -136,7 +136,7 @@ where
 impl<N, Resp, Output, Map> EthCallFut<'_, N, Resp, Output, Map>
 where
     N: Network,
-    Resp: RpcReturn,
+    Resp: RpcRecv,
     Output: 'static,
     Map: Fn(Resp) -> Output,
 {
@@ -177,7 +177,7 @@ where
 impl<N, Resp, Output, Map> Future for EthCallFut<'_, N, Resp, Output, Map>
 where
     N: Network,
-    Resp: RpcReturn,
+    Resp: RpcRecv,
     Output: 'static,
     Map: Fn(Resp) -> Output,
 {
@@ -207,7 +207,7 @@ where
 pub struct EthCall<'req, N, Resp, Output = Resp, Map = fn(Resp) -> Output>
 where
     N: Network,
-    Resp: RpcReturn,
+    Resp: RpcRecv,
     Map: Fn(Resp) -> Output,
 {
     caller: Arc<dyn Caller<N, Resp>>,
@@ -220,7 +220,7 @@ where
 impl<N, Resp> core::fmt::Debug for EthCall<'_, N, Resp>
 where
     N: Network,
-    Resp: RpcReturn,
+    Resp: RpcRecv,
 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("EthCall")
@@ -233,7 +233,7 @@ where
 impl<'req, N, Resp> EthCall<'req, N, Resp>
 where
     N: Network,
-    Resp: RpcReturn,
+    Resp: RpcRecv,
 {
     /// Create a new [`EthCall`].
     pub fn new(
@@ -267,7 +267,7 @@ where
 impl<'req, N, Resp, Output, Map> EthCall<'req, N, Resp, Output, Map>
 where
     N: Network,
-    Resp: RpcReturn,
+    Resp: RpcRecv,
     Map: Fn(Resp) -> Output,
 {
     /// Map the response to a different type. This is usable for converting
@@ -313,7 +313,7 @@ where
 impl<'req, N, Resp, Output, Map> std::future::IntoFuture for EthCall<'req, N, Resp, Output, Map>
 where
     N: Network,
-    Resp: RpcReturn,
+    Resp: RpcRecv,
     Output: 'static,
     Map: Fn(Resp) -> Output,
 {

--- a/crates/provider/src/provider/root.rs
+++ b/crates/provider/src/provider/root.rs
@@ -90,7 +90,7 @@ impl<N: Network> RootProvider<N> {
 
     /// Gets the subscription corresponding to the given RPC subscription ID.
     #[cfg(feature = "pubsub")]
-    pub async fn get_subscription<R: alloy_json_rpc::RpcReturn>(
+    pub async fn get_subscription<R: alloy_json_rpc::RpcRecv>(
         &self,
         id: alloy_primitives::B256,
     ) -> alloy_transport::TransportResult<Subscription<R>> {

--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 use alloy_consensus::BlockHeader;
 use alloy_eips::eip2718::Encodable2718;
-use alloy_json_rpc::{RpcError, RpcParam, RpcReturn};
+use alloy_json_rpc::{RpcError, RpcRecv, RpcSend};
 use alloy_network::{Ethereum, Network};
 use alloy_network_primitives::{BlockResponse, BlockTransactionsKind, ReceiptResponse};
 use alloy_primitives::{
@@ -501,7 +501,7 @@ pub trait Provider<N: Network = Ethereum>: Send + Sync {
     /// The return value depends on what stream `id` corresponds to.
     /// See [`FilterChanges`] for all possible return values.
     #[auto_impl(keep_default_for(&, &mut, Rc, Arc, Box))]
-    async fn get_filter_changes<R: RpcReturn>(&self, id: U256) -> TransportResult<Vec<R>>
+    async fn get_filter_changes<R: RpcRecv>(&self, id: U256) -> TransportResult<Vec<R>>
     where
         Self: Sized,
     {
@@ -951,8 +951,8 @@ pub trait Provider<N: Network = Ethereum>: Send + Sync {
     #[auto_impl(keep_default_for(&, &mut, Rc, Arc, Box))]
     async fn subscribe<P, R>(&self, params: P) -> TransportResult<alloy_pubsub::Subscription<R>>
     where
-        P: RpcParam,
-        R: RpcReturn,
+        P: RpcSend,
+        R: RpcRecv,
         Self: Sized,
     {
         self.root().pubsub_frontend()?;
@@ -1017,8 +1017,8 @@ pub trait Provider<N: Network = Ethereum>: Send + Sync {
     /// [`PubsubUnavailable`]: alloy_transport::TransportErrorKind::PubsubUnavailable
     async fn raw_request<P, R>(&self, method: Cow<'static, str>, params: P) -> TransportResult<R>
     where
-        P: RpcParam,
-        R: RpcReturn,
+        P: RpcSend,
+        R: RpcRecv,
         Self: Sized,
     {
         self.client().request(method, &params).await

--- a/crates/provider/src/provider/with_block.rs
+++ b/crates/provider/src/provider/with_block.rs
@@ -1,5 +1,5 @@
 use alloy_eips::BlockId;
-use alloy_json_rpc::{RpcParam, RpcReturn};
+use alloy_json_rpc::{RpcSend, RpcRecv};
 use alloy_primitives::B256;
 use alloy_rpc_client::RpcCall;
 use alloy_transport::TransportResult;
@@ -9,14 +9,14 @@ use crate::ProviderCall;
 
 /// Helper struct that houses the params along with the BlockId.
 #[derive(Debug, Clone)]
-pub struct ParamsWithBlock<Params: RpcParam> {
+pub struct ParamsWithBlock<Params: RpcSend> {
     /// The params to be sent to the RPC call.
     pub params: Params,
     /// The block id to be used for the RPC call.
     pub block_id: BlockId,
 }
 
-impl<Params: RpcParam> serde::Serialize for ParamsWithBlock<Params> {
+impl<Params: RpcSend> serde::Serialize for ParamsWithBlock<Params> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -45,8 +45,8 @@ type ProviderCallProducer<Params, Resp, Output, Map> =
 /// Container for varous types of calls dependent on a block id.
 enum WithBlockInner<Params, Resp, Output = Resp, Map = fn(Resp) -> Output>
 where
-    Params: RpcParam,
-    Resp: RpcReturn,
+    Params: RpcSend,
+    Resp: RpcRecv,
     Map: Fn(Resp) -> Output,
 {
     /// [RpcCall] which params are getting wrapped into [ParamsWithBlock] once the block id is set.
@@ -57,8 +57,8 @@ where
 
 impl<Params, Resp, Output, Map> core::fmt::Debug for WithBlockInner<Params, Resp, Output, Map>
 where
-    Params: RpcParam,
-    Resp: RpcReturn,
+    Params: RpcSend,
+    Resp: RpcRecv,
     Map: Fn(Resp) -> Output,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -78,8 +78,8 @@ where
 #[derive(Debug)]
 pub struct RpcWithBlock<Params, Resp, Output = Resp, Map = fn(Resp) -> Output>
 where
-    Params: RpcParam,
-    Resp: RpcReturn,
+    Params: RpcSend,
+    Resp: RpcRecv,
     Map: Fn(Resp) -> Output + Clone,
 {
     inner: WithBlockInner<Params, Resp, Output, Map>,
@@ -88,8 +88,8 @@ where
 
 impl<Params, Resp, Output, Map> RpcWithBlock<Params, Resp, Output, Map>
 where
-    Params: RpcParam,
-    Resp: RpcReturn,
+    Params: RpcSend,
+    Resp: RpcRecv,
     Map: Fn(Resp) -> Output + Clone,
 {
     /// Create a new [`RpcWithBlock`] from a [`RpcCall`].
@@ -110,8 +110,8 @@ where
 impl<Params, Resp, Output, Map> From<RpcCall<Params, Resp, Output, Map>>
     for RpcWithBlock<Params, Resp, Output, Map>
 where
-    Params: RpcParam,
-    Resp: RpcReturn,
+    Params: RpcSend,
+    Resp: RpcRecv,
     Map: Fn(Resp) -> Output + Clone,
 {
     fn from(inner: RpcCall<Params, Resp, Output, Map>) -> Self {
@@ -121,8 +121,8 @@ where
 
 impl<F, Params, Resp, Output, Map> From<F> for RpcWithBlock<Params, Resp, Output, Map>
 where
-    Params: RpcParam,
-    Resp: RpcReturn,
+    Params: RpcSend,
+    Resp: RpcRecv,
     Map: Fn(Resp) -> Output + Clone,
     F: Fn(BlockId) -> ProviderCall<ParamsWithBlock<Params>, Resp, Output, Map> + Send + 'static,
 {
@@ -133,8 +133,8 @@ where
 
 impl<Params, Resp, Output, Map> RpcWithBlock<Params, Resp, Output, Map>
 where
-    Params: RpcParam,
-    Resp: RpcReturn,
+    Params: RpcSend,
+    Resp: RpcRecv,
     Map: Fn(Resp) -> Output + Clone,
 {
     /// Set the block id.
@@ -188,8 +188,8 @@ where
 
 impl<Params, Resp, Output, Map> IntoFuture for RpcWithBlock<Params, Resp, Output, Map>
 where
-    Params: RpcParam,
-    Resp: RpcReturn,
+    Params: RpcSend,
+    Resp: RpcRecv,
     Output: 'static,
     Map: Fn(Resp) -> Output + Clone,
 {

--- a/crates/provider/src/provider/with_block.rs
+++ b/crates/provider/src/provider/with_block.rs
@@ -1,5 +1,5 @@
 use alloy_eips::BlockId;
-use alloy_json_rpc::{RpcSend, RpcRecv};
+use alloy_json_rpc::{RpcRecv, RpcSend};
 use alloy_primitives::B256;
 use alloy_rpc_client::RpcCall;
 use alloy_transport::TransportResult;

--- a/crates/rpc-client/src/batch.rs
+++ b/crates/rpc-client/src/batch.rs
@@ -1,7 +1,7 @@
 use crate::{client::RpcClientInner, ClientRef};
 use alloy_json_rpc::{
-    transform_response, try_deserialize_ok, Id, Request, RequestPacket, ResponsePacket, RpcParam,
-    RpcReturn, SerializedRequest,
+    transform_response, try_deserialize_ok, Id, Request, RequestPacket, ResponsePacket, RpcSend,
+    RpcRecv, SerializedRequest,
 };
 use alloy_primitives::map::HashMap;
 use alloy_transport::{
@@ -80,7 +80,7 @@ impl<Resp> From<oneshot::Receiver<TransportResult<Box<RawValue>>>> for Waiter<Re
 
 impl<Resp, Output, Map> std::future::Future for Waiter<Resp, Output, Map>
 where
-    Resp: RpcReturn,
+    Resp: RpcRecv,
     Map: FnOnce(Resp) -> Output,
 {
     type Output = TransportResult<Output>;
@@ -135,7 +135,7 @@ impl<'a> BatchRequest<'a> {
         rx
     }
 
-    fn push<Params: RpcParam, Resp: RpcReturn>(
+    fn push<Params: RpcSend, Resp: RpcRecv>(
         &mut self,
         request: Request<Params>,
     ) -> TransportResult<Waiter<Resp>> {
@@ -148,7 +148,7 @@ impl<'a> BatchRequest<'a> {
     /// ### Errors
     ///
     /// If the request cannot be serialized, this will return an error.
-    pub fn add_call<Params: RpcParam, Resp: RpcReturn>(
+    pub fn add_call<Params: RpcSend, Resp: RpcRecv>(
         &mut self,
         method: impl Into<Cow<'static, str>>,
         params: &Params,

--- a/crates/rpc-client/src/batch.rs
+++ b/crates/rpc-client/src/batch.rs
@@ -1,7 +1,7 @@
 use crate::{client::RpcClientInner, ClientRef};
 use alloy_json_rpc::{
-    transform_response, try_deserialize_ok, Id, Request, RequestPacket, ResponsePacket, RpcSend,
-    RpcRecv, SerializedRequest,
+    transform_response, try_deserialize_ok, Id, Request, RequestPacket, ResponsePacket, RpcRecv,
+    RpcSend, SerializedRequest,
 };
 use alloy_primitives::map::HashMap;
 use alloy_transport::{

--- a/crates/rpc-client/src/client.rs
+++ b/crates/rpc-client/src/client.rs
@@ -1,5 +1,5 @@
 use crate::{poller::PollerBuilder, BatchRequest, ClientBuilder, RpcCall};
-use alloy_json_rpc::{Id, Request, RpcParam, RpcReturn};
+use alloy_json_rpc::{Id, Request, RpcRecv, RpcSend};
 use alloy_transport::{BoxTransport, IntoBoxTransport};
 use alloy_transport_http::Http;
 use std::{
@@ -101,8 +101,8 @@ impl RpcClient {
         params: Params,
     ) -> PollerBuilder<Params, Resp>
     where
-        Params: RpcParam + 'static,
-        Resp: RpcReturn + Clone,
+        Params: RpcSend + 'static,
+        Resp: RpcRecv + Clone,
     {
         PollerBuilder::new(self.get_weak(), method, params)
     }
@@ -230,7 +230,7 @@ impl RpcClientInner {
     ///
     /// To send a request, use [`RpcClientInner::request`] and await the returned [`RpcCall`].
     #[inline]
-    pub fn make_request<Params: RpcParam>(
+    pub fn make_request<Params: RpcSend>(
         &self,
         method: impl Into<Cow<'static, str>>,
         params: Params,
@@ -278,7 +278,7 @@ impl RpcClientInner {
     /// This means that if a serializer error occurs, it will not be caught until the call is
     /// awaited.
     #[doc(alias = "prepare")]
-    pub fn request<Params: RpcParam, Resp: RpcReturn>(
+    pub fn request<Params: RpcSend, Resp: RpcRecv>(
         &self,
         method: impl Into<Cow<'static, str>>,
         params: Params,
@@ -290,7 +290,7 @@ impl RpcClientInner {
     /// Prepares an [`RpcCall`] with no parameters.
     ///
     /// See [`request`](Self::request) for more details.
-    pub fn request_noparams<Resp: RpcReturn>(
+    pub fn request_noparams<Resp: RpcRecv>(
         &self,
         method: impl Into<Cow<'static, str>>,
     ) -> RpcCall<NoParams, Resp> {

--- a/crates/rpc-client/src/poller.rs
+++ b/crates/rpc-client/src/poller.rs
@@ -1,5 +1,5 @@
 use crate::WeakClient;
-use alloy_json_rpc::{RpcError, RpcSend, RpcRecv};
+use alloy_json_rpc::{RpcError, RpcRecv, RpcSend};
 use alloy_transport::utils::Spawnable;
 use futures::{Stream, StreamExt};
 use serde::Serialize;

--- a/crates/rpc-client/src/poller.rs
+++ b/crates/rpc-client/src/poller.rs
@@ -1,5 +1,5 @@
 use crate::WeakClient;
-use alloy_json_rpc::{RpcError, RpcParam, RpcReturn};
+use alloy_json_rpc::{RpcError, RpcSend, RpcRecv};
 use alloy_transport::utils::Spawnable;
 use futures::{Stream, StreamExt};
 use serde::Serialize;
@@ -81,8 +81,8 @@ pub struct PollerBuilder<Params, Resp> {
 
 impl<Params, Resp> PollerBuilder<Params, Resp>
 where
-    Params: RpcParam + 'static,
-    Resp: RpcReturn + Clone,
+    Params: RpcSend + 'static,
+    Resp: RpcRecv + Clone,
 {
     /// Create a new poller task.
     pub fn new(client: WeakClient, method: impl Into<Cow<'static, str>>, params: Params) -> Self {
@@ -248,7 +248,7 @@ impl<Resp> DerefMut for PollChannel<Resp> {
 
 impl<Resp> PollChannel<Resp>
 where
-    Resp: RpcReturn + Clone,
+    Resp: RpcRecv + Clone,
 {
     /// Resubscribe to the poller task.
     pub fn resubscribe(&self) -> Self {


### PR DESCRIPTION
## Motivation

Make the RPC trait system more clear and flexible, provide non-owned options requirements baked into the traits

## Solution

* Rename `RpcParam` to `RpcSend` and `RpcReturn` to `RpcReceive` to make them clearer
* Add lifetimed versions of `RpcReturn` and `RpcObject` to allow borrowing from deserializers
* relax many bounds from `RpcObject` to either `RpcBorrow` or `RpcSend`, e.g. in `ResponsePayload::serialize_payload` we can relax to `RpcSend`

## Note

The implementation of `RpcRecv` is still **more** strict than `DeserializeOwned`, as it requires `+ 'static` rather than `for<'de> Deserialize<'de>`. This means that it is not iplemented on (e.g.) things that borrow from some non-deserializer context or environment during deserialization. Some parts of our future and streaming systems rely on this, and it seems like just marginal benefit to change

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [x] Breaking changes
