### PR TITLE
fix(json-rpc): transport crate deadlinks in doc

### DIFF
--- a/crates/json-rpc/README.md
+++ b/crates/json-rpc/README.md
@@ -14,7 +14,7 @@ an arbitrary parameters object. The parameters object may be omitted if empty.
 
 Any object that may be Serialized and Cloned may be used as RPC Parameters.
 
-Requests are sent via transports (see [alloy-transports]). This results in 1 of
+Requests are sent via transports (see [alloy-transport]). This results in 1 of
 3 outcomes, captured in the `RpcResult<E>` enum:
 
 - `Ok(Response)` - The request was successful, and the server returned a
@@ -25,7 +25,7 @@ Requests are sent via transports (see [alloy-transports]). This results in 1 of
 - `Err(E)` - Some client-side error prevented the request from being received
   by the server, or prevented the response from being processed. This indicates a client-side or transport-related error.
 
-[alloy-transports]: ../transports
+[alloy-transport]: ../transport
 
 ### Limitations
 

--- a/crates/json-rpc/src/lib.rs
+++ b/crates/json-rpc/src/lib.rs
@@ -7,9 +7,9 @@
 //! If you find yourself importing this crate, and you are not implementing a
 //! JSON-RPC client or transport, you are likely at the wrong layer of
 //! abstraction. If you want to _use_ a JSON-RPC client, consider using the
-//! [`alloy-transports`] crate.
+//! [`alloy-transport`] crate.
 //!
-//! [`alloy-transports`]: https://docs.rs/alloy-transports/latest/alloy-transports
+//! [`alloy-transport`]: https://docs.rs/alloy-transport/latest/alloy_transport/
 //!
 //! ## Usage
 //!


### PR DESCRIPTION
Small fix in `alloy-json-rpc` doc to link to `alloy-transport` crate after it was split in different crates.

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
