### PR TITLE
wip: feat: delegator macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ redundant-clone = "warn"
 alloy-consensus = { version = "0.10", path = "crates/consensus", default-features = false }
 alloy-consensus-any = { version = "0.10", path = "crates/consensus-any", default-features = false }
 alloy-contract = { version = "0.10", path = "crates/contract", default-features = false }
+alloy-delegate-macro = { version = "0.10", path = "crates/delegate-macro", default-features = false }
 alloy-eips = { version = "0.10", path = "crates/eips", default-features = false }
 alloy-eip7547 = { version = "0.10", path = "crates/eip7547", default-features = false }
 alloy-genesis = { version = "0.10", path = "crates/genesis", default-features = false }
@@ -151,6 +152,12 @@ semver = "1.0"
 strum = { version = "0.26", default-features = false }
 thiserror = { version = "2.0", default-features = false }
 url = "2.5"
+
+# macros
+proc-macro-error2 = "2.0.0"
+proc-macro2 = "1.0"
+quote = "1.0"
+syn = "2.0"
 
 # misc-testing
 arbitrary = "1.3"

--- a/crates/delegate-macro/Cargo.toml
+++ b/crates/delegate-macro/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "alloy-delegate-macro"
+description = "Delegate macro generator"
+
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+exclude.workspace = true
+
+[lib]
+proc-macro = true
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = [
+    "-Zunstable-options",
+    "--generate-link-to-definition",
+    "--show-type-layout",
+]
+
+[lints]
+workspace = true
+
+[dependencies]
+proc-macro-error2.workspace = true
+proc-macro2.workspace = true
+quote.workspace = true
+syn = { workspace = true, features = ["extra-traits"] }

