### PR TITLE
chore(`provider`): fix `mocked` ret type

### DIFF
--- a/crates/provider/src/builder.rs
+++ b/crates/provider/src/builder.rs
@@ -148,15 +148,23 @@ impl
         ProviderBuilder { layer: self.layer, filler: Identity, network: self.network }
     }
 
-    /// Create a new [`MockProvider`] for testing purposes.
+    /// Create a new [`MockProvider`] for the [`Ethereum`] network.
     ///
     /// Sets the dummy RPC_URL to `http://localhost:8545`.
     #[cfg(all(not(target_arch = "wasm32"), any(test, feature = "reqwest", feature = "hyper")))]
     pub fn mocked() -> MockProvider<RootProvider, Ethereum> {
+        Self::mocked_network()
+    }
+
+    /// Create a new [`MockProvider`] for a specific network.
+    ///
+    /// Sets the dummy RPC_URL to `http://localhost:8545`.
+    #[cfg(all(not(target_arch = "wasm32"), any(test, feature = "reqwest", feature = "hyper")))]
+    pub fn mocked_network<Net: Network>() -> MockProvider<RootProvider<Net>, Net> {
         let asserter = Asserter::new();
         let layer = MockLayer::new(asserter.clone());
 
-        let builder = ProviderBuilder::<_, _, Ethereum>::default().layer(layer);
+        let builder = ProviderBuilder::<_, _, Net>::default().layer(layer);
 
         #[cfg(any(test, feature = "reqwest"))]
         let mock_provider = builder.on_http("http://localhost:8545".parse().unwrap());

--- a/crates/provider/src/builder.rs
+++ b/crates/provider/src/builder.rs
@@ -152,7 +152,7 @@ impl
     ///
     /// Sets the dummy RPC_URL to `http://localhost:8545`.
     #[cfg(all(not(target_arch = "wasm32"), any(test, feature = "reqwest", feature = "hyper")))]
-    pub fn mocked() -> (MockProvider<RootProvider, Ethereum>, Asserter) {
+    pub fn mocked() -> MockProvider<RootProvider, Ethereum> {
         let asserter = Asserter::new();
         let layer = MockLayer::new(asserter.clone());
 
@@ -164,7 +164,7 @@ impl
         #[cfg(all(feature = "hyper", not(feature = "reqwest")))]
         let mock_provider = builder.on_hyper_http("http://localhost:8545".parse().unwrap());
 
-        (mock_provider, asserter)
+        mock_provider
     }
 }
 

--- a/crates/provider/src/builder.rs
+++ b/crates/provider/src/builder.rs
@@ -162,7 +162,7 @@ impl
     #[cfg(all(not(target_arch = "wasm32"), any(test, feature = "reqwest", feature = "hyper")))]
     pub fn mocked_network<Net: Network>() -> MockProvider<RootProvider<Net>, Net> {
         let asserter = Asserter::new();
-        let layer = MockLayer::new(asserter.clone());
+        let layer = MockLayer::new(asserter);
 
         let builder = ProviderBuilder::<_, _, Net>::default().layer(layer);
 

--- a/crates/provider/src/layers/mock.rs
+++ b/crates/provider/src/layers/mock.rs
@@ -426,8 +426,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_mock() {
-        let (provider, asserter) = ProviderBuilder::mocked();
+        let provider = ProviderBuilder::mocked();
 
+        let asserter = provider.asserter();
         asserter.push_success(21965802);
         asserter.push_success(21965803);
         asserter.push_err(TransportError::NullResp);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Currently, `ProviderBuilder::mocked` returns `(MockProvider, Asserter)`.
Returning `Asserter` is redundant, since it can accessed via the provider, `provider.asserter()`.

We also don't have an easy way to build a mocked provider for a specific network.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

- Remove `Asserter` from return type.
- Add `mocked_network<Net: Network>`

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
