### PR TITLE
feat(`multicall`): add `CallItem` to dynamic builder

### DIFF
--- a/crates/provider/src/provider/multicall/mod.rs
+++ b/crates/provider/src/provider/multicall/mod.rs
@@ -177,6 +177,12 @@ where
         self
     }
 
+    /// Add a dynamic [`CallItem`] to the builder
+    pub fn add_call_dynamic(mut self, call: CallItem<D>) -> Self {
+        self.calls.push(call.to_call3_value());
+        self
+    }
+
     /// Extend the builder with a sequence of calls
     pub fn extend(
         mut self,
@@ -184,6 +190,14 @@ where
     ) -> Self {
         for item in items {
             self = self.add_dynamic(item);
+        }
+        self
+    }
+
+    /// Extend the builder with a sequence of [`CallItem`]s
+    pub fn extend_calls(mut self, calls: impl IntoIterator<Item = CallItem<D>>) -> Self {
+        for call in calls {
+            self = self.add_call_dynamic(call);
         }
         self
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Closes #2306 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

- Adds two new builder methods to the dynamic builder for adding `CallItem`'s to the builder 

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
