### PR TITLE
test: fix inference fail in test

### DIFF
--- a/crates/contract/src/call.rs
+++ b/crates/contract/src/call.rs
@@ -835,14 +835,14 @@ mod tests {
             .expect("tx not included");
         assert_eq!(
             transaction.max_fee_per_gas(),
-            max_fee_per_gas.to(),
+            max_fee_per_gas.to::<u128>(),
             "max_fee_per_gas of the transaction should be set to the right value"
         );
         assert_eq!(
             transaction
                 .max_priority_fee_per_gas()
                 .expect("max_priority_fee_per_gas of the transaction should be set"),
-            max_priority_fee_per_gas.to(),
+            max_priority_fee_per_gas.to::<u128>(),
             "max_priority_fee_per_gas of the transaction should be set to the right value"
         )
     }


### PR DESCRIPTION
```rust
error[E0283]: type annotations needed
   --> crates/contract/src/call.rs:838:29
    |
838 |             max_fee_per_gas.to(),
    |                             ^^ cannot infer type of the type parameter `T` declared on the method `to`
    |
    = note: multiple `impl`s satisfying `alloy_primitives::Uint<256, 4>: alloy_primitives::ruint::UintTryTo<_>` found in the `ruint` crate:
            - impl<BITS, LIMBS, BITS_DST, LIMBS_DST> alloy_primitives::ruint::UintTryTo<alloy_primitives::Uint<BITS_DST, LIMBS_DST>> for alloy_primitives::Uint<BITS, LIMBS>
              where the constant `BITS` has type `usize`, the constant `LIMBS` has type `usize`, the constant `BITS_DST` has type `usize`, the constant `LIMBS_DST` has type `usize`;
            - impl<BITS, LIMBS, T> alloy_primitives::ruint::UintTryTo<T> for alloy_primitives::Uint<BITS, LIMBS>
              where for<'a> <T as std::convert::TryFrom<&'a alloy_primitives::Uint<BITS, LIMBS>>>::Error == alloy_primitives::ruint::FromUintError<T>, the constant `LIMBS` has type `usize`, for<'a> T: std::convert::TryFrom<&'a alloy_primitives::Uint<BITS, LIMBS>>, the constant `BITS` has type `usize`;
note: required by a bound in `alloy_primitives::ruint::from::<impl alloy_primitives::Uint<BITS, LIMBS>>::to`
   --> ~/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/ruint-1.13.1/src/from.rs:233:15
    |
231 |     pub fn to<T>(&self) -> T
    |            -- required by a bound in this associated function
232 |     where
233 |         Self: UintTryTo<T>,
    |               ^^^^^^^^^^^^ required by this bound in `alloy_primitives::ruint::from::<impl Uint<BITS, LIMBS>>::to`
help: consider specifying the generic argument
    |
838 |             max_fee_per_gas.to::<T>(),
    |                               +++++
```