### PR TITLE
chore: add error message for reconnect failure

### DIFF
--- a/crates/pubsub/src/service.rs
+++ b/crates/pubsub/src/service.rs
@@ -206,6 +206,7 @@ impl<T: PubSubConnect> PubSubService<T> {
                                 break Err(e)
                             }
                         } else if let Err(e) = self.reconnect().await {
+                            error!("Reconnect failed, shutting down: {e}");
                             break Err(e)
                         }
                     }
@@ -213,6 +214,7 @@ impl<T: PubSubConnect> PubSubService<T> {
                     _ = &mut self.handle.error => {
                         error!("Pubsub service backend error.");
                         if let Err(e) = self.reconnect().await {
+                            error!("Reconnect failed, shutting down: {e}");
                             break Err(e)
                         }
                     }


### PR DESCRIPTION
ref #2252

@yash-atreya I believe what's happening here is that the reconnect is also failing, in the context of #2252 this seems to happen if "Connection reset by peer" == os error 104 usually, which could indidate that the socket is unavailable.

there could be a race condition on the remote that then righout rejects the new attempt.

I think it would be reasonable to introduce a retry + sleep mechanism on reconnect as well