### PR TITLE
feat: introduce maybe helpers for blob calc

### DIFF
--- a/crates/consensus/src/block/header.rs
+++ b/crates/consensus/src/block/header.rs
@@ -643,7 +643,7 @@ pub trait BlockHeader {
     /// [`BlobParams`] argument.
     ///
     /// Returns `None` if the `blob_params` are `None`.
-    fn maybe_next_block_excess_blob_gas(&self, blob_params: Option<BlobParams>) -> Option<u128> {
+    fn maybe_next_block_excess_blob_gas(&self, blob_params: Option<BlobParams>) -> Option<u64> {
         self.next_block_excess_blob_gas(blob_params?)
     }
 

--- a/crates/consensus/src/block/header.rs
+++ b/crates/consensus/src/block/header.rs
@@ -639,6 +639,14 @@ pub trait BlockHeader {
         Some(blob_params.next_block_excess_blob_gas(self.excess_blob_gas()?, self.blob_gas_used()?))
     }
 
+    /// Convenience function for [`Self::next_block_excess_blob_gas`] with an optional
+    /// [`BlobParams`] argument.
+    ///
+    /// Returns `None` if the `blob_params` are `None`.
+    fn maybe_next_block_excess_blob_gas(&self, blob_params: Option<BlobParams>) -> Option<u128> {
+        self.next_block_excess_blob_gas(blob_params?)
+    }
+
     /// Returns the blob fee for the next block according to the EIP-4844 spec.
     ///
     /// Returns `None` if `excess_blob_gas` is None.
@@ -646,6 +654,14 @@ pub trait BlockHeader {
     /// See also [BlockHeader::next_block_excess_blob_gas]
     fn next_block_blob_fee(&self, blob_params: BlobParams) -> Option<u128> {
         Some(blob_params.calc_blob_fee(self.next_block_excess_blob_gas(blob_params)?))
+    }
+
+    /// Convenience function for [`Self::next_block_blob_fee`] with an optional [`BlobParams`]
+    /// argument.
+    ///
+    /// Returns `None` if the `blob_params` are `None`.
+    fn maybe_next_block_blob_fee(&self, blob_params: Option<BlobParams>) -> Option<u128> {
+        self.next_block_blob_fee(blob_params?)
     }
 
     /// Calculate base fee for next block according to the EIP-1559 spec.


### PR DESCRIPTION
now that we have configurable blobparams that are hardfork specific, this means we need to deal with a case where blobs are not active: `None`

https://github.com/paradigmxyz/reth/pull/14049

this adds helpers with default impl for this so that we don't need to use `maybe_params.map(|params| header.next_blob_fee(params))`