### PR TITLE
fix(signer-gcp): default public key format

### DIFF
--- a/crates/signer-gcp/src/signer.rs
+++ b/crates/signer-gcp/src/signer.rs
@@ -231,7 +231,11 @@ async fn request_get_pubkey(
     client: &Client,
     kms_key_name: &str,
 ) -> Result<PublicKey, GcpSignerError> {
-    let mut request = tonic::Request::new(GetPublicKeyRequest { name: kms_key_name.to_string() });
+    let mut request = tonic::Request::new(GetPublicKeyRequest {
+        name: kms_key_name.to_string(),
+        // When not specified, the default will be used.
+        public_key_format: Default::default(),
+    });
     request
         .metadata_mut()
         .insert("x-goog-request-params", format!("name={}", &kms_key_name).parse().unwrap());


### PR DESCRIPTION
## Motivation

https://github.com/abdolence/gcloud-sdk-rs/releases/tag/v0.26.4 has a breaking API change with a new field. See https://cloud.google.com/php/docs/reference/cloud-kms/latest/V1.GetPublicKeyRequest#_Google_Cloud_Kms_V1_GetPublicKeyRequest____construct__ for fields.

## Solution

Add default field value.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
