### PR TITLE
feat: add additional payloadbody conversion fn

### DIFF
--- a/crates/rpc-types-engine/src/payload.rs
+++ b/crates/rpc-types-engine/src/payload.rs
@@ -1080,18 +1080,29 @@ pub struct ExecutionPayloadBodyV1 {
 }
 
 impl ExecutionPayloadBodyV1 {
-    /// Converts a [`alloy_consensus::Block`] into an execution payload body.
-    pub fn from_block<T: Encodable2718, H>(block: Block<T, H>) -> Self {
+    /// Creates an [`ExecutionPayloadBodyV1`] from the given withdrawals and transactions
+    pub fn new<'a, T>(
+        withdrawals: Option<Withdrawals>,
+        transactions: impl IntoIterator<Item = &'a T>,
+    ) -> Self
+    where
+        T: Encodable2718 + 'a,
+    {
         Self {
-            transactions: block.body.transactions().map(|tx| tx.encoded_2718().into()).collect(),
-            withdrawals: block.body.withdrawals.map(Withdrawals::into_inner),
+            transactions: transactions.into_iter().map(|tx| tx.encoded_2718().into()).collect(),
+            withdrawals: withdrawals.map(Withdrawals::into_inner),
         }
+    }
+
+    /// Converts a [`alloy_consensus::Block`] into an execution payload body.
+    pub fn from_block<T: Encodable2718, H>(block: &Block<T, H>) -> Self {
+        Self::new(block.body.withdrawals.clone(), block.body.transactions())
     }
 }
 
 impl<T: Encodable2718, H> From<Block<T, H>> for ExecutionPayloadBodyV1 {
     fn from(value: Block<T, H>) -> Self {
-        Self::from_block(value)
+        Self::from_block(&value)
     }
 }
 


### PR DESCRIPTION
this type doesn't need the entire block, only txs

this way we get a constructor decoupled from the block type which is more helpful for reth:

https://github.com/paradigmxyz/reth/blob/209b44829ee80a2e5a7b3e673c02b4fa1d81233e/crates/rpc/rpc-types-compat/src/engine/payload.rs#L9-L10