### PR TITLE
chore: add blob gas method to TransactionRequest impl

### DIFF
--- a/crates/rpc-types-eth/src/transaction/request.rs
+++ b/crates/rpc-types-eth/src/transaction/request.rs
@@ -229,6 +229,12 @@ impl TransactionRequest {
         self
     }
 
+    /// Sets the maximum fee per blob gas for the transaction.
+    pub const fn max_fee_per_blob_gas(mut self, max_fee_per_blob_gas: u128) -> Self {
+        self.max_fee_per_blob_gas = Some(max_fee_per_blob_gas);
+        self
+    }
+
     /// Sets the recipient address for the transaction.
     #[inline]
     pub const fn to(mut self, to: Address) -> Self {


### PR DESCRIPTION
This PR adds a method to set the blob gas fee for a transaction following the same pattern as other tx fields.
This can currently be done via `tx.set_max_fee_per_blob_gas()` which doesn't use the same builder pattern.

there is a similar method name in [`TransactionBuilder4844`](https://github.com/alloy-rs/alloy/blob/main/crates/rpc-types-eth/src/transaction/request.rs#L717), but it doesn't take the same parameter.