### PR TITLE
chore: dont enable serde in tests

### DIFF
--- a/crates/consensus/src/block/mod.rs
+++ b/crates/consensus/src/block/mod.rs
@@ -20,7 +20,7 @@ use alloy_rlp::{Decodable, Encodable, RlpDecodable, RlpEncodable};
 ///
 /// See p2p block encoding reference: <https://github.com/ethereum/devp2p/blob/master/caps/eth.md#block-encoding-and-validity>
 #[derive(Debug, Clone, PartialEq, Eq, derive_more::Deref)]
-#[cfg_attr(any(test, feature = "serde"), derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Block<T, H = Header> {
     /// Block header.
     #[deref]
@@ -145,7 +145,7 @@ where
 ///
 /// Withdrawals can be optionally included at the end of the RLP encoded message.
 #[derive(Debug, Clone, PartialEq, Eq, RlpEncodable, RlpDecodable)]
-#[cfg_attr(any(test, feature = "serde"), derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[rlp(trailing)]
 pub struct BlockBody<T, H = Header> {
     /// Transactions in this block.


### PR DESCRIPTION
we dont derive serde for tests by default to make test compile because we test serde only if serde feature is active