### PR TITLE
chore(`provider`): use `WeakClient` in `GetSubscription`

### DIFF
--- a/crates/provider/Cargo.toml
+++ b/crates/provider/Cargo.toml
@@ -98,7 +98,7 @@ ci_info.workspace = true
 similar-asserts.workspace = true
 
 [features]
-default = ["reqwest", "reqwest-default-tls"]
+default = ["reqwest", "reqwest-default-tls", "pubsub", "ws"]
 pubsub = ["alloy-rpc-client/pubsub", "dep:alloy-pubsub"]
 reqwest = [
     "dep:reqwest",

--- a/crates/provider/Cargo.toml
+++ b/crates/provider/Cargo.toml
@@ -98,7 +98,7 @@ ci_info.workspace = true
 similar-asserts.workspace = true
 
 [features]
-default = ["reqwest", "reqwest-default-tls", "pubsub", "ws"]
+default = ["reqwest", "reqwest-default-tls"]
 pubsub = ["alloy-rpc-client/pubsub", "dep:alloy-pubsub"]
 reqwest = [
     "dep:reqwest",

--- a/crates/provider/src/fillers/mod.rs
+++ b/crates/provider/src/fillers/mod.rs
@@ -611,25 +611,20 @@ where
     }
 
     #[cfg(feature = "pubsub")]
-    async fn subscribe_pending_transactions(
-        &self,
-    ) -> TransportResult<alloy_pubsub::Subscription<B256>> {
-        self.inner.subscribe_pending_transactions().await
+    fn subscribe_pending_transactions(&self) -> crate::GetSubscription<(String,), B256> {
+        self.inner.subscribe_pending_transactions()
     }
 
     #[cfg(feature = "pubsub")]
-    async fn subscribe_full_pending_transactions(
+    fn subscribe_full_pending_transactions(
         &self,
-    ) -> TransportResult<alloy_pubsub::Subscription<N::TransactionResponse>> {
-        self.inner.subscribe_full_pending_transactions().await
+    ) -> crate::GetSubscription<(String, bool), N::TransactionResponse> {
+        self.inner.subscribe_full_pending_transactions()
     }
 
     #[cfg(feature = "pubsub")]
-    async fn subscribe_logs(
-        &self,
-        filter: &Filter,
-    ) -> TransportResult<alloy_pubsub::Subscription<Log>> {
-        self.inner.subscribe_logs(filter).await
+    fn subscribe_logs(&self, filter: &Filter) -> crate::GetSubscription<(String, Filter), Log> {
+        self.inner.subscribe_logs(filter)
     }
 
     #[cfg(feature = "pubsub")]

--- a/crates/provider/src/fillers/mod.rs
+++ b/crates/provider/src/fillers/mod.rs
@@ -606,10 +606,8 @@ where
     }
 
     #[cfg(feature = "pubsub")]
-    async fn subscribe_blocks(
-        &self,
-    ) -> TransportResult<alloy_pubsub::Subscription<N::HeaderResponse>> {
-        self.inner.subscribe_blocks().await
+    fn subscribe_blocks(&self) -> crate::GetSubscription<(String,), N::HeaderResponse> {
+        self.inner.subscribe_blocks()
     }
 
     #[cfg(feature = "pubsub")]

--- a/crates/provider/src/fillers/mod.rs
+++ b/crates/provider/src/fillers/mod.rs
@@ -606,24 +606,24 @@ where
     }
 
     #[cfg(feature = "pubsub")]
-    fn subscribe_blocks(&self) -> crate::GetSubscription<(String,), N::HeaderResponse> {
+    fn subscribe_blocks(&self) -> crate::GetSubscription<N::HeaderResponse> {
         self.inner.subscribe_blocks()
     }
 
     #[cfg(feature = "pubsub")]
-    fn subscribe_pending_transactions(&self) -> crate::GetSubscription<(String,), B256> {
+    fn subscribe_pending_transactions(&self) -> crate::GetSubscription<B256> {
         self.inner.subscribe_pending_transactions()
     }
 
     #[cfg(feature = "pubsub")]
     fn subscribe_full_pending_transactions(
         &self,
-    ) -> crate::GetSubscription<(String, bool), N::TransactionResponse> {
+    ) -> crate::GetSubscription<N::TransactionResponse> {
         self.inner.subscribe_full_pending_transactions()
     }
 
     #[cfg(feature = "pubsub")]
-    fn subscribe_logs(&self, filter: &Filter) -> crate::GetSubscription<(String, Filter), Log> {
+    fn subscribe_logs(&self, filter: &Filter) -> crate::GetSubscription<Log> {
         self.inner.subscribe_logs(filter)
     }
 

--- a/crates/provider/src/fillers/mod.rs
+++ b/crates/provider/src/fillers/mod.rs
@@ -606,7 +606,7 @@ where
     }
 
     #[cfg(feature = "pubsub")]
-    fn subscribe_blocks(&self) -> crate::GetSubscription<(String,), N::HeaderResponse> {
+    fn subscribe_blocks(&self) -> crate::GetSubscription<(&'static str,), N::HeaderResponse> {
         self.inner.subscribe_blocks()
     }
 

--- a/crates/provider/src/fillers/mod.rs
+++ b/crates/provider/src/fillers/mod.rs
@@ -611,20 +611,25 @@ where
     }
 
     #[cfg(feature = "pubsub")]
-    fn subscribe_pending_transactions(&self) -> crate::GetSubscription<(String,), B256> {
-        self.inner.subscribe_pending_transactions()
-    }
-
-    #[cfg(feature = "pubsub")]
-    fn subscribe_full_pending_transactions(
+    async fn subscribe_pending_transactions(
         &self,
-    ) -> crate::GetSubscription<(String, bool), N::TransactionResponse> {
-        self.inner.subscribe_full_pending_transactions()
+    ) -> TransportResult<alloy_pubsub::Subscription<B256>> {
+        self.inner.subscribe_pending_transactions().await
     }
 
     #[cfg(feature = "pubsub")]
-    fn subscribe_logs(&self, filter: &Filter) -> crate::GetSubscription<(String, Filter), Log> {
-        self.inner.subscribe_logs(filter)
+    async fn subscribe_full_pending_transactions(
+        &self,
+    ) -> TransportResult<alloy_pubsub::Subscription<N::TransactionResponse>> {
+        self.inner.subscribe_full_pending_transactions().await
+    }
+
+    #[cfg(feature = "pubsub")]
+    async fn subscribe_logs(
+        &self,
+        filter: &Filter,
+    ) -> TransportResult<alloy_pubsub::Subscription<Log>> {
+        self.inner.subscribe_logs(filter).await
     }
 
     #[cfg(feature = "pubsub")]

--- a/crates/provider/src/fillers/mod.rs
+++ b/crates/provider/src/fillers/mod.rs
@@ -606,24 +606,24 @@ where
     }
 
     #[cfg(feature = "pubsub")]
-    fn subscribe_blocks(&self) -> crate::GetSubscription<N::HeaderResponse> {
+    fn subscribe_blocks(&self) -> crate::GetSubscription<(String,), N::HeaderResponse> {
         self.inner.subscribe_blocks()
     }
 
     #[cfg(feature = "pubsub")]
-    fn subscribe_pending_transactions(&self) -> crate::GetSubscription<B256> {
+    fn subscribe_pending_transactions(&self) -> crate::GetSubscription<(String,), B256> {
         self.inner.subscribe_pending_transactions()
     }
 
     #[cfg(feature = "pubsub")]
     fn subscribe_full_pending_transactions(
         &self,
-    ) -> crate::GetSubscription<N::TransactionResponse> {
+    ) -> crate::GetSubscription<(String, bool), N::TransactionResponse> {
         self.inner.subscribe_full_pending_transactions()
     }
 
     #[cfg(feature = "pubsub")]
-    fn subscribe_logs(&self, filter: &Filter) -> crate::GetSubscription<Log> {
+    fn subscribe_logs(&self, filter: &Filter) -> crate::GetSubscription<(String, Filter), Log> {
         self.inner.subscribe_logs(filter)
     }
 

--- a/crates/provider/src/layers/batch.rs
+++ b/crates/provider/src/layers/batch.rs
@@ -449,7 +449,7 @@ impl<N: Network> Caller<N, Bytes> for CallBatchCaller {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{ext::AnvilApi, ProviderBuilder};
+    use crate::ProviderBuilder;
     use alloy_primitives::{address, hex};
     use alloy_rpc_types_eth::TransactionRequest;
     use alloy_transport::mock::Asserter;
@@ -500,7 +500,9 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(feature = "anvil-api")]
     async fn basic() {
+        use crate::ext::AnvilApi;
         let provider = ProviderBuilder::new().with_call_batching().on_anvil();
         provider.anvil_set_code(COUNTER_ADDRESS, COUNTER_DEPLOYED_CODE.into()).await.unwrap();
         provider.anvil_set_balance(COUNTER_ADDRESS, U256::from(123)).await.unwrap();

--- a/crates/provider/src/provider/erased.rs
+++ b/crates/provider/src/provider/erased.rs
@@ -350,7 +350,7 @@ impl<N: Network> Provider<N> for DynProvider<N> {
     }
 
     #[cfg(feature = "pubsub")]
-    fn subscribe_blocks(&self) -> crate::GetSubscription<(String,), N::HeaderResponse> {
+    fn subscribe_blocks(&self) -> crate::GetSubscription<(&'static str,), N::HeaderResponse> {
         self.0.subscribe_blocks()
     }
 

--- a/crates/provider/src/provider/erased.rs
+++ b/crates/provider/src/provider/erased.rs
@@ -355,20 +355,25 @@ impl<N: Network> Provider<N> for DynProvider<N> {
     }
 
     #[cfg(feature = "pubsub")]
-    fn subscribe_pending_transactions(&self) -> crate::GetSubscription<(String,), B256> {
-        self.0.subscribe_pending_transactions()
-    }
-
-    #[cfg(feature = "pubsub")]
-    fn subscribe_full_pending_transactions(
+    async fn subscribe_pending_transactions(
         &self,
-    ) -> crate::GetSubscription<(String, bool), N::TransactionResponse> {
-        self.0.subscribe_full_pending_transactions()
+    ) -> TransportResult<alloy_pubsub::Subscription<B256>> {
+        self.0.subscribe_pending_transactions().await
     }
 
     #[cfg(feature = "pubsub")]
-    fn subscribe_logs(&self, filter: &Filter) -> crate::GetSubscription<(String, Filter), Log> {
-        self.0.subscribe_logs(filter)
+    async fn subscribe_full_pending_transactions(
+        &self,
+    ) -> TransportResult<alloy_pubsub::Subscription<N::TransactionResponse>> {
+        self.0.subscribe_full_pending_transactions().await
+    }
+
+    #[cfg(feature = "pubsub")]
+    async fn subscribe_logs(
+        &self,
+        filter: &Filter,
+    ) -> TransportResult<alloy_pubsub::Subscription<Log>> {
+        self.0.subscribe_logs(filter).await
     }
 
     #[cfg(feature = "pubsub")]

--- a/crates/provider/src/provider/erased.rs
+++ b/crates/provider/src/provider/erased.rs
@@ -355,25 +355,20 @@ impl<N: Network> Provider<N> for DynProvider<N> {
     }
 
     #[cfg(feature = "pubsub")]
-    async fn subscribe_pending_transactions(
-        &self,
-    ) -> TransportResult<alloy_pubsub::Subscription<B256>> {
-        self.0.subscribe_pending_transactions().await
+    fn subscribe_pending_transactions(&self) -> crate::GetSubscription<(String,), B256> {
+        self.0.subscribe_pending_transactions()
     }
 
     #[cfg(feature = "pubsub")]
-    async fn subscribe_full_pending_transactions(
+    fn subscribe_full_pending_transactions(
         &self,
-    ) -> TransportResult<alloy_pubsub::Subscription<N::TransactionResponse>> {
-        self.0.subscribe_full_pending_transactions().await
+    ) -> crate::GetSubscription<(String, bool), N::TransactionResponse> {
+        self.0.subscribe_full_pending_transactions()
     }
 
     #[cfg(feature = "pubsub")]
-    async fn subscribe_logs(
-        &self,
-        filter: &Filter,
-    ) -> TransportResult<alloy_pubsub::Subscription<Log>> {
-        self.0.subscribe_logs(filter).await
+    fn subscribe_logs(&self, filter: &Filter) -> crate::GetSubscription<(String, Filter), Log> {
+        self.0.subscribe_logs(filter)
     }
 
     #[cfg(feature = "pubsub")]

--- a/crates/provider/src/provider/erased.rs
+++ b/crates/provider/src/provider/erased.rs
@@ -350,24 +350,24 @@ impl<N: Network> Provider<N> for DynProvider<N> {
     }
 
     #[cfg(feature = "pubsub")]
-    fn subscribe_blocks(&self) -> crate::GetSubscription<(String,), N::HeaderResponse> {
+    fn subscribe_blocks(&self) -> crate::GetSubscription<N::HeaderResponse> {
         self.0.subscribe_blocks()
     }
 
     #[cfg(feature = "pubsub")]
-    fn subscribe_pending_transactions(&self) -> crate::GetSubscription<(String,), B256> {
+    fn subscribe_pending_transactions(&self) -> crate::GetSubscription<B256> {
         self.0.subscribe_pending_transactions()
     }
 
     #[cfg(feature = "pubsub")]
     fn subscribe_full_pending_transactions(
         &self,
-    ) -> crate::GetSubscription<(String, bool), N::TransactionResponse> {
+    ) -> crate::GetSubscription<N::TransactionResponse> {
         self.0.subscribe_full_pending_transactions()
     }
 
     #[cfg(feature = "pubsub")]
-    fn subscribe_logs(&self, filter: &Filter) -> crate::GetSubscription<(String, Filter), Log> {
+    fn subscribe_logs(&self, filter: &Filter) -> crate::GetSubscription<Log> {
         self.0.subscribe_logs(filter)
     }
 

--- a/crates/provider/src/provider/erased.rs
+++ b/crates/provider/src/provider/erased.rs
@@ -350,10 +350,8 @@ impl<N: Network> Provider<N> for DynProvider<N> {
     }
 
     #[cfg(feature = "pubsub")]
-    async fn subscribe_blocks(
-        &self,
-    ) -> TransportResult<alloy_pubsub::Subscription<N::HeaderResponse>> {
-        self.0.subscribe_blocks().await
+    fn subscribe_blocks(&self) -> crate::GetSubscription<(String,), N::HeaderResponse> {
+        self.0.subscribe_blocks()
     }
 
     #[cfg(feature = "pubsub")]

--- a/crates/provider/src/provider/erased.rs
+++ b/crates/provider/src/provider/erased.rs
@@ -350,24 +350,24 @@ impl<N: Network> Provider<N> for DynProvider<N> {
     }
 
     #[cfg(feature = "pubsub")]
-    fn subscribe_blocks(&self) -> crate::GetSubscription<N::HeaderResponse> {
+    fn subscribe_blocks(&self) -> crate::GetSubscription<(String,), N::HeaderResponse> {
         self.0.subscribe_blocks()
     }
 
     #[cfg(feature = "pubsub")]
-    fn subscribe_pending_transactions(&self) -> crate::GetSubscription<B256> {
+    fn subscribe_pending_transactions(&self) -> crate::GetSubscription<(String,), B256> {
         self.0.subscribe_pending_transactions()
     }
 
     #[cfg(feature = "pubsub")]
     fn subscribe_full_pending_transactions(
         &self,
-    ) -> crate::GetSubscription<N::TransactionResponse> {
+    ) -> crate::GetSubscription<(String, bool), N::TransactionResponse> {
         self.0.subscribe_full_pending_transactions()
     }
 
     #[cfg(feature = "pubsub")]
-    fn subscribe_logs(&self, filter: &Filter) -> crate::GetSubscription<Log> {
+    fn subscribe_logs(&self, filter: &Filter) -> crate::GetSubscription<(String, Filter), Log> {
         self.0.subscribe_logs(filter)
     }
 

--- a/crates/provider/src/provider/mod.rs
+++ b/crates/provider/src/provider/mod.rs
@@ -28,5 +28,7 @@ pub use multicall::*;
 mod erased;
 pub use erased::DynProvider;
 
+#[cfg(feature = "pubsub")]
 mod subscription;
+#[cfg(feature = "pubsub")]
 pub use subscription::GetSubscription;

--- a/crates/provider/src/provider/subscription.rs
+++ b/crates/provider/src/provider/subscription.rs
@@ -59,8 +59,10 @@ where
 
     fn into_future(self) -> Self::IntoFuture {
         Box::pin(async move {
-            let client =
-                self.client.upgrade().ok_or(TransportErrorKind::custom_str("client dropped"))?;
+            let client = self
+                .client
+                .upgrade()
+                .ok_or_else(|| TransportErrorKind::custom_str("client dropped"))?;
             let pubsub = client.pubsub_frontend().ok_or(TransportErrorKind::PubsubUnavailable)?;
 
             // Set config channel size if any

--- a/crates/provider/src/provider/subscription.rs
+++ b/crates/provider/src/provider/subscription.rs
@@ -11,6 +11,10 @@ use alloy_transport::{TransportErrorKind, TransportResult};
 ///
 /// This struct allows configuring subscription parameters and channel size
 /// before initiating a request to subscribe to Ethereum events.
+///
+/// By default, this sets the [`SubscriptionKind`] to [`SubscriptionKind::NewHeads`] and params to
+/// [`Params::None`]. These can be altered using the [`GetSubscription::kind`] and
+/// [`GetSubscription::params`] methods.
 pub struct GetSubscription<R>
 where
     R: RpcRecv,

--- a/crates/provider/src/provider/subscription.rs
+++ b/crates/provider/src/provider/subscription.rs
@@ -27,28 +27,49 @@ where
     R: RpcRecv,
 {
     /// Creates a new [`GetSubscription`] instance
-    pub fn new(client: WeakClient, kind: SubscriptionKind, params: Params) -> Self {
-        Self { client, kind, params, channel_size: None, _marker: std::marker::PhantomData }
+    ///
+    /// By default, this sets the [`SubscriptionKind`] to [`SubscriptionKind::NewHeads`] and params
+    /// to [`Params::None`].
+    pub fn new(client: WeakClient) -> Self {
+        Self {
+            client,
+            kind: SubscriptionKind::NewHeads,
+            params: Params::None,
+            channel_size: None,
+            _marker: std::marker::PhantomData,
+        }
+    }
+
+    /// Set the [`SubscriptionKind`]
+    pub fn kind(mut self, kind: SubscriptionKind) -> Self {
+        self.kind = kind;
+        self
+    }
+
+    /// Set the params for the subscription
+    pub fn params(mut self, params: Params) -> Self {
+        self.params = params;
+        self
     }
 
     /// Create a [`SubscriptionKind::NewHeads`] subscription
     pub fn new_heads(client: WeakClient) -> Self {
-        Self::new(client, SubscriptionKind::NewHeads, Params::None)
+        Self::new(client).kind(SubscriptionKind::NewHeads)
     }
 
     /// Create a [`SubscriptionKind::Logs`] subscription
     pub fn logs(client: WeakClient, filter: Filter) -> Self {
-        Self::new(client, SubscriptionKind::Logs, Params::Logs(Box::new(filter)))
+        Self::new(client).kind(SubscriptionKind::Logs).params(Params::Logs(Box::new(filter)))
     }
 
     /// Create a [`SubscriptionKind::Syncing`] subscription
     pub fn syncing(client: WeakClient) -> Self {
-        Self::new(client, SubscriptionKind::Syncing, Params::None)
+        Self::new(client).kind(SubscriptionKind::Syncing)
     }
 
     /// Create a [`SubscriptionKind::NewPendingTransactions`] subscription
     pub fn new_pending_transactions(client: WeakClient) -> Self {
-        Self::new(client, SubscriptionKind::NewPendingTransactions, Params::Bool(false))
+        Self::new(client).kind(SubscriptionKind::NewPendingTransactions).params(Params::Bool(false))
     }
 
     /// Set the channel_size for the subscription stream.

--- a/crates/provider/src/provider/subscription.rs
+++ b/crates/provider/src/provider/subscription.rs
@@ -3,7 +3,6 @@ use alloy_primitives::B256;
 use alloy_pubsub::Subscription;
 use alloy_rpc_client::{RpcCall, WeakClient};
 use alloy_transport::{TransportErrorKind, TransportResult};
-use std::{future::Future, pin::Pin};
 
 /// A general-purpose subscription request builder
 ///
@@ -56,7 +55,7 @@ where
     R: RpcRecv,
 {
     type Output = TransportResult<alloy_pubsub::Subscription<R>>;
-    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send>>;
+    type IntoFuture = futures_utils_wasm::BoxFuture<'static, Self::Output>;
 
     fn into_future(self) -> Self::IntoFuture {
         Box::pin(async move {

--- a/crates/provider/src/provider/subscription.rs
+++ b/crates/provider/src/provider/subscription.rs
@@ -7,7 +7,7 @@ use alloy_rpc_types_eth::{
 };
 use alloy_transport::{TransportErrorKind, TransportResult};
 
-/// A build for `"eth_subscribe"`  requests.
+/// A builder for `"eth_subscribe"`  requests.
 ///
 /// This struct allows configuring subscription parameters and channel size
 /// before initiating a request to subscribe to Ethereum events.

--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -1044,15 +1044,15 @@ pub trait Provider<N: Network = Ethereum>: Send + Sync {
     /// Subscribe to an `"eth_subscribe"` RPC event.
     #[cfg(feature = "pubsub")]
     #[auto_impl(keep_default_for(&, &mut, Rc, Arc, Box))]
-    async fn subscribe<P, R>(&self, params: P) -> TransportResult<alloy_pubsub::Subscription<R>>
+    fn subscribe<R>(
+        &self,
+        kind: alloy_rpc_types_eth::pubsub::SubscriptionKind,
+    ) -> GetSubscription<R>
     where
-        P: RpcSend,
         R: RpcRecv,
         Self: Sized,
     {
-        self.root().pubsub_frontend()?;
-        let id = self.client().request("eth_subscribe", params).await?;
-        self.root().get_subscription(id).await
+        GetSubscription::new(self.weak_client()).kind(kind)
     }
 
     /// Cancels a subscription given the subscription ID.

--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -937,9 +937,8 @@ pub trait Provider<N: Network = Ethereum>: Send + Sync {
     /// # }
     /// ```
     #[cfg(feature = "pubsub")]
-    fn subscribe_blocks(&self) -> GetSubscription<(String,), N::HeaderResponse> {
-        let rpc_call = self.client().request("eth_subscribe", ("newHeads".to_string(),));
-        GetSubscription::new(self.weak_client(), rpc_call)
+    fn subscribe_blocks(&self) -> GetSubscription<N::HeaderResponse> {
+        GetSubscription::new_heads(self.weak_client())
     }
 
     /// Subscribe to a stream of pending transaction hashes.
@@ -968,10 +967,8 @@ pub trait Provider<N: Network = Ethereum>: Send + Sync {
     /// # }
     /// ```
     #[cfg(feature = "pubsub")]
-    fn subscribe_pending_transactions(&self) -> GetSubscription<(String,), B256> {
-        let rpc_call =
-            self.client().request("eth_subscribe", ("newPendingTransactions".to_string(),));
-        GetSubscription::new(self.weak_client(), rpc_call)
+    fn subscribe_pending_transactions(&self) -> GetSubscription<B256> {
+        GetSubscription::new_pending_transactions(self.weak_client())
     }
 
     /// Subscribe to a stream of pending transaction bodies.
@@ -1005,12 +1002,8 @@ pub trait Provider<N: Network = Ethereum>: Send + Sync {
     /// # }
     /// ```
     #[cfg(feature = "pubsub")]
-    fn subscribe_full_pending_transactions(
-        &self,
-    ) -> GetSubscription<(String, bool), N::TransactionResponse> {
-        let rpc_call =
-            self.client().request("eth_subscribe", ("newPendingTransactions".to_string(), true));
-        GetSubscription::new(self.weak_client(), rpc_call)
+    fn subscribe_full_pending_transactions(&self) -> GetSubscription<N::TransactionResponse> {
+        GetSubscription::new_pending_transactions(self.weak_client()).full_pending_txs(true)
     }
 
     /// Subscribe to a stream of logs matching given filter.
@@ -1044,22 +1037,22 @@ pub trait Provider<N: Network = Ethereum>: Send + Sync {
     /// # }
     /// ```
     #[cfg(feature = "pubsub")]
-    fn subscribe_logs(&self, filter: &Filter) -> GetSubscription<(String, Filter), Log> {
-        let rpc_call = self.client().request("eth_subscribe", ("logs".to_string(), filter.clone()));
-        GetSubscription::new(self.weak_client(), rpc_call)
+    fn subscribe_logs(&self, filter: &Filter) -> GetSubscription<Log> {
+        GetSubscription::logs(self.weak_client(), filter.clone())
     }
 
-    /// Subscribe to an RPC event.
+    /// Subscribe to an `"eth_subscribe"` RPC event.
     #[cfg(feature = "pubsub")]
     #[auto_impl(keep_default_for(&, &mut, Rc, Arc, Box))]
-    fn subscribe<P, R>(&self, params: P) -> GetSubscription<P, R>
+    async fn subscribe<P, R>(&self, params: P) -> TransportResult<alloy_pubsub::Subscription<R>>
     where
         P: RpcSend,
         R: RpcRecv,
         Self: Sized,
     {
-        let rpc_call = self.client().request("eth_subscribe", params);
-        GetSubscription::new(self.weak_client(), rpc_call)
+        self.root().pubsub_frontend()?;
+        let id = self.client().request("eth_subscribe", params).await?;
+        self.root().get_subscription(id).await
     }
 
     /// Cancels a subscription given the subscription ID.

--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -937,8 +937,8 @@ pub trait Provider<N: Network = Ethereum>: Send + Sync {
     /// # }
     /// ```
     #[cfg(feature = "pubsub")]
-    fn subscribe_blocks(&self) -> GetSubscription<(String,), N::HeaderResponse> {
-        let rpc_call = self.client().request("eth_subscribe", ("newHeads".to_string(),));
+    fn subscribe_blocks(&self) -> GetSubscription<(&'static str,), N::HeaderResponse> {
+        let rpc_call = self.client().request("eth_subscribe", ("newHeads",));
         GetSubscription::new(self.weak_client(), rpc_call)
     }
 

--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -968,12 +968,10 @@ pub trait Provider<N: Network = Ethereum>: Send + Sync {
     /// # }
     /// ```
     #[cfg(feature = "pubsub")]
-    async fn subscribe_pending_transactions(
-        &self,
-    ) -> TransportResult<alloy_pubsub::Subscription<B256>> {
-        self.root().pubsub_frontend()?;
-        let id = self.client().request("eth_subscribe", ("newPendingTransactions",)).await?;
-        self.root().get_subscription(id).await
+    fn subscribe_pending_transactions(&self) -> GetSubscription<(String,), B256> {
+        let rpc_call =
+            self.client().request("eth_subscribe", ("newPendingTransactions".to_string(),));
+        GetSubscription::new(self.weak_client(), rpc_call)
     }
 
     /// Subscribe to a stream of pending transaction bodies.
@@ -1007,12 +1005,12 @@ pub trait Provider<N: Network = Ethereum>: Send + Sync {
     /// # }
     /// ```
     #[cfg(feature = "pubsub")]
-    async fn subscribe_full_pending_transactions(
+    fn subscribe_full_pending_transactions(
         &self,
-    ) -> TransportResult<alloy_pubsub::Subscription<N::TransactionResponse>> {
-        self.root().pubsub_frontend()?;
-        let id = self.client().request("eth_subscribe", ("newPendingTransactions", true)).await?;
-        self.root().get_subscription(id).await
+    ) -> GetSubscription<(String, bool), N::TransactionResponse> {
+        let rpc_call =
+            self.client().request("eth_subscribe", ("newPendingTransactions".to_string(), true));
+        GetSubscription::new(self.weak_client(), rpc_call)
     }
 
     /// Subscribe to a stream of logs matching given filter.
@@ -1046,27 +1044,22 @@ pub trait Provider<N: Network = Ethereum>: Send + Sync {
     /// # }
     /// ```
     #[cfg(feature = "pubsub")]
-    async fn subscribe_logs(
-        &self,
-        filter: &Filter,
-    ) -> TransportResult<alloy_pubsub::Subscription<Log>> {
-        self.root().pubsub_frontend()?;
-        let id = self.client().request("eth_subscribe", ("logs", filter)).await?;
-        self.root().get_subscription(id).await
+    fn subscribe_logs(&self, filter: &Filter) -> GetSubscription<(String, Filter), Log> {
+        let rpc_call = self.client().request("eth_subscribe", ("logs".to_string(), filter.clone()));
+        GetSubscription::new(self.weak_client(), rpc_call)
     }
 
     /// Subscribe to an RPC event.
     #[cfg(feature = "pubsub")]
     #[auto_impl(keep_default_for(&, &mut, Rc, Arc, Box))]
-    async fn subscribe<P, R>(&self, params: P) -> TransportResult<alloy_pubsub::Subscription<R>>
+    fn subscribe<P, R>(&self, params: P) -> GetSubscription<P, R>
     where
         P: RpcSend,
         R: RpcRecv,
         Self: Sized,
     {
-        self.root().pubsub_frontend()?;
-        let id = self.client().request("eth_subscribe", params).await?;
-        self.root().get_subscription(id).await
+        let rpc_call = self.client().request("eth_subscribe", params);
+        GetSubscription::new(self.weak_client(), rpc_call)
     }
 
     /// Cancels a subscription given the subscription ID.

--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -3,6 +3,8 @@
 #![allow(unknown_lints, elided_named_lifetimes)]
 
 use super::{DynProvider, Empty, EthCallMany, MulticallBuilder};
+#[cfg(feature = "pubsub")]
+use crate::GetSubscription;
 use crate::{
     heart::PendingTransactionError,
     utils::{self, Eip1559Estimation, Eip1559Estimator},
@@ -935,12 +937,9 @@ pub trait Provider<N: Network = Ethereum>: Send + Sync {
     /// # }
     /// ```
     #[cfg(feature = "pubsub")]
-    async fn subscribe_blocks(
-        &self,
-    ) -> TransportResult<alloy_pubsub::Subscription<N::HeaderResponse>> {
-        self.root().pubsub_frontend()?;
-        let id = self.client().request("eth_subscribe", ("newHeads",)).await?;
-        self.root().get_subscription(id).await
+    fn subscribe_blocks(&self) -> GetSubscription<(String,), N::HeaderResponse> {
+        let rpc_call = self.client().request("eth_subscribe", ("newHeads".to_string(),));
+        GetSubscription::new(self.weak_client(), rpc_call)
     }
 
     /// Subscribe to a stream of pending transaction hashes.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

The `GetSubscription` future type was introduced in https://github.com/alloy-rs/alloy/pull/2203
Remove it's reliance on `N: Network` by using `WeakClient`

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

- Remove `N: Network` generic from `GetSubscription` by using `WeakClient`

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
