### PR TITLE
feat: add Eip4844 variant generic to TypedTransaction

### DIFF
--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -36,8 +36,9 @@ pub mod transaction;
 #[cfg(feature = "kzg")]
 pub use transaction::BlobTransactionValidationError;
 pub use transaction::{
-    SignableTransaction, Transaction, TxEip1559, TxEip2930, TxEip4844, TxEip4844Variant,
-    TxEip4844WithSidecar, TxEip7702, TxEnvelope, TxLegacy, TxType, TypedTransaction,
+    EthereumTypedTransaction, SignableTransaction, Transaction, TxEip1559, TxEip2930, TxEip4844,
+    TxEip4844Variant, TxEip4844WithSidecar, TxEip7702, TxEnvelope, TxLegacy, TxType,
+    TypedTransaction,
 };
 
 pub use alloy_eips::{

--- a/crates/consensus/src/transaction/mod.rs
+++ b/crates/consensus/src/transaction/mod.rs
@@ -43,7 +43,7 @@ mod rlp;
 pub use rlp::{RlpEcdsaDecodableTx, RlpEcdsaEncodableTx, RlpEcdsaTx};
 
 mod typed;
-pub use typed::TypedTransaction;
+pub use typed::{EthereumTypedTransaction, TypedTransaction};
 
 mod meta;
 pub use meta::{TransactionInfo, TransactionMeta};

--- a/crates/consensus/src/transaction/typed.rs
+++ b/crates/consensus/src/transaction/typed.rs
@@ -11,6 +11,9 @@ use alloy_primitives::{
     bytes::BufMut, Bytes, ChainId, PrimitiveSignature as Signature, TxHash, TxKind, B256, U256,
 };
 
+/// Basic typed transaction which can contain both [`TxEip4844`] and [`TxEip4844WithSidecar`].
+pub type TypedTransaction = EthereumTypedTransaction<TxEip4844Variant>;
+
 /// The TypedTransaction enum represents all Ethereum transaction request types.
 ///
 /// Its variants correspond to specific allowed transactions:
@@ -18,18 +21,27 @@ use alloy_primitives::{
 /// 2. EIP2930 (state access lists) [`TxEip2930`]
 /// 3. EIP1559 [`TxEip1559`]
 /// 4. EIP4844 [`TxEip4844Variant`]
+///
+/// This type is generic over Eip4844 variant to support the following cases:
+/// 1. Only-[`TxEip4844`] transaction type, such transaction representation is returned by RPC and
+///    stored by nodes internally.
+/// 2. Only-[`TxEip4844WithSidecar`] transactions which are broadcasted over the network, submitted
+///    to RPC and stored in transaction pool.
+/// 3. Dynamic [`TxEip4844Variant`] transactions to support both of the above cases via a single
+///    type.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     feature = "serde",
     serde(
-        from = "serde_from::MaybeTaggedTypedTransaction",
-        into = "serde_from::TaggedTypedTransaction"
+        from = "serde_from::MaybeTaggedTypedTransaction<Eip4844>",
+        into = "serde_from::TaggedTypedTransaction<Eip4844>",
+        bound = "Eip4844: Clone + serde::Serialize + serde::de::DeserializeOwned"
     )
 )]
 #[cfg_attr(all(any(test, feature = "arbitrary"), feature = "k256"), derive(arbitrary::Arbitrary))]
 #[doc(alias = "TypedTx", alias = "TxTyped", alias = "TransactionTyped")]
