### PR TITLE
Add encodable and decodable for `Signed<T>`

### DIFF
--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -519,28 +519,6 @@ impl<Eip4844: RlpEcdsaEncodableTx> EthereumTxEnvelope<Eip4844> {
     }
 }
 
-impl<T> Encodable for Signed<T>
-where
-    Self: Encodable2718,
-{
-    fn encode(&self, out: &mut dyn alloy_rlp::BufMut) {
-        self.network_encode(out)
-    }
-
-    fn length(&self) -> usize {
-        self.network_len()
-    }
-}
-
-impl<T> Decodable for Signed<T>
-where
-    T: RlpEcdsaDecodableTx,
-{
-    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
-        Ok(Self::network_decode(buf)?)
-    }
-}
-
 impl<Eip4844> Encodable for EthereumTxEnvelope<Eip4844>
 where
     Self: Encodable2718,

--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -580,6 +580,19 @@ where
     }
 }
 
+impl<T> Decodable2718 for Signed<T>
+where
+    T: RlpEcdsaDecodableTx + Typed2718 + Send + Sync,
+{
+    fn typed_decode(_ty: u8, buf: &mut &[u8]) -> Eip2718Result<Self> {
+        T::rlp_decode_signed(buf).map_err(Into::into)
+    }
+
+    fn fallback_decode(buf: &mut &[u8]) -> Eip2718Result<Self> {
+        T::rlp_decode_signed(buf).map_err(Into::into)
+    }
+}
+
 impl<Eip4844> Encodable2718 for EthereumTxEnvelope<Eip4844>
 where
     Eip4844: RlpEcdsaEncodableTx + Typed2718 + Send + Sync,

--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -18,7 +18,6 @@ use core::{
     fmt::{self, Debug},
     hash::{Hash, Hasher},
 };
-use alloy_primitives::bytes::BufMut;
 use super::SignableTransaction;
 
 /// The Ethereum [EIP-2718] Transaction Envelope.

--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -18,6 +18,7 @@ use core::{
     fmt::{self, Debug},
     hash::{Hash, Hasher},
 };
+
 use super::SignableTransaction;
 
 /// The Ethereum [EIP-2718] Transaction Envelope.

--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -584,8 +584,14 @@ impl<T> Decodable2718 for Signed<T>
 where
     T: RlpEcdsaDecodableTx + Typed2718 + Send + Sync,
 {
-    fn typed_decode(_ty: u8, buf: &mut &[u8]) -> Eip2718Result<Self> {
-        T::rlp_decode_signed(buf).map_err(Into::into)
+    fn typed_decode(ty: u8, buf: &mut &[u8]) -> Eip2718Result<Self> {
+        let decoded = T::rlp_decode_signed(buf).map_err(Into::into)?;
+
+        if decoded.ty() != ty {
+            return Err(Eip2718Error::UnexpectedType(ty));
+        }
+
+        Ok(decoded)
     }
 
     fn fallback_decode(buf: &mut &[u8]) -> Eip2718Result<Self> {

--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -585,7 +585,7 @@ where
     T: RlpEcdsaDecodableTx + Typed2718 + Send + Sync,
 {
     fn typed_decode(ty: u8, buf: &mut &[u8]) -> Eip2718Result<Self> {
-        let decoded = T::rlp_decode_signed(buf).map_err(Into::into)?;
+        let decoded = T::rlp_decode_signed(buf)?;
 
         if decoded.ty() != ty {
             return Err(Eip2718Error::UnexpectedType(ty));

--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -519,6 +519,28 @@ impl<Eip4844: RlpEcdsaEncodableTx> EthereumTxEnvelope<Eip4844> {
     }
 }
 
+impl<T> Encodable for Signed<T>
+where
+    Self: Encodable2718,
+{
+    fn encode(&self, out: &mut dyn alloy_rlp::BufMut) {
+        self.network_encode(out)
+    }
+
+    fn length(&self) -> usize {
+        self.network_len()
+    }
+}
+
+impl<T> Decodable for Signed<T>
+where
+    T: RlpEcdsaDecodableTx,
+{
+    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        Ok(Self::network_decode(buf)?)
+    }
+}
+
 impl<Eip4844> Encodable for EthereumTxEnvelope<Eip4844>
 where
     Self: Encodable2718,


### PR DESCRIPTION
## Motivation

This is regarding the following [issue](https://github.com/alloy-rs/alloy/issues/2191)

## Solution

Added `Encodable` and `Decodable` for `Signed<T>`

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
