### PR TITLE
fix(rpc-types-mev): SimBundleLogs should contain all logs fields.

### DIFF
--- a/crates/rpc-types-mev/src/mev_calls.rs
+++ b/crates/rpc-types-mev/src/mev_calls.rs
@@ -1,8 +1,8 @@
 use crate::common::{Privacy, ProtocolVersion, Validity};
 
 use alloy_eips::BlockId;
-use alloy_primitives::{Bytes, Log, TxHash, U256};
-use alloy_rpc_types_eth::BlockOverrides;
+use alloy_primitives::{Bytes, TxHash, U256};
+use alloy_rpc_types_eth::{BlockOverrides, Log};
 use serde::{Deserialize, Serialize};
 
 /// A bundle of transactions to send to the matchmaker.


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

The `mev_simBundle` RPC should return "rpc" log objects that contain `transactionHash`, `blockNumber` etc.  Currently we are using the "primitive" version that just contains the "consensus" fields.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Use `alloy_rpc_types_eth::Log` instead of `alloy_primitives::Log`.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [x] Breaking changes
