### PR TITLE
make PubSubFrontend new public

### DIFF
--- a/crates/pubsub/src/frontend.rs
+++ b/crates/pubsub/src/frontend.rs
@@ -27,7 +27,7 @@ pub struct PubSubFrontend {
 
 impl PubSubFrontend {
     /// Create a new frontend.
-    pub(crate) fn new(tx: mpsc::UnboundedSender<PubSubInstruction>) -> Self {
+    pub fn new(tx: mpsc::UnboundedSender<PubSubInstruction>) -> Self {
         Self { tx, channel_size: Arc::new(AtomicUsize::new(16)) }
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
We want to implement a customized pub sub backend. i.e. make subscription to multiple nodes and merge data from different nodes. We don't think it is good idea to implement such a feature in alloy itself. So we looking for a way to implement customized pub sub backend. But the crate protected new function in PubSubFrontend prevent us to do so without using unsafe hacking.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Just make PubSubFrontend new function public, so that we can channel the pub sub request into our customized backend.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
