### PR TITLE
feat(`eth-wallet`): set default signer helper

### DIFF
--- a/crates/network/src/ethereum/wallet.rs
+++ b/crates/network/src/ethereum/wallet.rs
@@ -76,6 +76,8 @@ impl EthereumWallet {
     ///
     /// If you're looking to add a new signer and set it as default, use
     /// [`EthereumWallet::register_default_signer`].
+    ///
+    /// [`TransactionRequest`]: alloy_rpc_types_eth::TransactionRequest
     pub fn set_default_signer(&mut self, address: Address) -> alloy_signer::Result<()> {
         if self.signers.contains_key(&address) {
             self.default = address;

--- a/crates/network/src/ethereum/wallet.rs
+++ b/crates/network/src/ethereum/wallet.rs
@@ -81,7 +81,9 @@ impl EthereumWallet {
             self.default = address;
             Ok(())
         } else {
-            Err(alloy_signer::Error::message(format!("{address} is not a registered signer")))
+            Err(alloy_signer::Error::message(format!(
+                "{address} is not a registered signer. Use `register_default_signer`"
+            )))
         }
     }
 

--- a/crates/network/src/ethereum/wallet.rs
+++ b/crates/network/src/ethereum/wallet.rs
@@ -67,6 +67,24 @@ impl EthereumWallet {
         self.register_signer(signer);
     }
 
+    /// Sets the default signer to the given address.
+    ///
+    /// The default signer is used to sign [`TransactionRequest`] and [`TypedTransaction`] objects
+    /// that do not specify a signer address in the `from` field.
+    ///
+    /// The provided address must be a registered signer otherwise an error is returned.
+    ///
+    /// If you're looking to add a new signer and set it as default, use
+    /// [`EthereumWallet::register_default_signer`].
+    pub fn set_default_signer(&mut self, address: Address) -> alloy_signer::Result<()> {
+        if self.signers.contains_key(&address) {
+            self.default = address;
+            Ok(())
+        } else {
+            Err(alloy_signer::Error::message(format!("{address} is not a registered signer")))
+        }
+    }
+
     /// Get the default signer.
     pub fn default_signer(&self) -> Arc<dyn TxSigner<Signature> + Send + Sync + 'static> {
         self.signers.get(&self.default).cloned().expect("invalid signer")


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

We don't have a method to set the default signer (amongst existing signers) using the address after the `EthereumWallet` instantiation. One needs to use `register_default_signer` and pass the signer that may already exist.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

- Add `set_default_signer` that set the default signer using provided address.
- Errors out if signer is not registered.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
