### PR TITLE
fix: broken links `eip1559/constants.rs`

### DIFF
--- a/crates/eips/src/eip1559/constants.rs
+++ b/crates/eips/src/eip1559/constants.rs
@@ -37,29 +37,29 @@ pub const DEFAULT_BASE_FEE_MAX_CHANGE_DENOMINATOR: u64 = 8;
 pub const DEFAULT_ELASTICITY_MULTIPLIER: u64 = 2;
 
 /// Base fee max change denominator for Optimism Sepolia as defined in the Optimism
-/// [transaction costs](https://community.optimism.io/docs/developers/build/differences/#transaction-costs) doc.
+/// [transaction costs](https://docs.optimism.io/stack/differences#transactions) doc.
 pub(crate) const OP_SEPOLIA_EIP1559_DEFAULT_BASE_FEE_MAX_CHANGE_DENOMINATOR: u128 = 50;
 
 /// Base fee max change denominator for Optimism Sepolia as defined in the Optimism Canyon hardfork.
 pub(crate) const OP_SEPOLIA_EIP1559_BASE_FEE_MAX_CHANGE_DENOMINATOR_CANYON: u128 = 250;
 
 /// Base fee max change denominator for Optimism Sepolia as defined in the Optimism
-/// [transaction costs](https://community.optimism.io/docs/developers/build/differences/#transaction-costs) doc.
+/// [transaction costs](https://docs.optimism.io/stack/differences#transactions) doc.
 pub(crate) const OP_SEPOLIA_EIP1559_DEFAULT_ELASTICITY_MULTIPLIER: u128 = 6;
 
 /// Base fee max change denominator for Optimism Mainnet as defined in the Optimism
-/// [transaction costs](https://community.optimism.io/docs/developers/build/differences/#transaction-costs) doc.
+/// [transaction costs](https://docs.optimism.io/stack/differences#transactions) doc.
 pub(crate) const OP_MAINNET_EIP1559_DEFAULT_BASE_FEE_MAX_CHANGE_DENOMINATOR: u128 = 50;
 
 /// Base fee max change denominator for Optimism Mainnet as defined in the Optimism Canyon hardfork.
 pub(crate) const OP_MAINNET_EIP1559_BASE_FEE_MAX_CHANGE_DENOMINATOR_CANYON: u128 = 250;
 
 /// Base fee max change denominator for Optimism Mainnet as defined in the Optimism
-/// [transaction costs](https://community.optimism.io/docs/developers/build/differences/#transaction-costs) doc.
+/// [transaction costs](https://docs.optimism.io/stack/differences#transactions) doc.
 pub(crate) const OP_MAINNET_EIP1559_DEFAULT_ELASTICITY_MULTIPLIER: u128 = 6;
 
 /// Base fee max change denominator for Base Sepolia as defined in the Optimism
-/// [transaction costs](https://community.optimism.io/docs/developers/build/differences/#transaction-costs) doc.
+/// [transaction costs](https://docs.optimism.io/stack/differences#transactions) doc.
 pub(crate) const BASE_SEPOLIA_EIP1559_DEFAULT_ELASTICITY_MULTIPLIER: u128 = 10;
 
 #[cfg(test)]


### PR DESCRIPTION
Hi! I fixed broken links in the `constants.rs` file related to Optimism's transaction costs documentation. 