### PR TITLE
fix: don't validate when ABI decoding

### DIFF
--- a/crates/contract/src/eth_call.rs
+++ b/crates/contract/src/eth_call.rs
@@ -135,7 +135,7 @@ where
         let pin = std::pin::pin!(&mut this.inner);
         match pin.poll(cx) {
             std::task::Poll::Ready(Ok(data)) => {
-                std::task::Poll::Ready(this.decoder.abi_decode_output(data, true))
+                std::task::Poll::Ready(this.decoder.abi_decode_output(data, false))
             }
             std::task::Poll::Ready(Err(e)) => std::task::Poll::Ready(Err(e.into())),
             std::task::Poll::Pending => std::task::Poll::Pending,


### PR DESCRIPTION
This is being removed here: https://github.com/alloy-rs/core/pull/863

It causes valid data to be rejected: https://t.me/ethers_rs/43150.