### PR TITLE
fix: opt-in to keep stdout

### DIFF
--- a/crates/node-bindings/src/nodes/anvil.rs
+++ b/crates/node-bindings/src/nodes/anvil.rs
@@ -264,7 +264,7 @@ impl Anvil {
 
     /// Keep the handle to anvil's stdout in order to read from it.
     ///
-    /// Caution: if the stdout handle is unused, this can end up blocking.
+    /// Caution: if the stdout handle isn't used, this can end up blocking.
     pub const fn keep_stdout(mut self) -> Self {
         self.keep_stdout = true;
         self

--- a/crates/node-bindings/src/nodes/anvil.rs
+++ b/crates/node-bindings/src/nodes/anvil.rs
@@ -136,6 +136,7 @@ pub struct Anvil {
     fork_block_number: Option<u64>,
     args: Vec<OsString>,
     timeout: Option<u64>,
+    keep_stdout: bool,
 }
 
 impl Anvil {
@@ -261,6 +262,14 @@ impl Anvil {
         self
     }
 
+    /// Keep the handle to anvil's stdout in order to read from it.
+    ///
+    /// Caution: if the stdout handle is unused, this can end up blocking.
+    pub const fn keep_stdout(mut self) -> Self {
+        self.keep_stdout = true;
+        self
+    }
+
     /// Consumes the builder and spawns `anvil`.
     ///
     /// # Panics
@@ -360,7 +369,10 @@ impl Anvil {
             }
         }
 
-        child.stdout = Some(reader.into_inner());
+        if self.keep_stdout {
+            // re-attach the stdout handle if requested
+            child.stdout = Some(reader.into_inner());
+        }
 
         Ok(AnvilInstance {
             child,

--- a/crates/node-bindings/src/nodes/reth.rs
+++ b/crates/node-bindings/src/nodes/reth.rs
@@ -162,6 +162,7 @@ pub struct Reth {
     chain_or_path: Option<String>,
     genesis: Option<Genesis>,
     args: Vec<OsString>,
+    keep_stdout: bool,
 }
 
 impl Reth {
@@ -187,6 +188,7 @@ impl Reth {
             chain_or_path: None,
             genesis: None,
             args: Vec::new(),
+            keep_stdout: false,
         }
     }
 
@@ -306,6 +308,14 @@ impl Reth {
     /// This is destructive and will overwrite any existing data in the data directory.
     pub fn genesis(mut self, genesis: Genesis) -> Self {
         self.genesis = Some(genesis);
+        self
+    }
+
+    /// Keep the handle to reth's stdout in order to read from it.
+    ///
+    /// Caution: if the stdout handle is unused, this can end up blocking.
+    pub const fn keep_stdout(mut self) -> Self {
+        self.keep_stdout = true;
         self
     }
 
@@ -510,7 +520,10 @@ impl Reth {
             }
         }
 
-        child.stdout = Some(reader.into_inner());
+        if self.keep_stdout {
+            // re-attach the stdout handle if requested
+            child.stdout = Some(reader.into_inner());
+        }
 
         Ok(RethInstance {
             pid: child,

--- a/crates/node-bindings/src/nodes/reth.rs
+++ b/crates/node-bindings/src/nodes/reth.rs
@@ -313,7 +313,7 @@ impl Reth {
 
     /// Keep the handle to reth's stdout in order to read from it.
     ///
-    /// Caution: if the stdout handle is unused, this can end up blocking.
+    /// Caution: if the stdout handle isn't used, this can end up blocking.
     pub const fn keep_stdout(mut self) -> Self {
         self.keep_stdout = true;
         self

--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -1956,7 +1956,7 @@ mod tests {
 
     #[tokio::test]
     async fn capture_anvil_logs() {
-        let mut anvil = Anvil::new().spawn();
+        let mut anvil = Anvil::new().keep_stdout().spawn();
 
         let provider = ProviderBuilder::new().on_http(anvil.endpoint_url());
 


### PR DESCRIPTION
fixes an issue introduced in #1920

closes #1983

what happens here is that, if stdout is not cleared the kernel buffer ends up blocking the program.

this makes keeping the stdout handle opt in