### PR TITLE
fix(`multicall`): impl Error for `Failure` +  clear returns `Empty` builder.

### DIFF
--- a/crates/contract/src/multicall.rs
+++ b/crates/contract/src/multicall.rs
@@ -261,12 +261,12 @@ mod tests {
         let provider = ProviderBuilder::new().on_anvil();
 
         let erc20 = ERC20::new(weth, &provider);
-        let mut multicall = provider
+        let multicall = provider
             .multicall()
             .add(erc20.totalSupply())
             .add(erc20.balanceOf(address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045")));
         assert_eq!(multicall.len(), 2);
-        multicall.clear();
+        let multicall = multicall.clear();
         assert_eq!(multicall.len(), 0);
     }
 

--- a/crates/provider/src/provider/multicall/inner_types.rs
+++ b/crates/provider/src/provider/multicall/inner_types.rs
@@ -11,8 +11,9 @@ use thiserror::Error;
 /// Result type for multicall operations.
 pub type Result<T, E = MulticallError> = core::result::Result<T, E>;
 
-/// A struct to representing a failure in a multicall
-#[derive(Debug, Clone)]
+/// A struct representing a failure in a multicall
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[error("Call failed at index {idx} with return data: {return_data:?}")]
 pub struct Failure {
     /// The index-position of the call that failed
     pub idx: usize,

--- a/crates/provider/src/provider/multicall/mod.rs
+++ b/crates/provider/src/provider/multicall/mod.rs
@@ -660,9 +660,18 @@ where
         self.add_call(call)
     }
 
-    /// Clear the calls from the builder
-    pub fn clear(&mut self) {
-        self.calls.clear();
+    /// Returns an [`Empty`] builder
+    ///
+    /// Retains previously set provider, address, block and state_override settings.
+    pub fn clear(self) -> MulticallBuilder<Empty, P, N> {
+        MulticallBuilder {
+            calls: Vec::new(),
+            provider: self.provider,
+            block: self.block,
+            state_override: self.state_override,
+            address: self.address,
+            _pd: Default::default(),
+        }
     }
 
     /// Get the number of calls in the builder


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

1. We can't use `?` on a multicall `Result<(), Failure`> since `Failure` doesn't implement `StdError`.
2. `clear` should return an `Empty` multicall builder otherwise it's of no use.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

1. Use `thiserror::Error` for `Failure`
2. Return `Empty` multicall builder on `multicall.clear()`

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
