### PR TITLE
Rename builder to `with_state_diff`

### DIFF
--- a/crates/rpc-types-trace/src/tracerequest.rs
+++ b/crates/rpc-types-trace/src/tracerequest.rs
@@ -78,7 +78,7 @@ impl TraceCallRequest {
     }
 
     /// Inserts [`TraceType::StateDiff`]
-    pub fn with_statediff(self) -> Self {
+    pub fn with_state_diff(self) -> Self {
         self.with_trace_type(TraceType::StateDiff)
     }
 }


### PR DESCRIPTION
Changes method name from `with_statediff` to `with_state_diff` to match Rust snake_case and other builder names.






