### PR TITLE
feat: improved mock server for unit and provider testing

### DIFF
--- a/crates/transport-ipc/Cargo.toml
+++ b/crates/transport-ipc/Cargo.toml
@@ -38,7 +38,8 @@ serde.workspace = true
 bytes = "1.5.0"
 interprocess = { version = "2", features = ["tokio"] }
 tempfile = { workspace = true, optional = true }
-parking_lot = { workspace = true, default-features = false, optional = true }
+parking_lot = { workspace = true, optional = true }
+fastrand = "2.3.0"
 
 [dev-dependencies]
 tokio-test.workspace = true

--- a/crates/transport-ipc/Cargo.toml
+++ b/crates/transport-ipc/Cargo.toml
@@ -39,7 +39,6 @@ bytes = "1.5.0"
 interprocess = { version = "2", features = ["tokio"] }
 tempfile = { workspace = true, optional = true }
 parking_lot = { workspace = true, optional = true }
-fastrand = "2.3.0"
 
 [dev-dependencies]
 tokio-test.workspace = true

--- a/crates/transport-ipc/Cargo.toml
+++ b/crates/transport-ipc/Cargo.toml
@@ -38,10 +38,11 @@ serde.workspace = true
 bytes = "1.5.0"
 interprocess = { version = "2", features = ["tokio"] }
 tempfile = { workspace = true, optional = true }
+parking_lot = { workspace = true, default-features = false, optional = true }
 
 [dev-dependencies]
 tokio-test.workspace = true
 
 [features]
 default = []
-mock = ["dep:tempfile"]
+mock = ["dep:tempfile", "dep:parking_lot"]

