### PR TITLE
chore!: remove Service impls for &T

### DIFF
--- a/crates/pubsub/src/frontend.rs
+++ b/crates/pubsub/src/frontend.rs
@@ -109,22 +109,6 @@ impl tower::Service<RequestPacket> for PubSubFrontend {
     type Future = TransportFut<'static>;
 
     #[inline]
-    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        (&*self).poll_ready(cx)
-    }
-
-    #[inline]
-    fn call(&mut self, req: RequestPacket) -> Self::Future {
-        (&*self).call(req)
-    }
-}
-
-impl tower::Service<RequestPacket> for &PubSubFrontend {
-    type Response = ResponsePacket;
-    type Error = TransportError;
-    type Future = TransportFut<'static>;
-
-    #[inline]
     fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         let result =
             if self.tx.is_closed() { Err(TransportErrorKind::backend_gone()) } else { Ok(()) };

--- a/crates/transport-http/src/hyper_transport.rs
+++ b/crates/transport-http/src/hyper_transport.rs
@@ -155,33 +155,12 @@ where
     type Future = TransportFut<'static>;
 
     #[inline]
-    fn poll_ready(&mut self, cx: &mut task::Context<'_>) -> task::Poll<Result<(), Self::Error>> {
-        (&*self).poll_ready(cx)
-    }
-
-    #[inline]
-    fn call(&mut self, req: RequestPacket) -> Self::Future {
-        (&*self).call(req)
-    }
-}
-
-impl<B, S> Service<RequestPacket> for &Http<HyperClient<B, S>>
-where
-    S: Service<Request<B>, Response = HyperResponse> + Clone + Send + Sync + 'static,
-    S::Future: Send,
-    S::Error: std::error::Error + Send + Sync + 'static,
-    B: From<Vec<u8>> + Send + 'static + Clone + Sync,
-{
-    type Response = ResponsePacket;
-    type Error = TransportError;
-    type Future = TransportFut<'static>;
-
-    #[inline]
     fn poll_ready(&mut self, _cx: &mut task::Context<'_>) -> task::Poll<Result<(), Self::Error>> {
         // `hyper` always returns `Ok(())`.
         task::Poll::Ready(Ok(()))
     }
 
+    #[inline]
     fn call(&mut self, req: RequestPacket) -> Self::Future {
         let this = self.clone();
         let span = debug_span!("HyperTransport", url = %this.url);

--- a/crates/transport-http/src/reqwest_transport.rs
+++ b/crates/transport-http/src/reqwest_transport.rs
@@ -75,27 +75,12 @@ impl Service<RequestPacket> for Http<reqwest::Client> {
     type Future = TransportFut<'static>;
 
     #[inline]
-    fn poll_ready(&mut self, cx: &mut task::Context<'_>) -> task::Poll<Result<(), Self::Error>> {
-        (&*self).poll_ready(cx)
-    }
-
-    #[inline]
-    fn call(&mut self, req: RequestPacket) -> Self::Future {
-        (&*self).call(req)
-    }
-}
-
-impl Service<RequestPacket> for &Http<reqwest::Client> {
-    type Response = ResponsePacket;
-    type Error = TransportError;
-    type Future = TransportFut<'static>;
-
-    #[inline]
     fn poll_ready(&mut self, _cx: &mut task::Context<'_>) -> task::Poll<Result<(), Self::Error>> {
         // `reqwest` always returns `Ok(())`.
         task::Poll::Ready(Ok(()))
     }
 
+    #[inline]
     fn call(&mut self, req: RequestPacket) -> Self::Future {
         let this = self.clone();
         let span = debug_span!("ReqwestTransport", url = %this.url);

--- a/crates/transport/src/boxed.rs
+++ b/crates/transport/src/boxed.rs
@@ -94,9 +94,7 @@ where
 
 impl Service<RequestPacket> for BoxTransport {
     type Response = ResponsePacket;
-
     type Error = TransportError;
-
     type Future = TransportFut<'static>;
 
     #[inline]


### PR DESCRIPTION
Remove an unused and unusable layer of indirection, as we require `Transport: 'static`.
