### PR TITLE
fix: version number of installation is out of date

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ cargo add alloy --features full
 Alternatively, you can add the following to your `Cargo.toml` file:
 
 ```toml
-alloy = { version = "0.3", features = ["full"] }
+alloy = { version = "0.10", features = ["full"] }
 ```
 
 For a more fine-grained control over the features you wish to include, you can add the individual crates to your `Cargo.toml` file, or use the `alloy` crate with the features you need.

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -13,6 +13,7 @@ changed or not.
 
 ## Steps
 
+- [ ] Update the version number in the [README](./README.md#installation) to the new version.
 - [ ] Make sure you're on the `main` branch.
 - [ ] (optional) Dry run `cargo-release`: `cargo release <version>`
 - [ ] Run `cargo-release`: `PUBLISH_GRACE_SLEEP=10 cargo release --execute [--no-verify] <version>`


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Version number is out of date in documentation

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Update to `0.10`, added updating the number as step into release process document

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
