### PR TITLE
feat: add calc tx root fn for rpc types

### DIFF
--- a/crates/network-primitives/src/block.rs
+++ b/crates/network-primitives/src/block.rs
@@ -1,10 +1,10 @@
 use alloy_primitives::B256;
 use serde::{Deserialize, Serialize};
 
-use alloc::{vec, vec::Vec};
-use core::slice;
-
 use crate::TransactionResponse;
+use alloc::{vec, vec::Vec};
+use alloy_eips::Encodable2718;
+use core::slice;
 
 /// Block Transactions depending on the boolean attribute of `eth_getBlockBy*`,
 /// or if used by `eth_getUncle*`
@@ -81,6 +81,16 @@ impl<T> BlockTransactions<T> {
             Self::Full(txs) => Some(txs),
             _ => None,
         }
+    }
+
+    /// Calculate the transaction root for the full transactions.
+    ///
+    /// Returns `None` if this is not the [`BlockTransactions::Full`] variant
+    pub fn calculate_transactions_root(&self) -> Option<B256>
+    where
+        T: Encodable2718,
+    {
+        self.as_transactions().map(alloy_consensus::proofs::calculate_transaction_root)
     }
 
     /// Returns true if the enum variant is used for an uncle response.

--- a/crates/rpc-types-eth/src/block.rs
+++ b/crates/rpc-types-eth/src/block.rs
@@ -11,11 +11,11 @@ use alloy_primitives::{Address, BlockHash, Bloom, Bytes, Sealable, B256, B64, U2
 use alloy_rlp::Encodable;
 use core::ops::{Deref, DerefMut};
 
-use alloy_eips::eip7840::BlobParams;
 pub use alloy_eips::{
     calc_blob_gasprice, calc_excess_blob_gas, BlockHashOrNumber, BlockId, BlockNumHash,
     BlockNumberOrTag, ForkBlock, RpcBlockHash,
 };
+use alloy_eips::{eip7840::BlobParams, Encodable2718};
 
 /// Block representation for RPC.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -142,6 +142,16 @@ impl<T, H> Block<T, H> {
             transactions: self.transactions.try_map(f)?,
             withdrawals: self.withdrawals,
         })
+    }
+
+    /// Calculate the transaction root for the full transactions in this block type.
+    ///
+    /// Returns `None` if the `transactions` is not the [`BlockTransactions::Full`] variant.
+    pub fn calculate_transactions_root(&self) -> Option<B256>
+    where
+        T: Encodable2718,
+    {
+        self.transactions.calculate_transactions_root()
     }
 }
 


### PR DESCRIPTION
towards #1939

add calc tx root helper for the rpc response types

cc @Wollac 