### PR TITLE
feat: some covenience signer impls

### DIFF
--- a/crates/node-bindings/src/nodes/anvil.rs
+++ b/crates/node-bindings/src/nodes/anvil.rs
@@ -55,6 +55,21 @@ impl AnvilInstance {
         &self.private_keys
     }
 
+    /// Convenience function that returns the first key.
+    ///
+    /// # Panics
+    ///
+    /// If this instance does not contain any keys
+    #[track_caller]
+    pub fn first_key(&self) -> &K256SecretKey {
+        self.private_keys.first().unwrap()
+    }
+
+    /// Returns the private key for the given index.
+    pub fn nth_key(&self, idx: usize) -> Option<&K256SecretKey> {
+        self.private_keys.get(idx)
+    }
+
     /// Returns the addresses used to instantiate this instance
     pub fn addresses(&self) -> &[Address] {
         &self.addresses

--- a/crates/signer-local/src/private_key.rs
+++ b/crates/signer-local/src/private_key.rs
@@ -165,6 +165,12 @@ impl From<K256SecretKey> for LocalSigner<SigningKey> {
     }
 }
 
+impl From<&K256SecretKey> for LocalSigner<SigningKey> {
+    fn from(value: &K256SecretKey) -> Self {
+        Self::from_signing_key(value.into())
+    }
+}
+
 impl FromStr for LocalSigner<SigningKey> {
     type Err = LocalSignerError;
 


### PR DESCRIPTION
@yash-atreya we can use this to simplify some examples:

```
let alice: PrivateKeySigner = anvil.keys()[0].clone().into();
    let bob: PrivateKeySigner = anvil.keys()[1].clone().into();
```