### PR TITLE
chore: relax rpc tx conversions

### DIFF
--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -312,6 +312,32 @@ impl<Eip4844> EthereumTxEnvelope<Eip4844> {
             Self::Eip7702(tx) => EthereumTxEnvelope::Eip7702(tx),
         }
     }
+
+    /// Return the [`TxType`] of the inner txn.
+    #[doc(alias = "transaction_type")]
+    pub const fn tx_type(&self) -> TxType {
+        match self {
+            Self::Legacy(_) => TxType::Legacy,
+            Self::Eip2930(_) => TxType::Eip2930,
+            Self::Eip1559(_) => TxType::Eip1559,
+            Self::Eip4844(_) => TxType::Eip4844,
+            Self::Eip7702(_) => TxType::Eip7702,
+        }
+    }
+
+    /// Consumes the type into a [`Signed`]
+    pub fn into_signed(self) -> Signed<EthereumTypedTransaction<Eip4844>>
+    where
+        EthereumTypedTransaction<Eip4844>: From<Eip4844>,
+    {
+        match self {
+            Self::Legacy(tx) => tx.convert(),
+            Self::Eip2930(tx) => tx.convert(),
+            Self::Eip1559(tx) => tx.convert(),
+            Self::Eip4844(tx) => tx.convert(),
+            Self::Eip7702(tx) => tx.convert(),
+        }
+    }
 }
 
 impl<Eip4844: RlpEcdsaEncodableTx> EthereumTxEnvelope<Eip4844> {
@@ -343,20 +369,6 @@ impl<Eip4844: RlpEcdsaEncodableTx> EthereumTxEnvelope<Eip4844> {
     #[inline]
     pub const fn is_eip7702(&self) -> bool {
         matches!(self, Self::Eip7702(_))
-    }
-
-    /// Consumes the type into a [`Signed`]
-    pub fn into_signed(self) -> Signed<EthereumTypedTransaction<Eip4844>>
-    where
-        EthereumTypedTransaction<Eip4844>: From<Eip4844>,
-    {
-        match self {
-            Self::Legacy(tx) => tx.convert(),
-            Self::Eip2930(tx) => tx.convert(),
-            Self::Eip1559(tx) => tx.convert(),
-            Self::Eip4844(tx) => tx.convert(),
-            Self::Eip7702(tx) => tx.convert(),
-        }
     }
 
     /// Returns true if the transaction is replay protected.
@@ -501,18 +513,6 @@ impl<Eip4844: RlpEcdsaEncodableTx> EthereumTxEnvelope<Eip4844> {
             Self::Eip1559(tx) => tx.hash(),
             Self::Eip7702(tx) => tx.hash(),
             Self::Eip4844(tx) => tx.hash(),
-        }
-    }
-
-    /// Return the [`TxType`] of the inner txn.
-    #[doc(alias = "transaction_type")]
-    pub const fn tx_type(&self) -> TxType {
-        match self {
-            Self::Legacy(_) => TxType::Legacy,
-            Self::Eip2930(_) => TxType::Eip2930,
-            Self::Eip1559(_) => TxType::Eip1559,
-            Self::Eip4844(_) => TxType::Eip4844,
-            Self::Eip7702(_) => TxType::Eip7702,
         }
     }
 

--- a/crates/rpc-types-eth/src/call.rs
+++ b/crates/rpc-types-eth/src/call.rs
@@ -119,8 +119,7 @@ impl<'de> serde::Deserialize<'de> for TransactionIndex {
         match isize::deserialize(deserializer)? {
             -1 => Ok(Self::All),
             idx if idx < -1 => Err(serde::de::Error::custom(format!(
-                "Invalid transaction index, expected -1 or positive integer, got {}",
-                idx
+                "Invalid transaction index, expected -1 or positive integer, got {idx}"
             ))),
             idx => Ok(Self::Index(idx as usize)),
         }

--- a/crates/rpc-types-eth/src/transaction/mod.rs
+++ b/crates/rpc-types-eth/src/transaction/mod.rs
@@ -185,8 +185,8 @@ where
 }
 
 impl<Eip4844> Transaction<EthereumTxEnvelope<Eip4844>> {
-    /// Consumes the transaction and returns it as [`Signed`] with [`TypedTransaction`] as the
-    /// transaction type.
+    /// Consumes the transaction and returns it as [`Signed`] with [`EthereumTypedTransaction`] as
+    /// the transaction type.
     pub fn into_signed(self) -> Signed<EthereumTypedTransaction<Eip4844>>
     where
         EthereumTypedTransaction<Eip4844>: From<Eip4844>,
@@ -194,7 +194,7 @@ impl<Eip4844> Transaction<EthereumTxEnvelope<Eip4844>> {
         self.inner.into_inner().into_signed()
     }
 
-    /// Consumes the transaction and returns it a [`Recovered`] signed [`TypedTransaction`].
+    /// Consumes the transaction and returns it a [`Recovered`] signed [`EthereumTypedTransaction`].
     pub fn into_signed_recovered(self) -> Recovered<Signed<EthereumTypedTransaction<Eip4844>>>
     where
         EthereumTypedTransaction<Eip4844>: From<Eip4844>,

--- a/crates/rpc-types-eth/src/transaction/mod.rs
+++ b/crates/rpc-types-eth/src/transaction/mod.rs
@@ -1,8 +1,8 @@
 //! RPC types for transactions
 
 use alloy_consensus::{
-    Signed, TxEip1559, TxEip2930, TxEip4844, TxEip4844Variant, TxEip7702, TxEnvelope, TxLegacy,
-    Typed2718, TypedTransaction,
+    EthereumTxEnvelope, EthereumTypedTransaction, Signed, TxEip1559, TxEip2930, TxEip4844,
+    TxEip4844Variant, TxEip7702, TxEnvelope, TxLegacy, Typed2718,
 };
 use alloy_eips::{eip2718::Encodable2718, eip7702::SignedAuthorization};
 use alloy_network_primitives::TransactionResponse;
@@ -184,16 +184,22 @@ where
     }
 }
 
