### PR TITLE
fix(`provider`): introduce `new_with_network` constructor

### DIFF
--- a/crates/provider/src/builder.rs
+++ b/crates/provider/src/builder.rs
@@ -712,6 +712,7 @@ impl<L, F, N: Network> ProviderBuilder<L, F, N> {
 mod tests {
     use super::*;
     use crate::Provider;
+    use alloy_network::AnyNetwork;
 
     #[tokio::test]
     async fn basic() {
@@ -722,5 +723,10 @@ mod tests {
         let _ = provider.get_account(Default::default());
         let provider = provider.erased();
         let _ = provider.get_account(Default::default());
+    }
+
+    #[test]
+    fn compile_with_network() {
+        let _ = ProviderBuilder::new_with_network::<AnyNetwork>().connect_anvil();
     }
 }

--- a/crates/provider/src/builder.rs
+++ b/crates/provider/src/builder.rs
@@ -725,8 +725,10 @@ mod tests {
         let _ = provider.get_account(Default::default());
     }
 
-    #[test]
-    fn compile_with_network() {
-        let _ = ProviderBuilder::new_with_network::<AnyNetwork>().connect_anvil();
+    #[tokio::test]
+    async fn compile_with_network() {
+        let p = ProviderBuilder::new_with_network::<AnyNetwork>().connect_anvil();
+        let num = p.get_block_number().await.unwrap();
+        assert_eq!(num, 0);
     }
 }

--- a/crates/provider/src/builder.rs
+++ b/crates/provider/src/builder.rs
@@ -155,6 +155,19 @@ impl<N> Default for ProviderBuilder<Identity, Identity, N> {
     }
 }
 
+impl ProviderBuilder<Identity, Identity, Ethereum> {
+    /// Create a new [`ProviderBuilder`] with the [`RecommendedFillers`] for the provided
+    /// [`Network`].
+    pub fn new_with_network<Net: RecommendedFillers>(
+    ) -> ProviderBuilder<Identity, JoinFill<Identity, Net::RecommendedFillers>, Net> {
+        ProviderBuilder {
+            layer: Identity,
+            filler: JoinFill::new(Identity, Net::recommended_fillers()),
+            network: PhantomData,
+        }
+    }
+}
+
 impl<L, N: Network> ProviderBuilder<L, Identity, N> {
     /// Add preconfigured set of layers handling gas estimation, nonce
     /// management, and chain-id fetching.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
towards #2478 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Introduces `new_with_network` constructor for the `ProviderBuilder`. This enables the provider to be built with the recommended fillers of the provided network via the `RecommendedFillers trait`

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
