### PR TITLE
fix: store pubsubfrontend clone in rpcinner

### DIFF
--- a/crates/provider/tests/it/ipc.rs
+++ b/crates/provider/tests/it/ipc.rs
@@ -1,0 +1,37 @@
+use alloy_provider::{IpcConnect, Provider, ProviderBuilder};
+use alloy_rpc_client::RpcClient;
+use alloy_transport::layers::RetryBackoffLayer;
+use tracing_subscriber::EnvFilter;
+
+struct ProviderConfig {
+    ipc: String,
+    max_rate_limit_retries: u32,
+    initial_backoff: u64,
+    compute_units_per_second: u64,
+}
+
+// <https://github.com/alloy-rs/alloy/issues/1972>
+#[tokio::test]
+async fn ipc_retry_pubsub() -> Result<(), Box<dyn std::error::Error>> {
+    let provider_config = ProviderConfig {
+        ipc: "/tmp/reth.ipc".to_string(),
+        max_rate_limit_retries: 1,
+        initial_backoff: 50,
+        compute_units_per_second: 1600,
+    };
+
+    let ipc_connect = IpcConnect::new(provider_config.ipc);
+    let retry_layer = RetryBackoffLayer::new(
+        provider_config.max_rate_limit_retries,
+        provider_config.initial_backoff,
+        provider_config.compute_units_per_second,
+    );
+
+    let rpc_client = RpcClient::builder().layer(retry_layer).ipc(ipc_connect).await?;
+
+    let provider = ProviderBuilder::new().disable_recommended_fillers().on_client(rpc_client);
+
+    let _ = provider.subscribe_blocks().await?;
+
+    Ok(())
+}

--- a/crates/provider/tests/it/ipc.rs
+++ b/crates/provider/tests/it/ipc.rs
@@ -1,7 +1,6 @@
 use alloy_provider::{IpcConnect, Provider, ProviderBuilder};
 use alloy_rpc_client::RpcClient;
 use alloy_transport::layers::RetryBackoffLayer;
