### PR TITLE
fix(pubsub): wrap channel_size with Arc

### DIFF
--- a/crates/pubsub/src/frontend.rs
+++ b/crates/pubsub/src/frontend.rs
@@ -5,7 +5,7 @@ use alloy_transport::{TransportError, TransportErrorKind, TransportFut, Transpor
 use futures::{future::try_join_all, FutureExt, TryFutureExt};
 use std::{
     future::Future,
-    sync::atomic::{AtomicUsize, Ordering},
+    sync::{atomic::{AtomicUsize, Ordering}, Arc},
     task::{Context, Poll},
 };
 use tokio::sync::{mpsc, oneshot};
@@ -14,25 +14,18 @@ use tokio::sync::{mpsc, oneshot};
 /// PubSub service.
 ///
 /// [`Transport`]: alloy_transport::Transport
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct PubSubFrontend {
     tx: mpsc::UnboundedSender<PubSubInstruction>,
     /// The number of items to buffer in new subscription channels. Defaults to
     /// 16. See [`tokio::sync::broadcast::channel`] for a description.
-    channel_size: AtomicUsize,
-}
-
-impl Clone for PubSubFrontend {
-    fn clone(&self) -> Self {
-        let channel_size = self.channel_size.load(Ordering::Relaxed);
-        Self { tx: self.tx.clone(), channel_size: AtomicUsize::new(channel_size) }
-    }
+    channel_size: Arc<AtomicUsize>,
 }
 
 impl PubSubFrontend {
     /// Create a new frontend.
-    pub(crate) const fn new(tx: mpsc::UnboundedSender<PubSubInstruction>) -> Self {
-        Self { tx, channel_size: AtomicUsize::new(16) }
+    pub(crate) fn new(tx: mpsc::UnboundedSender<PubSubInstruction>) -> Self {
+        Self { tx, channel_size: Arc::new(AtomicUsize::new(16)) }
     }
 
     /// Get the subscription ID for a local ID.


### PR DESCRIPTION
## Motivation

When attempting to increase the PubsubFrontend channel size to accommodate higher throughput, the current handling of channel_size turns out to be inaccessible. This is because it is stored as an AtomicUsize, but is not stored with an Arc making it independent for each PubsubFrontend during cloning.

This poses an issue when initializing a PubsubFrontend using WsConnect:

```rust
let mut ws_config = WebSocketConfig::default();
ws_config.max_frame_size = None;
ws_config.max_message_size = None;
let mut ws = WsConnect::new(self.ws_url.clone()).with_config(ws_config);

let client = ClientBuilder::default().ws(ws).await?;
client.set_channel_size(self.pubsub_channel_size);

let provider: _WsProvider = ProviderBuilder::new().on_client(client);
```

During the ClientBuilder.ws() initialization of PubsubFrontend, it is cloned before being returned to the user to adjust the channel size. This means it is impossible to actually change the channel size, as the PubsubFrontend used to dispatch subscriptions is not the same object as the one returned by ClientBuilder::default().ws(ws).await.

## Solution

The solution is very simple, wrapping an Arc<> around the channel_size AtomicUint inside of PubsubFrontend. This low-impact change means that changes to channel sizes will be reflected across all PubsubFrontends used by the provider. Without this solution, is is difficult/impossible to easily adjust the channel size in this situation.