### PR TITLE
docs: Fix typos and improve documentation clarity in serde-related modules

### DIFF
--- a/crates/consensus/src/block/header.rs
+++ b/crates/consensus/src/block/header.rs
@@ -899,7 +899,7 @@ impl<T: BlockHeader> BlockHeader for alloy_serde::WithOtherFields<T> {
     }
 }
 
-/// Bincode-compatibl [`Header`] serde implementation.
+/// Bincode-compatible [`Header`] serde implementation.
 #[cfg(all(feature = "serde", feature = "serde-bincode-compat"))]
 pub(crate) mod serde_bincode_compat {
     use alloc::borrow::Cow;

--- a/crates/consensus/src/receipt/envelope.rs
+++ b/crates/consensus/src/receipt/envelope.rs
@@ -396,7 +396,7 @@ pub(crate) mod serde_bincode_compat {
         use serde_with::serde_as;
 
         #[test]
-        fn test_receipt_evelope_bincode_roundtrip() {
+        fn test_receipt_envelope_bincode_roundtrip() {
             #[serde_as]
             #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
             struct Data {

--- a/crates/consensus/src/receipt/mod.rs
+++ b/crates/consensus/src/receipt/mod.rs
@@ -102,7 +102,7 @@ pub trait RlpDecodableReceipt: Sized {
 /// Receipt type that knows its EIP-2718 encoding.
 ///
 /// Main consumer of this trait is [`ReceiptWithBloom`]. It is expected that [`RlpEncodableReceipt`]
-/// implementation for this type produces network encoding whcih is used by [`alloy_rlp::Encodable`]
+/// implementation for this type produces network encoding which is used by [`alloy_rlp::Encodable`]
 /// implementation for [`ReceiptWithBloom`].
 #[auto_impl::auto_impl(&)]
 pub trait Eip2718EncodableReceipt: RlpEncodableReceipt + Typed2718 {

--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -1028,7 +1028,7 @@ pub mod serde_bincode_compat {
     pub struct EthereumTxEnvelope<'a, Eip4844: Clone = crate::transaction::TxEip4844> {
         /// Transaction signature
         signature: Signature,
-        /// bincode compatable transaction
+        /// bincode compatible transaction
         transaction:
             crate::serde_bincode_compat::transaction::EthereumTypedTransaction<'a, Eip4844>,
     }


### PR DESCRIPTION
## Description:
This pull request addresses minor documentation and test name improvements across several consensus modules to enhance clarity and correctness:

Fixed multiple typos such as "compatibl" → "compatible", "evelope" → "envelope", and "whcih" → "which".

Updated a test function name to accurately reflect the struct it tests: test_receipt_evelope_bincode_roundtrip → test_receipt_envelope_bincode_roundtrip.

These changes are purely cosmetic and do not affect runtime behavior or logic.

This PR improves code readability and documentation accuracy, making the codebase more maintainable.