### PR TITLE
feat(eth_call): fix serializion to include default block to latest

### DIFF
--- a/crates/provider/src/provider/eth_call/mod.rs
+++ b/crates/provider/src/provider/eth_call/mod.rs
@@ -302,7 +302,7 @@ mod test {
         assert_eq!(params.overrides(), None);
         assert_eq!(
             serde_json::to_string(&params).unwrap(),
-            r#"[{"from":"0x0000000000000000000000000000000000000001","to":"0x0000000000000000000000000000000000000002","maxFeePerGas":"0x4a817c800","maxPriorityFeePerGas":"0x3b9aca00","gas":"0x5208","value":"0x64","nonce":"0x0","chainId":"0x1"}]"#
+            r#"[{"from":"0x0000000000000000000000000000000000000001","to":"0x0000000000000000000000000000000000000002","maxFeePerGas":"0x4a817c800","maxPriorityFeePerGas":"0x3b9aca00","gas":"0x5208","value":"0x64","nonce":"0x0","chainId":"0x1"},"latest"]"#
         );
 
         // Expected: [data, block, overrides]

--- a/crates/provider/src/provider/eth_call/params.rs
+++ b/crates/provider/src/provider/eth_call/params.rs
@@ -64,12 +64,10 @@ impl<N: Network> serde::Serialize for EthCallParams<'_, N> {
 
         let mut seq = serializer.serialize_seq(Some(len))?;
         seq.serialize_element(&self.data())?;
+        seq.serialize_element(&self.block().unwrap_or_default())?;
 
         if let Some(overrides) = self.overrides() {
-            seq.serialize_element(&self.block().unwrap_or_default())?;
             seq.serialize_element(overrides)?;
-        } else if let Some(block) = self.block() {
-            seq.serialize_element(&block)?;
         }
 
         seq.end()


### PR DESCRIPTION
## Motivation

In an `eth_call` the `block` parameter is always required. In the current serialization logic, it does not add a block if the state_overrides is None and the block is None. 

This results in a node returning an invalid parameter error.

## Solution

I have updated the code to always set the block as the second argument, if it is None it will use the default `latest` value. The third argument will only be added if `state_overrides` is Some.

## PR Checklist

- [y] Added Tests
- [y] Added Documentation
- [n] Breaking changes
