### PR TITLE
chore(`consensus`)!: rename `Recovered` methods

### DIFF
--- a/crates/consensus/src/transaction/recovered.rs
+++ b/crates/consensus/src/transaction/recovered.rs
@@ -12,7 +12,7 @@ pub struct Recovered<T> {
     /// Signed object
     #[deref]
     #[as_ref]
-    tx: T,
+    inner: T,
 }
 
 impl<T> Recovered<T> {
@@ -28,12 +28,12 @@ impl<T> Recovered<T> {
 
     /// Reference to the inner signed object.
     pub const fn inner(&self) -> &T {
-        &self.tx
+        &self.inner
     }
 
     /// Reference to the inner signed object.
     pub fn into_inner(self) -> T {
-        self.tx
+        self.inner
     }
 
     /// Clone the inner signed object.
@@ -41,21 +41,21 @@ impl<T> Recovered<T> {
     where
         T: Clone,
     {
-        self.tx.clone()
+        self.inner.clone()
     }
 
     /// Returns a reference to the transaction.
     #[doc(alias = "transaction")]
     #[deprecated = "Use `inner` instead"]
     pub const fn tx(&self) -> &T {
-        &self.tx
+        &self.inner
     }
 
     /// Transform back to the transaction.
     #[doc(alias = "into_transaction")]
     #[deprecated = "Use `into_inner` instead"]
     pub fn into_tx(self) -> T {
-        self.tx
+        self.inner
     }
 
     /// Clone the inner transaction.
@@ -65,26 +65,26 @@ impl<T> Recovered<T> {
     where
         T: Clone,
     {
-        self.tx.clone()
+        self.inner.clone()
     }
 
     /// Dissolve Self to its component
     #[doc(alias = "split")]
     pub fn into_parts(self) -> (T, Address) {
-        (self.tx, self.signer)
+        (self.inner, self.signer)
     }
 
     /// Converts from `&Recovered<T>` to `Recovered<&T>`.
     pub const fn as_recovered_ref(&self) -> Recovered<&T> {
-        Recovered { tx: &self.tx, signer: self.signer() }
+        Recovered { inner: &self.inner, signer: self.signer() }
     }
 
     /// Create [`Recovered`] from the given transaction and [`Address`] of the signer.
     ///
     /// Note: This does not check if the signer is the actual signer of the transaction.
     #[inline]
-    pub const fn new_unchecked(tx: T, signer: Address) -> Self {
-        Self { tx, signer }
+    pub const fn new_unchecked(inner: T, signer: Address) -> Self {
+        Self { inner, signer }
     }
 
     /// Converts the inner signed object to the given alternative that is `From<T>`
@@ -123,13 +123,13 @@ impl<T> Recovered<T> {
 
     /// Applies the given closure to the inner signed object.
     pub fn map_inner<Tx>(self, f: impl FnOnce(T) -> Tx) -> Recovered<Tx> {
-        Recovered::new_unchecked(f(self.tx), self.signer)
+        Recovered::new_unchecked(f(self.inner), self.signer)
     }
 
     /// Applies the given closure to the inner transaction type.
     #[deprecated = "Use `map_inner` instead"]
     pub fn map_transaction<Tx>(self, f: impl FnOnce(T) -> Tx) -> Recovered<Tx> {
-        Recovered::new_unchecked(f(self.tx), self.signer)
+        Recovered::new_unchecked(f(self.inner), self.signer)
     }
 
     /// Applies the given fallible closure to the inner signed object.
@@ -137,7 +137,7 @@ impl<T> Recovered<T> {
         self,
         f: impl FnOnce(T) -> Result<Tx, E>,
     ) -> Result<Recovered<Tx>, E> {
-        Ok(Recovered::new_unchecked(f(self.tx)?, self.signer))
+        Ok(Recovered::new_unchecked(f(self.inner)?, self.signer))
     }
 
     /// Applies the given fallible closure to the inner transaction type.
@@ -146,7 +146,7 @@ impl<T> Recovered<T> {
         self,
         f: impl FnOnce(T) -> Result<Tx, E>,
     ) -> Result<Recovered<Tx>, E> {
-        Ok(Recovered::new_unchecked(f(self.tx)?, self.signer))
+        Ok(Recovered::new_unchecked(f(self.inner)?, self.signer))
     }
 }
 
@@ -156,19 +156,19 @@ impl<T> Recovered<&T> {
     where
         T: Clone,
     {
-        let Self { tx, signer } = self;
-        Recovered::new_unchecked(tx.clone(), signer)
+        let Self { inner, signer } = self;
+        Recovered::new_unchecked(inner.clone(), signer)
     }
 }
 
 impl<T: Encodable> Encodable for Recovered<T> {
     /// This encodes the transaction _with_ the signature, and an rlp header.
     fn encode(&self, out: &mut dyn bytes::BufMut) {
-        self.tx.encode(out)
+        self.inner.encode(out)
     }
 
     fn length(&self) -> usize {
-        self.tx.length()
+        self.inner.length()
     }
 }
 
@@ -184,21 +184,21 @@ impl<T: Decodable + SignerRecoverable> Decodable for Recovered<T> {
 
 impl<T: Typed2718> Typed2718 for Recovered<T> {
     fn ty(&self) -> u8 {
-        self.tx.ty()
+        self.inner.ty()
     }
 }
 
 impl<T: Encodable2718> Encodable2718 for Recovered<T> {
     fn encode_2718_len(&self) -> usize {
-        self.tx.encode_2718_len()
+        self.inner.encode_2718_len()
     }
 
     fn encode_2718(&self, out: &mut dyn alloy_rlp::BufMut) {
-        self.tx.encode_2718(out)
+        self.inner.encode_2718(out)
     }
 
     fn trie_hash(&self) -> B256 {
-        self.tx.trie_hash()
+        self.inner.trie_hash()
     }
 }
 

--- a/crates/consensus/src/transaction/recovered.rs
+++ b/crates/consensus/src/transaction/recovered.rs
@@ -92,7 +92,7 @@ impl<T> Recovered<T> {
     where
         Tx: From<T>,
     {
-        self.map_inner(Tx::from)
+        self.map(Tx::from)
     }
 
     /// Converts the transaction type to the given alternative that is `From<T>`
@@ -101,7 +101,7 @@ impl<T> Recovered<T> {
     where
         Tx: From<T>,
     {
-        self.map_inner(Tx::from)
+        self.map(Tx::from)
     }
 
     /// Converts the inner signed object to the given alternative that is `TryFrom<T>`
@@ -109,7 +109,7 @@ impl<T> Recovered<T> {
     where
         Tx: TryFrom<T>,
     {
-        self.try_map_inner(Tx::try_from)
+        self.try_map(Tx::try_from)
     }
 
     /// Converts the transaction to the given alternative that is `TryFrom<T>`
@@ -118,7 +118,7 @@ impl<T> Recovered<T> {
     where
         Tx: TryFrom<T>,
     {
-        self.try_map_inner(Tx::try_from)
+        self.try_map(Tx::try_from)
     }
 
     /// Applies the given closure to the inner signed object.
@@ -133,10 +133,7 @@ impl<T> Recovered<T> {
     }
 
     /// Applies the given fallible closure to the inner signed object.
-    pub fn try_map<Tx, E>(
-        self,
-        f: impl FnOnce(T) -> Result<Tx, E>,
-    ) -> Result<Recovered<Tx>, E> {
+    pub fn try_map<Tx, E>(self, f: impl FnOnce(T) -> Result<Tx, E>) -> Result<Recovered<Tx>, E> {
         Ok(Recovered::new_unchecked(f(self.inner)?, self.signer))
     }
 

--- a/crates/consensus/src/transaction/recovered.rs
+++ b/crates/consensus/src/transaction/recovered.rs
@@ -88,7 +88,7 @@ impl<T> Recovered<T> {
     }
 
     /// Converts the inner signed object to the given alternative that is `From<T>`
-    pub fn convert_inner<Tx>(self) -> Recovered<Tx>
+    pub fn convert<Tx>(self) -> Recovered<Tx>
     where
         Tx: From<T>,
     {
@@ -105,7 +105,7 @@ impl<T> Recovered<T> {
     }
 
     /// Converts the inner signed object to the given alternative that is `TryFrom<T>`
-    pub fn try_convert_inner<Tx, E>(self) -> Result<Recovered<Tx>, Tx::Error>
+    pub fn try_convert<Tx, E>(self) -> Result<Recovered<Tx>, Tx::Error>
     where
         Tx: TryFrom<T>,
     {
@@ -122,7 +122,7 @@ impl<T> Recovered<T> {
     }
 
     /// Applies the given closure to the inner signed object.
-    pub fn map_inner<Tx>(self, f: impl FnOnce(T) -> Tx) -> Recovered<Tx> {
+    pub fn map<Tx>(self, f: impl FnOnce(T) -> Tx) -> Recovered<Tx> {
         Recovered::new_unchecked(f(self.inner), self.signer)
     }
 
@@ -133,7 +133,7 @@ impl<T> Recovered<T> {
     }
 
     /// Applies the given fallible closure to the inner signed object.
-    pub fn try_map_inner<Tx, E>(
+    pub fn try_map<Tx, E>(
         self,
         f: impl FnOnce(T) -> Result<Tx, E>,
     ) -> Result<Recovered<Tx>, E> {

--- a/crates/network/src/any/mod.rs
+++ b/crates/network/src/any/mod.rs
@@ -180,7 +180,7 @@ impl AnyRpcTransaction {
     /// Returns the inner Ethereum transaction envelope, if it is an Ethereum transaction.
     /// If the transaction is not an Ethereum transaction, it is returned as an error.
     pub fn try_into_envelope(self) -> Result<TxEnvelope, ValueError<AnyTxEnvelope>> {
-        self.0.inner.inner.into_tx().try_into_envelope()
+        self.0.inner.inner.into_inner().try_into_envelope()
     }
 
     /// Maps the inner transaction to a new type that implements [`TxTrait`].

--- a/crates/network/src/any/unknowns.rs
+++ b/crates/network/src/any/unknowns.rs
@@ -410,7 +410,7 @@ mod tests {
 
         let tx: AnyRpcTransaction = serde_json::from_str(input).unwrap();
 
-        let AnyTxEnvelope::Unknown(inner) = tx.inner.inner.tx().clone() else {
+        let AnyTxEnvelope::Unknown(inner) = tx.inner.inner.inner().clone() else {
             panic!("expected unknown envelope");
         };
 

--- a/crates/rpc-types-eth/src/transaction/mod.rs
+++ b/crates/rpc-types-eth/src/transaction/mod.rs
@@ -79,7 +79,7 @@ where
 impl<T> Transaction<T> {
     /// Consumes the type and returns the wrapped transaction.
     pub fn into_inner(self) -> T {
-        self.inner.into_tx()
+        self.inner.into_inner()
     }
 
     /// Consumes the type and returns a [`Recovered`] transaction with the sender
@@ -114,7 +114,7 @@ impl<T> Transaction<T> {
     pub fn map<Tx>(self, f: impl FnOnce(T) -> Tx) -> Transaction<Tx> {
         let Self { inner, block_hash, block_number, transaction_index, effective_gas_price } = self;
         Transaction {
-            inner: inner.map_transaction(f),
+            inner: inner.map_inner(f),
             block_hash,
             block_number,
             transaction_index,
@@ -126,7 +126,7 @@ impl<T> Transaction<T> {
     pub fn try_map<Tx, E>(self, f: impl FnOnce(T) -> Result<Tx, E>) -> Result<Transaction<Tx>, E> {
         let Self { inner, block_hash, block_number, transaction_index, effective_gas_price } = self;
         Ok(Transaction {
-            inner: inner.try_map_transaction(f)?,
+            inner: inner.try_map_inner(f)?,
             block_hash,
             block_number,
             transaction_index,
@@ -180,7 +180,7 @@ where
     /// During this conversion data for [TransactionRequest::sidecar] is not
     /// populated as it is not part of [Transaction].
     pub fn into_request(self) -> TransactionRequest {
-        self.inner.into_tx().into()
+        self.inner.into_inner().into()
     }
 }
 
@@ -188,7 +188,7 @@ impl Transaction {
     /// Consumes the transaction and returns it as [`Signed`] with [`TypedTransaction`] as the
     /// transaction type.
     pub fn into_signed(self) -> Signed<TypedTransaction> {
-        self.inner.into_tx().into_signed()
+        self.inner.into_inner().into_signed()
     }
 
     /// Consumes the transaction and returns it a [`Recovered`] signed [`TypedTransaction`].
@@ -216,7 +216,7 @@ impl TryFrom<Transaction> for Signed<TxLegacy> {
     type Error = ConversionError;
 
     fn try_from(tx: Transaction) -> Result<Self, Self::Error> {
-        match tx.inner.into_tx() {
+        match tx.inner.into_inner() {
             TxEnvelope::Legacy(tx) => Ok(tx),
             tx => Err(ConversionError::Custom(format!("expected Legacy, got {}", tx.tx_type()))),
         }
@@ -227,7 +227,7 @@ impl TryFrom<Transaction> for Signed<TxEip1559> {
     type Error = ConversionError;
 
     fn try_from(tx: Transaction) -> Result<Self, Self::Error> {
-        match tx.inner.into_tx() {
+        match tx.inner.into_inner() {
             TxEnvelope::Eip1559(tx) => Ok(tx),
             tx => Err(ConversionError::Custom(format!("expected Eip1559, got {}", tx.tx_type()))),
         }
@@ -238,7 +238,7 @@ impl TryFrom<Transaction> for Signed<TxEip2930> {
     type Error = ConversionError;
 
     fn try_from(tx: Transaction) -> Result<Self, Self::Error> {
-        match tx.inner.into_tx() {
+        match tx.inner.into_inner() {
             TxEnvelope::Eip2930(tx) => Ok(tx),
             tx => Err(ConversionError::Custom(format!("expected Eip2930, got {}", tx.tx_type()))),
         }
@@ -261,7 +261,7 @@ impl TryFrom<Transaction> for Signed<TxEip4844Variant> {
     type Error = ConversionError;
 
     fn try_from(tx: Transaction) -> Result<Self, Self::Error> {
-        match tx.inner.into_tx() {
+        match tx.inner.into_inner() {
             TxEnvelope::Eip4844(tx) => Ok(tx),
             tx => Err(ConversionError::Custom(format!(
                 "expected TxEip4844Variant, got {}",
@@ -275,7 +275,7 @@ impl TryFrom<Transaction> for Signed<TxEip7702> {
     type Error = ConversionError;
 
     fn try_from(tx: Transaction) -> Result<Self, Self::Error> {
-        match tx.inner.into_tx() {
+        match tx.inner.into_inner() {
             TxEnvelope::Eip7702(tx) => Ok(tx),
             tx => Err(ConversionError::Custom(format!("expected Eip7702, got {}", tx.tx_type()))),
         }
@@ -284,7 +284,7 @@ impl TryFrom<Transaction> for Signed<TxEip7702> {
 
 impl From<Transaction> for TxEnvelope {
     fn from(tx: Transaction) -> Self {
-        tx.inner.into_tx()
+        tx.inner.into_inner()
     }
 }
 

--- a/crates/rpc-types-eth/src/transaction/mod.rs
+++ b/crates/rpc-types-eth/src/transaction/mod.rs
@@ -114,7 +114,7 @@ impl<T> Transaction<T> {
     pub fn map<Tx>(self, f: impl FnOnce(T) -> Tx) -> Transaction<Tx> {
         let Self { inner, block_hash, block_number, transaction_index, effective_gas_price } = self;
         Transaction {
-            inner: inner.map_inner(f),
+            inner: inner.map(f),
             block_hash,
             block_number,
             transaction_index,
@@ -126,7 +126,7 @@ impl<T> Transaction<T> {
     pub fn try_map<Tx, E>(self, f: impl FnOnce(T) -> Result<Tx, E>) -> Result<Transaction<Tx>, E> {
         let Self { inner, block_hash, block_number, transaction_index, effective_gas_price } = self;
         Ok(Transaction {
-            inner: inner.try_map_inner(f)?,
+            inner: inner.try_map(f)?,
             block_hash,
             block_number,
             transaction_index,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

`Recovered` can be used for any signed object not just transactions. 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

- Renames the methods and changes docs slightly to indicate the above

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [x] Breaking changes
