### PR TITLE
feat: add EIP1186AccountProofResponse::is_empty

### DIFF
--- a/crates/rpc-types-eth/src/account.rs
+++ b/crates/rpc-types-eth/src/account.rs
@@ -4,7 +4,6 @@ use alloc::{string::String, vec::Vec};
 use alloy_primitives::{Address, Bytes, B256, B512, U256};
 
 // re-export account type for `eth_getAccount`
-use alloy_consensus::constants::KECCAK_EMPTY;
 pub use alloy_consensus::Account;
 
 /// Account information.
@@ -64,14 +63,15 @@ pub struct EIP1186AccountProofResponse {
     pub storage_proof: Vec<EIP1186StorageProof>,
 }
 
+#[cfg(feature = "serde")]
 impl EIP1186AccountProofResponse {
     /// After `SpuriousDragon` empty account is defined as account with nonce == 0 && balance == 0
-    /// && bytecode = None (or hash is [`KECCAK_EMPTY`]).
+    /// && bytecode = None (or hash is [`KECCAK_EMPTY`](alloy_consensus::constants::KECCAK_EMPTY)).
     pub fn is_empty(&self) -> bool {
         self.nonce == 0
             && self.balance.is_zero()
             && self.storage_hash.is_zero()
-            && self.code_hash == KECCAK_EMPTY
+            && self.code_hash == alloy_consensus::constants::KECCAK_EMPTY
     }
 }
 

--- a/crates/rpc-types-eth/src/account.rs
+++ b/crates/rpc-types-eth/src/account.rs
@@ -4,6 +4,7 @@ use alloc::{string::String, vec::Vec};
 use alloy_primitives::{Address, Bytes, B256, B512, U256};
 
 // re-export account type for `eth_getAccount`
+use alloy_consensus::constants::KECCAK_EMPTY;
 pub use alloy_consensus::Account;
 
 /// Account information.
@@ -61,6 +62,17 @@ pub struct EIP1186AccountProofResponse {
     pub account_proof: Vec<Bytes>,
     /// The storage proof.
     pub storage_proof: Vec<EIP1186StorageProof>,
+}
+
+impl EIP1186AccountProofResponse {
+    /// After `SpuriousDragon` empty account is defined as account with nonce == 0 && balance == 0
+    /// && bytecode = None (or hash is [`KECCAK_EMPTY`]).
+    pub fn is_empty(&self) -> bool {
+        self.nonce == 0
+            && self.balance.is_zero()
+            && self.storage_hash.is_zero()
+            && self.code_hash == KECCAK_EMPTY
+    }
 }
 
 /// Extended account information (used by `parity_allAccountInfo`).


### PR DESCRIPTION
adds helper, ported from regular account type
