### PR TITLE
Add custom Either type for transactions

### DIFF
--- a/crates/consensus/src/transaction/either.rs
+++ b/crates/consensus/src/transaction/either.rs
@@ -1,0 +1,213 @@
+/// A type that represents exactly one of two possible variants: `Left(L)` or `Right(R)`.
+///
+/// `Either` is completely neutral with respect to the meaning of each variants.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Either<L, R> {
+    /// The left variant.
+    Left(L),
+    /// The right variant.
+    Right(R),
+}
+
+impl<L, R> Either<L, R> {
+    /// Returns `true` if this is a `Left` variant.
+    #[inline]
+    pub fn is_left(&self) -> bool {
+        matches!(self, Self::Left(_))
+    }
+
+    /// Returns `true` if this is a `Right` variant.
+    #[inline]
+    pub fn is_right(&self) -> bool {
+        matches!(self, Self::Right(_))
+    }
+
+    /// Converts from `Either<L, R>` to `Option<L>`.
+    ///
+    /// Returns `Some` if this is a `Left` variant, otherwise returns `None`.
+    #[inline]
+    pub fn left(self) -> Option<L> {
+        match self {
+            Self::Left(l) => Some(l),
+            Self::Right(_) => None,
+        }
+    }
+
+    /// Converts from `Either<L, R>` to `Option<R>`.
+    ///
+    /// Returns `Some` if this is a `Right` variant, otherwise returns `None`.
+    #[inline]
+    pub fn right(self) -> Option<R> {
+        match self {
+            Self::Left(_) => None,
+            Self::Right(r) => Some(r),
+        }
+    }
+
+    /// Returns a reference to the left value if this is a `Left` variant.
+    #[inline]
+    pub fn as_left(&self) -> Option<&L> {
+        match self {
+            Self::Left(l) => Some(l),
+            Self::Right(_) => None,
+        }
+    }
+
+    /// Returns a reference to the right value if this is a `Right` variant.
+    #[inline]
+    pub fn as_right(&self) -> Option<&R> {
+        match self {
+            Self::Left(_) => None,
+            Self::Right(r) => Some(r),
+        }
+    }
+
+    /// Returns a mutable reference to the left value if this is a `Left` variant.
+    #[inline]
+    pub fn as_left_mut(&mut self) -> Option<&mut L> {
+        match self {
+            Self::Left(l) => Some(l),
+            Self::Right(_) => None,
+        }
+    }
+
+    /// Returns a mutable reference to the right value if this is a `Right` variant.
+    #[inline]
+    pub fn as_right_mut(&mut self) -> Option<&mut R> {
+        match self {
+            Self::Left(_) => None,
+            Self::Right(r) => Some(r),
+        }
+    }
+
+    /// Returns the contained left value or a default.
+    ///
+    /// Consumes the `self` value and returns the contained value if left,
+    /// or returns the provided default if right.
+    #[inline]
+    pub fn left_or(self, default: L) -> L {
+        match self {
+            Self::Left(l) => l,
+            Self::Right(_) => default,
+        }
+    }
+
+    /// Returns the contained right value or a default.
+    ///
+    /// Consumes the `self` value and returns the contained value if right,
+    /// or returns the provided default if left.
+    #[inline]
+    pub fn right_or(self, default: R) -> R {
+        match self {
+            Self::Left(_) => default,
+            Self::Right(r) => r,
+        }
+    }
+
+    /// Maps an `Either<L, R>` to `Either<T, R>` by applying a function
+    /// to the left value.
+    #[inline]
+    pub fn map_left<T, F>(self, f: F) -> Either<T, R>
+    where
+        F: FnOnce(L) -> T,
+    {
+        match self {
+            Self::Left(l) => Either::Left(f(l)),
+            Self::Right(r) => Either::Right(r),
+        }
+    }
+
+    /// Maps an `Either<L, R>` to `Either<L, T>` by applying
+    /// a function to the right value.
+    #[inline]
+    pub fn map_right<T, F>(self, f: F) -> Either<L, T>
+    where
+        F: FnOnce(R) -> T,
+    {
+        match self {
+            Self::Left(l) => Either::Left(l),
+            Self::Right(r) => Either::Right(f(r)),
+        }
+    }
+
+    /// Maps an `Either<L, R>` to `Either<T, U>` by applying one of two functions.
+    #[inline]
+    pub fn map_either<T, U, F, G>(self, f: F, g: G) -> Either<T, U>
+    where
+        F: FnOnce(L) -> T,
+        G: FnOnce(R) -> U,
+    {
+        match self {
+            Self::Left(l) => Either::Left(f(l)),
+            Self::Right(r) => Either::Right(g(r)),
+        }
+    }
+
+    /// Applies a function to the contained value, and returns the result for
+    /// both variants.
+    #[inline]
+    pub fn either<T, F, G>(self, f: F, g: G) -> T
+    where
+        F: FnOnce(L) -> T,
+        G: FnOnce(R) -> T,
+    {
+        match self {
+            Self::Left(l) => f(l),
+            Self::Right(r) => g(r),
+        }
+    }
+}
+
+impl<T> Either<T, T> {
+    /// Converts from `Either<T, T>` to `T`.
+    #[inline]
+    pub fn into_inner(self) -> T {
+        match self {
+            Self::Left(t) => t,
+            Self::Right(t) => t,
+        }
+    }
+}
+
+impl<L, R> From<Either<L, R>> for Result<L, R> {
+    fn from(either: Either<L, R>) -> Self {
+        match either {
+            Either::Left(l) => Ok(l),
+            Either::Right(r) => Err(r),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test_either {
+    use super::*;
+
+    #[test]
+    fn test_either_variants() {
+        let left: Either<i32, &str> = Either::Left(42);
+        let right: Either<i32, &str> = Either::Right("hello");
+
+        assert!(!left.is_right());
+        assert!(!right.is_left());
+    }
+
+    #[test]
+    fn test_either_mapping() {
+        let left: Either<i32, &str> = Either::Left(42);
+        let mapped = left.map_left(|x| x.to_string());
+        assert_eq!(mapped.left(), Some("42".to_string()));
+
+        let right: Either<i32, &str> = Either::Right("hello");
+        let mapped = right.map_right(|x| x.len());
+        assert_eq!(mapped.right(), Some(5));
+    }
+
+    #[test]
+    fn test_either_same_types() {
+        let left: Either<i32, i32> = Either::Left(42);
+        assert_eq!(left.into_inner(), 42);
+
+        let right: Either<i32, i32> = Either::Right(24);
+        assert_eq!(right.into_inner(), 24);
+    }
+}

--- a/crates/consensus/src/transaction/mod.rs
+++ b/crates/consensus/src/transaction/mod.rs
@@ -60,6 +60,9 @@ pub mod serde_bincode_compat {
     };
 }
 
+mod either;
+pub use either::Either;
+
 use alloy_eips::Typed2718;
 
 /// Represents a minimal EVM transaction.
@@ -363,5 +366,181 @@ impl<T: Transaction> Transaction for alloy_serde::WithOtherFields<T> {
     #[inline]
     fn authorization_list(&self) -> Option<&[SignedAuthorization]> {
         self.inner.authorization_list()
+    }
+}
+
+impl<L: Typed2718, R: Typed2718> Typed2718 for Either<L, R> {
+    fn ty(&self) -> u8 {
+        match self {
+            Self::Left(l) => l.ty(),
+            Self::Right(r) => r.ty(),
+        }
+    }
+}
+
+impl<L, R> Transaction for Either<L, R>
+where
+    L: Transaction,
+    R: Transaction,
+{
+    fn chain_id(&self) -> Option<ChainId> {
+        match self {
+            Self::Left(tx) => tx.chain_id(),
+            Self::Right(tx) => tx.chain_id(),
+        }
+    }
+
+    fn nonce(&self) -> u64 {
+        match self {
+            Self::Left(tx) => tx.nonce(),
+            Self::Right(tx) => tx.nonce(),
+        }
+    }
+
+    fn gas_limit(&self) -> u64 {
+        match self {
+            Self::Left(tx) => tx.gas_limit(),
+            Self::Right(tx) => tx.gas_limit(),
+        }
+    }
+
+    fn gas_price(&self) -> Option<u128> {
+        match self {
+            Self::Left(tx) => tx.gas_price(),
+            Self::Right(tx) => tx.gas_price(),
+        }
+    }
+
+    fn max_fee_per_gas(&self) -> u128 {
+        match self {
+            Self::Left(tx) => tx.max_fee_per_gas(),
+            Self::Right(tx) => tx.max_fee_per_gas(),
+        }
+    }
+
+    fn max_priority_fee_per_gas(&self) -> Option<u128> {
+        match self {
+            Self::Left(tx) => tx.max_priority_fee_per_gas(),
+            Self::Right(tx) => tx.max_priority_fee_per_gas(),
+        }
+    }
+
+    fn max_fee_per_blob_gas(&self) -> Option<u128> {
+        match self {
+            Self::Left(tx) => tx.max_fee_per_blob_gas(),
+            Self::Right(tx) => tx.max_fee_per_blob_gas(),
+        }
+    }
+
+    fn priority_fee_or_price(&self) -> u128 {
+        match self {
+            Self::Left(tx) => tx.priority_fee_or_price(),
+            Self::Right(tx) => tx.priority_fee_or_price(),
+        }
+    }
+
+    fn effective_gas_price(&self, base_fee: Option<u64>) -> u128 {
+        match self {
+            Self::Left(tx) => tx.effective_gas_price(base_fee),
+            Self::Right(tx) => tx.effective_gas_price(base_fee),
+        }
+    }
+
+    fn effective_tip_per_gas(&self, base_fee: u64) -> Option<u128> {
+        match self {
+            Self::Left(tx) => tx.effective_tip_per_gas(base_fee),
+            Self::Right(tx) => tx.effective_tip_per_gas(base_fee),
+        }
+    }
+
+    fn is_dynamic_fee(&self) -> bool {
+        match self {
+            Self::Left(tx) => tx.is_dynamic_fee(),
+            Self::Right(tx) => tx.is_dynamic_fee(),
+        }
+    }
+
+    fn kind(&self) -> TxKind {
+        match self {
+            Self::Left(tx) => tx.kind(),
+            Self::Right(tx) => tx.kind(),
+        }
+    }
+
+    fn is_create(&self) -> bool {
+        match self {
+            Self::Left(tx) => tx.is_create(),
+            Self::Right(tx) => tx.is_create(),
+        }
+    }
+
+    fn to(&self) -> Option<Address> {
+        match self {
+            Self::Left(tx) => tx.to(),
+            Self::Right(tx) => tx.to(),
+        }
+    }
+
+    fn value(&self) -> U256 {
+        match self {
+            Self::Left(tx) => tx.value(),
+            Self::Right(tx) => tx.value(),
+        }
+    }
+
+    fn input(&self) -> &Bytes {
+        match self {
+            Self::Left(tx) => tx.input(),
+            Self::Right(tx) => tx.input(),
+        }
+    }
+
+    fn function_selector(&self) -> Option<&Selector> {
+        match self {
+            Self::Left(tx) => tx.function_selector(),
+            Self::Right(tx) => tx.function_selector(),
+        }
+    }
+
+    fn access_list(&self) -> Option<&AccessList> {
+        match self {
+            Self::Left(tx) => tx.access_list(),
+            Self::Right(tx) => tx.access_list(),
+        }
+    }
+
+    fn blob_versioned_hashes(&self) -> Option<&[B256]> {
+        match self {
+            Self::Left(tx) => tx.blob_versioned_hashes(),
+            Self::Right(tx) => tx.blob_versioned_hashes(),
+        }
+    }
+
+    fn blob_count(&self) -> Option<u64> {
+        match self {
+            Self::Left(tx) => tx.blob_count(),
+            Self::Right(tx) => tx.blob_count(),
+        }
+    }
+
+    fn blob_gas_used(&self) -> Option<u64> {
+        match self {
+            Self::Left(tx) => tx.blob_gas_used(),
+            Self::Right(tx) => tx.blob_gas_used(),
+        }
+    }
+
+    fn authorization_list(&self) -> Option<&[SignedAuthorization]> {
+        match self {
+            Self::Left(tx) => tx.authorization_list(),
+            Self::Right(tx) => tx.authorization_list(),
+        }
+    }
+
+    fn authorization_count(&self) -> Option<u64> {
+        match self {
+            Self::Left(tx) => tx.authorization_count(),
+            Self::Right(tx) => tx.authorization_count(),
+        }
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
See #2051
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
A new module called either is added, this is useful to handle different transactions types
as it implements `Transaction` trait. The Either type here is a bit similar to [this](https://crates.io/crates/either), however a custom one might be more useful to customize.
<!-- 
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x ] Added Tests
- [x ] Added Documentation
- [ ] Breaking changes
