### PR TITLE
chore: mark 4844 constants deprecated

### DIFF
--- a/crates/eips/src/eip4844/mod.rs
+++ b/crates/eips/src/eip4844/mod.rs
@@ -63,43 +63,43 @@ pub const BYTES_PER_BLOB: usize = 131_072;
 /// Maximum data gas for data blobs in a single block.
 #[deprecated(
     since = "0.15.3",
-    note = "use hardfork specific MAX_DATA_GAS_PER_BLOCK_CANCUN constant or `BlobParams::max_blob_gas_per_block`"
+    note = "use hardfork specific MAX_DATA_GAS_PER_BLOCK_DENCUN constant or `BlobParams::max_blob_gas_per_block`"
 )]
-pub const MAX_DATA_GAS_PER_BLOCK: u64 = MAX_DATA_GAS_PER_BLOCK_CANCUN;
+pub const MAX_DATA_GAS_PER_BLOCK: u64 = MAX_DATA_GAS_PER_BLOCK_DENCUN;
 
 /// Maximum data gas for data blobs in a single block.
-pub const MAX_DATA_GAS_PER_BLOCK_CANCUN: u64 = 786_432u64; // 0xC0000 = 6 * 0x20000
+pub const MAX_DATA_GAS_PER_BLOCK_DENCUN: u64 = 786_432u64; // 0xC0000 = 6 * 0x20000
 
 /// Target data gas for data blobs in a single block.
 #[deprecated(
     since = "0.15.3",
-    note = "use hardfork specific TARGET_DATA_GAS_PER_BLOCK_CANCUN constant or `BlobParams::target_blob_gas_per_block`"
+    note = "use hardfork specific TARGET_DATA_GAS_PER_BLOCK_DENCUN constant or `BlobParams::target_blob_gas_per_block`"
 )]
-pub const TARGET_DATA_GAS_PER_BLOCK: u64 = TARGET_DATA_GAS_PER_BLOCK_CANCUN;
+pub const TARGET_DATA_GAS_PER_BLOCK: u64 = TARGET_DATA_GAS_PER_BLOCK_DENCUN;
 
 /// Target data gas for data blobs in a single block.
-pub const TARGET_DATA_GAS_PER_BLOCK_CANCUN: u64 = 393_216u64; // 0x60000 = 3 * 0x20000
+pub const TARGET_DATA_GAS_PER_BLOCK_DENCUN: u64 = 393_216u64; // 0x60000 = 3 * 0x20000
 
 /// Maximum number of data blobs in a single block.
 #[deprecated(
     since = "0.15.3",
-    note = "use hardfork specific MAX_BLOBS_PER_BLOCK_CANCUN constant or `BlobParams.max_blob_count`"
+    note = "use hardfork specific MAX_BLOBS_PER_BLOCK_DENCUN constant or `BlobParams.max_blob_count`"
 )]
-pub const MAX_BLOBS_PER_BLOCK: usize = MAX_BLOBS_PER_BLOCK_CANCUN; // 786432 / 131072  = 6
+pub const MAX_BLOBS_PER_BLOCK: usize = MAX_BLOBS_PER_BLOCK_DENCUN; // 786432 / 131072  = 6
 
 /// Maximum number of data blobs in a single block.
-pub const MAX_BLOBS_PER_BLOCK_CANCUN: usize =
-    (MAX_DATA_GAS_PER_BLOCK_CANCUN / DATA_GAS_PER_BLOB) as usize; // 786432 / 131072  = 6
+pub const MAX_BLOBS_PER_BLOCK_DENCUN: usize =
+    (MAX_DATA_GAS_PER_BLOCK_DENCUN / DATA_GAS_PER_BLOB) as usize; // 786432 / 131072  = 6
 
 /// Target number of data blobs in a single block.
 #[deprecated(
     since = "0.15.3",
-    note = "use hardfork specific TARGET_BLOBS_PER_BLOCK_CANCUN constant or `BlobParams.target_blob_count`"
+    note = "use hardfork specific TARGET_BLOBS_PER_BLOCK_DENCUN constant or `BlobParams.target_blob_count`"
 )]
-pub const TARGET_BLOBS_PER_BLOCK: u64 = TARGET_BLOBS_PER_BLOCK_CANCUN; // 393216 / 131072 = 3
+pub const TARGET_BLOBS_PER_BLOCK: u64 = TARGET_BLOBS_PER_BLOCK_DENCUN; // 393216 / 131072 = 3
 
 /// Target number of data blobs in a single block.
