### PR TITLE
feat: add `From<TxHash>` for `PendingTxConfig`

### DIFF
--- a/crates/provider/src/heart.rs
+++ b/crates/provider/src/heart.rs
@@ -335,6 +335,12 @@ impl PendingTransactionConfig {
     }
 }
 
+impl From<TxHash> for PendingTransactionConfig {
+    fn from(tx_hash: TxHash) -> Self {
+        Self::new(tx_hash)
+    }
+}
+
 /// Errors which may occur in heartbeat when watching a transaction.
 #[derive(Debug, thiserror::Error)]
 pub enum WatchTxError {


### PR DESCRIPTION
## Motivation

Using `Provider::watch_pending_transaction` to wait for 1 confirmation can be simpler if we allow you to write `provider.watch_pending_transaction(tx_hash.into())`

## Solution

Impl `From<TxHash>` for `PendingTransactionConfig`

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
