### PR TITLE
chore: add serde support for Eip1559Estimation

### DIFF
--- a/crates/eips/src/eip1559/helpers.rs
+++ b/crates/eips/src/eip1559/helpers.rs
@@ -1,5 +1,19 @@
 use crate::eip1559::{constants::GAS_LIMIT_BOUND_DIVISOR, BaseFeeParams};
 
+/// Return type of EIP1155 gas fee estimator.
+///
+/// Contains EIP-1559 fields
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Eip1559Estimation {
+    /// The base fee per gas.
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
+    pub max_fee_per_gas: u128,
+    /// The max priority fee per gas.
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
+    pub max_priority_fee_per_gas: u128,
+}
+
 /// Calculate the base fee for the next block based on the EIP-1559 specification.
 ///
 /// This function calculates the base fee for the next block according to the rules defined in the

--- a/crates/eips/src/eip1559/mod.rs
+++ b/crates/eips/src/eip1559/mod.rs
@@ -9,4 +9,4 @@ mod constants;
 pub use constants::*;
 
 mod helpers;
-pub use helpers::{calc_next_block_base_fee, calculate_block_gas_limit};
+pub use helpers::{calc_next_block_base_fee, calculate_block_gas_limit, Eip1559Estimation};

--- a/crates/provider/src/utils.rs
+++ b/crates/provider/src/utils.rs
@@ -1,11 +1,12 @@
 //! Provider-related utilities.
 
-use alloy_primitives::{U128, U64};
-
 use crate::{
     fillers::{BlobGasFiller, ChainIdFiller, GasFiller, JoinFill, NonceFiller},
     Identity,
 };
+use alloy_primitives::{U128, U64};
+
+pub use alloy_eips::eip1559::Eip1559Estimation;
 
 /// The number of blocks from the past for which the fee rewards are fetched for fee estimation.
 pub const EIP1559_FEE_ESTIMATION_PAST_BLOCKS: u64 = 10;
@@ -18,15 +19,6 @@ pub const EIP1559_MIN_PRIORITY_FEE: u128 = 1;
 
 /// An estimator function for EIP1559 fees.
 pub type EstimatorFunction = fn(u128, &[Vec<u128>]) -> Eip1559Estimation;
-
-/// Return type of EIP1155 gas fee estimator.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct Eip1559Estimation {
-    /// The base fee per gas.
-    pub max_fee_per_gas: u128,
-    /// The max priority fee per gas.
-    pub max_priority_fee_per_gas: u128,
-}
 
 fn estimate_priority_fee(rewards: &[Vec<u128>]) -> u128 {
     let mut rewards =


### PR DESCRIPTION
adds missing serde support to Eip1559Estimation type

moved to eips/1559 because seems useful there as well