### PR TITLE
feat(`meta`): enable pubsub,trace,txpool,debug,anvil apis via `full`

### DIFF
--- a/crates/alloy/Cargo.toml
+++ b/crates/alloy/Cargo.toml
@@ -89,6 +89,11 @@ full = [
     "network",
     "provider-ws",
     "provider-ipc",
+    "provider-trace-api",
+    "provider-txpool-api",
+    "provider-debug-api",
+    "provider-anvil-api",
+    "pubsub",
 ]
 
 # configuration


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Currently `full` doesn't enable most provider APIs and related rpc-types. 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Enable the trace, txpool, debug, anvil provider APIs, and rpc-types + pubsub feature.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
