### PR TITLE
feat(provider): expose inner `AnvilInstance` from `AnvilProvider`

### DIFF
--- a/crates/provider/src/layers/anvil.rs
+++ b/crates/provider/src/layers/anvil.rs
@@ -70,6 +70,11 @@ where
     pub fn new(inner: P, _anvil: Arc<AnvilInstance>) -> Self {
         Self { inner, _anvil }
     }
+
+    /// Expose inner anvil instance.
+    pub fn anvil(&self) -> &Arc<AnvilInstance> {
+        &self._anvil
+    }
 }
 
 impl<P> Provider for AnvilProvider<P>

--- a/crates/provider/src/layers/anvil.rs
+++ b/crates/provider/src/layers/anvil.rs
@@ -57,7 +57,7 @@ where
 #[derive(Clone, Debug)]
 pub struct AnvilProvider<P> {
     inner: P,
-    _anvil: Arc<AnvilInstance>,
+    anvil: Arc<AnvilInstance>,
 }
 
 impl<P> AnvilProvider<P>
@@ -67,13 +67,13 @@ where
     /// Creates a new `AnvilProvider` with the given inner provider and anvil
     /// instance.
     #[allow(clippy::missing_const_for_fn)]
-    pub fn new(inner: P, _anvil: Arc<AnvilInstance>) -> Self {
-        Self { inner, _anvil }
+    pub fn new(inner: P, anvil: Arc<AnvilInstance>) -> Self {
+        Self { inner, anvil }
     }
 
     /// Expose inner anvil instance.
     pub fn anvil(&self) -> &Arc<AnvilInstance> {
-        &self._anvil
+        &self.anvil
     }
 }
 


### PR DESCRIPTION
Some questions:
1. Not sure what kind of test to add for this
2. Does returning `&Arc<T>` feel right or should i return a cloned `Arc<T>`?

## Motivation

There is no way to access some of the `AnvilInstance` methods like `keys()`, `addresses()` right now when you spawn the anvil provider with `ProviderBuilder::on_anvil_XXX` methods.

## Solution

Exposing a reference to inner `AnvilInstance` will allow to access those methods instead of writing a wrapper delegate method for all the underlying methods.


## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
