### PR TITLE
chore: add helper to set trace's gas used

### DIFF
--- a/crates/rpc-types-trace/src/parity.rs
+++ b/crates/rpc-types-trace/src/parity.rs
@@ -483,6 +483,18 @@ pub struct LocalizedTransactionTrace {
     pub transaction_position: Option<u64>,
 }
 
+impl LocalizedTransactionTrace {
+    /// Sets the gas used of this trace.
+    ///
+    /// This is intended to manually set the root trace's gas used to the actual gas used by the
+    /// transaction, e.g. for geth's [`FlatCallFrame`](crate::geth::call::FlatCallFrame)
+    pub fn set_gas_used(&mut self, gas_used: u64) {
+        if let Some(res) = self.trace.result.as_mut() {
+            res.set_gas_used(gas_used);
+        }
+    }
+}
+
 // Implement Serialize manually to ensure consistent ordering of fields to match other client's
 // format
 impl Serialize for LocalizedTransactionTrace {


### PR DESCRIPTION
prep for

https://github.com/paradigmxyz/reth/issues/14726

we need an easy way to set the gas used of the top level trace for the geth flatcall tracer