### PR TITLE
feat: add helpers to create a BlobSidecar

### DIFF
--- a/crates/eips/src/eip4844/sidecar.rs
+++ b/crates/eips/src/eip4844/sidecar.rs
@@ -303,6 +303,38 @@ impl BlobTransactionSidecar {
             self.proofs.len() * BYTES_PER_PROOF // proofs
     }
 
+    /// Tries to create a new [`BlobTransactionSidecar`] from the hex encoded blob str.
+    ///
+    /// See also [`Blob::from_hex`](c_kzg::Blob::from_hex)
+    #[cfg(all(feature = "kzg", any(test, feature = "arbitrary")))]
+    pub fn try_from_blobs_hex<I, B>(blobs: I) -> Result<Self, c_kzg::Error>
+    where
+        I: IntoIterator<Item = B>,
+        B: AsRef<str>,
+    {
+        let blobs = blobs
+            .into_iter()
+            .map(|blob| c_kzg::Blob::from_hex(blob.as_ref()))
+            .collect::<Result<Vec<_>, _>>()?;
+        Self::try_from_blobs(blobs)
+    }
+
+    /// Tries to create a new [`BlobTransactionSidecar`] from the given blob bytes.
+    ///
+    /// See also [`Blob::from_bytes`](c_kzg::Blob::from_bytes)
+    #[cfg(all(feature = "kzg", any(test, feature = "arbitrary")))]
+    pub fn try_from_blobs_bytes<I, B>(blobs: I) -> Result<Self, c_kzg::Error>
+    where
+        I: IntoIterator<Item = B>,
+        B: AsRef<[u8]>,
+    {
+        let blobs = blobs
+            .into_iter()
+            .map(|blob| c_kzg::Blob::from_bytes(blob.as_ref()))
+            .collect::<Result<Vec<_>, _>>()?;
+        Self::try_from_blobs(blobs)
+    }
+
     /// Tries to create a new [`BlobTransactionSidecar`] from the given blobs.
     #[cfg(all(feature = "kzg", any(test, feature = "arbitrary")))]
     pub fn try_from_blobs(blobs: Vec<c_kzg::Blob>) -> Result<Self, c_kzg::Error> {


### PR DESCRIPTION
makes it possible to create a sidecar from blobs encoded as hex or byte slice

this way we don't need to import c_kzg if we have hex test data for example