-pub const TARGET_BLOBS_PER_BLOCK_CANCUN: u64 = TARGET_DATA_GAS_PER_BLOCK_CANCUN / DATA_GAS_PER_BLOB; // 393216 / 131072 = 3
+pub const TARGET_BLOBS_PER_BLOCK_DENCUN: u64 = TARGET_DATA_GAS_PER_BLOCK_DENCUN / DATA_GAS_PER_BLOB; // 393216 / 131072 = 3
 
 /// Determines the maximum rate of change for blob fee
 pub const BLOB_GASPRICE_UPDATE_FRACTION: u128 = 3_338_477u128; // 3338477
@@ -305,34 +305,34 @@ mod tests {
             // slots are below - or equal - to the target.
             (0, 0, 0),
             (0, 1, 0),
-            (0, TARGET_DATA_GAS_PER_BLOCK_CANCUN / DATA_GAS_PER_BLOB, 0),
+            (0, TARGET_DATA_GAS_PER_BLOCK_DENCUN / DATA_GAS_PER_BLOB, 0),
             // If the target blob gas is exceeded, the excessBlobGas should increase
             // by however much it was overshot
-            (0, (TARGET_DATA_GAS_PER_BLOCK_CANCUN / DATA_GAS_PER_BLOB) + 1, DATA_GAS_PER_BLOB),
-            (1, (TARGET_DATA_GAS_PER_BLOCK_CANCUN / DATA_GAS_PER_BLOB) + 1, DATA_GAS_PER_BLOB + 1),
+            (0, (TARGET_DATA_GAS_PER_BLOCK_DENCUN / DATA_GAS_PER_BLOB) + 1, DATA_GAS_PER_BLOB),
+            (1, (TARGET_DATA_GAS_PER_BLOCK_DENCUN / DATA_GAS_PER_BLOB) + 1, DATA_GAS_PER_BLOB + 1),
             (
                 1,
-                (TARGET_DATA_GAS_PER_BLOCK_CANCUN / DATA_GAS_PER_BLOB) + 2,
+                (TARGET_DATA_GAS_PER_BLOCK_DENCUN / DATA_GAS_PER_BLOB) + 2,
                 2 * DATA_GAS_PER_BLOB + 1,
             ),
             // The excess blob gas should decrease by however much the target was
             // under-shot, capped at zero.
             (
-                TARGET_DATA_GAS_PER_BLOCK_CANCUN,
-                TARGET_DATA_GAS_PER_BLOCK_CANCUN / DATA_GAS_PER_BLOB,
-                TARGET_DATA_GAS_PER_BLOCK_CANCUN,
+                TARGET_DATA_GAS_PER_BLOCK_DENCUN,
+                TARGET_DATA_GAS_PER_BLOCK_DENCUN / DATA_GAS_PER_BLOB,
+                TARGET_DATA_GAS_PER_BLOCK_DENCUN,
             ),
             (
-                TARGET_DATA_GAS_PER_BLOCK_CANCUN,
-                (TARGET_DATA_GAS_PER_BLOCK_CANCUN / DATA_GAS_PER_BLOB) - 1,
-                TARGET_DATA_GAS_PER_BLOCK_CANCUN - DATA_GAS_PER_BLOB,
+                TARGET_DATA_GAS_PER_BLOCK_DENCUN,
+                (TARGET_DATA_GAS_PER_BLOCK_DENCUN / DATA_GAS_PER_BLOB) - 1,
+                TARGET_DATA_GAS_PER_BLOCK_DENCUN - DATA_GAS_PER_BLOB,
             ),
             (
-                TARGET_DATA_GAS_PER_BLOCK_CANCUN,
-                (TARGET_DATA_GAS_PER_BLOCK_CANCUN / DATA_GAS_PER_BLOB) - 2,
-                TARGET_DATA_GAS_PER_BLOCK_CANCUN - (2 * DATA_GAS_PER_BLOB),
+                TARGET_DATA_GAS_PER_BLOCK_DENCUN,
+                (TARGET_DATA_GAS_PER_BLOCK_DENCUN / DATA_GAS_PER_BLOB) - 2,
+                TARGET_DATA_GAS_PER_BLOCK_DENCUN - (2 * DATA_GAS_PER_BLOB),
             ),
-            (DATA_GAS_PER_BLOB - 1, (TARGET_DATA_GAS_PER_BLOCK_CANCUN / DATA_GAS_PER_BLOB) - 1, 0),
+            (DATA_GAS_PER_BLOB - 1, (TARGET_DATA_GAS_PER_BLOCK_DENCUN / DATA_GAS_PER_BLOB) - 1, 0),
         ] {
             let actual = calc_excess_blob_gas(excess, blobs * DATA_GAS_PER_BLOB);
             assert_eq!(actual, expected, "test: {t:?}");

--- a/crates/eips/src/eip4844/mod.rs
+++ b/crates/eips/src/eip4844/mod.rs
@@ -61,16 +61,45 @@ pub const DATA_GAS_PER_BLOB: u64 = 131_072u64; // 32*4096 = 131072 == 2^17 == 0x
 pub const BYTES_PER_BLOB: usize = 131_072;
 
 /// Maximum data gas for data blobs in a single block.
-pub const MAX_DATA_GAS_PER_BLOCK: u64 = 786_432u64; // 0xC0000 = 6 * 0x20000
+#[deprecated(
+    since = "0.15.3",
+    note = "use hardfork specific MAX_DATA_GAS_PER_BLOCK_CANCUN constant or `BlobParams::max_blob_gas_per_block`"
+)]
+pub const MAX_DATA_GAS_PER_BLOCK: u64 = MAX_DATA_GAS_PER_BLOCK_CANCUN;
+
+/// Maximum data gas for data blobs in a single block.
+pub const MAX_DATA_GAS_PER_BLOCK_CANCUN: u64 = 786_432u64; // 0xC0000 = 6 * 0x20000
 
 /// Target data gas for data blobs in a single block.
