### PR TITLE
feat: allow getting mutable inner from receipt envelope

### DIFF
--- a/crates/consensus/src/receipt/envelope.rs
+++ b/crates/consensus/src/receipt/envelope.rs
@@ -126,6 +126,18 @@ impl<T> ReceiptEnvelope<T> {
         }
     }
 
+    /// Return the mutable inner receipt with bloom. Currently this is
+    /// infallible, however, future receipt types may be added.
+    pub const fn as_receipt_with_bloom_mut(&mut self) -> Option<&mut ReceiptWithBloom<Receipt<T>>> {
+        match self {
+            Self::Legacy(t)
+            | Self::Eip2930(t)
+            | Self::Eip1559(t)
+            | Self::Eip4844(t)
+            | Self::Eip7702(t) => Some(t),
+        }
+    }
+
     /// Return the inner receipt. Currently this is infallible, however, future
     /// receipt types may be added.
     pub const fn as_receipt(&self) -> Option<&Receipt<T>> {


### PR DESCRIPTION
## Motivation

Sometimes it's useful to modify parts of a receipt for the sake of testing. For example in a recent case I wanted to test with real mainnet data while injecting some custom logs/events into the receipts for testing purposes.

## Solution

The added method is a light modification on `as_receipt_with_bloom` that gives you mutable access to the inner wrapped value. This is mainly for convenience.

## PR Checklist

- [ ] Added Tests (did not add any tests as the method is very simple and the method it's based on `as_receipt_with_bloom` doesn't have any tests)
- [x] Added Documentation
- [x] Breaking changes (Not breaking so no note added)
