### PR TITLE
Adding input helper methods to TransactionRequest

### DIFF
--- a/crates/rpc-types-eth/src/transaction/request.rs
+++ b/crates/rpc-types-eth/src/transaction/request.rs
@@ -130,7 +130,7 @@ pub struct TransactionRequest {
         serde(default, flatten, skip_serializing_if = "Option::is_none")
     )]
     pub sidecar: Option<BlobTransactionSidecar>,
-    /// Authorization list for for EIP-7702 transactions.
+    /// Authorization list for EIP-7702 transactions.
     #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
     pub authorization_list: Option<Vec<SignedAuthorization>>,
 }
@@ -255,6 +255,14 @@ impl TransactionRequest {
     }
 
     /// Sets the input data for the transaction.
+    ///
+    /// This can be used to set both `input` and the `data` field, because some chains or services
+    /// still expect of the deprecated `data` field
+    ///
+    /// ```
+    /// use alloy_rpc_types_eth::{TransactionInput, TransactionRequest};
+    /// let req = TransactionRequest::default().input(TransactionInput::both(b"00".into()));
+    /// ```
     pub fn input(mut self, input: TransactionInput) -> Self {
         self.input = input;
         self
@@ -265,7 +273,7 @@ impl TransactionRequest {
         self.input = TransactionInput::new(data.into());
         self
     }
-        
+
     /// Sets the transaction input from a hex string like "0x1234".
     /// Panics if the hex is invalid.
     pub fn with_input_hex(mut self, hex: &str) -> Self {
@@ -274,7 +282,7 @@ impl TransactionRequest {
         self.input = TransactionInput::new(bytes.into());
         self
     }
-        
+
     /// Clears the transaction input.
     pub fn clear_input(mut self) -> Self {
         self.input = TransactionInput::default();

--- a/crates/rpc-types-eth/src/transaction/request.rs
+++ b/crates/rpc-types-eth/src/transaction/request.rs
@@ -278,7 +278,7 @@ impl TransactionRequest {
     /// Panics if the hex is invalid.
     pub fn with_input_hex(mut self, hex: &str) -> Self {
         let bytes = alloy_primitives::hex::decode(hex.trim_start_matches("0x"))
-        .expect("Invalid hex string for transaction input");
+            .expect("Invalid hex string for transaction input");
         self.input = TransactionInput::new(bytes.into());
         self
     }

--- a/crates/rpc-types-eth/src/transaction/request.rs
+++ b/crates/rpc-types-eth/src/transaction/request.rs
@@ -270,7 +270,8 @@ impl TransactionRequest {
 
     /// Sets the transaction input from a byte vector (calldata).
     pub fn with_input_bytes(mut self, data: Vec<u8>) -> Self {
-        self.input = TransactionInput::new(data.into());
+        let bytes = data.into();
+        self.input = TransactionInput::set_both(bytes);
         self
     }
 
@@ -278,14 +279,21 @@ impl TransactionRequest {
     /// Panics if the hex is invalid.
     pub fn with_input_hex(mut self, hex: &str) -> Self {
         let bytes = alloy_primitives::hex::decode(hex.trim_start_matches("0x"))
-            .expect("Invalid hex string for transaction input");
-        self.input = TransactionInput::new(bytes.into());
+            .expect("Invalid hex string")
+            .into();
+        self.input = TransactionInput::set_both(bytes);
         self
     }
 
-    /// Clears the transaction input.
+    /// Swaps `input` and `data` fields inside the inner TransactionInput.
+    pub fn swap_input_and_data(mut self) -> Self {
+        self.input = self.input.swap();
+        self
+    }
+
+    /// Clears both input and data fields.
     pub fn clear_input(mut self) -> Self {
-        self.input = TransactionInput::default();
+        self.input = TransactionInput::clear();
         self
     }
 
@@ -1118,6 +1126,28 @@ impl TransactionInput {
             }
         }
         Ok(())
+    }
+
+    /// sets both `input` and `data` to the same value.
+    pub fn set_both(bytes: Bytes) -> Self {
+        Self {
+            input: Some(bytes.clone()),
+            data: Some(bytes),
+        }
+    }
+
+    /// Swaps the values of `input` and `data`.
+    pub fn swap(mut self) -> Self {
+        std::mem::swap(&mut self.input, &mut self.data);
+        self
+    }
+
+    /// Clears both `input` and `data`.
+    pub fn clear() -> Self {
+        Self {
+            input: None,
+            data: None,
+        }
     }
 }
 

--- a/crates/rpc-types-eth/src/transaction/request.rs
+++ b/crates/rpc-types-eth/src/transaction/request.rs
@@ -1215,11 +1215,11 @@ mod tests {
     fn serde_tx_chain_id_field() {
         let chain_id: ChainId = 12345678;
 
-        let chain_id_as_num = format!(r#"{{"chainId": {} }}"#, chain_id);
+        let chain_id_as_num = format!(r#"{{"chainId": {chain_id} }}"#);
         let req1 = serde_json::from_str::<TransactionRequest>(&chain_id_as_num).unwrap();
         assert_eq!(req1.chain_id.unwrap(), chain_id);
 
-        let chain_id_as_hex = format!(r#"{{"chainId": "0x{:x}" }}"#, chain_id);
+        let chain_id_as_hex = format!(r#"{{"chainId": "0x{chain_id:x}" }}"#);
         let req2 = serde_json::from_str::<TransactionRequest>(&chain_id_as_hex).unwrap();
         assert_eq!(req2.chain_id.unwrap(), chain_id);
     }


### PR DESCRIPTION
Hello @mattsse  , this should close #2381 . 

I’ve added three helper methods as described in the issue, If there are other helper methods or additional use cases you’d like me to cover, I’m happy to extend this PR or follow up with another one.