### PR TITLE
fix: send eth_unsubscribe with id

### DIFF
--- a/crates/provider/tests/it/ws.rs
+++ b/crates/provider/tests/it/ws.rs
@@ -90,7 +90,6 @@ async fn test_subscription_race_condition() -> Result<(), Box<dyn std::error::Er
     Ok(())
 }
 
-
 // <https://github.com/alloy-rs/alloy/issues/2362>
 #[tokio::test]
 async fn ws_unsubscribe() -> Result<(), Box<dyn std::error::Error>> {
@@ -117,6 +116,6 @@ async fn ws_unsubscribe() -> Result<(), Box<dyn std::error::Error>> {
     let id = sub.local_id();
 
     provider.unsubscribe(*id).unwrap();
-    
+
     Ok(())
 }

--- a/crates/provider/tests/it/ws.rs
+++ b/crates/provider/tests/it/ws.rs
@@ -76,7 +76,7 @@ async fn test_subscription_race_condition() -> Result<(), Box<dyn std::error::Er
 
     let addr = run_server().await?;
 
-    let ws_provider = ProviderBuilder::new().connect(format!("ws://{}", addr).as_str()).await?;
+    let ws_provider = ProviderBuilder::new().connect(format!("ws://{addr}").as_str()).await?;
     let mut request = ws_provider.client().request("subscribe_hello", ());
     // required if not eth_subscribe
     request.set_is_subscription();
@@ -87,5 +87,36 @@ async fn test_subscription_race_condition() -> Result<(), Box<dyn std::error::Er
     let num: usize = sub.recv().await.unwrap();
     assert_eq!(num, 0);
 
+    Ok(())
+}
+
+
+// <https://github.com/alloy-rs/alloy/issues/2362>
+#[tokio::test]
+async fn ws_unsubscribe() -> Result<(), Box<dyn std::error::Error>> {
+    let anvil = Anvil::new().spawn();
+    let provider_config = ProviderConfig {
+        endpoint: anvil.ws_endpoint(),
+        max_rate_limit_retries: 1,
+        initial_backoff: 50,
+        compute_units_per_second: 1600,
+    };
+
+    let ws = WsConnect::new(provider_config.endpoint);
+    let retry_layer = RetryBackoffLayer::new(
+        provider_config.max_rate_limit_retries,
+        provider_config.initial_backoff,
+        provider_config.compute_units_per_second,
+    );
+
+    let rpc_client = RpcClient::builder().layer(retry_layer).ws(ws).await?;
+
+    let provider = ProviderBuilder::new().disable_recommended_fillers().connect_client(rpc_client);
+
+    let sub = provider.subscribe_blocks().await?;
+    let id = sub.local_id();
+
+    provider.unsubscribe(*id).unwrap();
+    
     Ok(())
 }

--- a/crates/pubsub/src/service.rs
+++ b/crates/pubsub/src/service.rs
@@ -136,7 +136,8 @@ impl<T: PubSubConnect> PubSubService<T> {
     /// Service an unsubscribe instruction.
     fn service_unsubscribe(&mut self, local_id: B256) -> TransportResult<()> {
         if let Some(server_id) = self.subs.server_id_for(&local_id) {
-            let req = Request::new("eth_unsubscribe", Id::None, [server_id]);
+            // TODO: ideally we can send this with an unused id
+            let req = Request::new("eth_unsubscribe", Id::Number(1), [server_id]);
             let brv = req.serialize().expect("no ser error").take_request();
 
             self.dispatch_request(brv)?;


### PR DESCRIPTION
closes #2362

we don't track request ids in the service because this only dispatches raw requests, simply using 1 for the id here should be fine 

eth_unsubscribe requires an id because this is a regular request
```
{"jsonrpc":"2.0", "id": 1, "method": "eth_unsubscribe", "params": ["0x9cef478923ff08bf67fde6c64013158d"]}
```
ref https://docs.alchemy.com/reference/eth-unsubscribe