### PR TITLE
chore(provider): default to `Ethereum` network in `FillProvider`

### DIFF
--- a/crates/provider/src/fillers/mod.rs
+++ b/crates/provider/src/fillers/mod.rs
@@ -214,7 +214,7 @@ pub trait TxFiller<N: Network = Ethereum>: Clone + Send + Sync + std::fmt::Debug
 ///
 /// [`ProviderBuilder::filler`]: crate::ProviderBuilder::filler
 #[derive(Clone, Debug)]
-pub struct FillProvider<F, P, N>
+pub struct FillProvider<F, P, N = Ethereum>
 where
     F: TxFiller<N>,
     P: Provider<N>,


### PR DESCRIPTION
## Motivation

Although `FillProvider` isn't meant to be built directly, it's often used as return type of `ProviderBuilder::on_http`.
Since `Provider` uses this default, I think it makes sense to do the same for `FillProvider`.

## Solution

Set the default `N = Ethereum` with `N: Network`.
