### PR TITLE
feat: introduce error helper and fallible conversion

### DIFF
--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -51,6 +51,7 @@ derive_more = { workspace = true, features = [
     "into_iterator",
 ], default-features = false }
 auto_impl.workspace = true
+thiserror.workspace = true
 
 [dev-dependencies]
 alloy-eips = { workspace = true, features = ["arbitrary"] }

--- a/crates/consensus/src/error.rs
+++ b/crates/consensus/src/error.rs
@@ -1,5 +1,7 @@
 //! Helper errors.
 
+use alloc::string::{String, ToString};
+
 /// Helper type that is [`core::error::Error`] and wraps a value and an error message.
 ///
 /// This can be used to return an object as part of an `Err` and is used for fallible conversions.
@@ -7,17 +9,13 @@
 #[error("{msg}")]
 pub struct ValueError<T> {
     msg: String,
-    value: T
+    value: T,
 }
 
 impl<T> ValueError<T> {
-
     /// Creates a new error with the given value and error message.
     pub fn new(value: T, msg: impl core::fmt::Display) -> Self {
-        Self {
-            msg: msg.to_string(),
-            value,
-        }
+        Self { msg: msg.to_string(), value }
     }
 
     /// Consumes the type and returns the underlying value.
@@ -26,5 +24,7 @@ impl<T> ValueError<T> {
     }
 
     /// Returns a reference to the value.
-    pub const fn value(&self) -> &T { &self.value }
+    pub const fn value(&self) -> &T {
+        &self.value
+    }
 }

--- a/crates/consensus/src/error.rs
+++ b/crates/consensus/src/error.rs
@@ -1,0 +1,30 @@
+//! Helper errors.
+
+/// Helper type that is [`core::error::Error`] and wraps a value and an error message.
+///
+/// This can be used to return an object as part of an `Err` and is used for fallible conversions.
+#[derive(Debug, thiserror::Error)]
+#[error("{msg}")]
+pub struct ValueError<T> {
+    msg: String,
+    value: T
+}
+
+impl<T> ValueError<T> {
+
+    /// Creates a new error with the given value and error message.
+    pub fn new(value: T, msg: impl core::fmt::Display) -> Self {
+        Self {
+            msg: msg.to_string(),
+            value,
+        }
+    }
+
+    /// Consumes the type and returns the underlying value.
+    pub fn into_value(self) -> T {
+        self.value
+    }
+
+    /// Returns a reference to the value.
+    pub const fn value(&self) -> &T { &self.value }
+}

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -56,6 +56,8 @@ pub use alloy_primitives::{Sealable, Sealed};
 mod signed;
 pub use signed::Signed;
 
+pub mod error;
+
 /// Bincode-compatible serde implementations for consensus types.
 ///
 /// `bincode` crate doesn't work well with optionally serializable serde fields, but some of the

--- a/crates/network-primitives/src/block.rs
+++ b/crates/network-primitives/src/block.rs
@@ -5,6 +5,7 @@ use crate::TransactionResponse;
 use alloc::{vec, vec::Vec};
 use alloy_eips::Encodable2718;
 use core::slice;
+use alloy_consensus::error::ValueError;
 
 /// Block Transactions depending on the boolean attribute of `eth_getBlockBy*`,
 /// or if used by `eth_getUncle*`
@@ -123,6 +124,22 @@ impl<T> BlockTransactions<T> {
         match self {
             Self::Full(txs) => txs,
             _ => vec![],
+        }
+    }
+    
+    /// Attempts to unwrap the [`Self::Full`] variant.
+    /// 
+    /// Returns an error if the type is different variant.
+    pub fn try_into_transactions(self) -> Result<Vec<T>, ValueError<Self>> {
+         match self {
+            Self::Full(txs) => Ok(txs),
+            txs @ Self::Hashes(_) => {
+                Err(ValueError::new(txs, "Unexpected hashes variant"))
+            }
+            txs @ Self::Uncle => {
+                Err(ValueError::new(txs,  "Unexpected uncle variant"))
+               
+            }
         }
     }
 

--- a/crates/network-primitives/src/block.rs
+++ b/crates/network-primitives/src/block.rs
@@ -3,9 +3,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::TransactionResponse;
 use alloc::{vec, vec::Vec};
+use alloy_consensus::error::ValueError;
 use alloy_eips::Encodable2718;
 use core::slice;
-use alloy_consensus::error::ValueError;
 
 /// Block Transactions depending on the boolean attribute of `eth_getBlockBy*`,
 /// or if used by `eth_getUncle*`
@@ -126,20 +126,15 @@ impl<T> BlockTransactions<T> {
             _ => vec![],
         }
     }
-    
+
     /// Attempts to unwrap the [`Self::Full`] variant.
-    /// 
+    ///
     /// Returns an error if the type is different variant.
     pub fn try_into_transactions(self) -> Result<Vec<T>, ValueError<Self>> {
-         match self {
+        match self {
             Self::Full(txs) => Ok(txs),
-            txs @ Self::Hashes(_) => {
-                Err(ValueError::new(txs, "Unexpected hashes variant"))
-            }
-            txs @ Self::Uncle => {
-                Err(ValueError::new(txs,  "Unexpected uncle variant"))
-               
-            }
+            txs @ Self::Hashes(_) => Err(ValueError::new(txs, "Unexpected hashes variant")),
+            txs @ Self::Uncle => Err(ValueError::new(txs, "Unexpected uncle variant")),
         }
     }
 


### PR DESCRIPTION
for consuming conversions, the

https://github.com/alloy-rs/alloy/blob/8ce1c76b94155d71b6aff75096fc7f0fd1fb58fa/crates/rpc-types-eth/src/transaction/error.rs#L5-L10

isn't super convenient.

this introduces a helper error that allows returning the value on an error but is also Error, which makes it useful for `?` propagation.

moved this into consensus because this will be very useful when doing consensus type conversion across network types