### PR TITLE
feat(consensus): make fn tx_type() public

### DIFF
--- a/crates/consensus/src/transaction/eip1559.rs
+++ b/crates/consensus/src/transaction/eip1559.rs
@@ -75,7 +75,7 @@ pub struct TxEip1559 {
 impl TxEip1559 {
     /// Get the transaction type
     #[doc(alias = "transaction_type")]
-    pub(crate) const fn tx_type() -> TxType {
+    pub const fn tx_type() -> TxType {
         TxType::Eip1559
     }
 


### PR DESCRIPTION
## Motivation

The `tx_type` method for `TxEip1559` is available only within the `consensus` crate, while it is available to external crates for all other `TxEip...` structs.

## Solution

Change method to be available to external crates.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
