### PR TITLE
chore(ci): bump reth and geth to latest

### DIFF
--- a/.github/scripts/install_test_binaries.sh
+++ b/.github/scripts/install_test_binaries.sh
@@ -3,8 +3,8 @@
 # Note: intended for use only with CI (x86_64 Ubuntu, MacOS or Windows)
 set -e
 
-GETH_BUILD=${GETH_BUILD:-"1.14.8-a9523b64"}
-RETH_BUILD=${RETH_BUILD:-"1.0.6"}
+GETH_BUILD=${GETH_BUILD:-"1.15.5-4263936a"}
+RETH_BUILD=${RETH_BUILD:-"1.3.4"}
 
 BIN_DIR=${BIN_DIR:-"$HOME/bin"}
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Reth and geth in ci are using old versions.


<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Bump to latest releases.

This would fix [ci issues](https://github.com/alloy-rs/alloy/actions/runs/14035858744/job/39293599628?pr=2236) in #2236 

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
