### PR TITLE
feat(genesis): Deserialize ChainConfig from toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,6 +129,8 @@ serde = { version = "1.0", default-features = false, features = [
 ] }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 serde_with = { version = "3", default-features = false, features = ["macros"] }
+serde_alias = "0.0.2"
+toml = "0.8.20"
 
 # misc
 auto_impl = "1.2"

--- a/crates/genesis/Cargo.toml
+++ b/crates/genesis/Cargo.toml
@@ -31,7 +31,6 @@ alloy-trie = { workspace = true, features = ["ethereum"] }
 # serde
 serde.workspace = true
 serde_alias.workspace = true
-serde_with.workspace = true
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/crates/genesis/Cargo.toml
+++ b/crates/genesis/Cargo.toml
@@ -30,9 +30,12 @@ alloy-trie = { workspace = true, features = ["ethereum"] }
 
 # serde
 serde.workspace = true
+serde_alias.workspace = true
+serde_with.workspace = true
 
 [dev-dependencies]
 serde_json.workspace = true
+toml.workspace = true
 
 [features]
 default = ["std"]

--- a/crates/genesis/src/lib.rs
+++ b/crates/genesis/src/lib.rs
@@ -19,15 +19,13 @@ use alloy_trie::{TrieAccount, EMPTY_ROOT_HASH, KECCAK_EMPTY};
 use core::str::FromStr;
 use serde::{de::Error as DeError, Deserialize, Deserializer, Serialize};
 use serde_alias::serde_alias;
-use serde_with::{serde_as, DefaultOnNull};
 
 /// The genesis block specification.
-#[serde_as]
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", default)]
 pub struct Genesis {
     /// The fork configuration for this network.
-    #[serde_as(deserialize_as = "DefaultOnNull")]
+    #[serde(default)]
     pub config: ChainConfig,
     /// The genesis header nonce.
     #[serde(with = "alloy_serde::quantity")]

--- a/crates/transport/README.md
+++ b/crates/transport/README.md
@@ -23,8 +23,8 @@ specific Ethereum endpoints.
 Alloy maintains the following transports:
 
 - [alloy-transport-http]: JSON-RPC via HTTP.
-- [alloy-transport-ws]: JSON-RPC via Websocket, supports pubsub via
-    [alloy-pubsub].
+- [alloy-transport-ws]: JSON-RPC via Websocket, supports pubsub via.
+- [alloy-pubsub]: JSON-RPC publish-subscribe tower service.
 - [alloy-transport-ipc]: JSON-RPC via IPC, supports pubsub via [alloy-pubsub].
 
 [alloy-transport-http]: https://docs.rs/alloy_transport_http/

--- a/crates/transport/README.md
+++ b/crates/transport/README.md
@@ -23,8 +23,7 @@ specific Ethereum endpoints.
 Alloy maintains the following transports:
 
 - [alloy-transport-http]: JSON-RPC via HTTP.
-- [alloy-transport-ws]: JSON-RPC via Websocket, supports pubsub via.
-- [alloy-pubsub]: JSON-RPC publish-subscribe tower service.
+- [alloy-transport-ws]: JSON-RPC via Websocket, supports pubsub via [alloy-pubsub].
 - [alloy-transport-ipc]: JSON-RPC via IPC, supports pubsub via [alloy-pubsub].
 
 [alloy-transport-http]: https://docs.rs/alloy_transport_http/

--- a/deny.toml
+++ b/deny.toml
@@ -2,8 +2,8 @@
 version = 2
 yanked = "warn"
 ignore = [
-    # https://rustsec.org/advisories/RUSTSEC-2024-0388 used by ssz, will be removed https://github.com/sigp/ethereum_ssz/pull/34
-    "RUSTSEC-2024-0388"
+    # proc-macro-error 1.0.4 unmaintained. Used by serde_alias. https://rustsec.org/advisories/RUSTSEC-2024-0370
+    "RUSTSEC-2024-0370",
 ]
 
 [bans]
@@ -24,7 +24,6 @@ allow = [
     "0BSD",
     "ISC",
     "Unicode-3.0",
-    "Unicode-DFS-2016",
     "Unlicense",
     "MPL-2.0",
     "Zlib",


### PR DESCRIPTION
Allow to read ChainConfig from a toml file. The network configuration is stored as toml in [superchain-registry](https://github.com/ethereum-optimism/superchain-registry). The genesis files do not contain always the config field e.g. `base.json.zst` contains `"config":null`. Step toward resolving: https://github.com/paradigmxyz/reth/issues/14240

Changes:
- Allow parsing from json and toml
  - `serde_alias` introduces unmaintained exception for `proc-macro-error`
- Allow to parse Genesis from missing config field and `"config":null`

@mattsse 