### PR TITLE
fix(rpc-types-mev): compatibility with mev-geth responses.

### DIFF
--- a/crates/rpc-types-mev/src/eth_calls.rs
+++ b/crates/rpc-types-mev/src/eth_calls.rs
@@ -144,6 +144,9 @@ impl EthCallBundle {
 }
 
 /// Response for `eth_callBundle`
+///
+/// <https://docs.flashbots.net/flashbots-auction/advanced/rpc-endpoint#eth_callbundle>
+/// <https://github.com/flashbots/mev-geth/blob/fddf97beec5877483f879a77b7dea2e58a58d653/internal/ethapi/api.go#L2212-L2220>
 #[derive(Default, Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct EthCallBundleResponse {
@@ -164,10 +167,8 @@ pub struct EthCallBundleResponse {
     /// Results of individual transactions within the bundle
     pub results: Vec<EthCallBundleTransactionResult>,
     /// The block number used as a base for this simulation
-    #[serde(with = "alloy_serde::quantity")]
     pub state_block_number: u64,
     /// The total gas used by all transactions in the bundle
-    #[serde(with = "alloy_serde::quantity")]
     pub total_gas_used: u64,
 }
 
@@ -190,7 +191,6 @@ pub struct EthCallBundleTransactionResult {
     #[serde(with = "u256_numeric_string")]
     pub gas_price: U256,
     /// The amount of gas used by the transaction
-    #[serde(with = "alloy_serde::quantity")]
     pub gas_used: u64,
     /// The address to which the transaction is sent (optional)
     pub to_address: Option<Address>,
@@ -407,22 +407,22 @@ mod tests {
   {
     "coinbaseDiff": "10000000000063000",
     "ethSentToCoinbase": "10000000000000000",
-    "fromAddress": "0x02A727155aeF8609c9f7F2179b2a1f560B39F5A0",
+    "fromAddress": "0x02a727155aef8609c9f7f2179b2a1f560b39f5a0",
     "gasFees": "63000",
     "gasPrice": "476190476193",
     "gasUsed": 21000,
-    "toAddress": "0x73625f59CAdc5009Cb458B751b3E7b6b48C06f2C",
+    "toAddress": "0x73625f59cadc5009cb458b751b3e7b6b48c06f2c",
     "txHash": "0x669b4704a7d993a946cdd6e2f95233f308ce0c4649d2e04944e8299efcaa098a",
     "value": "0x"
   },
   {
     "coinbaseDiff": "10000000000063000",
     "ethSentToCoinbase": "10000000000000000",
-    "fromAddress": "0x02A727155aeF8609c9f7F2179b2a1f560B39F5A0",
+    "fromAddress": "0x02a727155aef8609c9f7f2179b2a1f560b39f5a0",
     "gasFees": "63000",
     "gasPrice": "476190476193",
     "gasUsed": 21000,
-    "toAddress": "0x73625f59CAdc5009Cb458B751b3E7b6b48C06f2C",
+    "toAddress": "0x73625f59cadc5009cb458b751b3e7b6b48c06f2c",
     "txHash": "0xa839ee83465657cac01adc1d50d96c1b586ed498120a84a64749c0034b4f19fa",
     "value": "0x"
   }
@@ -431,6 +431,8 @@ mod tests {
 "totalGasUsed": 42000
 }"#;
 
-        let _call = serde_json::from_str::<EthCallBundleResponse>(s).unwrap();
+        let response = serde_json::from_str::<EthCallBundleResponse>(s).unwrap();
+        let json: serde_json::Value = serde_json::from_str(s).unwrap();
+        similar_asserts::assert_eq!(json, serde_json::to_value(response).unwrap());
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Sadly, mev-geth made the choice to encode the gas-related and state block number fields as JSON numbers instead of `QUANTITY`: https://github.com/flashbots/mev-geth/blob/fddf97beec5877483f879a77b7dea2e58a58d653/internal/ethapi/api.go#L2212-L2220

So to keep things backwards compatible I had to remove some of the `ally_serde::quantity` usage.

## Solution

Also the unit tests wasn't really comparing the before and after, I was actually surprised to see that `alloy_serde::quantity` handles deserializing raw numbers, but they were in turn encoded as hex strings.

Examples of `reth` output before and after:

<details>

```
> cast rpc eth_callBundle '{"txs":["0x02f87382426802840337db58840337db6882b0199494373a4919b3240d86ea41593d5eba789fef3848872386f26fc1000080c080a040d920de9390a95442d0f44db365fa1673dbb67a80b5260e0373b33d56dd244ca0764d1d98c79d7147bb4535d0cd16ad16c5fe312f672449cee519a7df2bf5d68d"],"blockNumber":"0x339215","stateBlockNumber":"latest"}' | jq .

Before this change:

{
  "bundleHash": "0x278305192d760c0c1ee6dfed8f6ed1eece597670342389009f5ac0522677a814",
  "bundleGasPrice": "53992280",
  "coinbaseDiff": "2413562900560",
  "ethSentToCoinbase": "0",
  "gasFees": "2413563213474",
  "results": [
    {
      "coinbaseDiff": "2413562900560",
      "ethSentToCoinbase": "0",
      "fromAddress": "0x1b57edab586cbdabd4d914869ae8bb78dbc05571",
      "gasFees": "2413563213474",
      "gasPrice": "53992287",
      "gasUsed": "0xae9e",
      "toAddress": "0x94373a4919b3240d86ea41593d5eba789fef3848",
      "txHash": "0x7b61d8cd2e39699447b91e41aa4487d9e568bbb8176b43a5f70d2db39e22a975",
      "value": "0x"
    }
  ],
  "stateBlockNumber": "0x3394c4",
  "totalGasUsed": "0xae9e"
}

After:

{
  "bundleHash": "0x278305192d760c0c1ee6dfed8f6ed1eece597670342389009f5ac0522677a814",
  "bundleGasPrice": "53992280",
  "coinbaseDiff": "2413562900560",
  "ethSentToCoinbase": "0",
  "gasFees": "2413563213474",
  "results": [
    {
      "coinbaseDiff": "2413562900560",
      "ethSentToCoinbase": "0",
      "fromAddress": "0x1b57edab586cbdabd4d914869ae8bb78dbc05571",
      "gasFees": "2413563213474",
      "gasPrice": "53992287",
      "gasUsed": 44702,
      "toAddress": "0x94373a4919b3240d86ea41593d5eba789fef3848",
      "txHash": "0x7b61d8cd2e39699447b91e41aa4487d9e568bbb8176b43a5f70d2db39e22a975",
      "value": "0x"
    }
  ],
  "stateBlockNumber": 3380422,
  "totalGasUsed": 44702
}
```

</details>


## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
