### PR TITLE
chore: Fixed 404 link

### DIFF
--- a/crates/rpc-types-trace/src/otterscan.rs
+++ b/crates/rpc-types-trace/src/otterscan.rs
@@ -1,7 +1,7 @@
 //! Otterscan specific types for RPC responses.
 //!
 //! <https://www.quicknode.com/docs/ethereum/ots_getBlockTransactions>
-//! <https://github.com/otterscan/otterscan/blob/develop/docs/custom-jsonrpc.md>
+//! <https://github.com/otterscan/otterscan/blob/v2.6.1/docs/custom-jsonrpc.md>
 
 use alloy_primitives::{Address, Bloom, Bytes, TxHash, B256, U256};
 use alloy_rpc_types_eth::{Block, Header, Log, Transaction, TransactionReceipt, Withdrawals};


### PR DESCRIPTION
## Motivation

The original link to the Otterscan custom JSON-RPC documentation was outdated and returned a 404.  

## Solution

Replaced the broken link with the correct versioned URL pointing to [`v2.6.1`](https://github.com/otterscan/otterscan/blob/v2.6.1/docs/custom-jsonrpc.md).  
No code logic was changed.

## PR Checklist

- [ ] Added Tests  
- [x] Added Documentation  
- [ ] Breaking changes
