### PR TITLE
feat: add #[serde(default)] to accessList field in TxEip4844

### DIFF
--- a/crates/consensus/src/transaction/eip4844.rs
+++ b/crates/consensus/src/transaction/eip4844.rs
@@ -498,10 +498,10 @@ pub struct TxEip4844 {
     /// This is also known as `GasTipCap`
     #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
     pub max_priority_fee_per_gas: u128,
-    /// The 160-bit address of the message call’s recipient.
+    /// The 160-bit address of the message call's recipient.
     pub to: Address,
     /// A scalar value equal to the number of Wei to
-    /// be transferred to the message call’s recipient or,
+    /// be transferred to the message call's recipient or,
     /// in the case of contract creation, as an endowment
     /// to the newly created account; formally Tv.
     pub value: U256,
@@ -510,6 +510,7 @@ pub struct TxEip4844 {
     /// and `accessed_storage_keys` global sets (introduced in EIP-2929).
     /// A gas cost is charged, though at a discount relative to the cost of
     /// accessing outside the list.
+    #[cfg_attr(feature = "serde", serde(default))]
     pub access_list: AccessList,
 
     /// It contains a vector of fixed size hash(32 bytes)


### PR DESCRIPTION
## Motivation

When deserializing EIP-4844 transactions, the `accessList` field may be missing from some sources or networks. Without a default, deserialization fails if the field is absent, even though an empty access list is a valid default per the spec. This causes compatibility issues, especially when working with networks or tooling that omit this field.

## Solution

This PR adds `#[serde(default)]` to the `accessList` field in the `TxEip4844` struct. This ensures that if the field is missing during deserialization, it will default to an empty access list, improving compatibility and robustness. No breaking changes are introduced, and this aligns with how similar fields are handled in other transaction types.

---

You can copy and paste this into your PR description. If you want to check the box for tests or documentation, you can do so as appropriate for your changes. Let me know if you want to add more details or context!


## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
