### PR TITLE
feat(`contract`): decode as `SolError`

### DIFF
--- a/crates/contract/src/error.rs
+++ b/crates/contract/src/error.rs
@@ -68,8 +68,7 @@ impl Error {
         self.as_revert_data().and_then(|data| E::abi_decode(&data, false).ok())
     }
 
-    /// Decode the revert data into the specified typed
-    /// [`SolError`].
+    /// Decode the revert data into a custom [`SolError`] type.
     pub fn as_decoded_error<E: SolError>(&self) -> core::result::Result<E, alloy_sol_types::Error> {
         let data =
             self.as_revert_data().ok_or(alloy_sol_types::Error::custom("no revert data found"))?;

--- a/crates/contract/src/error.rs
+++ b/crates/contract/src/error.rs
@@ -64,11 +64,89 @@ impl Error {
     }
 
     /// Attempts to decode the revert data into one of the custom errors in [`SolInterface`].
+    ///
+    /// Returns an enum container type consisting of the custom errors defined in the interface.
+    ///
+    /// None is returned if the revert data is empty or if the data could not be decoded into one of
+    /// the custom errors defined in the interface.
+    ///
+    /// ## Example
+    ///
+    /// ```no_run
+    /// use alloy_provider::ProviderBuilder;
+    /// use alloy_sol_types::sol;
+    ///
+    /// sol! {
+    ///     #[derive(Debug, PartialEq, Eq)]
+    ///     #[sol(rpc, bytecode = "694207")]
+    ///     contract ThrowsError {
+    ///         error SomeCustomError(uint64 a);
+    ///         error AnotherError(uint64 b);
+    ///
+    ///         function error(uint64 a) external {
+    ///             revert SomeCustomError(a);
+    ///         }
+    ///     }
+    /// }
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let provider = ProviderBuilder::new().on_anvil_with_wallet();
+    ///
+    ///     let throws_err = ThrowsError::deploy(provider).await.unwrap();
+    ///
+    ///     let err = throws_err.error(42).call().await.unwrap_err();
+    ///
+    ///     let custom_err =
+    ///         err.as_decoded_interface_error::<ThrowsError::ThrowsErrorErrors>().unwrap();
+    ///
+    ///     // Handle the custom error enum
+    ///     match custom_err {
+    ///         ThrowsError::ThrowsErrorErrors::SomeCustomError(a) => { /* handle error */ }
+    ///         ThrowsError::ThrowsErrorErrors::AnotherError(b) => { /* handle error */ }
+    ///     }
+    /// }
+    /// ```
     pub fn as_decoded_interface_error<E: SolInterface>(&self) -> Option<E> {
         self.as_revert_data().and_then(|data| E::abi_decode(&data, false).ok())
     }
 
     /// Decode the revert data into a custom [`SolError`] type.
+    ///
+    /// Returns an instance of the custom error type if decoding was successful, otherwise None.
+    ///
+    /// ## Example
+    ///
+    /// ```no_run
+    /// use alloy_provider::ProviderBuilder;
+    /// use alloy_sol_types::sol;
+    /// use ThrowsError::SomeCustomError;
+    /// sol! {
+    ///     #[derive(Debug, PartialEq, Eq)]
+    ///     #[sol(rpc, bytecode = "694207")]
+    ///     contract ThrowsError {
+    ///         error SomeCustomError(uint64 a);
+    ///         error AnotherError(uint64 b);
+    ///
+    ///         function error(uint64 a) external {
+    ///             revert SomeCustomError(a);
+    ///         }
+    ///     }
+    /// }
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let provider = ProviderBuilder::new().on_anvil_with_wallet();
+    ///
+    ///     let throws_err = ThrowsError::deploy(provider).await.unwrap();
+    ///
+    ///     let err = throws_err.error(42).call().await.unwrap_err();
+    ///
+    ///     let custom_err = err.as_decoded_error::<SomeCustomError>().unwrap();
+    ///
+    ///     assert_eq!(custom_err, SomeCustomError { a: 42 });
+    /// }
+    /// ```
     pub fn as_decoded_error<E: SolError>(&self) -> Option<E> {
         self.as_revert_data().and_then(|data| E::abi_decode(&data, false).ok())
     }

--- a/crates/contract/src/error.rs
+++ b/crates/contract/src/error.rs
@@ -69,9 +69,7 @@ impl Error {
     }
 
     /// Decode the revert data into a custom [`SolError`] type.
-    pub fn as_decoded_error<E: SolError>(&self) -> core::result::Result<E, alloy_sol_types::Error> {
-        let data =
-            self.as_revert_data().ok_or(alloy_sol_types::Error::custom("no revert data found"))?;
-        E::abi_decode(&data, false)
+    pub fn as_decoded_error<E: SolError>(&self) -> Option<E> {
+        self.as_revert_data().and_then(|data| E::abi_decode(&data, false).ok())
     }
 }

--- a/crates/json-rpc/src/response/error.rs
+++ b/crates/json-rpc/src/response/error.rs
@@ -1,5 +1,5 @@
 use alloy_primitives::Bytes;
-use alloy_sol_types::SolInterface;
+use alloy_sol_types::{SolError, SolInterface};
 use serde::{
     de::{DeserializeOwned, MapAccess, Visitor},
     Deserialize, Deserializer, Serialize,
@@ -349,9 +349,17 @@ where
         }
     }
 
