### PR TITLE
fix: cell proofs in `BlobsBundleV2::take`

### DIFF
--- a/crates/rpc-types-engine/src/payload.rs
+++ b/crates/rpc-types-engine/src/payload.rs
@@ -871,7 +871,7 @@ impl BlobsBundleV2 {
     pub fn take(&mut self, len: usize) -> (Vec<Bytes48>, Vec<Bytes48>, Vec<Blob>) {
         (
             self.commitments.drain(0..len).collect(),
-            self.cell_proofs.drain(0..len * CELLS_PER_EXT_BLOB).collect(),
+            self.cell_proofs.drain(0..len * CELLS_PER_EXT_BLOB as usize).collect(),
             self.blobs.drain(0..len).collect(),
         )
     }

--- a/crates/rpc-types-engine/src/payload.rs
+++ b/crates/rpc-types-engine/src/payload.rs
@@ -13,6 +13,7 @@ use alloy_eips::{
     eip2718::{Decodable2718, Encodable2718},
     eip4844::BlobTransactionSidecar,
     eip4895::{Withdrawal, Withdrawals},
+    eip7594::CELLS_PER_EXT_BLOB,
     eip7685::Requests,
     BlockNumHash,
 };
@@ -870,7 +871,7 @@ impl BlobsBundleV2 {
     pub fn take(&mut self, len: usize) -> (Vec<Bytes48>, Vec<Bytes48>, Vec<Blob>) {
         (
             self.commitments.drain(0..len).collect(),
-            self.cell_proofs.drain(0..len).collect(),
+            self.cell_proofs.drain(0..len * CELLS_PER_EXT_BLOB).collect(),
             self.blobs.drain(0..len).collect(),
         )
     }


### PR DESCRIPTION
## Description

Each EIP-7594 style sidecar should contain `blobs.len() * CELLS_PER_EXT_BLOB` cell proofs.