### PR TITLE
fix: tokio interval not supported on wasm

### DIFF
--- a/crates/provider/src/heart.rs
+++ b/crates/provider/src/heart.rs
@@ -22,10 +22,16 @@ use tokio::{
 };
 
 #[cfg(target_arch = "wasm32")]
-use wasmtimer::{std::Instant, tokio::sleep_until};
+use wasmtimer::{
+    std::Instant,
+    tokio::{interval, sleep_until},
+};
 
 #[cfg(not(target_arch = "wasm32"))]
-use {std::time::Instant, tokio::time::sleep_until};
+use {
+    std::time::Instant,
+    tokio::time::{interval, sleep_until},
+};
 
 /// Errors which may occur when watching a pending transaction.
 #[derive(Debug, thiserror::Error)]
@@ -215,7 +221,7 @@ impl<N: Network> PendingTransactionBuilder<N> {
 
         // FIXME: this is a hotfix to prevent a race condition where the heartbeat would miss the
         // block the tx was mined in
-        let mut interval = tokio::time::interval(self.provider.client().poll_interval());
+        let mut interval = interval(self.provider.client().poll_interval());
 
         loop {
             let mut confirmed = false;


### PR DESCRIPTION
Replaces use of `tokio::time::interval` with `wasmtimer::tokio::interval`

## Motivation

When using `get_receipt()` in a wasm target it panics:

```
yttrium.wasm-021dcb26:0x630f9f Uncaught RuntimeError: unreachable
    at yttrium.wasm.__rust_start_panic (yttrium.wasm-021dcb26:0x630f9f)
    at yttrium.wasm.rust_panic (yttrium.wasm-021dcb26:0x630591)
    at yttrium.wasm.std::panicking::rust_panic_with_hook::he4d9735ef32eba33 (yttrium.wasm-021dcb26:0x50575d)
    at yttrium.wasm.std::panicking::begin_panic_handler::{{closure}}::h1a474c6509af61ac (yttrium.wasm-021dcb26:0x537885)
    at yttrium.wasm.std::sys::backtrace::__rust_end_short_backtrace::h03c81cbe3f887a1e (yttrium.wasm-021dcb26:0x630dd9)
    at yttrium.wasm.rust_begin_unwind (yttrium.wasm-021dcb26:0x627fb8)
    at yttrium.wasm.core::panicking::panic_fmt::h9d09ad2bc9d6fafd (yttrium.wasm-021dcb26:0x627fe5)
    at yttrium.wasm.std::time::Instant::now::h007b78dd9478758d (yttrium.wasm-021dcb26:0x61fdda)
    at yttrium.wasm.tokio::time::instant::variant::now::h210bb559f05c43eb (yttrium.wasm-021dcb26:0x5e0332)
    at yttrium.wasm.tokio::time::instant::Instant::now::h3753c75c0735fb8d (yttrium.wasm-021dcb26:0x630d1e)
    at yttrium.wasm.tokio::time::interval::interval::h272c80281ca34270 (yttrium.wasm-021dcb26:0x49158d)
    at yttrium.wasm.alloy_provider::heart::PendingTransactionBuilder<N>::get_receipt::{{closure}}::hc8dc499af98667a0 (yttrium.wasm-021dcb26:0xe3239)
    ...
```

## Solution

Replace use of `tokio::time::interval` with `wasmtimer::tokio::interval`. `wasmtimer` is already used elsewhere in alloy

## PR Checklist

- [ ] Added Tests - did not add, not sure how to. Manually tested the fix in my project.
- [ ] Added Documentation
- [ ] Breaking changes
