### PR TITLE
fix(engine): Fix BlockHash display message

### DIFF
--- a/crates/rpc-types-engine/src/error.rs
+++ b/crates/rpc-types-engine/src/error.rs
@@ -51,7 +51,7 @@ pub enum PayloadError {
     #[display("requests present in pre-prague payload")]
     PrePragueBlockRequests,
     /// Invalid payload block hash.
-    #[display("block hash mismatch: want {consensus}, got {execution}")]
+    #[display("block hash mismatch: want {execution}, got {consensus}")]
     BlockHash {
         /// The block hash computed from the payload.
         execution: B256,


### PR DESCRIPTION
Hash values displayed in the message are swapped. We "want" the hash computed in execution but "got" the hash coming from consensus.

## PR Checklist

- [ ] ~Added Tests~
- [ ] ~Added Documentation~
- [ ] ~Breaking changes~
