### PR TITLE
chore: add receipt conversion fns

### DIFF
--- a/crates/consensus/src/receipt/envelope.rs
+++ b/crates/consensus/src/receipt/envelope.rs
@@ -52,6 +52,40 @@ pub enum ReceiptEnvelope<T = Log> {
 }
 
 impl<T> ReceiptEnvelope<T> {
+
+    /// Converts the receipt's log type by applying a function to each log.
+    ///
+    /// Returns the receipt with the new log type.
+    pub fn map_logs<U>(self, f: impl FnMut(T) -> U) -> ReceiptEnvelope<U> {
+        match self {
+            Self::Legacy(r) => {
+                ReceiptEnvelope::Legacy(r.map_logs(f))
+            }
+            Self::Eip2930(r) => {
+                ReceiptEnvelope::Eip2930(r.map_logs(f))
+            }
+            Self::Eip1559(r) => {
+                ReceiptEnvelope::Eip1559(r.map_logs(f))
+            }
+            Self::Eip4844(r) => {
+                ReceiptEnvelope::Eip4844(r.map_logs(f))
+            }
+            Self::Eip7702(r) => {
+                ReceiptEnvelope::Eip7702(r.map_logs(f))
+            }
+        }
+    }
+
+    /// Converts a [`ReceiptEnvelope`] with a custom log type into a [`ReceiptEnvelope`] with the primitives [`Log`]
+    /// type by converting the logs.
+    ///
+    /// This is useful if log types that embed the primitives log type, e.g. the log receipt rpc
+    /// type.
+    pub fn into_primitives_receipt(self) -> ReceiptEnvelope<Log> where T: Into<Log> {
+        self.map_logs(Into::into)
+    }
+
+
     /// Return the [`TxType`] of the inner receipt.
     #[doc(alias = "transaction_type")]
     pub const fn tx_type(&self) -> TxType {

--- a/crates/consensus/src/receipt/envelope.rs
+++ b/crates/consensus/src/receipt/envelope.rs
@@ -52,39 +52,30 @@ pub enum ReceiptEnvelope<T = Log> {
 }
 
 impl<T> ReceiptEnvelope<T> {
-
     /// Converts the receipt's log type by applying a function to each log.
     ///
     /// Returns the receipt with the new log type.
     pub fn map_logs<U>(self, f: impl FnMut(T) -> U) -> ReceiptEnvelope<U> {
         match self {
-            Self::Legacy(r) => {
-                ReceiptEnvelope::Legacy(r.map_logs(f))
-            }
-            Self::Eip2930(r) => {
-                ReceiptEnvelope::Eip2930(r.map_logs(f))
-            }
-            Self::Eip1559(r) => {
-                ReceiptEnvelope::Eip1559(r.map_logs(f))
-            }
-            Self::Eip4844(r) => {
-                ReceiptEnvelope::Eip4844(r.map_logs(f))
-            }
-            Self::Eip7702(r) => {
-                ReceiptEnvelope::Eip7702(r.map_logs(f))
-            }
+            Self::Legacy(r) => ReceiptEnvelope::Legacy(r.map_logs(f)),
+            Self::Eip2930(r) => ReceiptEnvelope::Eip2930(r.map_logs(f)),
+            Self::Eip1559(r) => ReceiptEnvelope::Eip1559(r.map_logs(f)),
+            Self::Eip4844(r) => ReceiptEnvelope::Eip4844(r.map_logs(f)),
+            Self::Eip7702(r) => ReceiptEnvelope::Eip7702(r.map_logs(f)),
         }
     }
 
-    /// Converts a [`ReceiptEnvelope`] with a custom log type into a [`ReceiptEnvelope`] with the primitives [`Log`]
-    /// type by converting the logs.
+    /// Converts a [`ReceiptEnvelope`] with a custom log type into a [`ReceiptEnvelope`] with the
+    /// primitives [`Log`] type by converting the logs.
     ///
     /// This is useful if log types that embed the primitives log type, e.g. the log receipt rpc
     /// type.
-    pub fn into_primitives_receipt(self) -> ReceiptEnvelope<Log> where T: Into<Log> {
+    pub fn into_primitives_receipt(self) -> ReceiptEnvelope<Log>
+    where
+        T: Into<Log>,
+    {
         self.map_logs(Into::into)
     }
-
 
     /// Return the [`TxType`] of the inner receipt.
     #[doc(alias = "transaction_type")]

--- a/crates/consensus/src/receipt/receipts.rs
+++ b/crates/consensus/src/receipt/receipts.rs
@@ -327,7 +327,7 @@ impl<L> ReceiptWithBloom<Receipt<L>> {
         ReceiptWithBloom { receipt: receipt.map_logs(f), logs_bloom }
     }
 
-    /// Converts a [`ReceiptEnvelope`] with a custom log type into a [`ReceiptEnvelope`] with the
+    /// Converts a [`ReceiptWithBloom`] with a custom log type into a [`ReceiptWithBloom`] with the
     /// primitives [`Log`] type by converting the logs.
     ///
     /// This is useful if log types that embed the primitives log type, e.g. the log receipt rpc

--- a/crates/consensus/src/receipt/receipts.rs
+++ b/crates/consensus/src/receipt/receipts.rs
@@ -299,7 +299,6 @@ where
 }
 
 impl<R> ReceiptWithBloom<R> {
-
     /// Converts the receipt type by applying the given closure to it.
     ///
     /// Returns the type with the new receipt type.
@@ -319,8 +318,7 @@ impl<R> ReceiptWithBloom<R> {
     }
 }
 
-impl<L> ReceiptWithBloom<Receipt<L>>  {
-
+impl<L> ReceiptWithBloom<Receipt<L>> {
     /// Converts the receipt's log type by applying a function to each log.
     ///
     /// Returns the receipt with the new log type.
@@ -329,15 +327,17 @@ impl<L> ReceiptWithBloom<Receipt<L>>  {
         ReceiptWithBloom { receipt: receipt.map_logs(f), logs_bloom }
     }
 
-    /// Converts a [`ReceiptEnvelope`] with a custom log type into a [`ReceiptEnvelope`] with the primitives [`Log`]
-    /// type by converting the logs.
+    /// Converts a [`ReceiptEnvelope`] with a custom log type into a [`ReceiptEnvelope`] with the
+    /// primitives [`Log`] type by converting the logs.
     ///
     /// This is useful if log types that embed the primitives log type, e.g. the log receipt rpc
     /// type.
-    pub fn into_primitives_receipt(self) ->ReceiptWithBloom<Receipt<Log>> where L: Into<Log> {
+    pub fn into_primitives_receipt(self) -> ReceiptWithBloom<Receipt<Log>>
+    where
+        L: Into<Log>,
+    {
         self.map_logs(Into::into)
     }
-
 }
 
 impl<R: RlpEncodableReceipt> Encodable for ReceiptWithBloom<R> {

--- a/crates/rpc-types-eth/src/log.rs
+++ b/crates/rpc-types-eth/src/log.rs
@@ -51,6 +51,11 @@ impl<T> Log<T> {
     pub const fn data(&self) -> &T {
         &self.inner.data
     }
+
+    /// Consumes the type and returns the wrapped [`alloy_primitives::Log`]
+    pub fn into_inner(self) -> alloy_primitives::Log<T> {
+        self.inner
+    }
 }
 
 impl Log<LogData> {
@@ -148,6 +153,12 @@ impl<T> AsRef<T> for Log<T> {
 impl<T> AsMut<T> for Log<T> {
     fn as_mut(&mut self) -> &mut T {
         &mut self.inner.data
+    }
+}
+
+impl<L> From<Log<L>> for alloy_primitives::Log<L> {
+    fn from(value: Log<L>) -> Self {
+        value.into_inner()
     }
 }
 

--- a/crates/rpc-types-eth/src/transaction/receipt.rs
+++ b/crates/rpc-types-eth/src/transaction/receipt.rs
@@ -136,14 +136,18 @@ impl<L> TransactionReceipt<ReceiptEnvelope<L>> {
     ///
     /// Returns the receipt with the new log type.
     pub fn map_logs<U>(self, f: impl FnMut(L) -> U) -> TransactionReceipt<ReceiptEnvelope<U>> {
-        self.map_inner(|inner| {
-            inner.map_logs(f)
-        })
+        self.map_inner(|inner| inner.map_logs(f))
     }
 
-    /// Converts the transaction receipt's [`ReceiptEnvelope`] with a custom log type into a [`ReceiptEnvelope`] with the primitives [`alloy_primitives::Log`]
-    /// type by converting the logs.
-    pub fn into_primitives_receipt(self) -> TransactionReceipt<ReceiptEnvelope<alloy_primitives::Log>> where L: Into<alloy_primitives::Log> {
+    /// Converts the transaction receipt's [`ReceiptEnvelope`] with a custom log type into a
+    /// [`ReceiptEnvelope`] with the primitives [`alloy_primitives::Log`] type by converting the
+    /// logs.
+    pub fn into_primitives_receipt(
+        self,
+    ) -> TransactionReceipt<ReceiptEnvelope<alloy_primitives::Log>>
+    where
+        L: Into<alloy_primitives::Log>,
+    {
         self.map_logs(Into::into)
     }
 }

--- a/crates/rpc-types-eth/src/transaction/receipt.rs
+++ b/crates/rpc-types-eth/src/transaction/receipt.rs
@@ -13,7 +13,7 @@ use alloy_primitives::{Address, BlockHash, TxHash, B256};
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[doc(alias = "TxReceipt")]
 pub struct TransactionReceipt<T = ReceiptEnvelope<Log>> {
-    /// The receipt envelope, which contains the consensus receipt data..
+    /// The receipt envelope, which contains the consensus receipt data.
     #[cfg_attr(feature = "serde", serde(flatten))]
     pub inner: T,
     /// Transaction Hash.
@@ -124,6 +124,28 @@ impl<T> TransactionReceipt<T> {
             contract_address: self.contract_address,
         }
     }
+
+    /// Consumes the type and returns the wrapped receipt.
+    pub fn into_inner(self) -> T {
+        self.inner
+    }
+}
+
+impl<L> TransactionReceipt<ReceiptEnvelope<L>> {
+    /// Converts the receipt's log type by applying a function to each log.
+    ///
+    /// Returns the receipt with the new log type.
+    pub fn map_logs<U>(self, f: impl FnMut(L) -> U) -> TransactionReceipt<ReceiptEnvelope<U>> {
+        self.map_inner(|inner| {
+            inner.map_logs(f)
+        })
+    }
+
+    /// Converts the transaction receipt's [`ReceiptEnvelope`] with a custom log type into a [`ReceiptEnvelope`] with the primitives [`alloy_primitives::Log`]
+    /// type by converting the logs.
+    pub fn into_primitives_receipt(self) -> TransactionReceipt<ReceiptEnvelope<alloy_primitives::Log>> where L: Into<alloy_primitives::Log> {
+        self.map_logs(Into::into)
+    }
 }
 
 impl<T: TxReceipt<Log = Log>> ReceiptResponse for TransactionReceipt<T> {
@@ -181,6 +203,12 @@ impl<T: TxReceipt<Log = Log>> ReceiptResponse for TransactionReceipt<T> {
 
     fn state_root(&self) -> Option<B256> {
         self.inner.status_or_post_state().as_post_state()
+    }
+}
+
+impl From<TransactionReceipt> for TransactionReceipt<ReceiptEnvelope<alloy_primitives::Log>> {
+    fn from(value: TransactionReceipt) -> Self {
+        value.into_primitives_receipt()
     }
 }
 


### PR DESCRIPTION
towards #1939

adds helper conversion fn for the various receipt types to map logs and convert to primitives logs.

adds a from impl for the rpc txreceipt to convert the wrapped receipt envelope into an envelope with primitives logs

cc @Wollac 