### PR TITLE
Fix grammar typos in documentation

### DIFF
--- a/crates/contract/src/eth_call.rs
+++ b/crates/contract/src/eth_call.rs
@@ -86,7 +86,7 @@ where
         self.inner = self.inner.account_override(address, account_overrides);
         self
     }
-    /// Extends the the given [AccountOverride] to the state override.
+    /// Extends the given [AccountOverride] to the state override.
     ///
     /// Creates a new [`StateOverride`] if none has been set yet.
     pub fn account_overrides(

--- a/crates/node-bindings/src/nodes/anvil.rs
+++ b/crates/node-bindings/src/nodes/anvil.rs
@@ -198,7 +198,7 @@ impl Anvil {
         self
     }
 
-    /// Sets the path for the the ipc server
+    /// Sets the path for the ipc server
     pub fn ipc_path(mut self, path: impl Into<String>) -> Self {
         self.ipc_path = Some(path.into());
         self

--- a/crates/provider/src/layers/cache.rs
+++ b/crates/provider/src/layers/cache.rs
@@ -23,7 +23,7 @@ pub struct CacheLayer {
 }
 
 impl CacheLayer {
-    /// Instantiate a new cache layer with the the maximum number of
+    /// Instantiate a new cache layer with the maximum number of
     /// items to store.
     pub fn new(max_items: u32) -> Self {
         Self { cache: SharedCache::new(max_items) }

--- a/crates/provider/src/provider/eth_call/mod.rs
+++ b/crates/provider/src/provider/eth_call/mod.rs
@@ -248,7 +248,7 @@ where
         self
     }
 
-    /// Extends the the given [AccountOverride] to the state override.
+    /// Extends the given [AccountOverride] to the state override.
     ///
     /// Creates a new [`StateOverride`] if none has been set yet.
     pub fn account_overrides(


### PR DESCRIPTION
This PR corrects minor grammar mistakes in documentation comments across several files to improve readability:

In eth_call.rs, replaced duplicated the the with a single the.

In anvil.rs, fixed the the ipc server to the ipc server.

In cache.rs, removed duplicated the in the the maximum number.

In mod.rs, removed the unnecessary the before given in the given [AccountOverride].

These are small but meaningful changes that help maintain a clean and professional codebase. No functional code was affected.