### PR TITLE
feat(`ws`): retry mechanism in WsConnect

### DIFF
--- a/crates/pubsub/src/service.rs
+++ b/crates/pubsub/src/service.rs
@@ -37,11 +37,6 @@ pub(crate) struct PubSubService<T> {
 
     /// The request manager.
     pub(crate) in_flights: RequestManager,
-
-    /// Number of retries. Default is 10.
-    ///
-    /// Every retry is made at an interval of 3 seconds.
-    pub(crate) retries: u32,
 }
 
 impl<T: PubSubConnect> PubSubService<T> {
@@ -56,7 +51,6 @@ impl<T: PubSubConnect> PubSubService<T> {
             reqs,
             subs: SubscriptionManager::default(),
             in_flights: Default::default(),
-            retries: 10,
         };
         this.spawn();
         Ok(PubSubFrontend::new(tx))
@@ -205,7 +199,8 @@ impl<T: PubSubConnect> PubSubService<T> {
     /// Attempt to reconnect with retries
     async fn reconnect_with_retries(&mut self) -> TransportResult<()> {
         let mut retry_count = 0;
-        let max_retries = self.retries;
+        let max_retries = self.handle.max_retries;
+        let interval = self.handle.retry_interval;
         loop {
             match self.reconnect().await {
                 Ok(()) => break Ok(()),
@@ -215,13 +210,12 @@ impl<T: PubSubConnect> PubSubService<T> {
                         error!("Reconnect failed after {max_retries} attempts, shutting down: {e}");
                         break Err(e);
                     }
-                    let duration = std::time::Duration::from_secs(3);
                     warn!(
                         "Reconnection attempt {retry_count}/{max_retries} failed: {e}. \
-                         Retrying in {:.3}s...",
-                        duration.as_secs_f64(),
+                         Retrying in {:?}s...",
+                        interval.as_secs_f64(),
                     );
-                    sleep(duration).await;
+                    sleep(interval).await;
                 }
             }
         }

--- a/crates/transport-ws/src/native.rs
+++ b/crates/transport-ws/src/native.rs
@@ -25,12 +25,24 @@ pub struct WsConnect {
     pub auth: Option<Authorization>,
     /// The websocket config.
     pub config: Option<WebSocketConfig>,
+    /// Max number of retries before failing and exiting the connection.
+    /// Default is 10.
+    max_retries: u32,
+    /// The interval between retries.
+    /// Default is 3 seconds.
+    retry_interval: Duration,
 }
 
 impl WsConnect {
     /// Creates a new websocket connection configuration.
     pub fn new<S: Into<String>>(url: S) -> Self {
-        Self { url: url.into(), auth: None, config: None }
+        Self {
+            url: url.into(),
+            auth: None,
+            config: None,
+            max_retries: 10,
+            retry_interval: Duration::from_secs(3),
+        }
     }
 
     /// Sets the authorization header.
@@ -42,6 +54,20 @@ impl WsConnect {
     /// Sets the websocket config.
     pub const fn with_config(mut self, config: WebSocketConfig) -> Self {
         self.config = Some(config);
+        self
+    }
+
+    /// Sets the max number of retries before failing and exiting the connection.
+    /// Default is 10.
+    pub const fn with_max_retries(mut self, max_retries: u32) -> Self {
+        self.max_retries = max_retries;
+        self
+    }
+
+    /// Sets the interval between retries.
+    /// Default is 3 seconds.
+    pub const fn with_retry_interval(mut self, retry_interval: Duration) -> Self {
+        self.retry_interval = retry_interval;
         self
     }
 }
@@ -77,7 +103,7 @@ impl PubSubConnect for WsConnect {
 
         backend.spawn();
 
-        Ok(handle)
+        Ok(handle.with_max_retries(self.max_retries).with_retry_interval(self.retry_interval))
     }
 }
 

--- a/crates/transport-ws/src/wasm.rs
+++ b/crates/transport-ws/src/wasm.rs
@@ -6,6 +6,7 @@ use futures::{
     stream::{Fuse, StreamExt},
 };
 use serde_json::value::RawValue;
+use std::time::Duration;
 use ws_stream_wasm::{WsErr, WsMessage, WsMeta, WsStream};
 
 /// Simple connection info for the websocket.
@@ -24,7 +25,7 @@ pub struct WsConnect {
 impl WsConnect {
     /// Creates a new websocket connection configuration.
     pub fn new<S: Into<String>>(url: S) -> Self {
-        Self { url: url.into() }
+        Self { url: url.into(), max_retries: 10, retry_interval: Duration::from_secs(3) }
     }
 
     /// Sets the max number of retries before failing and exiting the connection.

--- a/crates/transport-ws/src/wasm.rs
+++ b/crates/transport-ws/src/wasm.rs
@@ -13,12 +13,32 @@ use ws_stream_wasm::{WsErr, WsMessage, WsMeta, WsStream};
 pub struct WsConnect {
     /// The URL to connect to.
     pub url: String,
+    /// Max number of retries before failing and exiting the connection.
+    /// Default is 10.
+    max_retries: u32,
+    /// The interval between retries.
+    /// Default is 3 seconds.
+    retry_interval: Duration,
 }
 
 impl WsConnect {
     /// Creates a new websocket connection configuration.
     pub fn new<S: Into<String>>(url: S) -> Self {
         Self { url: url.into() }
+    }
+
+    /// Sets the max number of retries before failing and exiting the connection.
+    /// Default is 10.
+    pub const fn with_max_retries(mut self, max_retries: u32) -> Self {
+        self.max_retries = max_retries;
+        self
+    }
+
+    /// Sets the interval between retries.
+    /// Default is 3 seconds.
+    pub const fn with_retry_interval(mut self, retry_interval: Duration) -> Self {
+        self.retry_interval = retry_interval;
+        self
     }
 }
 
@@ -36,7 +56,7 @@ impl PubSubConnect for WsConnect {
 
         backend.spawn();
 
-        Ok(handle)
+        Ok(handle.with_max_retries(self.max_retries).with_retry_interval(self.retry_interval))
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Closes #2252 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

- Adds `max_retries` and `retry_interval` param to `WsConnect`
- These are propagated to the `PubsubService` handling retries via the `ConnectionHandle`
- Default `max_retries: 10` and `retry_interval: 3s`

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
