### PR TITLE
chore: Make `alloy-rpc-types-debug` `no_std` compatible

### DIFF
--- a/crates/rpc-types-debug/Cargo.toml
+++ b/crates/rpc-types-debug/Cargo.toml
@@ -23,6 +23,6 @@ rustdoc-args = [
 workspace = true
 
 [dependencies]
-alloy-primitives = { workspace = true, features = ["serde", "std", "map"] }
+alloy-primitives = { workspace = true, features = ["serde"] }
 
 serde.workspace = true

--- a/crates/rpc-types-debug/src/debug.rs
+++ b/crates/rpc-types-debug/src/debug.rs
@@ -2,6 +2,7 @@
 
 use alloy_primitives::Bytes;
 use serde::{Deserialize, Serialize};
+use alloc::vec::Vec;
 
 /// Represents the execution witness of a block. Contains an optional map of state preimages.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/rpc-types-debug/src/debug.rs
+++ b/crates/rpc-types-debug/src/debug.rs
@@ -1,8 +1,8 @@
 //! Types for the `debug` API.
 
+use alloc::vec::Vec;
 use alloy_primitives::Bytes;
 use serde::{Deserialize, Serialize};
-use alloc::vec::Vec;
 
 /// Represents the execution witness of a block. Contains an optional map of state preimages.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/rpc-types-debug/src/lib.rs
+++ b/crates/rpc-types-debug/src/lib.rs
@@ -5,6 +5,9 @@
 )]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![no_std]
+
+extern crate alloc;
 
 mod debug;
 pub use debug::*;


### PR DESCRIPTION
closes #2399