-pub const TARGET_DATA_GAS_PER_BLOCK: u64 = 393_216u64; // 0x60000 = 3 * 0x20000
+#[deprecated(
+    since = "0.15.3",
+    note = "use hardfork specific TARGET_DATA_GAS_PER_BLOCK_CANCUN constant or `BlobParams::target_blob_gas_per_block`"
+)]
+pub const TARGET_DATA_GAS_PER_BLOCK: u64 = TARGET_DATA_GAS_PER_BLOCK_CANCUN;
+
+/// Target data gas for data blobs in a single block.
+pub const TARGET_DATA_GAS_PER_BLOCK_CANCUN: u64 = 393_216u64; // 0x60000 = 3 * 0x20000
 
 /// Maximum number of data blobs in a single block.
-pub const MAX_BLOBS_PER_BLOCK: usize = (MAX_DATA_GAS_PER_BLOCK / DATA_GAS_PER_BLOB) as usize; // 786432 / 131072  = 6
+#[deprecated(
+    since = "0.15.3",
+    note = "use hardfork specific MAX_BLOBS_PER_BLOCK_CANCUN constant or `BlobParams.max_blob_count`"
+)]
+pub const MAX_BLOBS_PER_BLOCK: usize = MAX_BLOBS_PER_BLOCK_CANCUN; // 786432 / 131072  = 6
+
+/// Maximum number of data blobs in a single block.
+pub const MAX_BLOBS_PER_BLOCK_CANCUN: usize =
+    (MAX_DATA_GAS_PER_BLOCK_CANCUN / DATA_GAS_PER_BLOB) as usize; // 786432 / 131072  = 6
 
 /// Target number of data blobs in a single block.
-pub const TARGET_BLOBS_PER_BLOCK: u64 = TARGET_DATA_GAS_PER_BLOCK / DATA_GAS_PER_BLOB; // 393216 / 131072 = 3
+#[deprecated(
+    since = "0.15.3",
+    note = "use hardfork specific TARGET_BLOBS_PER_BLOCK_CANCUN constant or `BlobParams.target_blob_count`"
+)]
+pub const TARGET_BLOBS_PER_BLOCK: u64 = TARGET_BLOBS_PER_BLOCK_CANCUN; // 393216 / 131072 = 3
+
+/// Target number of data blobs in a single block.
+pub const TARGET_BLOBS_PER_BLOCK_CANCUN: u64 = TARGET_DATA_GAS_PER_BLOCK_CANCUN / DATA_GAS_PER_BLOB; // 393216 / 131072 = 3
 
 /// Determines the maximum rate of change for blob fee
 pub const BLOB_GASPRICE_UPDATE_FRACTION: u128 = 3_338_477u128; // 3338477
