### PR TITLE
chore: propagate arbitrary feature

### DIFF
--- a/.config/zepter.yaml
+++ b/.config/zepter.yaml
@@ -12,7 +12,7 @@ workflows:
         # Check that `A` activates the features of `B`.
         "propagate-feature",
         # These are the features to check:
-        "--features=std,serde,ssz",
+        "--features=arbitrary,std,serde,ssz",
         # Do not try to add a new section into `[features]` of `A` only because `B` expose that feature. There are edge-cases where this is still needed, but we can add them manually.
         "--left-side-feature-missing=ignore",
         # Ignore the case that `A` it outside of the workspace. Otherwise it will report errors in external dependencies that we have no influence on.

--- a/crates/alloy/Cargo.toml
+++ b/crates/alloy/Cargo.toml
@@ -306,9 +306,10 @@ eip712 = [
 ]
 
 arbitrary = [
-    "alloy-core/arbitrary",
-    "alloy-consensus?/arbitrary",
-    "alloy-eips?/arbitrary",
-    "alloy-rpc-types?/arbitrary",
+	"alloy-core/arbitrary",
+	"alloy-consensus?/arbitrary",
+	"alloy-eips?/arbitrary",
+	"alloy-rpc-types?/arbitrary",
+	"alloy-serde?/arbitrary"
 ]
 postgres = ["alloy-core/postgres"]

--- a/crates/consensus-any/Cargo.toml
+++ b/crates/consensus-any/Cargo.toml
@@ -48,7 +48,14 @@ std = [
 	"alloy-rlp/std",
 	"serde?/std"
 ]
-arbitrary = ["std", "dep:arbitrary", "alloy-eips/arbitrary"]
+arbitrary = [
+	"std",
+	"dep:arbitrary",
+	"alloy-eips/arbitrary",
+	"alloy-consensus/arbitrary",
+	"alloy-primitives/arbitrary",
+	"alloy-serde?/arbitrary"
+]
 serde = [
 	"dep:serde",
 	"alloy-primitives/serde",

--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -86,7 +86,15 @@ std = [
 ]
 k256 = ["dep:k256", "alloy-primitives/k256", "alloy-eips/k256"]
 kzg = ["dep:c-kzg", "alloy-eips/kzg", "std"]
-arbitrary = ["std", "dep:rand", "dep:arbitrary", "alloy-eips/arbitrary"]
+arbitrary = [
+	"std",
+	"dep:rand",
+	"dep:arbitrary",
+	"alloy-eips/arbitrary",
+	"alloy-primitives/arbitrary",
+	"alloy-serde?/arbitrary",
+	"alloy-trie/arbitrary"
+]
 serde = [
 	"dep:serde",
 	"alloy-primitives/serde",

--- a/crates/rpc-types-eth/Cargo.toml
+++ b/crates/rpc-types-eth/Cargo.toml
@@ -86,11 +86,14 @@ serde = [
 	"rand/serde",
 ]
 arbitrary = [
-    "std",
-    "dep:arbitrary",
-    "alloy-primitives/arbitrary",
-    "alloy-serde?/arbitrary",
-    "alloy-eips/arbitrary",
+	"std",
+	"dep:arbitrary",
+	"alloy-consensus/arbitrary",
+	"alloy-primitives/arbitrary",
+	"alloy-serde?/arbitrary",
+	"alloy-eips/arbitrary",
+	"alloy-consensus-any/arbitrary",
+	"alloy-sol-types/arbitrary"
 ]
 jsonrpsee-types = ["dep:jsonrpsee-types"]
 k256 = ["alloy-consensus/k256", "alloy-eips/k256"]

--- a/crates/rpc-types/Cargo.toml
+++ b/crates/rpc-types/Cargo.toml
@@ -60,7 +60,11 @@ mev = ["dep:alloy-rpc-types-mev"]
 trace = ["dep:alloy-rpc-types-trace"]
 txpool = ["dep:alloy-rpc-types-txpool"]
 
-arbitrary = ["alloy-rpc-types-eth?/arbitrary", "alloy-serde/arbitrary"]
+arbitrary = [
+	"alloy-rpc-types-eth?/arbitrary",
+	"alloy-serde/arbitrary",
+	"alloy-primitives/arbitrary"
+]
 jsonrpsee-types = [
     "alloy-rpc-types-eth?/jsonrpsee-types",
     "alloy-rpc-types-engine?/jsonrpsee-types",


### PR DESCRIPTION
Found when running cargo-semver-checks, which fails to build alloy-rpc-types-eth because of a missing propagation