### PR TITLE
feat(eip4844): Implement `AsRef` and `AsMut` for `TxEip4844`

### DIFF
--- a/crates/consensus/src/transaction/eip4844.rs
+++ b/crates/consensus/src/transaction/eip4844.rs
@@ -102,6 +102,7 @@ impl From<TxEip4844Variant> for TxEip4844 {
         }
     }
 }
+
 impl AsRef<TxEip4844> for TxEip4844Variant {
     fn as_ref(&self) -> &TxEip4844 {
         match self {
@@ -119,6 +120,19 @@ impl AsMut<TxEip4844> for TxEip4844Variant {
         }
     }
 }
+
+impl AsRef<Self> for TxEip4844 {
+    fn as_ref(&self) -> &Self {
+        self
+    }
+}
+
+impl AsMut<Self> for TxEip4844 {
+    fn as_mut(&mut self) -> &mut Self {
+        self
+    }
+}
+
 impl TxEip4844Variant {
     /// Verifies that the transaction's blob data, commitments, and proofs are all valid.
     ///


### PR DESCRIPTION
## Motivation

Implementations for `TxEip4844` have strict bounds to this type in cases where they only require a reference.

## Solution

To allow implementing traits with bounds relaxed to any type that can extract reference to `TxEip4844`, the following standard trait implementations are added:

* `AsRef` for `TxEip4844`
* `AsMut` for `TxEip4844`

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
