### PR TITLE
feat: add Recovered::cloned

### DIFF
--- a/crates/consensus/src/transaction/recovered.rs
+++ b/crates/consensus/src/transaction/recovered.rs
@@ -71,13 +71,12 @@ impl<T> Recovered<T> {
 }
 
 impl<T> Recovered<&T> {
-
     /// Maps a `Recovered<&T>` to a `Recovered<T>` by cloning the transaction.
     pub fn cloned(self) -> Recovered<T>
     where
         T: Clone,
     {
-       let Self { tx, signer } = self;
+        let Self { tx, signer } = self;
         Recovered::new_unchecked(tx.clone(), signer)
     }
 }

--- a/crates/consensus/src/transaction/recovered.rs
+++ b/crates/consensus/src/transaction/recovered.rs
@@ -70,6 +70,18 @@ impl<T> Recovered<T> {
     }
 }
 
+impl<T> Recovered<&T> {
+
+    /// Maps a `Recovered<&T>` to a `Recovered<T>` by cloning the transaction.
+    pub fn cloned(self) -> Recovered<T>
+    where
+        T: Clone,
+    {
+       let Self { tx, signer } = self;
+        Recovered::new_unchecked(tx.clone(), signer)
+    }
+}
+
 impl<T: Encodable> Encodable for Recovered<T> {
     /// This encodes the transaction _with_ the signature, and an rlp header.
     fn encode(&self, out: &mut dyn bytes::BufMut) {


### PR DESCRIPTION
we have certain tx traits implemented for references so `Recovered<&Tx>` can be useful,

this adds a helper just like `Option::cloned` to obtain a `Recovered<Tx>`