### PR TITLE
fix(`pubsub`): retry connecting to backend

### DIFF
--- a/crates/pubsub/src/service.rs
+++ b/crates/pubsub/src/service.rs
@@ -199,7 +199,7 @@ impl<T: PubSubConnect> PubSubService<T> {
     /// Attempt to reconnect with retries
     async fn reconnect_with_retries(&mut self) -> TransportResult<()> {
         let mut retry_count = 0;
-        let result = loop {
+        loop {
             match self.reconnect().await {
                 Ok(()) => break Ok(()),
                 Err(e) => {
@@ -218,8 +218,7 @@ impl<T: PubSubConnect> PubSubService<T> {
                     tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
                 }
             }
-        };
-        result
+        }
     }
 
     /// Spawn the service.
@@ -237,10 +236,8 @@ impl<T: PubSubConnect> PubSubService<T> {
                             if let Err(e) = self.handle_item(item) {
                                 break Err(e)
                             }
-                        } else {
-                            if let Err(e) = self.reconnect_with_retries().await {
-                                break Err(e)
-                            }
+                        } else if let Err(e) = self.reconnect_with_retries().await {
+                            break Err(e)
                         }
                     }
 

--- a/crates/pubsub/src/service.rs
+++ b/crates/pubsub/src/service.rs
@@ -31,6 +31,11 @@ pub(crate) struct PubSubService<T> {
 
     /// The request manager.
     pub(crate) in_flights: RequestManager,
+
+    /// Number of retries. Default is 10.
+    ///
+    /// Every retry is made at an interval of 3 seconds.
+    pub(crate) retries: u32,
 }
 
 impl<T: PubSubConnect> PubSubService<T> {
@@ -45,6 +50,7 @@ impl<T: PubSubConnect> PubSubService<T> {
             reqs,
             subs: SubscriptionManager::default(),
             in_flights: Default::default(),
+            retries: 10,
         };
         this.spawn();
         Ok(PubSubFrontend::new(tx))
@@ -190,6 +196,32 @@ impl<T: PubSubConnect> PubSubService<T> {
         Ok(())
     }
 
+    /// Attempt to reconnect with retries
+    async fn reconnect_with_retries(&mut self) -> TransportResult<()> {
+        let mut retry_count = 0;
+        let result = loop {
+            match self.reconnect().await {
+                Ok(()) => break Ok(()),
+                Err(e) => {
+                    retry_count += 1;
+                    if retry_count >= self.retries {
+                        error!(
+                            "Reconnect failed after {} attempts, shutting down: {e}",
+                            retry_count
+                        );
+                        break Err(e);
+                    }
+                    warn!(
+                        "Reconnection attempt {}/{} failed: {}. Retrying in 3 seconds...",
+                        retry_count, self.retries, e
+                    );
+                    tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
+                }
+            }
+        };
+        result
+    }
+
     /// Spawn the service.
     pub(crate) fn spawn(mut self) {
         let fut = async move {
@@ -205,16 +237,16 @@ impl<T: PubSubConnect> PubSubService<T> {
                             if let Err(e) = self.handle_item(item) {
                                 break Err(e)
                             }
-                        } else if let Err(e) = self.reconnect().await {
-                            error!("Reconnect failed, shutting down: {e}");
-                            break Err(e)
+                        } else {
+                            if let Err(e) = self.reconnect_with_retries().await {
+                                break Err(e)
+                            }
                         }
                     }
 
                     _ = &mut self.handle.error => {
                         error!("Pubsub service backend error.");
-                        if let Err(e) = self.reconnect().await {
-                            error!("Reconnect failed, shutting down: {e}");
+                        if let Err(e) = self.reconnect_with_retries().await {
                             break Err(e)
                         }
                     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Closes #2252 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

- retry mechanism in `PubsubService`
- Retries at least 10 times before exiting
- Interval between retires is 3 seconds

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
