### PR TITLE
fix: filter out requests with len 1

### DIFF
--- a/crates/eips/src/eip7685.rs
+++ b/crates/eips/src/eip7685.rs
@@ -92,7 +92,17 @@ impl Requests {
         use sha2::{Digest, Sha256};
         let mut hash = Sha256::new();
 
-        let mut requests: Vec<_> = self.0.iter().filter(|req| !req.is_empty()).collect();
+        let mut requests: Vec<_> = self
+            .0
+            .iter()
+            .filter(|req| {
+                // filter out all requests that are empty or only have the type byte
+                // <type-id> <data>
+                req.len() > 1
+            })
+            .collect();
+
+        // requests should only contain unique types: `id [r1,r2,..]`
         requests.sort_unstable_by_key(|req| {
             // SAFETY: only includes non-empty requests
             req[0]


### PR DESCRIPTION
the filter function defined in the eip https://eips.ethereum.org/EIPS/eip-7685 is:

```
def compute_requests_hash(block_requests: Sequence[bytes]):
    m = sha256()
    for r in block_requests:
        if len(r) > 1:
            m.update(sha256(r).digest())
    return m.digest()
```