### PR TITLE
feat: use `OnceCell` for `Signed::hash`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,11 +68,11 @@ alloy-transport-ipc = { version = "0.11", path = "crates/transport-ipc", default
 alloy-transport-ws = { version = "0.11", path = "crates/transport-ws", default-features = false }
 alloy-eip5792 = { version = "0.11", path = "crates/eip5792", default-features = false }
 
-alloy-core = { version = "0.8.15", default-features = false }
-alloy-dyn-abi = { version = "0.8.15", default-features = false }
-alloy-json-abi = { version = "0.8.15", default-features = false }
-alloy-primitives = { version = "0.8.15", default-features = false }
-alloy-sol-types = { version = "0.8.15", default-features = false }
+alloy-core = { version = "0.8.22", default-features = false }
+alloy-dyn-abi = { version = "0.8.22", default-features = false }
+alloy-json-abi = { version = "0.8.22", default-features = false }
+alloy-primitives = { version = "0.8.22", default-features = false }
+alloy-sol-types = { version = "0.8.22", default-features = false }
 
 alloy-rlp = { version = "0.3.9", default-features = false }
 alloy-trie = { version = "0.7.6", default-features = false }

--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -81,7 +81,8 @@ std = [
 	"serde_json/std",
 	"serde_with?/std",
 	"thiserror/std",
-	"either/std"
+	"either/std",
+	"once_cell/std"
 ]
 k256 = ["dep:k256", "alloy-primitives/k256", "alloy-eips/k256"]
 kzg = ["dep:c-kzg", "alloy-eips/kzg", "std"]

--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -53,6 +53,7 @@ derive_more = { workspace = true, features = [
 auto_impl.workspace = true
 thiserror.workspace = true
 either.workspace = true
+once_cell = { workspace = true, features = ["critical-section"]}
 
 [dev-dependencies]
 alloy-eips = { workspace = true, features = ["arbitrary"] }

--- a/crates/consensus/src/transaction/eip1559.rs
+++ b/crates/consensus/src/transaction/eip1559.rs
@@ -1,4 +1,4 @@
-use crate::{transaction::RlpEcdsaTx, SignableTransaction, Transaction, TxType};
+use crate::{SignableTransaction, Transaction, TxType};
 use alloy_eips::{eip2930::AccessList, eip7702::SignedAuthorization, Typed2718};
 use alloy_primitives::{Bytes, ChainId, PrimitiveSignature as Signature, TxKind, B256, U256};
 use alloy_rlp::{BufMut, Decodable, Encodable};
@@ -272,10 +272,6 @@ impl SignableTransaction<Signature> for TxEip1559 {
 
     fn payload_len_for_signature(&self) -> usize {
         self.length() + 1
-    }
-
-    fn tx_hash_with_signature(&self, signature: &Signature) -> B256 {
-        self.tx_hash(signature)
     }
 }
 

--- a/crates/consensus/src/transaction/eip1559.rs
+++ b/crates/consensus/src/transaction/eip1559.rs
@@ -1,4 +1,4 @@
-use crate::{SignableTransaction, Signed, Transaction, TxType};
+use crate::{transaction::RlpEcdsaTx, SignableTransaction, Transaction, TxType};
 use alloy_eips::{eip2930::AccessList, eip7702::SignedAuthorization, Typed2718};
 use alloy_primitives::{Bytes, ChainId, PrimitiveSignature as Signature, TxKind, B256, U256};
 use alloy_rlp::{BufMut, Decodable, Encodable};
@@ -274,9 +274,8 @@ impl SignableTransaction<Signature> for TxEip1559 {
         self.length() + 1
     }
 
-    fn into_signed(self, signature: Signature) -> Signed<Self> {
-        let tx_hash = self.tx_hash(&signature);
-        Signed::new_unchecked(self, signature, tx_hash)
+    fn tx_hash_with_signature(&self, signature: &Signature) -> B256 {
+        self.tx_hash(signature)
     }
 }
 

--- a/crates/consensus/src/transaction/eip2930.rs
+++ b/crates/consensus/src/transaction/eip2930.rs
@@ -1,4 +1,4 @@
-use crate::{SignableTransaction, Signed, Transaction, TxType};
+use crate::{transaction::RlpEcdsaTx, SignableTransaction, Transaction, TxType};
 use alloy_eips::{eip2930::AccessList, eip7702::SignedAuthorization, Typed2718};
 use alloy_primitives::{Bytes, ChainId, PrimitiveSignature as Signature, TxKind, B256, U256};
 use alloy_rlp::{BufMut, Decodable, Encodable};
@@ -230,9 +230,8 @@ impl SignableTransaction<Signature> for TxEip2930 {
         self.length() + 1
     }
 
-    fn into_signed(self, signature: Signature) -> Signed<Self> {
-        let tx_hash = self.tx_hash(&signature);
-        Signed::new_unchecked(self, signature, tx_hash)
+    fn tx_hash_with_signature(&self, signature: &Signature) -> B256 {
+        self.tx_hash(signature)
     }
 }
 

--- a/crates/consensus/src/transaction/eip2930.rs
+++ b/crates/consensus/src/transaction/eip2930.rs
@@ -1,4 +1,4 @@
-use crate::{transaction::RlpEcdsaTx, SignableTransaction, Transaction, TxType};
+use crate::{SignableTransaction, Transaction, TxType};
 use alloy_eips::{eip2930::AccessList, eip7702::SignedAuthorization, Typed2718};
 use alloy_primitives::{Bytes, ChainId, PrimitiveSignature as Signature, TxKind, B256, U256};
 use alloy_rlp::{BufMut, Decodable, Encodable};
@@ -228,10 +228,6 @@ impl SignableTransaction<Signature> for TxEip2930 {
 
     fn payload_len_for_signature(&self) -> usize {
         self.length() + 1
-    }
-
-    fn tx_hash_with_signature(&self, signature: &Signature) -> B256 {
-        self.tx_hash(signature)
     }
 }
 

--- a/crates/consensus/src/transaction/eip4844.rs
+++ b/crates/consensus/src/transaction/eip4844.rs
@@ -408,10 +408,6 @@ impl SignableTransaction<Signature> for TxEip4844Variant {
     fn payload_len_for_signature(&self) -> usize {
         self.tx().payload_len_for_signature()
     }
-
-    fn tx_hash_with_signature(&self, signature: &Signature) -> B256 {
-        self.tx_hash(signature)
-    }
 }
 
 /// [EIP-4844 Blob Transaction](https://eips.ethereum.org/EIPS/eip-4844#blob-transaction)
@@ -607,10 +603,6 @@ impl SignableTransaction<Signature> for TxEip4844 {
 
     fn payload_len_for_signature(&self) -> usize {
         self.length() + 1
-    }
-
-    fn tx_hash_with_signature(&self, signature: &Signature) -> B256 {
-        self.tx_hash(signature)
     }
 }
 
@@ -828,10 +820,6 @@ impl SignableTransaction<Signature> for TxEip4844WithSidecar {
         // The payload length is the length of the `transaction_payload_body` list.
         // The sidecar is NOT included.
         self.tx.payload_len_for_signature()
-    }
-
-    fn tx_hash_with_signature(&self, signature: &Signature) -> B256 {
-        self.tx_hash(signature)
     }
 }
 

--- a/crates/consensus/src/transaction/eip4844.rs
+++ b/crates/consensus/src/transaction/eip4844.rs
@@ -409,10 +409,8 @@ impl SignableTransaction<Signature> for TxEip4844Variant {
         self.tx().payload_len_for_signature()
     }
 
-    fn into_signed(self, signature: Signature) -> Signed<Self> {
-        let hash = self.tx_hash(&signature);
-
-        Signed::new_unchecked(self, signature, hash)
+    fn tx_hash_with_signature(&self, signature: &Signature) -> B256 {
+        self.tx_hash(signature)
     }
 }
 
@@ -611,9 +609,8 @@ impl SignableTransaction<Signature> for TxEip4844 {
         self.length() + 1
     }
 
-    fn into_signed(self, signature: Signature) -> Signed<Self> {
-        let hash = self.tx_hash(&signature);
-        Signed::new_unchecked(self, signature, hash)
+    fn tx_hash_with_signature(&self, signature: &Signature) -> B256 {
+        self.tx_hash(signature)
     }
 }
 
@@ -833,11 +830,8 @@ impl SignableTransaction<Signature> for TxEip4844WithSidecar {
         self.tx.payload_len_for_signature()
     }
 
-    fn into_signed(self, signature: Signature) -> Signed<Self, Signature> {
-        // important: must hash the tx WITHOUT the sidecar
-        let hash = self.tx_hash(&signature);
-
-        Signed::new_unchecked(self, signature, hash)
+    fn tx_hash_with_signature(&self, signature: &Signature) -> B256 {
+        self.tx_hash(signature)
     }
 }
 

--- a/crates/consensus/src/transaction/eip7702.rs
+++ b/crates/consensus/src/transaction/eip7702.rs
@@ -264,10 +264,6 @@ impl SignableTransaction<Signature> for TxEip7702 {
     fn payload_len_for_signature(&self) -> usize {
         self.length() + 1
     }
-
-    fn tx_hash_with_signature(&self, signature: &Signature) -> B256 {
-        self.tx_hash(signature)
-    }
 }
 
 impl Typed2718 for TxEip7702 {

--- a/crates/consensus/src/transaction/eip7702.rs
+++ b/crates/consensus/src/transaction/eip7702.rs
@@ -1,4 +1,4 @@
-use crate::{SignableTransaction, Signed, Transaction, TxType};
+use crate::{SignableTransaction, Transaction, TxType};
 use alloc::vec::Vec;
 use alloy_eips::{
     eip2930::AccessList,
@@ -265,10 +265,8 @@ impl SignableTransaction<Signature> for TxEip7702 {
         self.length() + 1
     }
 
-    fn into_signed(self, signature: Signature) -> Signed<Self> {
-        let tx_hash = self.tx_hash(&signature);
-
-        Signed::new_unchecked(self, signature, tx_hash)
+    fn tx_hash_with_signature(&self, signature: &Signature) -> B256 {
+        self.tx_hash(signature)
     }
 }
 

--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -411,7 +411,7 @@ impl TxEnvelope {
 
     /// Return the hash of the inner Signed.
     #[doc(alias = "transaction_hash")]
-    pub const fn tx_hash(&self) -> &B256 {
+    pub fn tx_hash(&self) -> &B256 {
         match self {
             Self::Legacy(tx) => tx.hash(),
             Self::Eip2930(tx) => tx.hash(),

--- a/crates/consensus/src/transaction/legacy.rs
+++ b/crates/consensus/src/transaction/legacy.rs
@@ -342,10 +342,6 @@ impl SignableTransaction<Signature> for TxLegacy {
         // 'header length' + 'payload length'
         Header { list: true, payload_length }.length_with_payload()
     }
-
-    fn tx_hash_with_signature(&self, signature: &Signature) -> B256 {
-        self.tx_hash(signature)
-    }
 }
 
 impl Typed2718 for TxLegacy {

--- a/crates/consensus/src/transaction/legacy.rs
+++ b/crates/consensus/src/transaction/legacy.rs
@@ -343,9 +343,8 @@ impl SignableTransaction<Signature> for TxLegacy {
         Header { list: true, payload_length }.length_with_payload()
     }
 
-    fn into_signed(self, signature: Signature) -> Signed<Self> {
-        let hash = self.tx_hash(&signature);
-        Signed::new_unchecked(self, signature, hash)
+    fn tx_hash_with_signature(&self, signature: &Signature) -> B256 {
+        self.tx_hash(signature)
     }
 }
 

--- a/crates/consensus/src/transaction/mod.rs
+++ b/crates/consensus/src/transaction/mod.rs
@@ -263,9 +263,6 @@ pub trait SignableTransaction<Signature>: Transaction {
         keccak256(self.encoded_for_signing())
     }
 
-    /// Calculate the transaction hash for this transaction with the given signature.
-    fn tx_hash_with_signature(&self, signature: &Signature) -> B256;
-
     /// Convert to a [`Signed`] object.
     fn into_signed(self, signature: Signature) -> Signed<Self, Signature>
     where

--- a/crates/consensus/src/transaction/mod.rs
+++ b/crates/consensus/src/transaction/mod.rs
@@ -263,11 +263,16 @@ pub trait SignableTransaction<Signature>: Transaction {
         keccak256(self.encoded_for_signing())
     }
 
-    /// Convert to a signed transaction by adding a signature and computing the
-    /// hash.
+    /// Calculate the transaction hash for this transaction with the given signature.
+    fn tx_hash_with_signature(&self, signature: &Signature) -> B256;
+
+    /// Convert to a [`Signed`] object.
     fn into_signed(self, signature: Signature) -> Signed<Self, Signature>
     where
-        Self: Sized;
+        Self: Sized,
+    {
+        Signed::new_unhashed(self, signature)
+    }
 }
 
 // TODO: Remove in favor of dyn trait upcasting (TBD, see https://github.com/rust-lang/rust/issues/65991#issuecomment-1903120162)

--- a/crates/consensus/src/transaction/pooled.rs
+++ b/crates/consensus/src/transaction/pooled.rs
@@ -56,7 +56,7 @@ impl PooledTransaction {
     }
 
     /// Reference to transaction hash. Used to identify transaction.
-    pub const fn hash(&self) -> &TxHash {
+    pub fn hash(&self) -> &TxHash {
         match self {
             Self::Legacy(tx) => tx.hash(),
             Self::Eip2930(tx) => tx.hash(),

--- a/crates/consensus/src/transaction/typed.rs
+++ b/crates/consensus/src/transaction/typed.rs
@@ -3,7 +3,7 @@ use crate::{
         eip4844::{TxEip4844, TxEip4844Variant, TxEip4844WithSidecar},
         RlpEcdsaEncodableTx,
     },
-    SignableTransaction, Signed, Transaction, TxEip1559, TxEip2930, TxEip7702, TxEnvelope,
+    SignableTransaction, Transaction, TxEip1559, TxEip2930, TxEip7702, TxEnvelope,
     TxLegacy, TxType,
 };
 use alloy_eips::{eip2930::AccessList, eip7702::SignedAuthorization, Typed2718};

--- a/crates/consensus/src/transaction/typed.rs
+++ b/crates/consensus/src/transaction/typed.rs
@@ -472,16 +472,6 @@ impl SignableTransaction<Signature> for TypedTransaction {
             Self::Eip7702(tx) => tx.payload_len_for_signature(),
         }
     }
-
-    fn tx_hash_with_signature(&self, signature: &Signature) -> B256 {
-        match self {
-            Self::Legacy(tx) => tx.tx_hash_with_signature(signature),
-            Self::Eip2930(tx) => tx.tx_hash_with_signature(signature),
-            Self::Eip1559(tx) => tx.tx_hash_with_signature(signature),
-            Self::Eip4844(tx) => tx.tx_hash_with_signature(signature),
-            Self::Eip7702(tx) => tx.tx_hash_with_signature(signature),
-        }
-    }
 }
 
 #[cfg(feature = "serde")]

--- a/crates/consensus/src/transaction/typed.rs
+++ b/crates/consensus/src/transaction/typed.rs
@@ -473,12 +473,14 @@ impl SignableTransaction<Signature> for TypedTransaction {
         }
     }
 
-    fn into_signed(self, signature: Signature) -> Signed<Self, Signature>
-    where
-        Self: Sized,
-    {
-        let hash = self.tx_hash(&signature);
-        Signed::new_unchecked(self, signature, hash)
+    fn tx_hash_with_signature(&self, signature: &Signature) -> B256 {
+        match self {
+            Self::Legacy(tx) => tx.tx_hash_with_signature(signature),
+            Self::Eip2930(tx) => tx.tx_hash_with_signature(signature),
+            Self::Eip1559(tx) => tx.tx_hash_with_signature(signature),
+            Self::Eip4844(tx) => tx.tx_hash_with_signature(signature),
+            Self::Eip7702(tx) => tx.tx_hash_with_signature(signature),
+        }
     }
 }
 

--- a/crates/consensus/src/transaction/typed.rs
+++ b/crates/consensus/src/transaction/typed.rs
@@ -3,8 +3,8 @@ use crate::{
         eip4844::{TxEip4844, TxEip4844Variant, TxEip4844WithSidecar},
         RlpEcdsaEncodableTx,
     },
-    SignableTransaction, Transaction, TxEip1559, TxEip2930, TxEip7702, TxEnvelope,
-    TxLegacy, TxType,
+    SignableTransaction, Transaction, TxEip1559, TxEip2930, TxEip7702, TxEnvelope, TxLegacy,
+    TxType,
 };
 use alloy_eips::{eip2930::AccessList, eip7702::SignedAuthorization, Typed2718};
 use alloy_primitives::{


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

closes #1987

Lazily computes hash for the transaction in `Signed`. Methods relying on hash are now bounded by `T: RlpEcdsaTx` which works for all of the transactions we have but would likely get trickier for custom signature usecases 
## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