--- a/crates/transport-ipc/src/mock.rs
+++ b/crates/transport-ipc/src/mock.rs
@@ -460,9 +460,6 @@ mod tests {
                     write.write_all(b"\n").await?;
                     write.flush().await?;
 
-                    // Add small random delay to test concurrency
-                    tokio::time::sleep(Duration::from_millis(fastrand::u64(10..50))).await;
-
                     // Read response
                     if let Some(response) = reader.next().await {
                         responses.push(response);

--- a/crates/transport-ipc/src/mock.rs
+++ b/crates/transport-ipc/src/mock.rs
@@ -1,39 +1,116 @@
-//! Mock IPC server.
+//! An IPC mock server and client for testing Ethereum JSON-RPC providers.
+//! This module provides a way to mock responses from an IPC-based Ethereum node
+//! by creating a Unix domain socket that responds with pre-configured replies.
 
 use alloy_json_rpc::Response;
-use interprocess::local_socket::tokio::prelude::*;
 use serde::Serialize;
-use std::{collections::VecDeque, path::PathBuf};
+use serde_json::Value;
+use std::{collections::VecDeque, sync::Arc};
 use tempfile::NamedTempFile;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::{
+    fs,
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::UnixListener,
+    sync::{oneshot, Mutex},
+};
 
-/// Mock IPC server.
+/// A handle to control a running mock IPC server.
 ///
-/// Currently unix socket only, due to use of namedtempfile.
+/// The handle allows adding responses that will be returned to the provider
+/// and triggering server shutdown. Multiple handles can exist for the same
+/// server instance.
+#[derive(Debug, Clone)]
+pub struct MockIpcHandle {
+    /// Queue of responses to return to the provider
+    replies: Arc<Mutex<VecDeque<Vec<u8>>>>,
+    /// Channel for triggering server shutdown
+    shutdown: Arc<Mutex<Option<oneshot::Sender<()>>>>,
+    /// Keeps the temporary socket file alive while the handle exists
+    _temp_file: Arc<NamedTempFile>,
+}
+
+/// ```rust,no_run,ignore
+/// 
+///  let server = MockIpcServer::new();
+///  let path = server.path();
+///  let handle = server.spawn().await?;
 ///
-/// ## Example:
+///  // Queue a mock response for eth_getBalance
+///  handle
+///     .add_reply(json!({
+///         "jsonrpc": "2.0",
+///         "id": 0,
+///         "result": "0x0000000000000000000000000000000000000000000000000000000000000064"
+///   }))
+///     .await;
 ///
+///  // Create a provider connected to our mock
+///  let provider = ProviderBuilder::new().on_ipc(IpcConnect::new(path)).await?;
+///
+///  // Make a request and verify the response
+///  let balance = provider
+///     .get_balance("0x742d35Cc6634C0532925a3b844Bc454e4438f44e".parse()?)
+///     .await?;
+///
+///  assert_eq!(balance, U256::from(100));
+///
+///  // Clean shutdown
+///  handle.shutdown().await;
+///
+///  Ok(())
 /// ```
-/// use alloy_transport_ipc::MockIpcServer;
-/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// // Instantiate a new mock server.
-/// let mut server = MockIpcServer::new();
-/// // Get the path to the socket.
-/// let path = server.path();
-/// // Add a reply to the server. Can also use `add_raw_reply` to add a raw
-/// // byte vector, or `add_response` to add a json-rpc response.
-/// server.add_reply("hello");
-/// // Run the server. The first request will get "hello" as a response.
-/// MockIpcServer::new().spawn();
-/// # Ok(())
-/// # }
-/// ```
+impl MockIpcHandle {
+    /// Add a raw byte vector as a response to be returned to the provider.
+    /// Responses are returned in FIFO order.
+    pub async fn add_raw_reply(&self, reply: Vec<u8>) {
+        debug!(reply_len = reply.len(), "Adding raw reply");
+        self.replies.lock().await.push_back(reply);
+    }
+
+    /// Add a serializable value as a response to be returned to the provider.
+    /// The value will be serialized to JSON before being queued.
+    /// This is the primary method for adding JSON-RPC responses.
+    pub async fn add_reply<S: Serialize>(&self, s: S) {
+        let reply = match serde_json::to_vec(&s) {
+            Ok(r) => r,
+            Err(e) => {
+                error!(?e, "Failed to serialize reply");
+                return;
+            }
+        };
+        debug!(reply_len = reply.len(), "Adding JSON reply");
+        self.add_raw_reply(reply).await;
+    }
+
+    /// Add a json-rpc response to the server.
+    pub async fn add_response<S: Serialize>(&mut self, response: Response<S>) {
+        self.add_reply(response).await;
+    }
+
+    /// Trigger a graceful shutdown of the mock IPC server.
+    /// This will cause the server to stop accepting new connections and
+    /// close the Unix domain socket.
+    pub async fn shutdown(&self) {
+        debug!("Shutting down server");
+        if let Some(tx) = self.shutdown.lock().await.take() {
+            let _ = tx.send(());
+        }
+    }
+}
+
+/// A mock IPC server that can be used to test providers without connecting to a real node.
+///
+/// The server creates a Unix domain socket and responds to JSON-RPC requests with
+/// pre-configured replies. This allows testing provider implementations without needing
+/// a real Ethereum node.
 #[derive(Debug)]
 pub struct MockIpcServer {
-    /// Replies to send, in order
-    replies: VecDeque<Vec<u8>>,
-    /// Path to the socket
-    path: NamedTempFile,
+    /// Queue of responses to return to the provider
+    replies: Arc<Mutex<VecDeque<Vec<u8>>>>,
+    /// Temporary file used for the Unix domain socket
+    temp_file: Arc<NamedTempFile>,
+    /// Channel for triggering server shutdown
+    shutdown: Arc<Mutex<Option<oneshot::Sender<()>>>>,
 }
 
 impl Default for MockIpcServer {
@@ -43,47 +120,152 @@ impl Default for MockIpcServer {
 }
 
 impl MockIpcServer {
-    /// Create a new mock IPC server.
+    /// Create a new mock IPC server instance.
+    /// This creates a temporary file to use as the Unix domain socket path.
     pub fn new() -> Self {
-        Self { replies: VecDeque::new(), path: NamedTempFile::new().unwrap() }
+        let temp_file = Arc::new(NamedTempFile::new().expect("Failed to create temp file"));
+        let path = temp_file.path();
+
+        // Clean up any existing socket file at this path
+        if path.exists() {
+            let _ = fs::remove_file(path);
+        }
+
+        Self {
+            replies: Arc::new(Mutex::new(VecDeque::new())),
+            temp_file,
+            shutdown: Arc::new(Mutex::new(None)),
+        }
     }
 
-    /// Add a raw reply to the server.
-    pub fn add_raw_reply(&mut self, reply: Vec<u8>) {
-        self.replies.push_back(reply);
-    }
-
-    /// Add a reply to the server.
-    pub fn add_reply<S: Serialize>(&mut self, s: S) {
-        let reply = serde_json::to_vec(&s).unwrap();
-        self.add_raw_reply(reply);
-    }
-
-    /// Add a json-rpc response to the server.
-    pub fn add_response<S: Serialize>(&mut self, response: Response<S>) {
-        self.add_reply(response);
-    }
-
-    /// Get the path to the socket.
+    /// Get the path to the Unix domain socket that this server will listen on.
+    /// This path should be passed to the provider being tested.
     pub fn path(&self) -> PathBuf {
-        self.path.path().to_owned()
+        self.temp_file.path().to_owned()
     }
 
-    /// Run the server.
-    pub async fn spawn(mut self) {
-        tokio::spawn(async move {
-            let tmp = self.path.into_temp_path();
-            let name = crate::connect::to_name(tmp.as_os_str()).unwrap();
-            let socket = LocalSocketStream::connect(name).await.unwrap();
+    /// Create a new handle to control this server.
+    /// The handle can be used to add responses and trigger shutdown.
+    pub fn handle(&self) -> MockIpcHandle {
+        MockIpcHandle {
+            replies: self.replies.clone(),
+            shutdown: self.shutdown.clone(),
+            _temp_file: self.temp_file.clone(),
+        }
+    }
 
-            let (mut reader, mut writer) = socket.split();
+    /// Handle a single client connection.
+    /// This function runs in a separate task for each connected client.
+    async fn handle_connection(
+        mut stream: tokio::net::UnixStream,
+        replies: Arc<Mutex<VecDeque<Vec<u8>>>>,
+    ) {
+        debug!("New connection established");
 
-            let mut buf = [0u8; 4096];
-            loop {
-                let _ = reader.read(&mut buf).await.unwrap();
-                let reply = self.replies.pop_front().unwrap_or_default();
-                writer.write_all(&reply).await.unwrap();
+        let mut buf = [0u8; 4096];
+
+        loop {
+            match stream.read(&mut buf).await {
+                Ok(0) => {
+                    debug!("Connection closed by client");
+                    break;
+                }
+                Ok(n) => {
+                    // Parse the request data as a string
+                    let request_str = String::from_utf8_lossy(&buf[..n]).trim().to_string();
+                    debug!(request = %request_str, "Received request");
+
+                    // Try to parse as JSON-RPC request
+                    if let Ok(request) = serde_json::from_str::<Value>(&request_str) {
+                        debug!(
+                            id = ?request.get("id"),
+                            method = ?request.get("method"),
+                            "Parsed JSON-RPC request"
+                        );
+
+                        // Get and send the next queued response
+                        if let Some(response) = replies.lock().await.pop_front() {
+                            if let Err(e) = stream.write_all(&response).await {
+                                error!(?e, "Failed to write response");
+                                break;
+                            }
+                            if let Err(e) = stream.write_all(b"\n").await {
+                                error!(?e, "Failed to write newline");
+                                break;
+                            }
+                            if let Err(e) = stream.flush().await {
+                                error!(?e, "Failed to flush");
+                                break;
+                            }
+                            debug!("Response sent successfully");
+                        } else {
+                            // No response was queued, send an error
+                            warn!("No queued response available");
+                            let error_response = serde_json::to_vec(&json!({
+                                "jsonrpc": "2.0",
+                                "id": request.get("id"),
+                                "error": {
+                                    "code": -32603,
+                                    "message": "No response queued"
+                                }
+                            }))
+                            .unwrap();
+
+                            if let Err(e) = stream.write_all(&error_response).await {
+                                error!(?e, "Failed to write error response");
+                                break;
+                            }
+                            if let Err(e) = stream.write_all(b"\n").await {
+                                error!(?e, "Failed to write newline");
+                                break;
+                            }
+                            if let Err(e) = stream.flush().await {
+                                error!(?e, "Failed to flush");
+                                break;
+                            }
+                        }
+                    }
+                }
+                Err(e) => {
+                    error!(?e, "Failed to read from connection");
+                    break;
+                }
             }
+        }
+        debug!("Connection handler finished");
+    }
+
+    /// Start the mock IPC server.
+    /// Returns a handle that can be used to control the server.
+    /// The server will run until shutdown is triggered via the handle.
+    pub async fn spawn(self) -> eyre::Result<MockIpcHandle> {
+        let (shutdown_tx, mut shutdown_rx) = oneshot::channel();
+        *self.shutdown.lock().await = Some(shutdown_tx);
+        let handle = self.handle();
+
+        let socket_path = self.temp_file.path().to_owned();
+        let listener = UnixListener::bind(&socket_path)?;
+
+        let task_handle = handle.clone();
+
+        // Spawn the main server task
+        tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    _ = &mut shutdown_rx => {
+                        debug!("Shutdown signal received");
+                        break;
+                    }
+                    Ok((stream, _)) = listener.accept() => {
+                        debug!("New connection accepted");
+                        let replies = task_handle.replies.clone();
+                        tokio::spawn(Self::handle_connection(stream, replies));
+                    }
+                }
+            }
+            debug!("Server shutdown complete");
         });
+
+        Ok(handle)
     }
 }

--- a/crates/transport-ipc/src/mock.rs
+++ b/crates/transport-ipc/src/mock.rs
@@ -1,115 +1,166 @@
-//! An IPC mock server and client for testing Ethereum JSON-RPC providers.
-//! This module provides a way to mock responses from an IPC-based Ethereum node
-//! by creating a Unix domain socket that responds with pre-configured replies.
+//! # Mock IPC server for testing Ethereum JSON-RPC providers
+//!
+//! This module provides functionality to create a mock IPC server that emulates an
+//! Ethereum node's IPC interface. It's primarily intended for testing JSON-RPC provider
+//! implementations without needing a real Ethereum node.
+//!
+//! ## Key Features
+//!
+//! - Create mock IPC servers that respond to JSON-RPC requests
+//! - Pre-configure responses to be returned to clients
+//! - Support for both raw and JSON-serialized responses
+//! - Clean handling of socket file lifecycle
+//! - Graceful shutdown support
+//!
+//! ## Example
+//!
+//! ```rust,no_run
+//! use alloy_json_rpc::Response;
+//! use serde_json::json;
+//!
+//! use alloy_transport_ipc::MockIpcServer;
+//!
+//! async fn example() -> std::io::Result<()> {
+//! // Create and spawn server
+//! let server = MockIpcServer::new();
+//! let path = server.path();
+//! let handle = server.spawn().await?;
+//!
+//! // Queue multiple responses
+//! handle.add_reply(json!({
+//!     "jsonrpc": "2.0",
+//!     "id": 1,
+//!     "result": "0x123"
+//! }))?;
+//!
+//! handle.add_reply(json!({
+//!     "jsonrpc": "2.0",
+//!     "id": 2,
+//!     "result": ["0x456", "0x789"]
+//! }))?;
+//!
+//! // Add a raw response
+//! handle.add_raw_reply(b"{\"jsonrpc\":\"2.0\",\"id\":3,\"result\":true}".to_vec());
+//!
+//! // Do the things
+//!
+//! // Shutdown when done
+//! handle.shutdown();
+//! # Ok(())
+//! # }
+//! ```
 
-use alloy_json_rpc::Response;
+use std::{collections::VecDeque, fs, path::PathBuf, sync::Arc};
+
+use futures::StreamExt;
+use parking_lot::Mutex;
 use serde::Serialize;
 use serde_json::{json, Value};
-use std::{collections::VecDeque, path::PathBuf, sync::Arc};
 use tempfile::NamedTempFile;
-use tokio::{
-    io::{AsyncReadExt, AsyncWriteExt},
-    net::UnixListener,
-    sync::{oneshot, Mutex},
-};
+use tokio::{io::AsyncWriteExt, sync::oneshot};
+
+use alloy_json_rpc::Response;
+
+/// Represents the shared state between the IPC server and its handles.
+/// This state includes:
+/// - A queue of pre-configured responses
+/// - A shutdown signal channel
+/// - A temporary file used for the Unix domain socket
+#[derive(Debug)]
+struct Inner {
+    /// Queue of responses to be sent to clients
+    replies: Mutex<VecDeque<Vec<u8>>>,
+    /// Channel for triggering server shutdown
+    shutdown: Mutex<Option<oneshot::Sender<()>>>,
+    /// Temporary file backing the Unix domain socket
+    temp_file: NamedTempFile,
+}
+
+impl Drop for Inner {
+    fn drop(&mut self) {
+        // Ensure socket file cleanup on drop
+        // This is important for preventing resource leaks and socket file conflicts
+        if let Ok(path) = self.temp_file.path().canonicalize() {
+            if path.exists() {
+                debug!(?path, "Cleaning up socket file on drop");
+                let _ = fs::remove_file(&path);
+            }
+        }
+    }
+}
 
 /// A handle to control a running mock IPC server.
 ///
-/// The handle allows adding responses that will be returned to the provider
-/// and triggering server shutdown. Multiple handles can exist for the same
-/// server instance.
+/// This handle can be used to:
+/// - Add responses that will be returned to clients
+/// - Trigger server shutdown
+/// - Multiple handles can exist for the same server instance
 #[derive(Debug, Clone)]
 pub struct MockIpcHandle {
-    /// Queue of responses to return to the provider
-    replies: Arc<Mutex<VecDeque<Vec<u8>>>>,
-    /// Channel for triggering server shutdown
-    shutdown: Arc<Mutex<Option<oneshot::Sender<()>>>>,
-    /// Keeps the temporary socket file alive while the handle exists
-    _temp_file: Arc<NamedTempFile>,
+    /// Reference to shared server state
+    inner: Arc<Inner>,
 }
 
-/// ```rust,no_run,ignore
-/// 
-///  let server = MockIpcServer::new();
-///  let path = server.path();
-///  let handle = server.spawn().await?;
-///
-///  // Queue a mock response for eth_getBalance
-///  handle
-///     .add_reply(json!({
-///         "jsonrpc": "2.0",
-///         "id": 0,
-///         "result": "0x0000000000000000000000000000000000000000000000000000000000000064"
-///   }))
-///     .await;
-///
-///  // Create a provider connected to our mock
-///  let provider = ProviderBuilder::new().on_ipc(IpcConnect::new(path)).await?;
-///
-///  // Make a request and verify the response
-///  let balance = provider
-///     .get_balance("0x742d35Cc6634C0532925a3b844Bc454e4438f44e".parse()?)
-///     .await?;
-///
-///  assert_eq!(balance, U256::from(100));
-///
-///  // Clean shutdown
-///  handle.shutdown().await;
-///
-///  Ok(())
-/// ```
 impl MockIpcHandle {
-    /// Add a raw byte vector as a response to be returned to the provider.
+    /// Add a raw byte vector as a response to be returned to clients.
     /// Responses are returned in FIFO order.
-    pub async fn add_raw_reply(&self, reply: Vec<u8>) {
-        debug!(reply_len = reply.len(), "Adding raw reply");
-        self.replies.lock().await.push_back(reply);
+    ///
+    /// # Arguments
+    /// * `reply` - Raw bytes to send as response
+    pub fn add_raw_reply(&self, reply: Vec<u8>) {
+        debug!(reply_len = reply.len(), "Adding raw reply to response queue");
+        self.inner.replies.lock().push_back(reply);
     }
 
-    /// Add a serializable value as a response to be returned to the provider.
+    /// Add a serializable value as a response to be returned to clients.
     /// The value will be serialized to JSON before being queued.
-    /// This is the primary method for adding JSON-RPC responses.
-    pub async fn add_reply<S: Serialize>(&self, s: S) {
-        let reply = match serde_json::to_vec(&s) {
-            Ok(r) => r,
-            Err(e) => {
-                error!(?e, "Failed to serialize reply");
-                return;
-            }
-        };
-        debug!(reply_len = reply.len(), "Adding JSON reply");
-        self.add_raw_reply(reply).await;
+    ///
+    /// # Arguments
+    /// * `s` - Any value that implements serde::Serialize
+    ///
+    /// # Returns
+    /// * `Result<(), serde_json::Error>` - Ok if serialization succeeds
+    pub fn add_reply<S: Serialize>(&self, s: S) -> Result<(), serde_json::Error> {
+        let reply = serde_json::to_vec(&s)?;
+        debug!(reply_len = reply.len(), "Adding JSON reply to response queue");
+        self.add_raw_reply(reply);
+        Ok(())
     }
 
-    /// Add a json-rpc response to the server.
-    pub async fn add_response<S: Serialize>(&mut self, response: Response<S>) {
-        self.add_reply(response).await;
+    /// Add a JSON-RPC response to the server's response queue.
+    ///
+    /// # Arguments
+    /// * `response` - A JSON-RPC Response object
+    ///
+    /// # Returns
+    /// * `Result<(), serde_json::Error>` - Ok if serialization succeeds
+    pub fn add_response<S: Serialize>(
+        &mut self,
+        response: Response<S>,
+    ) -> Result<(), serde_json::Error> {
+        self.add_reply(response)
     }
 
     /// Trigger a graceful shutdown of the mock IPC server.
     /// This will cause the server to stop accepting new connections and
-    /// close the Unix domain socket.
-    pub async fn shutdown(&self) {
-        debug!("Shutting down server");
-        if let Some(tx) = self.shutdown.lock().await.take() {
+    /// clean up its resources.
+    pub fn shutdown(&self) {
+        debug!("Initiating server shutdown");
+        if let Some(tx) = self.inner.shutdown.lock().take() {
             let _ = tx.send(());
         }
     }
 }
 
-/// A mock IPC server that can be used to test providers without connecting to a real node.
+/// A mock IPC server that emulates an Ethereum JSON-RPC over IPC provider.
 ///
 /// The server creates a Unix domain socket and responds to JSON-RPC requests with
-/// pre-configured replies. This allows testing provider implementations without needing
-/// a real Ethereum node.
+/// pre-configured replies. This allows testing provider implementations without
+/// needing a real Ethereum node.
 #[derive(Debug)]
 pub struct MockIpcServer {
-    /// Queue of responses to return to the provider
-    replies: Arc<Mutex<VecDeque<Vec<u8>>>>,
-    /// Temporary file used for the Unix domain socket
-    temp_file: Arc<NamedTempFile>,
-    /// Channel for triggering server shutdown
-    shutdown: Arc<Mutex<Option<oneshot::Sender<()>>>>,
+    /// Reference to shared server state
+    inner: Arc<Inner>,
 }
 
 impl Default for MockIpcServer {
@@ -121,139 +172,126 @@ impl Default for MockIpcServer {
 impl MockIpcServer {
     /// Create a new mock IPC server instance.
     /// This creates a temporary file to use as the Unix domain socket path.
+    ///
+    /// # Returns
+    /// * A new `MockIpcServer` instance
     pub fn new() -> Self {
-        let temp_file = Arc::new(NamedTempFile::new().expect("Failed to create temp file"));
+        let temp_file = NamedTempFile::new().expect("Failed to create temp file");
         let path = temp_file.path();
         debug!(?path, "Created new mock IPC server");
 
-        Self {
-            replies: Arc::new(Mutex::new(VecDeque::new())),
+        let inner = Arc::new(Inner {
+            replies: Mutex::new(VecDeque::new()),
+            shutdown: Mutex::new(None),
             temp_file,
-            shutdown: Arc::new(Mutex::new(None)),
-        }
+        });
+
+        Self { inner }
     }
 
     /// Get the path to the Unix domain socket that this server will listen on.
     /// This path should be passed to the provider being tested.
+    ///
+    /// # Returns
+    /// * `PathBuf` containing the socket path
     pub fn path(&self) -> PathBuf {
-        self.temp_file.path().to_owned()
+        self.inner.temp_file.path().to_owned()
     }
 
     /// Create a new handle to control this server.
     /// The handle can be used to add responses and trigger shutdown.
+    ///
+    /// # Returns
+    /// * A new `MockIpcHandle` instance
     pub fn handle(&self) -> MockIpcHandle {
-        MockIpcHandle {
-            replies: self.replies.clone(),
-            shutdown: self.shutdown.clone(),
-            _temp_file: self.temp_file.clone(),
-        }
+        MockIpcHandle { inner: self.inner.clone() }
     }
 
     /// Handle a single client connection.
     /// This function runs in a separate task for each connected client.
+    ///
+    /// # Arguments
+    /// * `stream` - The Unix domain socket stream for the client
+    /// * `inner` - Reference to shared server state
     async fn handle_connection(
-        mut stream: tokio::net::UnixStream,
-        replies: Arc<Mutex<VecDeque<Vec<u8>>>>,
-    ) {
-        debug!("New connection established");
+        stream: tokio::net::UnixStream,
+        inner: Arc<Inner>,
+    ) -> std::io::Result<()> {
+        use crate::ReadJsonStream;
 
-        let mut buf = [0u8; 4096];
+        let (read, mut writer) = stream.into_split();
+        let mut reader = ReadJsonStream::new(read);
 
-        loop {
-            match stream.read(&mut buf).await {
-                Ok(0) => {
-                    debug!("Connection closed by client");
-                    break;
-                }
-                Ok(n) => {
-                    // Parse the request data as a string
-                    let request_str = String::from_utf8_lossy(&buf[..n]).trim().to_string();
-                    debug!(request = %request_str, "Received request");
+        debug!("Starting connection handler loop");
+        while let Some(request) = reader.next().await {
+            if let Ok(request) = serde_json::from_value::<Value>(request) {
+                debug!(
+                    id = ?request.get("id"),
+                    method = ?request.get("method"),
+                    "Received JSON-RPC request"
+                );
 
-                    // Try to parse as JSON-RPC request
-                    if let Ok(request) = serde_json::from_str::<Value>(&request_str) {
-                        debug!(
-                            id = ?request.get("id"),
-                            method = ?request.get("method"),
-                            "Parsed JSON-RPC request"
-                        );
-
-                        // Get and send the next queued response
-                        if let Some(response) = replies.lock().await.pop_front() {
-                            if let Err(e) = stream.write_all(&response).await {
-                                error!(?e, "Failed to write response");
-                                break;
-                            }
-                            if let Err(e) = stream.write_all(b"\n").await {
-                                error!(?e, "Failed to write newline");
-                                break;
-                            }
-                            if let Err(e) = stream.flush().await {
-                                error!(?e, "Failed to flush");
-                                break;
-                            }
-                            debug!("Response sent successfully");
-                        } else {
-                            // No response was queued, send an error
-                            warn!("No queued response available");
-                            let error_response = serde_json::to_vec(&json!({
-                                "jsonrpc": "2.0",
-                                "id": request.get("id"),
-                                "error": {
-                                    "code": -32603,
-                                    "message": "No response queued"
-                                }
-                            }))
-                            .unwrap();
-
-                            if let Err(e) = stream.write_all(&error_response).await {
-                                error!(?e, "Failed to write error response");
-                                break;
-                            }
-                            if let Err(e) = stream.write_all(b"\n").await {
-                                error!(?e, "Failed to write newline");
-                                break;
-                            }
-                            if let Err(e) = stream.flush().await {
-                                error!(?e, "Failed to flush");
-                                break;
-                            }
+                // Get the next queued response or generate an error
+                let response = if let Some(response) = inner.replies.lock().pop_front() {
+                    trace!(response_len = response.len(), "Using queued response");
+                    response
+                } else {
+                    warn!("No queued response available for request");
+                    serde_json::to_vec(&json!({
+                        "jsonrpc": "2.0",
+                        "id": request.get("id"),
+                        "error": {
+                            "code": -32603,
+                            "message": "No response queued"
                         }
-                    }
-                }
-                Err(e) => {
-                    error!(?e, "Failed to read from connection");
-                    break;
-                }
+                    }))?
+                };
+
+                // Send the response
+                writer.write_all(&response).await?;
+                writer.write_all(b"\n").await?;
+                writer.flush().await?;
+                debug!("Response sent successfully");
             }
         }
-        debug!("Connection handler finished");
+
+        debug!("Connection handler completed");
+        Ok(())
     }
 
     /// Start the mock IPC server.
     /// Returns a handle that can be used to control the server.
     /// The server will run until shutdown is triggered via the handle.
-    pub async fn spawn(self) -> Result<MockIpcHandle, std::io::Error> {
+    ///
+    /// # Returns
+    /// * `Result<MockIpcHandle, std::io::Error>` - Handle to control the server
+    pub async fn spawn(self) -> std::io::Result<MockIpcHandle> {
         let (shutdown_tx, mut shutdown_rx) = oneshot::channel();
-        *self.shutdown.lock().await = Some(shutdown_tx);
+        *self.inner.shutdown.lock() = Some(shutdown_tx);
         let handle = self.handle();
 
-        let socket_path = self.temp_file.path().to_owned();
-        let listener = match UnixListener::bind(&socket_path) {
-            Ok(l) => l,
-            Err(e) => {
-                error!(?e, "Failed to bind Unix socket");
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    "Failed to bind Unix socket",
-                ));
-            }
-        };
+        let socket_path = self.inner.temp_file.path().to_owned();
 
-        let task_handle = handle.clone();
+        // Clean up any existing socket file
+        if socket_path.exists() {
+            debug!(?socket_path, "Removing existing socket file");
+            fs::remove_file(&socket_path)?;
+        }
+
+        // Create and bind the Unix domain socket
+        let listener = tokio::net::UnixListener::bind(&socket_path).map_err(|e| {
+            error!(?e, ?socket_path, "Failed to bind Unix socket");
+            std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!("Failed to bind Unix socket at {:?}: {}", socket_path, e),
+            )
+        })?;
+
+        let inner = self.inner.clone();
 
         // Spawn the main server task
         tokio::spawn(async move {
+            debug!("Starting main server loop");
             loop {
                 tokio::select! {
                     _ = &mut shutdown_rx => {
@@ -261,15 +299,64 @@ impl MockIpcServer {
                         break;
                     }
                     Ok((stream, _)) = listener.accept() => {
-                        debug!("New connection accepted");
-                        let replies = task_handle.replies.clone();
-                        tokio::spawn(Self::handle_connection(stream, replies));
+                        debug!("New client connection accepted");
+                        let inner = inner.clone();
+                        tokio::spawn(Self::handle_connection(stream, inner));
                     }
                 }
             }
             debug!("Server shutdown complete");
+
+            // Clean up the socket file
+            if let Ok(path) = socket_path.canonicalize() {
+                if path.exists() {
+                    debug!(?path, "Cleaning up socket file on shutdown");
+                    let _ = fs::remove_file(&path);
+                }
+            }
         });
 
         Ok(handle)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::net::UnixStream;
+
+    use super::*;
+
+    /// Test basic server functionality:
+    /// 1. Server creation and startup
+    /// 2. Adding a response
+    /// 3. Client connection and request
+    /// 4. Response verification
+    /// 5. Server shutdown
+    #[tokio::test]
+    async fn test_mock_ipc_server() -> std::io::Result<()> {
+        let server = MockIpcServer::new();
+        let path = server.path();
+        let handle = server.spawn().await?;
+
+        // Queue a test response
+        handle
+            .add_reply(json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": "0x123"
+            }))
+            .unwrap();
+
+        // Connect and send request
+        let mut stream = UnixStream::connect(path).await?;
+        stream.write_all(b"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"eth_getBalance\"}\n").await?;
+
+        // Read and verify response
+        let mut reader = crate::ReadJsonStream::new(stream);
+        let response: Value = reader.next().await.unwrap();
+        assert_eq!(response["result"], "0x123");
+
+        handle.shutdown();
+        Ok(())
     }
 }


### PR DESCRIPTION
## Motivation

As a user of the ecosystem, I need a robust way to unit test code without having to connect to a node or fork alloy, for example when I need the presence of a provider I control the responses of. The existing mock provider was limited in that it could not handle concurrent requests, nor did it have a proper handle for management.

## Solution

This pull request implements a much improved mock provider that can be used, and is usable, for flexible unit tests across the ecosystem where a provider is involved.

Additionally, there are tests, which could be included here at will.

```rust
#[cfg(test)]
mod tests {
    use super::*;
    use crate::test_utils::RUSTLS;
    use alloy::primitives::U256;
    use alloy::providers::{Provider, ProviderBuilder};
    use alloy::transports::ipc::IpcConnect;
    use once_cell::sync::Lazy;
    use serde_json::json;
    use telemetry::TRACING;

    /// Test the basic functionality of the mock IPC server:
    /// - Server creation and startup
    /// - Adding a response
    /// - Connecting a provider
    /// - Making a request and receiving the mocked response
    /// - Clean shutdown
    #[tokio::test(flavor = "multi_thread")]
    async fn test_mock_ipc_server() -> eyre::Result<()> {
        // Initialize logging
        Lazy::force(&RUSTLS);
        Lazy::force(&TRACING);

        // Create and start the mock server
        let server = MockIpcServer::new();
        let path = server.path();
        let handle = server.spawn().await?;

        // Queue a mock response for eth_getBalance
        handle
            .add_reply(json!({
                "jsonrpc": "2.0",
                "id": 0,
                "result": "0x0000000000000000000000000000000000000000000000000000000000000064"
            }))
            .await;

        // Create a provider connected to our mock
        let provider = ProviderBuilder::new().on_ipc(IpcConnect::new(path)).await?;

        // Make a request and verify the response
        let balance = provider
            .get_balance("0x742d35Cc6634C0532925a3b844Bc454e4438f44e".parse()?)
            .await?;

        assert_eq!(balance, U256::from(100));

        // Clean shutdown
        handle.shutdown().await;
        Ok(())
    }
}
```

However, I didn't want to presume to add dependencies to this crate.

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [x] Breaking changes
