### PR TITLE
docs: minor correction

### DIFF
--- a/crates/rpc-types-eth/src/filter.rs
+++ b/crates/rpc-types-eth/src/filter.rs
@@ -108,7 +108,7 @@ impl<T: Eq + Hash> FilterSet<T> {
         self.0.is_empty()
     }
 
-    /// Returns whether the given value matches the filter. It the filter is empty
+    /// Returns whether the given value matches the filter. If the filter is empty
     /// any value matches. Otherwise, the filter must include the value
     pub fn matches(&self, value: &T) -> bool {
         self.is_empty() || self.0.contains(value)

--- a/crates/rpc-types-trace/src/geth/mod.rs
+++ b/crates/rpc-types-trace/src/geth/mod.rs
@@ -282,7 +282,7 @@ pub enum GethDebugBuiltInTracerType {
     /// The output is an object where the keys correspond to account addresses.
     #[serde(rename = "prestateTracer")]
     PreStateTracer,
-    /// This tracer is noop. It returns an empty object and is only meant for testing the setup.
+    /// This tracer is a noop. It returns an empty object and is only meant for testing the setup.
     #[serde(rename = "noopTracer")]
     NoopTracer,
     /// The mux tracer is a tracer that can run multiple tracers at once.
@@ -412,7 +412,7 @@ pub struct GethDebugTracingOptions {
     pub tracer: Option<GethDebugTracerType>,
     /// Config specific to given `tracer`.
     ///
-    /// Note default struct logger config are historically embedded in main object.
+    /// Note default struct logger config is historically embedded in main object.
     ///
     /// tracerConfig is slated for Geth v1.11.0
     /// See <https://github.com/ethereum/go-ethereum/issues/26513>


### PR DESCRIPTION
It the filter is empty - If the filter is empty
is noop - is a noop
config are historically - config is historically

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
