### PR TITLE
feat: introduce `IntoWallet` to pass signer directly to `ProviderBuilder`

### DIFF
--- a/crates/network/src/ethereum/mod.rs
+++ b/crates/network/src/ethereum/mod.rs
@@ -3,7 +3,7 @@ use crate::Network;
 mod builder;
 
 mod wallet;
-pub use wallet::EthereumWallet;
+pub use wallet::{EthereumWallet, IntoWallet};
 
 /// Types for a mainnet-like Ethereum network.
 #[derive(Clone, Copy, Debug)]

--- a/crates/network/src/ethereum/wallet.rs
+++ b/crates/network/src/ethereum/wallet.rs
@@ -1,7 +1,7 @@
 use crate::{AnyNetwork, AnyTxEnvelope, AnyTypedTransaction, Network, NetworkWallet, TxSigner};
 use alloy_consensus::{SignableTransaction, TxEnvelope, TypedTransaction};
 use alloy_primitives::{map::AddressHashMap, Address, PrimitiveSignature as Signature};
-use std::sync::Arc;
+use std::{fmt::Debug, sync::Arc};
 
 use super::Ethereum;
 
@@ -167,5 +167,29 @@ impl NetworkWallet<AnyNetwork> for EthereumWallet {
             )),
             _ => Err(alloy_signer::Error::other("cannot sign UnknownTypedTransaction")),
         }
+    }
+}
+
+/// A trait for converting a signer into a [`NetworkWallet`].
+pub trait IntoWallet<N: Network>: Send + Sync + Debug {
+    /// The wallet type for the network.
+    type NetworkWallet: NetworkWallet<N>;
+    /// Convert the signer into a wallet.
+    fn into_wallet(&self) -> Self::NetworkWallet;
+}
+
+impl IntoWallet<Ethereum> for EthereumWallet {
+    type NetworkWallet = Self;
+
+    fn into_wallet(&self) -> Self::NetworkWallet {
+        self.clone()
+    }
+}
+
+impl IntoWallet<AnyNetwork> for EthereumWallet {
+    type NetworkWallet = Self;
+
+    fn into_wallet(&self) -> Self::NetworkWallet {
+        self.clone()
     }
 }

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -20,7 +20,7 @@ pub use transaction::{
 };
 
 mod ethereum;
-pub use ethereum::{Ethereum, EthereumWallet};
+pub use ethereum::{Ethereum, EthereumWallet, IntoWallet};
 
 mod any;
 pub use any::{

--- a/crates/signer-local/src/lib.rs
+++ b/crates/signer-local/src/lib.rs
@@ -7,7 +7,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 use alloy_consensus::SignableTransaction;
-use alloy_network::{TxSigner, TxSignerSync};
+use alloy_network::{AnyNetwork, Ethereum, EthereumWallet, IntoWallet, TxSigner, TxSignerSync};
 use alloy_primitives::{Address, ChainId, PrimitiveSignature as Signature, B256};
 use alloy_signer::{sign_transaction_with_chain_id, Result, Signer, SignerSync};
 use async_trait::async_trait;
@@ -35,6 +35,22 @@ pub use coins_bip39;
 
 /// A signer instantiated with a locally stored private key.
 pub type PrivateKeySigner = LocalSigner<k256::ecdsa::SigningKey>;
+
+impl IntoWallet<Ethereum> for PrivateKeySigner {
+    type NetworkWallet = EthereumWallet;
+
+    fn into_wallet(&self) -> Self::NetworkWallet {
+        EthereumWallet::new(self.clone())
+    }
+}
+
+impl IntoWallet<AnyNetwork> for PrivateKeySigner {
+    type NetworkWallet = EthereumWallet;
+
+    fn into_wallet(&self) -> Self::NetworkWallet {
+        EthereumWallet::new(self.clone())
+    }
+}
 
 #[doc(hidden)]
 #[deprecated(note = "use `PrivateKeySigner` instead")]


### PR DESCRIPTION
…rovider builder

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Closes #2094 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

WIP

- Introduce the `IntoWallet` trait, to be implemented by signers to return a wallet that implements `NetworkWallet`.
- Changes bounds on `WalletFiller` to `IntoWallet`. 
- Retains the type of signer `.wallet(signer)` was called with.
- Note: Some cloning overhead while calling `into_wallet`.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