@@ -276,30 +305,34 @@ mod tests {
             // slots are below - or equal - to the target.
             (0, 0, 0),
             (0, 1, 0),
-            (0, TARGET_DATA_GAS_PER_BLOCK / DATA_GAS_PER_BLOB, 0),
+            (0, TARGET_DATA_GAS_PER_BLOCK_CANCUN / DATA_GAS_PER_BLOB, 0),
             // If the target blob gas is exceeded, the excessBlobGas should increase
             // by however much it was overshot
-            (0, (TARGET_DATA_GAS_PER_BLOCK / DATA_GAS_PER_BLOB) + 1, DATA_GAS_PER_BLOB),
-            (1, (TARGET_DATA_GAS_PER_BLOCK / DATA_GAS_PER_BLOB) + 1, DATA_GAS_PER_BLOB + 1),
-            (1, (TARGET_DATA_GAS_PER_BLOCK / DATA_GAS_PER_BLOB) + 2, 2 * DATA_GAS_PER_BLOB + 1),
+            (0, (TARGET_DATA_GAS_PER_BLOCK_CANCUN / DATA_GAS_PER_BLOB) + 1, DATA_GAS_PER_BLOB),
+            (1, (TARGET_DATA_GAS_PER_BLOCK_CANCUN / DATA_GAS_PER_BLOB) + 1, DATA_GAS_PER_BLOB + 1),
+            (
+                1,
+                (TARGET_DATA_GAS_PER_BLOCK_CANCUN / DATA_GAS_PER_BLOB) + 2,
+                2 * DATA_GAS_PER_BLOB + 1,
+            ),
             // The excess blob gas should decrease by however much the target was
             // under-shot, capped at zero.
             (
-                TARGET_DATA_GAS_PER_BLOCK,
-                TARGET_DATA_GAS_PER_BLOCK / DATA_GAS_PER_BLOB,
-                TARGET_DATA_GAS_PER_BLOCK,
+                TARGET_DATA_GAS_PER_BLOCK_CANCUN,
+                TARGET_DATA_GAS_PER_BLOCK_CANCUN / DATA_GAS_PER_BLOB,
+                TARGET_DATA_GAS_PER_BLOCK_CANCUN,
             ),
             (
-                TARGET_DATA_GAS_PER_BLOCK,
-                (TARGET_DATA_GAS_PER_BLOCK / DATA_GAS_PER_BLOB) - 1,
-                TARGET_DATA_GAS_PER_BLOCK - DATA_GAS_PER_BLOB,
+                TARGET_DATA_GAS_PER_BLOCK_CANCUN,
+                (TARGET_DATA_GAS_PER_BLOCK_CANCUN / DATA_GAS_PER_BLOB) - 1,
+                TARGET_DATA_GAS_PER_BLOCK_CANCUN - DATA_GAS_PER_BLOB,
             ),
             (
-                TARGET_DATA_GAS_PER_BLOCK,
-                (TARGET_DATA_GAS_PER_BLOCK / DATA_GAS_PER_BLOB) - 2,
-                TARGET_DATA_GAS_PER_BLOCK - (2 * DATA_GAS_PER_BLOB),
+                TARGET_DATA_GAS_PER_BLOCK_CANCUN,
+                (TARGET_DATA_GAS_PER_BLOCK_CANCUN / DATA_GAS_PER_BLOB) - 2,
+                TARGET_DATA_GAS_PER_BLOCK_CANCUN - (2 * DATA_GAS_PER_BLOB),
             ),
-            (DATA_GAS_PER_BLOB - 1, (TARGET_DATA_GAS_PER_BLOCK / DATA_GAS_PER_BLOB) - 1, 0),
+            (DATA_GAS_PER_BLOB - 1, (TARGET_DATA_GAS_PER_BLOCK_CANCUN / DATA_GAS_PER_BLOB) - 1, 0),
         ] {
             let actual = calc_excess_blob_gas(excess, blobs * DATA_GAS_PER_BLOB);
             assert_eq!(actual, expected, "test: {t:?}");

--- a/crates/eips/src/eip4844/sidecar.rs
+++ b/crates/eips/src/eip4844/sidecar.rs
@@ -9,7 +9,7 @@ use alloy_primitives::{bytes::BufMut, B256};
 use alloy_rlp::{Decodable, Encodable, Header};
 
 #[cfg(any(test, feature = "arbitrary"))]
-use crate::eip4844::MAX_BLOBS_PER_BLOCK;
+use crate::eip4844::MAX_BLOBS_PER_BLOCK_CANCUN;
 
 /// The versioned hash version for KZG.
 #[cfg(feature = "kzg")]
@@ -178,7 +178,7 @@ impl BlobTransactionSidecarItem {
 #[cfg(any(test, feature = "arbitrary"))]
 impl<'a> arbitrary::Arbitrary<'a> for BlobTransactionSidecar {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
-        let num_blobs = u.int_in_range(1..=MAX_BLOBS_PER_BLOCK)?;
+        let num_blobs = u.int_in_range(1..=MAX_BLOBS_PER_BLOCK_CANCUN)?;
         let mut blobs = Vec::with_capacity(num_blobs);
         for _ in 0..num_blobs {
             blobs.push(Blob::arbitrary(u)?);

--- a/crates/eips/src/eip4844/sidecar.rs
+++ b/crates/eips/src/eip4844/sidecar.rs
@@ -9,7 +9,7 @@ use alloy_primitives::{bytes::BufMut, B256};
 use alloy_rlp::{Decodable, Encodable, Header};
 
 #[cfg(any(test, feature = "arbitrary"))]
-use crate::eip4844::MAX_BLOBS_PER_BLOCK_CANCUN;
+use crate::eip4844::MAX_BLOBS_PER_BLOCK_DENCUN;
 
 /// The versioned hash version for KZG.
 #[cfg(feature = "kzg")]
@@ -178,7 +178,7 @@ impl BlobTransactionSidecarItem {
 #[cfg(any(test, feature = "arbitrary"))]
 impl<'a> arbitrary::Arbitrary<'a> for BlobTransactionSidecar {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
-        let num_blobs = u.int_in_range(1..=MAX_BLOBS_PER_BLOCK_CANCUN)?;
+        let num_blobs = u.int_in_range(1..=MAX_BLOBS_PER_BLOCK_DENCUN)?;
         let mut blobs = Vec::with_capacity(num_blobs);
         for _ in 0..num_blobs {
             blobs.push(Blob::arbitrary(u)?);

--- a/crates/eips/src/eip7840.rs
+++ b/crates/eips/src/eip7840.rs
@@ -36,8 +36,8 @@ impl BlobParams {
     /// Returns [`BlobParams`] configuration activated with Cancun hardfork.
     pub const fn cancun() -> Self {
         Self {
-            target_blob_count: eip4844::TARGET_BLOBS_PER_BLOCK,
-            max_blob_count: eip4844::MAX_BLOBS_PER_BLOCK as u64,
+            target_blob_count: eip4844::TARGET_BLOBS_PER_BLOCK_CANCUN,
+            max_blob_count: eip4844::MAX_BLOBS_PER_BLOCK_CANCUN as u64,
             update_fraction: eip4844::BLOB_GASPRICE_UPDATE_FRACTION,
             min_blob_fee: eip4844::BLOB_TX_MIN_BLOB_GASPRICE,
         }

--- a/crates/eips/src/eip7840.rs
+++ b/crates/eips/src/eip7840.rs
@@ -36,8 +36,8 @@ impl BlobParams {
     /// Returns [`BlobParams`] configuration activated with Cancun hardfork.
     pub const fn cancun() -> Self {
         Self {
-            target_blob_count: eip4844::TARGET_BLOBS_PER_BLOCK_CANCUN,
-            max_blob_count: eip4844::MAX_BLOBS_PER_BLOCK_CANCUN as u64,
+            target_blob_count: eip4844::TARGET_BLOBS_PER_BLOCK_DENCUN,
+            max_blob_count: eip4844::MAX_BLOBS_PER_BLOCK_DENCUN as u64,
             update_fraction: eip4844::BLOB_GASPRICE_UPDATE_FRACTION,
             min_blob_fee: eip4844::BLOB_TX_MIN_BLOB_GASPRICE,
         }


### PR DESCRIPTION
mark constants deprecated and introduce new ones with _CANCUN suffix.

this should show a warning when the constants are used (most likely incorrectly)