### PR TITLE
feat: add conversions for UnknownTxEnvelope

### DIFF
--- a/crates/consensus/src/transaction/mod.rs
+++ b/crates/consensus/src/transaction/mod.rs
@@ -29,6 +29,9 @@ pub use alloy_eips::eip4844::{
 pub use eip4844::BlobTransactionValidationError;
 pub use eip4844::{TxEip4844, TxEip4844Variant, TxEip4844WithSidecar};
 
+/// Re-export for convenience
+pub use either::Either;
+
 mod envelope;
 pub use envelope::{TxEnvelope, TxType};
 

--- a/crates/network/src/any/either.rs
+++ b/crates/network/src/any/either.rs
@@ -271,8 +271,8 @@ impl AnyTxEnvelope {
         f: impl FnOnce(UnknownTxEnvelope) -> Result<T, E>,
     ) -> Result<Either<TxEnvelope, T>, E> {
         match self {
-            AnyTxEnvelope::Ethereum(tx) => Ok(Either::Left(tx)),
-            AnyTxEnvelope::Unknown(tx) => Ok(Either::Right(f(tx)?)),
+            Self::Ethereum(tx) => Ok(Either::Left(tx)),
+            Self::Unknown(tx) => Ok(Either::Right(f(tx)?)),
         }
     }
 

--- a/crates/network/src/any/either.rs
+++ b/crates/network/src/any/either.rs
@@ -1,7 +1,7 @@
 use crate::{UnknownTxEnvelope, UnknownTypedTransaction};
 use alloy_consensus::{
-    Signed, Transaction as TransactionTrait, TxEip1559, TxEip2930, TxEip4844Variant, TxEip7702,
-    TxEnvelope, TxLegacy, Typed2718, TypedTransaction,
+    transaction::Either, Signed, Transaction as TransactionTrait, TxEip1559, TxEip2930,
+    TxEip4844Variant, TxEip7702, TxEnvelope, TxLegacy, Typed2718, TypedTransaction,
 };
 use alloy_eips::{
     eip2718::{Decodable2718, Encodable2718},
@@ -239,12 +239,40 @@ impl AnyTxEnvelope {
             this => Err(this),
         }
     }
+
     /// Returns the inner [`UnknownTxEnvelope`], if it is an unknown transaction.
     /// If the transaction is not an unknown transaction, it is returned as an error.
     pub fn try_into_unknown(self) -> Result<UnknownTxEnvelope, Self> {
         match self {
             Self::Unknown(inner) => Ok(inner),
             this => Err(this),
+        }
+    }
+
+    /// Attempts to convert the [`UnknownTxEnvelope`] into `Either::Right` if this is an unknown
+    /// variant.
+    ///
+    /// Returns `Either::Left` with the ethereum `TxEnvelope` if this is the
+    /// [`AnyTxEnvelope::Ethereum`] variant and [`Either::Right`] with the converted variant.
+    pub fn try_into_either<T>(self) -> Result<Either<TxEnvelope, T>, T::Error>
+    where
+        T: TryFrom<UnknownTxEnvelope>,
+    {
+        self.try_map_unknown(|inner| inner.try_into())
+    }
+
+    /// Attempts to convert the [`UnknownTxEnvelope`] into `Either::Right` if this is an
+    /// [`AnyTxEnvelope::Unknown`].
+    ///
+    /// Returns `Either::Left` with the ethereum `TxEnvelope` if this is the
+    /// [`AnyTxEnvelope::Ethereum`] variant and [`Either::Right`] with the converted variant.
+    pub fn try_map_unknown<T, E>(
+        self,
+        f: impl FnOnce(UnknownTxEnvelope) -> Result<T, E>,
+    ) -> Result<Either<TxEnvelope, T>, E> {
+        match self {
+            AnyTxEnvelope::Ethereum(tx) => Ok(Either::Left(tx)),
+            AnyTxEnvelope::Unknown(tx) => Ok(Either::Right(f(tx)?)),
         }
     }
 


### PR DESCRIPTION
this makes it possible to get an `Either` instance with two different tx types