### PR TITLE
feat(`rpc-types`): decode log from receipt

### DIFF
--- a/crates/rpc-types-eth/src/transaction/receipt.rs
+++ b/crates/rpc-types-eth/src/transaction/receipt.rs
@@ -109,8 +109,8 @@ impl TransactionReceipt {
     ///
     /// Returns None, if none of the logs could be decoded to the provided log type or if there
     /// are no logs.
-    pub fn decoded_log<SolLog: SolEvent>(&self) -> Option<alloy_primitives::Log<SolLog>> {
-        self.logs().iter().find_map(|log| SolLog::decode_log(&log.inner, false).ok())
+    pub fn decoded_log<E: SolEvent>(&self) -> Option<alloy_primitives::Log<E>> {
+        self.logs().iter().find_map(|log| E::decode_log(&log.inner, false).ok())
     }
 }
 

--- a/crates/rpc-types-eth/src/transaction/receipt.rs
+++ b/crates/rpc-types-eth/src/transaction/receipt.rs
@@ -2,6 +2,7 @@ use crate::Log;
 use alloy_consensus::{ReceiptEnvelope, TxReceipt, TxType};
 use alloy_network_primitives::ReceiptResponse;
 use alloy_primitives::{Address, BlockHash, TxHash, B256};
+use alloy_sol_types::SolEvent;
 
 /// Transaction receipt
 ///
@@ -101,6 +102,16 @@ impl TransactionReceipt {
         }
         Some(self.from.create(nonce))
     }
+
+    /// Attempts to decode the logs to the provided log type.
+    ///
+    /// Returns the first log that decodes successfully.
+    ///
+    /// Returns None, if none of the logs could be decoded to the provided log type or if there
+    /// are no logs.
+    pub fn decoded_log<SolLog: SolEvent>(&self) -> Option<alloy_primitives::Log<SolLog>> {
+        self.logs().iter().find_map(|log| SolLog::decode_log(&log.inner, false).ok())
+    }
 }
 
 impl<T> TransactionReceipt<T> {
@@ -149,6 +160,11 @@ impl<L> TransactionReceipt<ReceiptEnvelope<L>> {
         L: Into<alloy_primitives::Log>,
     {
         self.map_logs(Into::into)
+    }
+
+    /// Get the receipt logs.
+    pub fn logs(&self) -> &[L] {
+        self.inner.logs()
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Currently, we don't have any direct way to decode the receipt logs into a typed `SolEvent` log. See: https://t.me/ethers_rs/43321

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

- Add a `fn decoded_log<E: SolEvent>(&self) -> Option<Log<E>>` to `TransactionReceipt`. 

This enables users to do this:

```rust
let receipt = counter.increment().send().await.unwrap().get_receipt().await.unwrap();
let log = receipt.decoded_log::<Counter::Increment>();
assert!(log.is_some());
```

instead of 

```rust
let receipt = counter.increment().send().await.unwrap().get_receipt().await.unwrap();
let receipt = receipt.into_primitives_receipt();
let logs = receipt.logs();
let increment_log = Counter::Increment::decode_log(&logs[0], false).unwrap();
```

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
