### PR TITLE
feat: add bloom_ref

### DIFF
--- a/crates/consensus-any/src/lib.rs
+++ b/crates/consensus-any/src/lib.rs
@@ -7,6 +7,8 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(feature = "std"), no_std)]
 
+extern crate alloc;
+
 mod block;
 pub use block::AnyHeader;
 

--- a/crates/consensus-any/src/receipt/envelope.rs
+++ b/crates/consensus-any/src/receipt/envelope.rs
@@ -6,6 +6,7 @@ use alloy_eips::{
 use alloy_primitives::{bytes::BufMut, Bloom, Log};
 use alloy_rlp::{Decodable, Encodable};
 use core::fmt;
+use std::borrow::Cow;
 
 /// Receipt envelope, as defined in [EIP-2718].
 ///
@@ -78,6 +79,11 @@ impl<T> AnyReceiptEnvelope<T> {
         self.inner.logs_bloom
     }
 
+    /// Return a reference to the receipt's bloom.
+    pub const fn bloom_ref(&self) -> &Bloom {
+        &self.inner.logs_bloom
+    }
+
     /// Returns the cumulative gas used at this receipt.
     pub const fn cumulative_gas_used(&self) -> u64 {
         self.inner.receipt.cumulative_gas_used
@@ -105,6 +111,10 @@ where
 
     fn bloom(&self) -> Bloom {
         self.bloom()
+    }
+
+    fn bloom_ref(&self) -> Cow<'_, Bloom> {
+        Cow::Borrowed(self.bloom_ref())
     }
 
     fn cumulative_gas_used(&self) -> u64 {

--- a/crates/consensus-any/src/receipt/envelope.rs
+++ b/crates/consensus-any/src/receipt/envelope.rs
@@ -1,3 +1,4 @@
+use alloc::borrow::Cow;
 use alloy_consensus::{Eip658Value, Receipt, ReceiptWithBloom, TxReceipt};
 use alloy_eips::{
     eip2718::{Decodable2718, Eip2718Result, Encodable2718},
@@ -6,7 +7,6 @@ use alloy_eips::{
 use alloy_primitives::{bytes::BufMut, Bloom, Log};
 use alloy_rlp::{Decodable, Encodable};
 use core::fmt;
-use std::borrow::Cow;
 
 /// Receipt envelope, as defined in [EIP-2718].
 ///

--- a/crates/consensus/src/receipt/envelope.rs
+++ b/crates/consensus/src/receipt/envelope.rs
@@ -1,3 +1,4 @@
+use alloc::borrow::Cow;
 use core::fmt;
 
 use crate::{Eip658Value, Receipt, ReceiptWithBloom, TxReceipt, TxType};
@@ -172,6 +173,10 @@ where
 
     fn bloom_cheap(&self) -> Option<Bloom> {
         Some(self.bloom())
+    }
+
+    fn bloom_ref(&self) -> Cow<'_, Bloom> {
+        Cow::Borrowed(&self.as_receipt_with_bloom().unwrap().logs_bloom)
     }
 
     /// Returns the cumulative gas used at this receipt.

--- a/crates/consensus/src/receipt/mod.rs
+++ b/crates/consensus/src/receipt/mod.rs
@@ -1,3 +1,4 @@
+use alloc::borrow::Cow;
 use alloy_primitives::Bloom;
 use alloy_rlp::BufMut;
 use core::fmt;
@@ -60,6 +61,11 @@ pub trait TxReceipt: Clone + fmt::Debug + PartialEq + Eq + Send + Sync {
     /// compute.
     fn bloom_cheap(&self) -> Option<Bloom> {
         None
+    }
+
+    /// Returns the bloom filter for the logs in the receipt as a [`Cow`].
+    fn bloom_ref(&self) -> Cow<'_, Bloom> {
+        Cow::Owned(self.bloom())
     }
 
     /// Returns [`ReceiptWithBloom`] with the computed bloom filter [`Self::bloom`] and a reference

--- a/crates/consensus/src/receipt/receipts.rs
+++ b/crates/consensus/src/receipt/receipts.rs
@@ -1,7 +1,7 @@
 use crate::receipt::{
     Eip2718EncodableReceipt, Eip658Value, RlpDecodableReceipt, RlpEncodableReceipt, TxReceipt,
 };
-use alloc::{vec, vec::Vec};
+use alloc::{borrow::Cow, vec, vec::Vec};
 use alloy_eips::{eip2718::Encodable2718, Typed2718};
 use alloy_primitives::{Bloom, Log};
 use alloy_rlp::{BufMut, Decodable, Encodable, Header};
@@ -276,6 +276,10 @@ where
 
     fn bloom_cheap(&self) -> Option<Bloom> {
         Some(self.logs_bloom)
+    }
+
+    fn bloom_ref(&self) -> Cow<'_, Bloom> {
+        Cow::Borrowed(&self.logs_bloom)
     }
 
     fn cumulative_gas_used(&self) -> u64 {


### PR DESCRIPTION
copying an entire bloom isn't super cheap especially when it's used to compute the logs bloom.

we can add this in a non breaking way by introducing bloom_ref -> Cow