### PR TITLE
chore: add a new fn for TxType derivation

### DIFF
--- a/crates/rpc-types-eth/src/transaction/request.rs
+++ b/crates/rpc-types-eth/src/transaction/request.rs
@@ -332,28 +332,6 @@ impl TransactionRequest {
         self.max_fee_per_gas.is_some() || self.max_priority_fee_per_gas.is_some()
     }
 
-    /// Returns the transaction type based on the fields that are set.
-    ///
-    /// The type is determined in the following order:
-    /// - EIP-7702 if authorization_list is set
-    /// - EIP-4844 if any EIP-4844 fields are set (sidecar, blob hashes, max blob fee)
-    /// - EIP-1559 if any EIP-1559 fee fields are set (max fee per gas, max priority fee)
-    /// - EIP-2930 if access_list is set
-    /// - Legacy otherwise
-    pub const fn tx_type(&self) -> TxType {
-        if self.authorization_list.is_some() {
-            TxType::Eip7702
-        } else if self.has_eip4844_fields() {
-            TxType::Eip4844
-        } else if self.has_eip1559_fields() {
-            TxType::Eip1559
-        } else if self.access_list.is_some() {
-            TxType::Eip2930
-        } else {
-            TxType::Legacy
-        }
-    }
-
     /// Populate the `blob_versioned_hashes` key, if a sidecar exists. No
     /// effect otherwise.
     pub fn populate_blob_hashes(&mut self) {
@@ -623,6 +601,39 @@ impl TransactionRequest {
                 self.blob_versioned_hashes = None;
                 self.sidecar = None;
             }
+        }
+    }
+
+    /// Returns the minimal transaction type this request can be converted into based on the fields
+    /// that are set.
+    ///
+    /// Compared to [`Self::preferred_type`] which is intended for building and eventually signing
+    /// transactions and which prefers [`TxType::Eip1559`] if no conflicting fields are set, this
+    /// function is intended for deriving the minimal transaction type (legacy).
+    ///
+    /// [`Self::minimal_tx_type`] is mostly relevant for the server-side, for example executing
+    /// `eth_calls` against historic state (pre [`TxType::Eip1559`]) and is used to configure the
+    /// EVM's transaction environment with the minimal settings.
+    /// Whereas [`Self::preferred_type`] is recommend for using client-side (filling a
+    /// [`TransactionRequest`] and signing the transaction [`TransactionRequest::build_typed_tx`]).
+    ///
+    /// The type is determined in the following order:
+    /// - EIP-7702 if authorization_list is set
+    /// - EIP-4844 if any EIP-4844 fields are set (sidecar, blob hashes, max blob fee)
+    /// - EIP-1559 if any EIP-1559 fee fields are set (max fee per gas, max priority fee)
+    /// - EIP-2930 if access_list is set
+    /// - Legacy otherwise
+    pub const fn minimal_tx_type(&self) -> TxType {
+        if self.authorization_list.is_some() {
+            TxType::Eip7702
+        } else if self.has_eip4844_fields() {
+            TxType::Eip4844
+        } else if self.has_eip1559_fields() {
+            TxType::Eip1559
+        } else if self.access_list.is_some() {
+            TxType::Eip2930
+        } else {
+            TxType::Legacy
         }
     }
 

--- a/crates/rpc-types-eth/src/transaction/request.rs
+++ b/crates/rpc-types-eth/src/transaction/request.rs
@@ -332,6 +332,28 @@ impl TransactionRequest {
         self.max_fee_per_gas.is_some() || self.max_priority_fee_per_gas.is_some()
     }
 
+    /// Returns the transaction type based on the fields that are set.
+    ///
+    /// The type is determined in the following order:
+    /// - EIP-7702 if authorization_list is set
+    /// - EIP-4844 if any EIP-4844 fields are set (sidecar, blob hashes, max blob fee)
+    /// - EIP-1559 if any EIP-1559 fee fields are set (max fee per gas, max priority fee)
+    /// - EIP-2930 if access_list is set
+    /// - Legacy otherwise
+    pub const fn tx_type(&self) -> TxType {
+        if self.authorization_list.is_some() {
+            TxType::Eip7702
+        } else if self.has_eip4844_fields() {
+            TxType::Eip4844
+        } else if self.has_eip1559_fields() {
+            TxType::Eip1559
+        } else if self.access_list.is_some() {
+            TxType::Eip2930
+        } else {
+            TxType::Legacy
+        }
+    }
+
     /// Populate the `blob_versioned_hashes` key, if a sidecar exists. No
     /// effect otherwise.
     pub fn populate_blob_hashes(&mut self) {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
This is related to https://github.com/paradigmxyz/reth/issues/16231, to upstream `TxType` derive to `TransactionRequest`
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
This PR adds a new function in `TransactionRequest` with logic in https://github.com/paradigmxyz/reth/blob/3ac3e6ff11bac485272d023969bfd0377b820165/crates/optimism/rpc/src/eth/call.rs#L70-L80
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