-use tracing_subscriber::EnvFilter;
 
 struct ProviderConfig {
     ipc: String,

--- a/crates/provider/tests/it/main.rs
+++ b/crates/provider/tests/it/main.rs
@@ -1,5 +1,5 @@
 #![allow(dead_code)]
 #![allow(missing_docs)]
 
-#[cfg(feature = "ipc")]
-mod ipc;
+#[cfg(feature = "ws")]
+mod ws;

--- a/crates/provider/tests/it/main.rs
+++ b/crates/provider/tests/it/main.rs
@@ -1,0 +1,5 @@
+#![allow(dead_code)]
+#![allow(missing_docs)]
+
+#[cfg(feature = "ipc")]
+mod ipc;

--- a/crates/provider/tests/it/ws.rs
+++ b/crates/provider/tests/it/ws.rs
@@ -1,9 +1,11 @@
-use alloy_provider::{IpcConnect, Provider, ProviderBuilder};
+use alloy_node_bindings::Anvil;
+use alloy_provider::{Provider, ProviderBuilder};
 use alloy_rpc_client::RpcClient;
 use alloy_transport::layers::RetryBackoffLayer;
+use alloy_transport_ws::WsConnect;
 
 struct ProviderConfig {
-    ipc: String,
+    endpoint: String,
     max_rate_limit_retries: u32,
     initial_backoff: u64,
     compute_units_per_second: u64,
@@ -11,22 +13,23 @@ struct ProviderConfig {
 
 // <https://github.com/alloy-rs/alloy/issues/1972>
 #[tokio::test]
-async fn ipc_retry_pubsub() -> Result<(), Box<dyn std::error::Error>> {
+async fn ws_retry_pubsub() -> Result<(), Box<dyn std::error::Error>> {
+    let anvil = Anvil::new().spawn();
     let provider_config = ProviderConfig {
-        ipc: "/tmp/reth.ipc".to_string(),
+        endpoint: anvil.ws_endpoint(),
         max_rate_limit_retries: 1,
         initial_backoff: 50,
         compute_units_per_second: 1600,
     };
 
-    let ipc_connect = IpcConnect::new(provider_config.ipc);
+    let ws = WsConnect::new(provider_config.endpoint);
     let retry_layer = RetryBackoffLayer::new(
         provider_config.max_rate_limit_retries,
         provider_config.initial_backoff,
         provider_config.compute_units_per_second,
     );
 
-    let rpc_client = RpcClient::builder().layer(retry_layer).ipc(ipc_connect).await?;
+    let rpc_client = RpcClient::builder().layer(retry_layer).ws(ws).await?;
 
     let provider = ProviderBuilder::new().disable_recommended_fillers().on_client(rpc_client);
 

--- a/crates/rpc-client/src/builder.rs
+++ b/crates/rpc-client/src/builder.rs
@@ -36,7 +36,8 @@ impl<L> ClientBuilder<L> {
     /// Create a new [`RpcClient`] with the given transport and the configured
     /// layers.
     ///
-    /// This collapses the
+    /// This collapses the [`tower::ServiceBuilder`] with the given transport via
+    /// [`tower::ServiceBuilder::service`].
     pub fn transport<T>(self, transport: T, is_local: bool) -> RpcClient
     where
         L: Layer<T>,

--- a/crates/rpc-client/src/builder.rs
+++ b/crates/rpc-client/src/builder.rs
@@ -35,13 +35,15 @@ impl<L> ClientBuilder<L> {
 
     /// Create a new [`RpcClient`] with the given transport and the configured
     /// layers.
+    ///
+    /// This collapses the
     pub fn transport<T>(self, transport: T, is_local: bool) -> RpcClient
     where
         L: Layer<T>,
         T: IntoBoxTransport,
         L::Service: IntoBoxTransport,
     {
-        RpcClient::new(self.builder.service(transport), is_local)
+        RpcClient::new_layered(is_local, transport, move |t| self.builder.service(t))
     }
 
     /// Convenience function to create a new [`RpcClient`] with a [`reqwest`]
@@ -86,7 +88,7 @@ impl<L> ClientBuilder<L> {
     }
 
     /// Connect a WS transport, producing an [`RpcClient`] with the provided
-    /// connection
+    /// connection.
     #[cfg(feature = "ws")]
     pub async fn ws(self, ws_connect: alloy_transport_ws::WsConnect) -> TransportResult<RpcClient>
     where

--- a/crates/rpc-client/src/client.rs
+++ b/crates/rpc-client/src/client.rs
@@ -77,8 +77,8 @@ impl RpcClient {
     ///
     /// The `layer` fn is intended to be [`tower::ServiceBuilder::service`] that layers the
     /// transport services. The `main_transport` is expected to the type that actually emits the
-    /// request object: [`PubSubFrontend`]. This exists so that we can intercept the
-    /// [`PubSubFrontend`] which we need for [`RpcClientInner::pubsub_frontend`].
+    /// request object: `PubSubFrontend`. This exists so that we can intercept the
+    /// `PubSubFrontend` which we need for [`RpcClientInner::pubsub_frontend`].
     /// This workaround exists because due to how [`tower::ServiceBuilder::service`] collapses into
     /// a [`BoxTransport`] we wouldn't be obtain the [`MaybePubsub`] by downcasting the layered
     /// `transport`.
@@ -220,7 +220,7 @@ impl RpcClientInner {
     }
 
     /// Create a new [`RpcClient`] with the given transport and an optional handle to the
-    /// [`PubSubFrontend`].
+    /// `PubSubFrontend`.
     pub(crate) fn new_maybe_pubsub(
         t: impl IntoBoxTransport,
         is_local: bool,

--- a/crates/rpc-client/src/client.rs
+++ b/crates/rpc-client/src/client.rs
@@ -22,6 +22,12 @@ pub type ClientRef<'a> = &'a RpcClientInner;
 /// Parameter type of a JSON-RPC request with no parameters.
 pub type NoParams = [(); 0];
 
+#[cfg(feature = "pubsub")]
+type MaybePubsub = Option<alloy_pubsub::PubSubFrontend>;
+
+#[cfg(not(feature = "pubsub"))]
+type MaybePubsub = Option<()>;
+
 /// A JSON-RPC client.
 ///
 /// [`RpcClient`] should never be instantiated directly. Instead, use
@@ -55,7 +61,43 @@ impl RpcClient {
 
     /// Creates a new [`RpcClient`] with the given transport.
     pub fn new(t: impl IntoBoxTransport, is_local: bool) -> Self {
-        Self(Arc::new(RpcClientInner::new(t, is_local)))
+        Self::new_maybe_pubsub(t, is_local, None)
+    }
+
+    /// Creates a new [`RpcClient`] with the given transport and an optional [`MaybePubsub`].
+    pub(crate) fn new_maybe_pubsub(
+        t: impl IntoBoxTransport,
+        is_local: bool,
+        pubsub: MaybePubsub,
+    ) -> Self {
+        Self(Arc::new(RpcClientInner::new_maybe_pubsub(t, is_local, pubsub)))
+    }
+
+    /// Creates the [`RpcClient`] with the `main_transport` (ipc, ws, http) and a `layer` closure.
+    ///
+    /// The `layer` fn is intended to be [`tower::ServiceBuilder::service`] that layers the
+    /// transport services. The `main_transport` is expected to the type that actually emits the
+    /// request object: [`PubSubFrontend`]. This exists so that we can intercept the
+    /// [`PubSubFrontend`] which we need for [`RpcClientInner::pubsub_frontend`].
+    /// This workaround exists because due to how [`tower::ServiceBuilder::service`] collapses into
+    /// a [`BoxTransport`] we wouldn't be obtain the [`MaybePubsub`] by downcasting the layered
+    /// `transport`.
+    pub(crate) fn new_layered<F, T, R>(is_local: bool, main_transport: T, layer: F) -> Self
+    where
+        F: FnOnce(T) -> R,
+        T: IntoBoxTransport,
+        R: IntoBoxTransport,
+    {
+        #[cfg(feature = "pubsub")]
+        {
+            let t = main_transport.clone().into_box_transport();
+            let maybe_pubsub = t.as_any().downcast_ref::<alloy_pubsub::PubSubFrontend>().cloned();
+            Self::new_maybe_pubsub(layer(main_transport), is_local, maybe_pubsub)
+
+        }
+
+        #[cfg(not(feature = "pubsub"))]
+        Self::new_maybe_pubsub(layer(main_transport), is_local, None)
     }
 
     /// Creates a new [`RpcClient`] with the given inner client.
@@ -130,6 +172,7 @@ impl Deref for RpcClient {
     }
 }
 
+
 /// A JSON-RPC client.
 ///
 /// This struct manages a [`BoxTransport`] and a request ID counter. It is used to
@@ -146,6 +189,14 @@ impl Deref for RpcClient {
 pub struct RpcClientInner {
     /// The underlying transport.
     pub(crate) transport: BoxTransport,
+    /// Stores a handle to the PubSub service if pubsub.
+    ///
+    /// We store this _transport_ because if built through the
+    /// [`ClientBuilder`](crate::ClientBuilder) with an additional layer the actual transport can
+    /// be an arbitrary type and we would be unable to obtain the `PubSubFrontend` by downcasting
+    /// the `transport`. For example `RetryTransport<PubSubFrontend>`.
+    #[allow(unused)]
+    pub(crate) pubsub: MaybePubsub,
     /// `true` if the transport is local.
     pub(crate) is_local: bool,
     /// The next request ID to use.
@@ -163,10 +214,21 @@ impl RpcClientInner {
     pub fn new(t: impl IntoBoxTransport, is_local: bool) -> Self {
         Self {
             transport: t.into_box_transport(),
+            pubsub: None,
             is_local,
             id: AtomicU64::new(0),
             poll_interval: if is_local { AtomicU64::new(250) } else { AtomicU64::new(7000) },
         }
+    }
+
+    /// Create a new [`RpcClient`] with the given transport and an optional handle to the
+    /// [`PubSubFrontend`].
+    pub(crate) fn new_maybe_pubsub(
+        t: impl IntoBoxTransport,
+        is_local: bool,
+        pubsub: MaybePubsub,
+    ) -> Self {
+        Self { pubsub, ..Self::new(t.into_box_transport(), is_local) }
     }
 
     /// Sets the starting ID for the client.
@@ -209,6 +271,9 @@ impl RpcClientInner {
     #[inline]
     #[track_caller]
     pub fn pubsub_frontend(&self) -> Option<&alloy_pubsub::PubSubFrontend> {
+        if let Some(pubsub) = &self.pubsub {
+            return Some(pubsub);
+        }
         self.transport.as_any().downcast_ref::<alloy_pubsub::PubSubFrontend>()
     }
 

--- a/crates/rpc-client/src/client.rs
+++ b/crates/rpc-client/src/client.rs
@@ -189,10 +189,10 @@ pub struct RpcClientInner {
     pub(crate) transport: BoxTransport,
     /// Stores a handle to the PubSub service if pubsub.
     ///
-    /// We store this _transport_ because if built through the
-    /// [`ClientBuilder`](crate::ClientBuilder) with an additional layer the actual transport can
-    /// be an arbitrary type and we would be unable to obtain the `PubSubFrontend` by downcasting
-    /// the `transport`. For example `RetryTransport<PubSubFrontend>`.
+    /// We store this _transport_ because if built through the [`ClientBuilder`] with an additional
+    /// layer the actual transport can be an arbitrary type and we would be unable to obtain the
+    /// `PubSubFrontend` by downcasting the `transport`. For example
+    /// `RetryTransport<PubSubFrontend>`.
     #[allow(unused)]
     pub(crate) pubsub: MaybePubsub,
     /// `true` if the transport is local.

--- a/crates/rpc-client/src/client.rs
+++ b/crates/rpc-client/src/client.rs
@@ -93,7 +93,6 @@ impl RpcClient {
             let t = main_transport.clone().into_box_transport();
             let maybe_pubsub = t.as_any().downcast_ref::<alloy_pubsub::PubSubFrontend>().cloned();
             Self::new_maybe_pubsub(layer(main_transport), is_local, maybe_pubsub)
-
         }
 
         #[cfg(not(feature = "pubsub"))]
@@ -171,7 +170,6 @@ impl Deref for RpcClient {
         &self.0
     }
 }
-
 
 /// A JSON-RPC client.
 ///

--- a/crates/rpc-client/src/client.rs
+++ b/crates/rpc-client/src/client.rs
@@ -96,7 +96,7 @@ impl RpcClient {
         }
 
         #[cfg(not(feature = "pubsub"))]
-        Self::new_maybe_pubsub(layer(main_transport), is_local, None)
+        Self::new(layer(main_transport), is_local)
     }
 
     /// Creates a new [`RpcClient`] with the given inner client.


### PR DESCRIPTION
closes #1972

this is a bit cursed.
It described this in the docs but due to how:

https://github.com/alloy-rs/alloy/blob/bb77d2f8a2f587c9b220b8af2cd8cbcdd749c97d/crates/rpc-client/src/builder.rs#L44-L44

creates the transport service object if there's an additional layer, this downcast does not work:

https://github.com/alloy-rs/alloy/blob/bb77d2f8a2f587c9b220b8af2cd8cbcdd749c97d/crates/rpc-client/src/client.rs#L211-L212

the solution to this is a workaround that captures the Pubsubfrontend before we collapse the service builder.

this can still be bypassed manually via

https://github.com/alloy-rs/alloy/blob/bb77d2f8a2f587c9b220b8af2cd8cbcdd749c97d/crates/rpc-client/src/client.rs#L163-L163

but all the builtin transport fn should now capture the pubsubfrontend.
pubsubfrontend is just a channel so capturing an additional clone seems fine