-    /// Extracts revert data and tries decoding it into given custom errors set.
-    pub fn as_decoded_error<E: SolInterface>(&self, validate: bool) -> Option<E> {
+    /// Extracts revert data and tries decoding it into given custom errors set present in the
+    /// [`SolInterface`].
+    pub fn as_decoded_interface_error<E: SolInterface>(&self, validate: bool) -> Option<E> {
         self.as_revert_data().and_then(|data| E::abi_decode(&data, validate).ok())
+    }
+
+    /// Extracts revert data and tries decoding it into custom [`SolError`].
+    pub fn as_decoded_error<E: SolError>(&self) -> Result<E, alloy_sol_types::Error> {
+        let data =
+            self.as_revert_data().ok_or(alloy_sol_types::Error::custom("revert data not found"))?;
+        E::abi_decode(&data, false)
     }
 }
 
@@ -401,6 +409,7 @@ mod test {
     #[test]
     fn custom_error_decoding() {
         sol!(
+            #[derive(Debug, PartialEq, Eq)]
             library Errors {
                 error SomeCustomError(uint256 a);
             }
@@ -410,8 +419,12 @@ mod test {
         let payload: ErrorPayload = serde_json::from_str(json).unwrap();
 
         let Errors::ErrorsErrors::SomeCustomError(value) =
-            payload.as_decoded_error::<Errors::ErrorsErrors>(false).unwrap();
+            payload.as_decoded_interface_error::<Errors::ErrorsErrors>(false).unwrap();
 
         assert_eq!(value.a, U256::from(1));
+
+        let decoded_err = payload.as_decoded_error::<Errors::SomeCustomError>().unwrap();
+
+        assert_eq!(decoded_err, Errors::SomeCustomError { a: U256::from(1) });
     }
 }

--- a/crates/json-rpc/src/response/error.rs
+++ b/crates/json-rpc/src/response/error.rs
@@ -356,10 +356,8 @@ where
     }
 
     /// Extracts revert data and tries decoding it into custom [`SolError`].
-    pub fn as_decoded_error<E: SolError>(&self) -> Result<E, alloy_sol_types::Error> {
-        let data =
-            self.as_revert_data().ok_or(alloy_sol_types::Error::custom("revert data not found"))?;
-        E::abi_decode(&data, false)
+    pub fn as_decoded_error<E: SolError>(&self) -> Option<E> {
+        self.as_revert_data().and_then(|data| E::abi_decode(&data, false).ok())
     }
 }
 

--- a/crates/json-rpc/src/response/error.rs
+++ b/crates/json-rpc/src/response/error.rs
@@ -351,8 +351,8 @@ where
 
     /// Extracts revert data and tries decoding it into given custom errors set present in the
     /// [`SolInterface`].
-    pub fn as_decoded_interface_error<E: SolInterface>(&self, validate: bool) -> Option<E> {
-        self.as_revert_data().and_then(|data| E::abi_decode(&data, validate).ok())
+    pub fn as_decoded_interface_error<E: SolInterface>(&self) -> Option<E> {
+        self.as_revert_data().and_then(|data| E::abi_decode(&data, false).ok())
     }
 
     /// Extracts revert data and tries decoding it into custom [`SolError`].
@@ -417,7 +417,7 @@ mod test {
         let payload: ErrorPayload = serde_json::from_str(json).unwrap();
 
         let Errors::ErrorsErrors::SomeCustomError(value) =
-            payload.as_decoded_interface_error::<Errors::ErrorsErrors>(false).unwrap();
+            payload.as_decoded_interface_error::<Errors::ErrorsErrors>().unwrap();
 
         assert_eq!(value.a, U256::from(1));
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Currently, we have a method for decoding `ErrorPayload`'s and `contract::Error`'s into one of the `SolError`'s present in the `SolInterface`.

`fn as_decoded_error<E: SolInterface>(data) -> Option<E>`.

We also want a method that attempts decoding to a specific `SolError` and returns a `Result`. 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

- Add method `fn as_decoded_error<E: SolError>(data) -> Result<E, alloy_sol_types::Error>`
- [Breaking] Rename previous `as_decoded_error<E: SolInterface>` to `as_decoded_interface_error`. Avoidable but I think this naming is better, and breaking pre-1.0 makes sense.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
