### PR TITLE
docs: Fix Typos in Documentation Comments

### DIFF
--- a/crates/consensus-any/src/block/header.rs
+++ b/crates/consensus-any/src/block/header.rs
@@ -2,7 +2,7 @@ use alloy_consensus::{BlockHeader, Header};
 use alloy_primitives::{Address, BlockNumber, Bloom, Bytes, B256, B64, U256};
 
 /// Block header representation with certain fields made optional to account for possible
-/// differencies in network implementations.
+/// differences in network implementations.
 #[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/crates/consensus/src/block/header.rs
+++ b/crates/consensus/src/block/header.rs
@@ -603,7 +603,7 @@ pub trait BlockHeader {
     /// Retrieves the mix hash of the block, if available
     fn mix_hash(&self) -> Option<B256>;
 
-    /// Retrieves the nonce of the block, if avaialble
+    /// Retrieves the nonce of the block, if available
     fn nonce(&self) -> Option<B64>;
 
     /// Retrieves the base fee per gas of the block, if available

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -101,7 +101,7 @@ pub trait Network: Debug + Clone + Copy + Sized + Send + Sync + 'static {
         + BlockResponse<Transaction = Self::TransactionResponse, Header = Self::HeaderResponse>;
 }
 
-/// Utility to implment IntoWallet for signer over the specified network.
+/// Utility to implement IntoWallet for signer over the specified network.
 #[macro_export]
 macro_rules! impl_into_wallet {
     ($(@[$($generics:tt)*])? $signer:ty) => {

--- a/crates/provider/src/builder.rs
+++ b/crates/provider/src/builder.rs
@@ -140,7 +140,8 @@ impl
         ProviderBuilder::default().with_recommended_fillers()
     }
 
-    /// Opt-out of the recommended fillers by resetting the fillers stack in the [`ProviderBuilder`].
+    /// Opt-out of the recommended fillers by resetting the fillers stack in the
+    /// [`ProviderBuilder`].
     ///
     /// This is equivalent to creating the builder using `ProviderBuilder::default()`.
     pub fn disable_recommended_fillers(self) -> ProviderBuilder<Identity, Identity, Ethereum> {

--- a/crates/provider/src/builder.rs
+++ b/crates/provider/src/builder.rs
@@ -140,7 +140,7 @@ impl
         ProviderBuilder::default().with_recommended_fillers()
     }
 
-    /// Opt-out of the recommended fillers by reseting the fillers stack in the [`ProviderBuilder`].
+    /// Opt-out of the recommended fillers by resetting the fillers stack in the [`ProviderBuilder`].
     ///
     /// This is equivalent to creating the builder using `ProviderBuilder::default()`.
     pub fn disable_recommended_fillers(self) -> ProviderBuilder<Identity, Identity, Ethereum> {


### PR DESCRIPTION


**Description:**

This pull request addresses several typographical errors in the documentation comments across multiple files. The changes include:

1. **File:** `crates/consensus-any/src/block/header.rs`
   - Corrected "differencies" to "differences".
   - Fixed "avaialble" to "available" in the comment for the `nonce` function.

2. **File:** `crates/network/src/lib.rs`
   - Corrected "implment" to "implement" in the utility comment for `IntoWallet`.

3. **File:** `crates/provider/src/builder.rs`
   - Fixed "reseting" to "resetting" in the comment for `disable_recommended_fillers`.

These changes improve the readability and professionalism of the code documentation.
