### PR TITLE
fix(`consensus`): Allow `"accessList": null` when deserializing EIP-1559 transactions.

### DIFF
--- a/crates/consensus/src/transaction/eip1559.rs
+++ b/crates/consensus/src/transaction/eip1559.rs
@@ -67,6 +67,7 @@ pub struct TxEip1559 {
     /// and `accessed_storage_keys` global sets (introduced in EIP-2929).
     /// A gas cost is charged, though at a discount relative to the cost of
     /// accessing outside the list.
+    #[cfg_attr(feature = "serde", serde(deserialize_with = "alloy_serde::null_as_default"))]
     pub access_list: AccessList,
     /// Input has two uses depending if `to` field is Create or Call.
     /// pub init: An unlimited size byte array specifying the

--- a/crates/consensus/src/transaction/eip1559.rs
+++ b/crates/consensus/src/transaction/eip1559.rs
@@ -493,4 +493,38 @@ mod tests {
         assert_eq!(decoded, tx.into_signed(sig));
         assert_eq!(*decoded.hash(), hash);
     }
+
+    #[test]
+    fn json_decode_eip1559_null_access_list() {
+        let hash: B256 = b256!("0ec0b6a2df4d87424e5f6ad2a654e27aaeb7dac20ae9e8385cc09087ad532ee0");
+
+        let tx_json = r#"
+        {
+            "chainId": "0x1",
+            "nonce": "0x42",
+            "gas": "0xad62",
+            "to": "0x6069a6c32cf691f5982febae4faf8a6f3ab2f0f6",
+            "value": "0x0",
+            "input": "0xa22cb4650000000000000000000000005eee75727d804a2b13038928d36f8b188945a57a0000000000000000000000000000000000000000000000000000000000000000",
+            "maxFeePerGas": "0x4a817c800",
+            "maxPriorityFeePerGas": "0x3b9aca00",
+            "accessList": null
+        }
+        "#;
+        // Make sure that we can decode a `null` accessList
+        let tx: TxEip1559 = serde_json::from_str(tx_json).unwrap();
+        assert_eq!(tx.access_list, AccessList::default());
+
+        let sig = Signature::from_scalars_and_parity(
+            b256!("840cfc572845f5786e702984c2a582528cad4b49b2a10b9db1be7fca90058565"),
+            b256!("25e7109ceb98168d95b09b18bbf6b685130e0562f233877d492b94eee0c5b6d1"),
+            false,
+        );
+
+        let mut buf = vec![];
+        tx.rlp_encode_signed(&sig, &mut buf);
+        let decoded = TxEip1559::rlp_decode_signed(&mut &buf[..]).unwrap();
+        assert_eq!(decoded, tx.into_signed(sig));
+        assert_eq!(*decoded.hash(), hash);
+    }
 }

--- a/crates/consensus/src/transaction/eip1559.rs
+++ b/crates/consensus/src/transaction/eip1559.rs
@@ -67,6 +67,10 @@ pub struct TxEip1559 {
     /// and `accessed_storage_keys` global sets (introduced in EIP-2929).
     /// A gas cost is charged, though at a discount relative to the cost of
     /// accessing outside the list.
+    // Deserialize with `alloy_serde::null_as_default` to also accept a `null` value
+    // instead of an (empty) array. This is due to certain RPC providers (e.g., Filecoin's)
+    // sometimes returning `null` instead of an empty array `[]`.
+    // More details in <https://github.com/alloy-rs/alloy/pull/2450>.
     #[cfg_attr(feature = "serde", serde(deserialize_with = "alloy_serde::null_as_default"))]
     pub access_list: AccessList,
     /// Input has two uses depending if `to` field is Create or Call.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

This is a follow up from https://github.com/alloy-rs/eips/pull/37.

Under some conditions, Filecoin RPC providers return the details of EIP-1559 transactions with the `accessList` attribute set to `null` instead of `[]`, an empty array (see https://github.com/filecoin-project/lotus/issues/12214).

Example of such a transaction:
```bash
> curl -X POST \
  -H "Content-Type: application/json" \
  --data '{
    "jsonrpc":"2.0",
    "method":"eth_getTransactionByHash",
    "params":["0x96ca611648da9a1cb430a9124491b97bbd6fc0e0d8851b1a6fb261fdd128b1c8"],
    "id":1
  }' \                                     
  https://api.node.glif.io/rpc/v1 | jq

{
  "id": 1,
  "jsonrpc": "2.0",
  "result": {
    "chainId": "0x13a",
    "nonce": "0xc94",
    "hash": "0x96ca611648da9a1cb430a9124491b97bbd6fc0e0d8851b1a6fb261fdd128b1c8",
    "blockHash": "0x5a1b8e9b7788cc96cf7c52cd66dd57120893313426a484219fff288e0a84e7df",
    "blockNumber": "0x4bbd62",
    "transactionIndex": "0x1c",
    "from": "0x4f122d7fce7971e38801af5d96fcd4ed83efd654",
    "to": "0xa2aa501b19aff244d90cc15a4cf739d2725b5729",
    "value": "0x1",
    "type": "0x2",
    "input": "0x[removed]",
    "gas": "0x478bcff",
    "maxFeePerGas": "0x29e564f",
    "maxPriorityFeePerGas": "0x1be7d",
    "accessList": null,
    "v": "0x1",
    "r": "0xe1400ceeafde652752b510333a765cf9b6bd36c212f71e8731d85b30395d080d",
    "s": "0x5a97f9e33012c31dd00f74f67ff9170e28811b7e8ae7e156c8ff9f5319346551"
  }
}
```

This causes a deserialization error when attempting to deserialize the transaction into a `TxEip1559` since `accessList` is malformed.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

This PR adds the `serde(deserialize_with = "alloy_serde::null_as_default")` to the `access_list` attribute of the `TxEip1559` struct to ensure that it deserializes into an empty `AccessList` if the string is `null`. 

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
