### PR TITLE
Fix changelog duplicate and test name typo

### DIFF
--- a/crates/alloy/CHANGELOG.md
+++ b/crates/alloy/CHANGELOG.md
@@ -186,8 +186,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Miscellaneous Tasks
 
 - Release 0.7.0
-- Release 0.7.0
-- Release 0.7.0
 
 ## [0.6.4](https://github.com/alloy-rs/alloy/releases/tag/v0.6.4) - 2024-11-12
 

--- a/crates/consensus/src/receipt/envelope.rs
+++ b/crates/consensus/src/receipt/envelope.rs
@@ -390,7 +390,7 @@ pub(crate) mod serde_bincode_compat {
         use serde_with::serde_as;
 
         #[test]
-        fn test_receipt_evelope_bincode_roundtrip() {
+        fn test_receipt_envelope_bincode_roundtrip() {
             #[serde_as]
             #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
             struct Data {


### PR DESCRIPTION
  CHANGELOG.md
Removed duplicate Release 0.7.0 entries (was listed 3 times)

  envelope.rs
Renamed test: test_receipt_evelope_bincode_roundtrip → test_receipt_envelope_bincode_roundtrip (fix typo)
