### PR TITLE
fix(`transport`): enable hyper-tls via hyper feature

### DIFF
--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -2239,4 +2239,18 @@ mod tests {
         let elapsed = start.elapsed();
         assert_eq!(elapsed.as_secs_f64().round() as u32, 1);
     }
+
+    #[tokio::test]
+    #[cfg(feature = "hyper")]
+    async fn test_connect_hyper_tls() {
+        let p =
+            ProviderBuilder::new().connect("https://reth-ethereum.ithaca.xyz/rpc").await.unwrap();
+
+        let _num = p.get_block_number().await.unwrap();
+
+        let anvil = Anvil::new().spawn();
+        let p = ProviderBuilder::new().connect(&anvil.endpoint()).await.unwrap();
+
+        let _num = p.get_block_number().await.unwrap();
+    }
 }

--- a/crates/transport-http/Cargo.toml
+++ b/crates/transport-http/Cargo.toml
@@ -60,6 +60,7 @@ hyper = [
     "dep:serde_json",
     "dep:tower",
     "dep:tracing",
+    "hyper-tls",
 ]
 hyper-tls = ["hyper", "dep:hyper-tls"]
 jwt-auth = [


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

https://github.com/alloy-rs/alloy/pull/1899 added the `HttpsConnector` for hyper behind the `hyper-tls` feature. However, this feature isn't being enabled via the `hyper` feat. See: https://github.com/alloy-rs/examples/actions/runs/14471175068/job/40585218348?pr=212

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

- Enable the `hyper-tls` feature via `hyper`
- This makes the HttpsConnector the default which can be used with both http and https schemes

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
