### PR TITLE
feat: remove preimage hashes from execution witness

### DIFF
--- a/crates/rpc-types-debug/src/debug.rs
+++ b/crates/rpc-types-debug/src/debug.rs
@@ -1,25 +1,19 @@
 //! Types for the `debug` API.
 
-use alloy_primitives::{map::B256HashMap, Bytes};
+use alloy_primitives::Bytes;
 use serde::{Deserialize, Serialize};
 
 /// Represents the execution witness of a block. Contains an optional map of state preimages.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ExecutionWitness {
-    /// Map of all hashed trie nodes to their preimages that were required during the execution of
+    /// List of all hashed trie nodes preimages that were required during the execution of
     /// the block, including during state root recomputation.
-    ///
-    /// `keccak(rlp(node)) => rlp(node)`
-    pub state: B256HashMap<Bytes>,
-    /// Map of all contract codes (created / accessed) to their preimages that were required during
+    pub state: Vec<Bytes>,
+    /// List of all contract codes (created / accessed) preimages that were required during
     /// the execution of the block, including during state root recomputation.
-    ///
-    /// `keccak(bytecodes) => bytecodes`
-    pub codes: B256HashMap<Bytes>,
-    /// Map of all hashed account and storage keys (addresses and slots) to their preimages
+    pub codes: Vec<Bytes>,
+    /// List of all hashed account and storage keys (addresses and slots) preimages
     /// (unhashed account addresses and storage slots, respectively) that were required during
     /// the execution of the block.
-    ///
-    /// `keccak(address|slot) => address|slot`
-    pub keys: B256HashMap<Bytes>,
+    pub keys: Vec<Bytes>,
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Including the hashes gives callers an unnecessary reason to trust the client. They should just hash the returned preimages. Also saves on RPC bandwidth. Motivated by feedback on this geth PR: https://github.com/ethereum/go-ethereum/pull/30613#issuecomment-2531732780

reth PR: https://github.com/paradigmxyz/reth/pull/14503
