### PR TITLE
feat: add dynamic dispatch helper trait for (`Signer` +`TxSigner`) and (`SignerSync` + `TxSignerSync`)

### DIFF
--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -14,8 +14,9 @@ use core::fmt::{Debug, Display};
 
 mod transaction;
 pub use transaction::{
-    BuildResult, NetworkWallet, TransactionBuilder, TransactionBuilder4844, TransactionBuilder7702,
-    TransactionBuilderError, TxSigner, TxSignerSync, UnbuiltTransactionError,
+    AnySigner, AnySignerSync, BuildResult, NetworkWallet, TransactionBuilder,
+    TransactionBuilder4844, TransactionBuilder7702, TransactionBuilderError, TxSigner,
+    TxSignerSync, UnbuiltTransactionError,
 };
 
 mod ethereum;

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -14,7 +14,7 @@ use core::fmt::{Debug, Display};
 
 mod transaction;
 pub use transaction::{
-    AnySigner, AnySignerSync, BuildResult, NetworkWallet, TransactionBuilder,
+    BuildResult, FullSigner, FullSignerSync, NetworkWallet, TransactionBuilder,
     TransactionBuilder4844, TransactionBuilder7702, TransactionBuilderError, TxSigner,
     TxSignerSync, UnbuiltTransactionError,
 };

--- a/crates/network/src/transaction/mod.rs
+++ b/crates/network/src/transaction/mod.rs
@@ -5,4 +5,4 @@ pub use builder::{
 };
 
 mod signer;
-pub use signer::{AnySigner, AnySignerSync, NetworkWallet, TxSigner, TxSignerSync};
+pub use signer::{FullSigner, FullSignerSync, NetworkWallet, TxSigner, TxSignerSync};

--- a/crates/network/src/transaction/mod.rs
+++ b/crates/network/src/transaction/mod.rs
@@ -5,4 +5,4 @@ pub use builder::{
 };
 
 mod signer;
-pub use signer::{NetworkWallet, TxSigner, TxSignerSync};
+pub use signer::{AnySigner, AnySignerSync, NetworkWallet, TxSigner, TxSignerSync};

--- a/crates/network/src/transaction/signer.rs
+++ b/crates/network/src/transaction/signer.rs
@@ -123,15 +123,22 @@ pub trait TxSignerSync<Signature> {
 /// A unifying trait for asynchronous Ethereum signers that combine the functionalities of both
 /// [`Signer`] and [`TxSigner`].
 ///
-/// This trait enables dynamic dispatch (e.g., using `Box<dyn AnySigner>`) for types that combine
+/// This trait enables dynamic dispatch (e.g., using `Box<dyn FullSigner>`) for types that combine
 /// both asynchronous Ethereum signing and transaction signing functionalities.
-pub trait AnySigner<S>: Signer<S> + TxSigner<S> {}
-impl<T, S> AnySigner<S> for T where T: Signer<S> + TxSigner<S> {}
+pub trait FullSigner<S>: Signer<S> + TxSigner<S> {}
+impl<T, S> FullSigner<S> for T where T: Signer<S> + TxSigner<S> {}
 
 /// A unifying trait for synchronous Ethereum signers that implement both [`SignerSync`] and
 /// [`TxSignerSync`].
 ///
-/// This trait enables dynamic dispatch (e.g., using `Box<dyn AnySignerSync>`) for types that
+/// This trait enables dynamic dispatch (e.g., using `Box<dyn FullSignerSync>`) for types that
 /// combine both synchronous Ethereum signing and transaction signing functionalities.
-pub trait AnySignerSync<S>: SignerSync<S> + TxSignerSync<S> {}
-impl<T, S> AnySignerSync<S> for T where T: SignerSync<S> + TxSignerSync<S> {}
+pub trait FullSignerSync<S>: SignerSync<S> + TxSignerSync<S> {}
+impl<T, S> FullSignerSync<S> for T where T: SignerSync<S> + TxSignerSync<S> {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct _ObjectSafe(Box<dyn FullSigner<()>>, Box<dyn FullSignerSync<()>>);
+}

--- a/crates/network/src/transaction/signer.rs
+++ b/crates/network/src/transaction/signer.rs
@@ -1,6 +1,7 @@
 use crate::{Network, TransactionBuilder};
 use alloy_consensus::SignableTransaction;
 use alloy_primitives::Address;
+use alloy_signer::{Signer, SignerSync};
 use async_trait::async_trait;
 use auto_impl::auto_impl;
 use futures_utils_wasm::impl_future;
@@ -118,3 +119,19 @@ pub trait TxSignerSync<Signature> {
         tx: &mut dyn SignableTransaction<Signature>,
     ) -> alloy_signer::Result<Signature>;
 }
+
+/// A unifying trait for asynchronous Ethereum signers that combine the functionalities of both
+/// [`Signer`] and [`TxSigner`].
+///
+/// This trait enables dynamic dispatch (e.g., using `Box<dyn AnySigner>`) for types that combine
+/// both asynchronous Ethereum signing and transaction signing functionalities.
+pub trait AnySigner<S>: Signer<S> + TxSigner<S> {}
+impl<T, S> AnySigner<S> for T where T: Signer<S> + TxSigner<S> {}
+
+/// A unifying trait for synchronous Ethereum signers that implement both [`SignerSync`] and
+/// [`TxSignerSync`].
+///
+/// This trait enables dynamic dispatch (e.g., using `Box<dyn AnySignerSync>`) for types that
+/// combine both synchronous Ethereum signing and transaction signing functionalities.
+pub trait AnySignerSync<S>: SignerSync<S> + TxSignerSync<S> {}
+impl<T, S> AnySignerSync<S> for T where T: SignerSync<S> + TxSignerSync<S> {}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->
Closes: #2029 

This pr adds two unifying traits, `AnySigner` and `AnySignerSync`, to asynchronous (`Signer` + `TxSigner`) and synchronous (`SignerSync` + `TxSignerSync`) Ethereum signing functionalities, enabling dynamic dispatch (e.g., via `Box<dyn AnySigner>`).

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
