### PR TITLE
feat: remove poller task indirection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,6 +124,7 @@ tower = { version = "0.5", features = ["util"] }
 # tracing
 tracing = "0.1"
 tracing-subscriber = "0.3"
+tracing-futures = "0.2"
 
 # serde
 serde = { version = "1.0", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,6 +98,7 @@ sha2 = { version = "0.10", default-features = false }
 spki = { version = "0.7", default-features = false }
 
 # async
+async-stream = "0.3"
 async-trait = "0.1"
 futures = "0.3"
 futures-util = "0.3"

--- a/crates/provider/Cargo.toml
+++ b/crates/provider/Cargo.toml
@@ -49,7 +49,7 @@ alloy-primitives.workspace = true
 alloy-sol-types.workspace = true
 
 alloy-chains.workspace = true
-async-stream = "0.3"
+async-stream.workspace = true
 async-trait.workspace = true
 auto_impl.workspace = true
 dashmap = "6.0"

--- a/crates/provider/src/blocks.rs
+++ b/crates/provider/src/blocks.rs
@@ -100,9 +100,7 @@ impl<N: Network> NewBlocks<N> {
     fn into_poll_stream(mut self) -> impl Stream<Item = N::BlockResponse> + 'static {
         stream! {
         // Spawned lazily on the first `poll`.
-        let poll_task_builder: PollerBuilder<NoParams, U64> =
-            PollerBuilder::new(self.client.clone(), "eth_blockNumber", []);
-        let mut poll_task = poll_task_builder.spawn().into_stream_raw();
+        let mut poller = PollerBuilder::<NoParams, U64>::new(self.client.clone(), "eth_blockNumber", []).into_stream();
         'task: loop {
             // Clear any buffered blocks.
             while let Some(known_block) = self.known_blocks.pop(&self.next_yield) {
@@ -112,17 +110,9 @@ impl<N: Network> NewBlocks<N> {
             }
 
             // Get the tip.
-            let block_number = match poll_task.next().await {
-                Some(Ok(block_number)) => block_number,
-                Some(Err(err)) => {
-                    // This is fine.
-                    debug!(%err, "polling stream lagged");
-                    continue 'task;
-                }
-                None => {
-                    debug!("polling stream ended");
-                    break 'task;
-                }
+            let Some(block_number) = poller.next().await else {
+                debug!("polling stream ended");
+                break 'task;
             };
             let block_number = block_number.to::<u64>();
             trace!(%block_number, "got block number");

--- a/crates/rpc-client/Cargo.toml
+++ b/crates/rpc-client/Cargo.toml
@@ -28,6 +28,7 @@ alloy-json-rpc.workspace = true
 alloy-transport-http.workspace = true
 alloy-transport.workspace = true
 
+async-stream.workspace = true
 futures.workspace = true
 pin-project.workspace = true
 serde_json.workspace = true

--- a/crates/rpc-client/Cargo.toml
+++ b/crates/rpc-client/Cargo.toml
@@ -37,6 +37,7 @@ tokio = { workspace = true, features = ["sync"] }
 tokio-stream = { workspace = true, features = ["sync"] }
 tower.workspace = true
 tracing.workspace = true
+tracing-futures = { workspace = true, features = ["futures-03"] }
 
 alloy-pubsub = { workspace = true, optional = true }
 alloy-transport-ws = { workspace = true, optional = true }

--- a/crates/rpc-client/src/poller.rs
+++ b/crates/rpc-client/src/poller.rs
@@ -148,7 +148,7 @@ where
         self
     }
 
-    /// Starts the poller in a new Tokio task, returning a channel to receive the responses on.
+    /// Starts the poller in a new task, returning a channel to receive the responses on.
     pub fn spawn(self) -> PollChannel<Resp> {
         let (tx, rx) = broadcast::channel(self.channel_size);
         let span = debug_span!("poller", method = %self.method);


### PR DESCRIPTION
Don't spawn poller in a task by default by using the stream! macro to yield responses instead.

Requirement for https://github.com/alloy-rs/alloy/issues/1318.

~~Unfortunately not spawning it means we lose the ".instrument" span attached to the spawned task future. I have not found a way to "instrument" a stream without writing a Stream utility ourselves.~~

Just decided to claude it.