### PR TITLE
chore: added error handling for command execution

### DIFF
--- a/scripts/check_no_std.sh
+++ b/scripts/check_no_std.sh
@@ -18,4 +18,9 @@ for crate in "${crates[@]}"; do
 done
 
 echo "Running: ${cmd[*]}"
-"${cmd[@]}"
+
+# Execute the command and handle errors
+if ! "${cmd[@]}"; then
+    echo "Command failed: ${cmd[*]}"
+    exit 1
+fi


### PR DESCRIPTION
## Motivation  
The original script didn’t have explicit error handling, which could make troubleshooting more difficult in case of a failure. Adding error handling improves robustness and helps identify issues more clearly.

## Solution  
I’ve added an error handling block for the command execution (`"${cmd[@]}"`). This change ensures that any errors during the execution are caught and more explicit feedback is provided in case of failure.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes