### PR TITLE
feat: eip7594 constants

### DIFF
--- a/crates/eips/src/eip7594.rs
+++ b/crates/eips/src/eip7594.rs
@@ -1,0 +1,14 @@
+//! Constants for PeerDAS.
+//!
+//! See also [EIP-7594](https://eips.ethereum.org/EIPS/eip-7594): PeerDAS - Peer Data Availability Sampling
+
+use crate::eip4844::FIELD_ELEMENTS_PER_BLOB;
+
+/// Number of field elements in a Reed-Solomon extended blob.
+pub const FIELD_ELEMENTS_PER_EXT_BLOB: u64 = FIELD_ELEMENTS_PER_BLOB * 2;
+
+/// Number of field elements in a cell.
+pub const FIELD_ELEMENTS_PER_CELL: u64 = 64;
+
+/// The number of cells in an extended blob.
+pub const CELLS_PER_EXT_BLOB: u64 = FIELD_ELEMENTS_PER_EXT_BLOB / FIELD_ELEMENTS_PER_CELL;

--- a/crates/eips/src/lib.rs
+++ b/crates/eips/src/lib.rs
@@ -42,6 +42,8 @@ pub mod eip7002;
 
 pub mod eip7251;
 
+pub mod eip7594;
+
 pub mod eip7685;
 
 pub mod eip7691;


### PR DESCRIPTION
## Description

Add PeerDAS constants necessary for sidecar validation. Defined in https://github.com/ethereum/consensus-specs/blob/9d377fd53d029536e57cfda1a4d2c700c59f86bf/specs/fulu/polynomial-commitments-sampling.md#cells. See https://github.com/ethereum/execution-apis/pull/630 for validation methods.