### PR TITLE
docs: Fix deprecated note

### DIFF
--- a/crates/provider/src/builder.rs
+++ b/crates/provider/src/builder.rs
@@ -375,7 +375,7 @@ impl<L, F, N> ProviderBuilder<L, F, N> {
     ///
     /// This is a convenience function for
     /// `ProviderBuilder::on_client(RpcClient::mocked(asserter))`.
-    #[deprecated(since = "0.12.6", note = "use `on_mocked_client` instead")]
+    #[deprecated(since = "0.12.6", note = "use `connect_mocked_client` instead")]
     pub fn on_mocked_client(self, asserter: alloy_transport::mock::Asserter) -> F::Provider
     where
         L: ProviderLayer<RootProvider<N>, N>,


### PR DESCRIPTION
I changed the deprecated note for `on_mocked_client` which was pointing to `on_mocked_client` to the correct `connect_mocked_client`.

This change only makes documentation updates.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
