### PR TITLE
Fix typos in comments and string literals

### DIFF
--- a/crates/provider/src/ext/trace/with_block.rs
+++ b/crates/provider/src/ext/trace/with_block.rs
@@ -184,7 +184,7 @@ where
 
 /// Parameters for a trace call.
 ///
-/// Contains optional block id and trace types to accomodate `trace_*` api calls that don't require
+/// Contains optional block id and trace types to accommodate `trace_*` api calls that don't require
 /// them.
 #[derive(Debug, Clone)]
 pub struct TraceParams<Params: RpcSend> {

--- a/crates/provider/src/provider/with_block.rs
+++ b/crates/provider/src/provider/with_block.rs
@@ -49,7 +49,7 @@ impl<Params: RpcSend> serde::Serialize for ParamsWithBlock<Params> {
 type ProviderCallProducer<Params, Resp, Output, Map> =
     Box<dyn Fn(BlockId) -> ProviderCall<ParamsWithBlock<Params>, Resp, Output, Map> + Send>;
 
-/// Container for varous types of calls dependent on a block id.
+/// Container for various types of calls dependent on a block id.
 enum WithBlockInner<Params, Resp, Output = Resp, Map = fn(Resp) -> Output>
 where
     Params: RpcSend,

--- a/crates/rpc-types-engine/src/payload.rs
+++ b/crates/rpc-types-engine/src/payload.rs
@@ -1279,7 +1279,7 @@ impl<'de> serde::Deserialize<'de> for ExecutionPayload {
                 let gas_limit =
                     gas_limit.ok_or_else(|| serde::de::Error::missing_field("gasLimit"))?;
                 let gas_used =
-                    gas_used.ok_or_else(|| serde::de::Error::missing_field("gasUesd"))?;
+                    gas_used.ok_or_else(|| serde::de::Error::missing_field("gasUsed"))?;
                 let timestamp =
                     timestamp.ok_or_else(|| serde::de::Error::missing_field("timestamp"))?;
                 let extra_data =

--- a/crates/transport-http/src/layers/auth.rs
+++ b/crates/transport-http/src/layers/auth.rs
@@ -26,7 +26,7 @@ impl AuthLayer {
         Self { secret, latency_buffer: 5000 }
     }
 
-    /// We use this buffer to perfom an extra check on the `iat` field to prevent sending any
+    /// We use this buffer to perform an extra check on the `iat` field to prevent sending any
     /// requests with tokens that are valid now but may not be upon reaching the server.
     ///
     /// In milliseconds. Default is 5s.


### PR DESCRIPTION
This PR fixes several typos in the codebase:

- Corrects "accomodate" to "accommodate" in trace/with_block.rs
- Corrects "varous" to "various" in provider/with_block.rs
- Fixes string literal for "gasUsed" in payload.rs
- Corrects "perfom" to "perform" in layers/auth.rs