-pub enum TypedTransaction {
+pub enum EthereumTypedTransaction<Eip4844> {
     /// Legacy transaction
     #[cfg_attr(feature = "serde", serde(rename = "0x00", alias = "0x0"))]
     Legacy(TxLegacy),
@@ -41,49 +53,51 @@ pub enum TypedTransaction {
     Eip1559(TxEip1559),
     /// EIP-4844 transaction
     #[cfg_attr(feature = "serde", serde(rename = "0x03", alias = "0x3"))]
-    Eip4844(TxEip4844Variant),
+    Eip4844(Eip4844),
     /// EIP-7702 transaction
     #[cfg_attr(feature = "serde", serde(rename = "0x04", alias = "0x4"))]
     Eip7702(TxEip7702),
 }
 
-impl From<TxLegacy> for TypedTransaction {
+impl<Eip4844> From<TxLegacy> for EthereumTypedTransaction<Eip4844> {
     fn from(tx: TxLegacy) -> Self {
         Self::Legacy(tx)
     }
 }
 
-impl From<TxEip2930> for TypedTransaction {
+impl<Eip4844> From<TxEip2930> for EthereumTypedTransaction<Eip4844> {
     fn from(tx: TxEip2930) -> Self {
         Self::Eip2930(tx)
     }
 }
 
-impl From<TxEip1559> for TypedTransaction {
+impl<Eip4844> From<TxEip1559> for EthereumTypedTransaction<Eip4844> {
     fn from(tx: TxEip1559) -> Self {
         Self::Eip1559(tx)
     }
 }
 
-impl From<TxEip4844Variant> for TypedTransaction {
-    fn from(tx: TxEip4844Variant) -> Self {
-        Self::Eip4844(tx)
-    }
-}
-
-impl From<TxEip4844> for TypedTransaction {
+impl<Eip4844: From<TxEip4844>> From<TxEip4844> for EthereumTypedTransaction<Eip4844> {
     fn from(tx: TxEip4844) -> Self {
         Self::Eip4844(tx.into())
     }
 }
 
-impl From<TxEip4844WithSidecar> for TypedTransaction {
+impl<Eip4844: From<TxEip4844WithSidecar>> From<TxEip4844WithSidecar>
+    for EthereumTypedTransaction<Eip4844>
+{
     fn from(tx: TxEip4844WithSidecar) -> Self {
         Self::Eip4844(tx.into())
     }
 }
 
-impl From<TxEip7702> for TypedTransaction {
+impl<Eip4844: From<TxEip4844Variant>> From<TxEip4844Variant> for EthereumTypedTransaction<Eip4844> {
+    fn from(tx: TxEip4844Variant) -> Self {
+        Self::Eip4844(tx.into())
+    }
+}
+
+impl<Eip4844> From<TxEip7702> for EthereumTypedTransaction<Eip4844> {
     fn from(tx: TxEip7702) -> Self {
         Self::Eip7702(tx)
     }
@@ -101,7 +115,7 @@ impl From<TxEnvelope> for TypedTransaction {
     }
 }
 
-impl TypedTransaction {
+impl<Eip4844: RlpEcdsaEncodableTx> EthereumTypedTransaction<Eip4844> {
     /// Return the [`TxType`] of the inner txn.
     #[doc(alias = "transaction_type")]
     pub const fn tx_type(&self) -> TxType {
@@ -158,7 +172,7 @@ impl TypedTransaction {
     }
 }
 
-impl Transaction for TypedTransaction {
+impl<Eip4844: Transaction> Transaction for EthereumTypedTransaction<Eip4844> {
     #[inline]
     fn chain_id(&self) -> Option<ChainId> {
         match self {
@@ -346,7 +360,7 @@ impl Transaction for TypedTransaction {
     }
 }
 
-impl Typed2718 for TypedTransaction {
+impl<Eip4844: Typed2718> Typed2718 for EthereumTypedTransaction<Eip4844> {
     fn ty(&self) -> u8 {
         match self {
             Self::Legacy(tx) => tx.ty(),
@@ -358,7 +372,7 @@ impl Typed2718 for TypedTransaction {
     }
 }
 
-impl RlpEcdsaEncodableTx for TypedTransaction {
+impl<Eip4844: RlpEcdsaEncodableTx> RlpEcdsaEncodableTx for EthereumTypedTransaction<Eip4844> {
     const DEFAULT_TX_TYPE: u8 = 0;
 
     fn rlp_encoded_fields_length(&self) -> usize {
@@ -442,7 +456,9 @@ impl RlpEcdsaEncodableTx for TypedTransaction {
     }
 }
 
-impl SignableTransaction<Signature> for TypedTransaction {
+impl<Eip4844: SignableTransaction<Signature>> SignableTransaction<Signature>
+    for EthereumTypedTransaction<Eip4844>
+{
     fn set_chain_id(&mut self, chain_id: ChainId) {
         match self {
             Self::Legacy(tx) => tx.set_chain_id(chain_id),
@@ -475,8 +491,10 @@ impl SignableTransaction<Signature> for TypedTransaction {
 }
 
 #[cfg(feature = "serde")]
-impl<T: From<TypedTransaction>> From<TypedTransaction> for alloy_serde::WithOtherFields<T> {
-    fn from(value: TypedTransaction) -> Self {
+impl<Eip4844, T: From<EthereumTypedTransaction<Eip4844>>> From<EthereumTypedTransaction<Eip4844>>
+    for alloy_serde::WithOtherFields<T>
+{
+    fn from(value: EthereumTypedTransaction<Eip4844>) -> Self {
         Self::new(value.into())
     }
 }
@@ -501,12 +519,12 @@ mod serde_from {
     //!
     //! We serialize via [`TaggedTypedTransaction`] and deserialize via
     //! [`MaybeTaggedTypedTransaction`].
-    use crate::{TxEip1559, TxEip2930, TxEip4844Variant, TxEip7702, TxLegacy, TypedTransaction};
+    use crate::{EthereumTypedTransaction, TxEip1559, TxEip2930, TxEip7702, TxLegacy};
 
     #[derive(Debug, serde::Deserialize)]
     #[serde(untagged)]
-    pub(crate) enum MaybeTaggedTypedTransaction {
-        Tagged(TaggedTypedTransaction),
+    pub(crate) enum MaybeTaggedTypedTransaction<Eip4844> {
+        Tagged(TaggedTypedTransaction<Eip4844>),
         Untagged {
             #[serde(default, rename = "type", deserialize_with = "alloy_serde::reject_if_some")]
             _ty: Option<()>,
@@ -517,7 +535,7 @@ mod serde_from {
 
     #[derive(Debug, serde::Serialize, serde::Deserialize)]
     #[serde(tag = "type")]
-    pub(crate) enum TaggedTypedTransaction {
+    pub(crate) enum TaggedTypedTransaction<Eip4844> {
         /// Legacy transaction
         #[serde(rename = "0x00", alias = "0x0")]
         Legacy(TxLegacy),
@@ -529,14 +547,14 @@ mod serde_from {
         Eip1559(TxEip1559),
         /// EIP-4844 transaction
         #[serde(rename = "0x03", alias = "0x3")]
-        Eip4844(TxEip4844Variant),
+        Eip4844(Eip4844),
         /// EIP-7702 transaction
         #[serde(rename = "0x04", alias = "0x4")]
         Eip7702(TxEip7702),
     }
 
-    impl From<MaybeTaggedTypedTransaction> for TypedTransaction {
-        fn from(value: MaybeTaggedTypedTransaction) -> Self {
+    impl<Eip4844> From<MaybeTaggedTypedTransaction<Eip4844>> for EthereumTypedTransaction<Eip4844> {
+        fn from(value: MaybeTaggedTypedTransaction<Eip4844>) -> Self {
             match value {
                 MaybeTaggedTypedTransaction::Tagged(tagged) => tagged.into(),
                 MaybeTaggedTypedTransaction::Untagged { tx, .. } => Self::Legacy(tx),
@@ -544,8 +562,8 @@ mod serde_from {
         }
     }
 
-    impl From<TaggedTypedTransaction> for TypedTransaction {
-        fn from(value: TaggedTypedTransaction) -> Self {
+    impl<Eip4844> From<TaggedTypedTransaction<Eip4844>> for EthereumTypedTransaction<Eip4844> {
+        fn from(value: TaggedTypedTransaction<Eip4844>) -> Self {
             match value {
                 TaggedTypedTransaction::Legacy(signed) => Self::Legacy(signed),
                 TaggedTypedTransaction::Eip2930(signed) => Self::Eip2930(signed),
@@ -556,14 +574,14 @@ mod serde_from {
         }
     }
 
-    impl From<TypedTransaction> for TaggedTypedTransaction {
-        fn from(value: TypedTransaction) -> Self {
+    impl<Eip4844> From<EthereumTypedTransaction<Eip4844>> for TaggedTypedTransaction<Eip4844> {
+        fn from(value: EthereumTypedTransaction<Eip4844>) -> Self {
             match value {
-                TypedTransaction::Legacy(signed) => Self::Legacy(signed),
-                TypedTransaction::Eip2930(signed) => Self::Eip2930(signed),
-                TypedTransaction::Eip1559(signed) => Self::Eip1559(signed),
-                TypedTransaction::Eip4844(signed) => Self::Eip4844(signed),
-                TypedTransaction::Eip7702(signed) => Self::Eip7702(signed),
+                EthereumTypedTransaction::Legacy(signed) => Self::Legacy(signed),
+                EthereumTypedTransaction::Eip2930(signed) => Self::Eip2930(signed),
+                EthereumTypedTransaction::Eip1559(signed) => Self::Eip1559(signed),
+                EthereumTypedTransaction::Eip4844(signed) => Self::Eip4844(signed),
+                EthereumTypedTransaction::Eip7702(signed) => Self::Eip7702(signed),
             }
         }
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Renames `TypedTransaction` to `EthereumTypedTransaction` and makes it generic over `Eip4844` variant. `TypedTranaction` is still kept as a type alias making this change non-breaking

We can apply same approch to `TxEnvelope` and and de-duplicate it with `PooledTransaction` https://github.com/alloy-rs/alloy/blob/9442fefece4bd78587f3a5db8f6b871a2a426f7b/crates/consensus/src/transaction/pooled.rs#L32

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