-impl Transaction {
+impl<Eip4844> Transaction<EthereumTxEnvelope<Eip4844>> {
     /// Consumes the transaction and returns it as [`Signed`] with [`TypedTransaction`] as the
     /// transaction type.
-    pub fn into_signed(self) -> Signed<TypedTransaction> {
+    pub fn into_signed(self) -> Signed<EthereumTypedTransaction<Eip4844>>
+    where
+        EthereumTypedTransaction<Eip4844>: From<Eip4844>,
+    {
         self.inner.into_inner().into_signed()
     }
 
     /// Consumes the transaction and returns it a [`Recovered`] signed [`TypedTransaction`].
-    pub fn into_signed_recovered(self) -> Recovered<Signed<TypedTransaction>> {
-        self.convert().into_recovered()
+    pub fn into_signed_recovered(self) -> Recovered<Signed<EthereumTypedTransaction<Eip4844>>>
+    where
+        EthereumTypedTransaction<Eip4844>: From<Eip4844>,
+    {
+        self.inner.map(|tx| tx.into_signed())
     }
 }
 
@@ -212,34 +218,34 @@ impl<T> From<Transaction<T>> for Recovered<T> {
     }
 }
 
-impl TryFrom<Transaction> for Signed<TxLegacy> {
+impl<Eip4844> TryFrom<Transaction<EthereumTxEnvelope<Eip4844>>> for Signed<TxLegacy> {
     type Error = ConversionError;
 
-    fn try_from(tx: Transaction) -> Result<Self, Self::Error> {
+    fn try_from(tx: Transaction<EthereumTxEnvelope<Eip4844>>) -> Result<Self, Self::Error> {
         match tx.inner.into_inner() {
-            TxEnvelope::Legacy(tx) => Ok(tx),
+            EthereumTxEnvelope::Legacy(tx) => Ok(tx),
             tx => Err(ConversionError::Custom(format!("expected Legacy, got {}", tx.tx_type()))),
         }
     }
 }
 
-impl TryFrom<Transaction> for Signed<TxEip1559> {
+impl<Eip4844> TryFrom<Transaction<EthereumTxEnvelope<Eip4844>>> for Signed<TxEip1559> {
     type Error = ConversionError;
 
-    fn try_from(tx: Transaction) -> Result<Self, Self::Error> {
+    fn try_from(tx: Transaction<EthereumTxEnvelope<Eip4844>>) -> Result<Self, Self::Error> {
         match tx.inner.into_inner() {
-            TxEnvelope::Eip1559(tx) => Ok(tx),
+            EthereumTxEnvelope::Eip1559(tx) => Ok(tx),
             tx => Err(ConversionError::Custom(format!("expected Eip1559, got {}", tx.tx_type()))),
         }
     }
 }
 
-impl TryFrom<Transaction> for Signed<TxEip2930> {
+impl<Eip4844> TryFrom<Transaction<EthereumTxEnvelope<Eip4844>>> for Signed<TxEip2930> {
     type Error = ConversionError;
 
-    fn try_from(tx: Transaction) -> Result<Self, Self::Error> {
+    fn try_from(tx: Transaction<EthereumTxEnvelope<Eip4844>>) -> Result<Self, Self::Error> {
         match tx.inner.into_inner() {
-            TxEnvelope::Eip2930(tx) => Ok(tx),
+            EthereumTxEnvelope::Eip2930(tx) => Ok(tx),
             tx => Err(ConversionError::Custom(format!("expected Eip2930, got {}", tx.tx_type()))),
         }
     }
@@ -271,25 +277,29 @@ impl TryFrom<Transaction> for Signed<TxEip4844Variant> {
     }
 }
 
-impl TryFrom<Transaction> for Signed<TxEip7702> {
+impl<Eip4844> TryFrom<Transaction<EthereumTxEnvelope<Eip4844>>> for Signed<TxEip7702> {
     type Error = ConversionError;
 
-    fn try_from(tx: Transaction) -> Result<Self, Self::Error> {
+    fn try_from(tx: Transaction<EthereumTxEnvelope<Eip4844>>) -> Result<Self, Self::Error> {
         match tx.inner.into_inner() {
-            TxEnvelope::Eip7702(tx) => Ok(tx),
+            EthereumTxEnvelope::Eip7702(tx) => Ok(tx),
             tx => Err(ConversionError::Custom(format!("expected Eip7702, got {}", tx.tx_type()))),
         }
     }
 }
 
-impl From<Transaction> for TxEnvelope {
-    fn from(tx: Transaction) -> Self {
+impl<Eip4844> From<Transaction<Self>> for EthereumTypedTransaction<Eip4844> {
+    fn from(tx: Transaction<Self>) -> Self {
         tx.inner.into_inner()
     }
 }
 
-impl From<Transaction> for Signed<TypedTransaction> {
-    fn from(tx: Transaction) -> Self {
+impl<Eip4844> From<Transaction<EthereumTxEnvelope<Eip4844>>>
+    for Signed<EthereumTypedTransaction<Eip4844>>
+where
+    EthereumTypedTransaction<Eip4844>: From<Eip4844>,
+{
+    fn from(tx: Transaction<EthereumTxEnvelope<Eip4844>>) -> Self {
         tx.into_signed()
     }
 }

--- a/crates/rpc-types-eth/src/transaction/request.rs
+++ b/crates/rpc-types-eth/src/transaction/request.rs
@@ -1186,11 +1186,11 @@ mod tests {
     fn serde_tx_chain_id_field() {
         let chain_id: ChainId = 12345678;
 
-        let chain_id_as_num = format!(r#"{{"chainId": {} }}"#, chain_id);
+        let chain_id_as_num = format!(r#"{{"chainId": {chain_id} }}"#);
         let req1 = serde_json::from_str::<TransactionRequest>(&chain_id_as_num).unwrap();
         assert_eq!(req1.chain_id.unwrap(), chain_id);
 
-        let chain_id_as_hex = format!(r#"{{"chainId": "0x{:x}" }}"#, chain_id);
+        let chain_id_as_hex = format!(r#"{{"chainId": "0x{chain_id:x}" }}"#);
         let req2 = serde_json::from_str::<TransactionRequest>(&chain_id_as_hex).unwrap();
         assert_eq!(req2.chain_id.unwrap(), chain_id);
     }


### PR DESCRIPTION
we can relax those so that these work with all eip4844 variants