--- a/crates/delegate-macro/README.md
+++ b/crates/delegate-macro/README.md
@@ -1,0 +1,9 @@
+# alloy-sol-macro
+
+This crate provides the [`sol!`][sol] procedural macro, which parses Solidity
+syntax to generate types that implement [`alloy-sol-types`] traits.
+
+Refer to the [macro's documentation][sol] for more information.
+
+[sol]: https://docs.rs/alloy-sol-macro/latest/alloy_sol_macro/macro.sol.html
+[`alloy-sol-types`]: ../sol-types

--- a/crates/delegate-macro/README.md
+++ b/crates/delegate-macro/README.md
@@ -1,9 +1,3 @@
-# alloy-sol-macro
+# alloy-delegate-macro
 
-This crate provides the [`sol!`][sol] procedural macro, which parses Solidity
-syntax to generate types that implement [`alloy-sol-types`] traits.
-
-Refer to the [macro's documentation][sol] for more information.
-
-[sol]: https://docs.rs/alloy-sol-macro/latest/alloy_sol_macro/macro.sol.html
-[`alloy-sol-types`]: ../sol-types
+This crate provides proc-macros for implementing alloy traits by delegation.

--- a/crates/delegate-macro/src/delegate.rs
+++ b/crates/delegate-macro/src/delegate.rs
@@ -1,23 +1,23 @@
-use syn::Attribute;
-use syn::parse::{Parse, ParseStream};
+use syn::{
+    parse::{Parse, ParseStream},
+    Attribute,
+};
 
 /// Parsed input for `delegator!` macro.
 #[derive(Clone, Debug)]
 pub struct DelegatorInput {
-    /// Variants
+    /// All transaction variants
     pub variants: Vec<Attribute>,
 }
 
 impl Parse for DelegatorInput {
     fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
-        let attrs = Attribute::parse_inner(input)?;
-
         // // Ignore outer attributes when peeking.
         // let fork = input.fork();
         // let _fork_outer = Attribute::parse_outer(&fork)?;
         //
-        // if fork.peek(LitStr) || (fork.peek(Ident) && fork.peek2(Token![,]) && fork.peek3(LitStr)) {
-        //     Self::parse_abigen(attrs, input)
+        // if fork.peek(LitStr) || (fork.peek(Ident) && fork.peek2(Token![,]) && fork.peek3(LitStr))
+        // {     Self::parse_abigen(attrs, input)
         // } else {
         //     input.parse().map(|kind| Self { attrs, path: None, kind })
         // }

--- a/crates/delegate-macro/src/delegate.rs
+++ b/crates/delegate-macro/src/delegate.rs
@@ -1,0 +1,26 @@
+use syn::Attribute;
+use syn::parse::{Parse, ParseStream};
+
+/// Parsed input for `delegator!` macro.
+#[derive(Clone, Debug)]
+pub struct DelegatorInput {
+    /// Variants
+    pub variants: Vec<Attribute>,
+}
+
+impl Parse for DelegatorInput {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        let attrs = Attribute::parse_inner(input)?;
+
+        // // Ignore outer attributes when peeking.
+        // let fork = input.fork();
+        // let _fork_outer = Attribute::parse_outer(&fork)?;
+        //
+        // if fork.peek(LitStr) || (fork.peek(Ident) && fork.peek2(Token![,]) && fork.peek3(LitStr)) {
+        //     Self::parse_abigen(attrs, input)
+        // } else {
+        //     input.parse().map(|kind| Self { attrs, path: None, kind })
+        // }
+        todo!()
+    }
+}

--- a/crates/delegate-macro/src/lib.rs
+++ b/crates/delegate-macro/src/lib.rs
@@ -1,6 +1,7 @@
 //! # alloy-delegate-macro
 //!
-//! This crate provides the [`delegator!`] procedural macro, which generators a delegator macro intended to be use by transaction enums.
+//! This crate provides the [`delegator!`] procedural macro, which generators a delegator macro
+//! intended to be use by transaction enums.
 
 #![doc = include_str!("../README.md")]
 #![doc(
@@ -16,68 +17,30 @@ extern crate proc_macro_error2;
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::parse_macro_input;
+use crate::delegate::DelegatorInput;
 
 mod delegate;
 
+// TODO: add custom derive macro that auto delegates known alloy traits?
+
+/// Generate a delegator macro delegates function calls to variants
 #[proc_macro]
 #[proc_macro_error]
-pub fn sol(input: TokenStream) -> TokenStream {
-    let input = parse_macro_input!(input as alloy_sol_macro_input::SolInput);
-
-    SolMacroExpander.expand(&input).unwrap_or_else(syn::Error::into_compile_error).into()
+pub fn delegator(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as delegate::DelegatorInput);
+    expand_delegator_macro(&input).unwrap_or_else(syn::Error::into_compile_error).into()
 }
 
-struct SolMacroExpander;
-
-impl SolInputExpander for SolMacroExpander {
-    fn expand(&mut self, input: &SolInput) -> syn::Result<proc_macro2::TokenStream> {
-        let input = input.clone();
-
-        #[cfg(feature = "json")]
-        let is_json = matches!(input.kind, SolInputKind::Json { .. });
-        #[cfg(not(feature = "json"))]
-        let is_json = false;
-
-        // Convert JSON input to Solidity input
-        #[cfg(feature = "json")]
-        let input = input.normalize_json()?;
-
-        let SolInput { attrs, path, kind } = input;
-        let include = path.map(|p| {
-            let p = p.to_str().unwrap();
-            quote! { const _: &'static [u8] = ::core::include_bytes!(#p); }
-        });
-
-        let tokens = match kind {
-            SolInputKind::Sol(mut file) => {
-                // Attributes have already been added to the inner contract generated in
-                // `normalize_json`.
-                if !is_json {
-                    file.attrs.extend(attrs);
-                }
-
-                crate::expand::expand(file)
+fn expand_delegator_macro(input: &DelegatorInput) -> syn::Result<proc_macro2::TokenStream> {
+    let DelegatorInput { variants }  = input;
+    Ok(quote! {
+            /// Delegates the given function call to the value of each enum
+            macro_rules! delegate {
+                ($self:expr => $tx:ident.$method:ident($($arg:expr),*)) => {
+                    match $self {
+                        #(Self::#variants($tx) => $tx.$method($($arg),*),)*
+                    }
+                };
             }
-            SolInputKind::Type(ty) => {
-                let (sol_attrs, rest) = SolAttrs::parse(&attrs)?;
-                if !rest.is_empty() {
-                    return Err(syn::Error::new_spanned(
-                        rest.first().unwrap(),
-                        "only `#[sol]` attributes are allowed here",
-                    ));
-                }
-
-                let mut crates = crate::expand::ExternCrates::default();
-                crates.fill(&sol_attrs);
-                Ok(crate::expand::expand_type(&ty, &crates))
-            }
-            #[cfg(feature = "json")]
-            SolInputKind::Json(_, _) => unreachable!("input already normalized"),
-        }?;
-
-        Ok(quote! {
-            #include
-            #tokens
         })
-    }
 }

--- a/crates/delegate-macro/src/lib.rs
+++ b/crates/delegate-macro/src/lib.rs
@@ -1,0 +1,83 @@
+//! # alloy-delegate-macro
+//!
+//! This crate provides the [`delegator!`] procedural macro, which generators a delegator macro intended to be use by transaction enums.
+
+#![doc = include_str!("../README.md")]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/alloy-rs/core/main/assets/alloy.jpg",
+    html_favicon_url = "https://raw.githubusercontent.com/alloy-rs/core/main/assets/favicon.ico"
+)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+
+#[macro_use]
+extern crate proc_macro_error2;
+
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::parse_macro_input;
+
+mod delegate;
+
+#[proc_macro]
+#[proc_macro_error]
+pub fn sol(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as alloy_sol_macro_input::SolInput);
+
+    SolMacroExpander.expand(&input).unwrap_or_else(syn::Error::into_compile_error).into()
+}
+
+struct SolMacroExpander;
+
+impl SolInputExpander for SolMacroExpander {
+    fn expand(&mut self, input: &SolInput) -> syn::Result<proc_macro2::TokenStream> {
+        let input = input.clone();
+
+        #[cfg(feature = "json")]
+        let is_json = matches!(input.kind, SolInputKind::Json { .. });
+        #[cfg(not(feature = "json"))]
+        let is_json = false;
+
+        // Convert JSON input to Solidity input
+        #[cfg(feature = "json")]
+        let input = input.normalize_json()?;
+
+        let SolInput { attrs, path, kind } = input;
+        let include = path.map(|p| {
+            let p = p.to_str().unwrap();
+            quote! { const _: &'static [u8] = ::core::include_bytes!(#p); }
+        });
+
+        let tokens = match kind {
+            SolInputKind::Sol(mut file) => {
+                // Attributes have already been added to the inner contract generated in
+                // `normalize_json`.
+                if !is_json {
+                    file.attrs.extend(attrs);
+                }
+
+                crate::expand::expand(file)
+            }
+            SolInputKind::Type(ty) => {
+                let (sol_attrs, rest) = SolAttrs::parse(&attrs)?;
+                if !rest.is_empty() {
+                    return Err(syn::Error::new_spanned(
+                        rest.first().unwrap(),
+                        "only `#[sol]` attributes are allowed here",
+                    ));
+                }
+
+                let mut crates = crate::expand::ExternCrates::default();
+                crates.fill(&sol_attrs);
+                Ok(crate::expand::expand_type(&ty, &crates))
+            }
+            #[cfg(feature = "json")]
+            SolInputKind::Json(_, _) => unreachable!("input already normalized"),
+        }?;
+
+        Ok(quote! {
+            #include
+            #tokens
+        })
+    }
+}


### PR DESCRIPTION
adds a proc macro that generates delegate macros for a given type

https://github.com/paradigmxyz/reth/blob/6d2648dc1b786c1177c947395e4cd2d03d3adad9/crates/ethereum/primitives/src/transaction.rs#L30-L40

this is a common pattern for transaction types, for example:

https://github.com/alloy-rs/alloy/blob/9aadefa5c47c44d775a57a42e39268fd5d5306dc/crates/consensus/src/transaction/pooled.rs#L326-L335

we can simplify this boilerplate with 
1. a helper that generates the delegator macro
2. add builtin support for deriving alloy traits by delegating

1. could even be a derive I believe

still experimenting with this