### PR TITLE
feat(`node-bindings`): expose anvil wallet

### DIFF
--- a/crates/node-bindings/Cargo.toml
+++ b/crates/node-bindings/Cargo.toml
@@ -25,6 +25,9 @@ workspace = true
 [dependencies]
 alloy-primitives = { workspace = true, features = ["std", "k256", "serde"] }
 alloy-genesis.workspace = true
+alloy-network.workspace = true
+alloy-signer-local.workspace = true
+alloy-signer.workspace = true
 k256.workspace = true
 rand.workspace = true
 serde_json = { workspace = true, features = ["std"] }

--- a/crates/node-bindings/src/nodes/anvil.rs
+++ b/crates/node-bindings/src/nodes/anvil.rs
@@ -97,7 +97,7 @@ impl AnvilInstance {
         Url::parse(&self.ws_endpoint()).unwrap()
     }
 
-    /// Returns the [`EthereumWallet`] of this instance consisting of the anvil private keys
+    /// Returns the [`EthereumWallet`] of this instance generated from anvil dev accounts.
     pub fn wallet(&self) -> Option<EthereumWallet> {
         self.wallet.clone()
     }

--- a/crates/provider/Cargo.toml
+++ b/crates/provider/Cargo.toml
@@ -29,8 +29,6 @@ alloy-json-rpc.workspace = true
 alloy-network.workspace = true
 alloy-network-primitives.workspace = true
 alloy-node-bindings = { workspace = true, optional = true }
-alloy-signer-local = { workspace = true, optional = true }
-alloy-signer = { workspace = true, optional = true }
 alloy-rpc-client.workspace = true
 alloy-rpc-types-admin = { workspace = true, optional = true }
 alloy-rpc-types-anvil = { workspace = true, optional = true }
@@ -116,13 +114,7 @@ reqwest-rustls-tls = ["alloy-transport-http?/reqwest-rustls-tls"]
 reqwest-native-tls = ["alloy-transport-http?/reqwest-native-tls"]
 admin-api = ["dep:alloy-rpc-types-admin"]
 anvil-api = ["dep:alloy-rpc-types-anvil"]
-anvil-node = [
-    "anvil-api",
-    "reqwest",
-    "dep:alloy-node-bindings",
-    "dep:alloy-signer-local",
-    "dep:alloy-signer",
-]
+anvil-node = ["anvil-api", "reqwest", "dep:alloy-node-bindings"]
 debug-api = ["dep:alloy-rpc-types-trace", "dep:alloy-rpc-types-debug"]
 erc4337-api = []
 engine-api = ["dep:alloy-rpc-types-engine"]

--- a/crates/provider/src/builder.rs
+++ b/crates/provider/src/builder.rs
@@ -8,7 +8,6 @@ use crate::{
 };
 use alloy_chains::NamedChain;
 use alloy_network::{Ethereum, Network};
-use alloy_node_bindings::NodeError;
 use alloy_primitives::ChainId;
 use alloy_rpc_client::{ClientBuilder, RpcClient};
 use alloy_transport::{TransportError, TransportResult};
@@ -451,7 +450,10 @@ impl<L, F> ProviderBuilder<L, F, Ethereum> {
         let anvil_layer = crate::layers::AnvilLayer::from(f(Default::default()));
         let url = anvil_layer.endpoint_url();
 
-        let wallet = anvil_layer.instance().wallet().ok_or(NodeError::NoKeysAvailable)?;
+        let wallet = anvil_layer
+            .instance()
+            .wallet()
+            .ok_or(alloy_node_bindings::NodeError::NoKeysAvailable)?;
 
         let rpc_client = ClientBuilder::default().http(url);
 

--- a/crates/provider/src/builder.rs
+++ b/crates/provider/src/builder.rs
@@ -8,6 +8,7 @@ use crate::{
 };
 use alloy_chains::NamedChain;
 use alloy_network::{Ethereum, Network};
+use alloy_node_bindings::NodeError;
 use alloy_primitives::ChainId;
 use alloy_rpc_client::{ClientBuilder, RpcClient};
 use alloy_transport::{TransportError, TransportResult};
@@ -447,22 +448,10 @@ impl<L, F> ProviderBuilder<L, F, Ethereum> {
             crate::layers::AnvilProvider<crate::provider::RootProvider>,
         >,
     {
-        use alloy_signer::Signer;
-
         let anvil_layer = crate::layers::AnvilLayer::from(f(Default::default()));
         let url = anvil_layer.endpoint_url();
 
-        let default_keys = anvil_layer.instance().keys().to_vec();
-        let (default_key, remaining_keys) =
-            default_keys.split_first().ok_or(alloy_node_bindings::NodeError::NoKeysAvailable)?;
-
-        let default_signer = alloy_signer_local::LocalSigner::from(default_key.clone())
-            .with_chain_id(Some(anvil_layer.instance().chain_id()));
-        let mut wallet = alloy_network::EthereumWallet::from(default_signer);
-
-        for key in remaining_keys {
-            wallet.register_signer(alloy_signer_local::LocalSigner::from(key.clone()))
-        }
+        let wallet = anvil_layer.instance().wallet().ok_or(NodeError::NoKeysAvailable)?;
 
         let rpc_client = ClientBuilder::default().http(url);
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Currently, `AnvilInstance` doesn't expose `EthereumWallet` of its dev private keys.
One can create an `EthereumWallet` for the instance via `.keys()`, like:

```rust
let pk: PrivateKeySigner = anvil.keys()[0].into();
let wallet = EthereumWallet::new(pk);
```

This can be made simpler 

```rust
// Returns a wallet consisting of signers associated with all anvil private keys
let wallet = anvil.wallet().ok_or_eyre("No Keys Available")?;
```

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Instantiate and store the `EthereumWallet` when anvil is spawned. 

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
