### PR TITLE
refactor: create VersionedHashIter to remove unnecessary collect()

### DIFF
--- a/crates/eips/src/eip4844/sidecar.rs
+++ b/crates/eips/src/eip4844/sidecar.rs
@@ -5,7 +5,7 @@ use crate::{
         kzg_to_versioned_hash, Blob, BlobAndProofV1, Bytes48, BYTES_PER_BLOB, BYTES_PER_COMMITMENT,
         BYTES_PER_PROOF,
     },
-    eip7594::{Decodable7594, Encodable7594, VersionedHashIter},
+    eip7594::{Decodable7594, Encodable7594},
 };
 use alloc::{boxed::Box, vec::Vec};
 use alloy_primitives::{bytes::BufMut, B256};
@@ -534,6 +534,29 @@ impl core::fmt::Display for BlobTransactionValidationError {
 impl From<c_kzg::Error> for BlobTransactionValidationError {
     fn from(source: c_kzg::Error) -> Self {
         Self::KZGError(source)
+    }
+}
+
+/// Iterator that returns versioned hashes from commitments.
+#[derive(Debug, Clone)]
+pub struct VersionedHashIter<'a> {
+    /// The iterator over KZG commitments from which versioned hashes are generated.
+    commitments: core::slice::Iter<'a, Bytes48>,
+}
+
+impl<'a> Iterator for VersionedHashIter<'a> {
+    type Item = B256;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.commitments.next().map(|c| kzg_to_versioned_hash(c.as_slice()))
+    }
+}
+
+// Constructor method for VersionedHashIter
+impl<'a> VersionedHashIter<'a> {
+    /// Creates a new iterator over commitments to generate versioned hashes.
+    pub fn new(commitments: &'a [Bytes48]) -> Self {
+        Self { commitments: commitments.iter() }
     }
 }
 

--- a/crates/eips/src/eip4844/sidecar.rs
+++ b/crates/eips/src/eip4844/sidecar.rs
@@ -5,7 +5,7 @@ use crate::{
         kzg_to_versioned_hash, Blob, BlobAndProofV1, Bytes48, BYTES_PER_BLOB, BYTES_PER_COMMITMENT,
         BYTES_PER_PROOF,
     },
-    eip7594::{Decodable7594, Encodable7594},
+    eip7594::{Decodable7594, Encodable7594, VersionedHashIter},
 };
 use alloc::{boxed::Box, vec::Vec};
 use alloy_primitives::{bytes::BufMut, B256};
@@ -288,8 +288,8 @@ impl BlobTransactionSidecar {
     }
 
     /// Returns an iterator over the versioned hashes of the commitments.
-    pub fn versioned_hashes(&self) -> impl Iterator<Item = B256> + '_ {
-        self.commitments.iter().map(|c| kzg_to_versioned_hash(c.as_slice()))
+    pub fn versioned_hashes(&self) -> VersionedHashIter<'_> {
+        VersionedHashIter::new(&self.commitments)
     }
 
     /// Returns the versioned hash for the blob at the given index, if it

--- a/crates/eips/src/eip7594/sidecar.rs
+++ b/crates/eips/src/eip7594/sidecar.rs
@@ -1,7 +1,7 @@
 use crate::{
     eip4844::{
-        kzg_to_versioned_hash, Blob, BlobAndProofV2, BlobTransactionSidecar, Bytes48,
-        BYTES_PER_BLOB, BYTES_PER_COMMITMENT, BYTES_PER_PROOF,
+        Blob, BlobAndProofV2, BlobTransactionSidecar, Bytes48, BYTES_PER_BLOB,
+        BYTES_PER_COMMITMENT, BYTES_PER_PROOF,
     },
     eip7594::{CELLS_PER_EXT_BLOB, EIP_7594_WRAPPER_VERSION},
 };
@@ -9,33 +9,10 @@ use alloc::{boxed::Box, vec::Vec};
 use alloy_primitives::B256;
 use alloy_rlp::{BufMut, Decodable, Encodable, Header};
 
+use super::{Decodable7594, Encodable7594};
 #[cfg(feature = "kzg")]
 use crate::eip4844::BlobTransactionValidationError;
-
-use super::{Decodable7594, Encodable7594};
-
-/// Iterator that returns versioned hashes from commitments.
-#[derive(Debug)]
-pub struct VersionedHashIter<'a> {
-    /// The iterator over KZG commitments from which versioned hashes are generated.
-    pub commitments: core::slice::Iter<'a, Bytes48>,
-}
-
-impl<'a> Iterator for VersionedHashIter<'a> {
-    type Item = B256;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.commitments.next().map(|c| kzg_to_versioned_hash(c.as_slice()))
-    }
-}
-
-// Constructor method for VersionedHashIter
-impl<'a> VersionedHashIter<'a> {
-    /// Creates a new iterator over commitments to generate versioned hashes.
-    pub fn new(commitments: &'a [Bytes48]) -> Self {
-        Self { commitments: commitments.iter() }
-    }
-}
+use crate::eip4844::VersionedHashIter;
 
 /// This represents a set of blobs, and its corresponding commitments and proofs.
 /// Proof type depends on the sidecar variant.
@@ -117,12 +94,17 @@ impl BlobTransactionSidecarVariant {
         }
     }
 
+    /// Returns the commitments of the sidecar.
+    pub fn commitments(&self) -> &[Bytes48] {
+        match self {
+            Self::Eip4844(sidecar) => &sidecar.commitments,
+            Self::Eip7594(sidecar) => &sidecar.commitments,
+        }
+    }
+
     /// Returns an iterator over the versioned hashes of the commitments.
     pub fn versioned_hashes(&self) -> VersionedHashIter<'_> {
-        match self {
-            Self::Eip4844(sidecar) => VersionedHashIter::new(&sidecar.commitments),
-            Self::Eip7594(sidecar) => VersionedHashIter::new(&sidecar.commitments),
-        }
+        VersionedHashIter::new(self.commitments())
     }
 
     /// Outputs the RLP length of the [BlobTransactionSidecarVariant] fields, without a RLP header.
@@ -386,7 +368,8 @@ impl BlobTransactionSidecarEip7594 {
             let commitment = c_kzg::KzgCommitment::from(commitment.0);
 
             // calculate & verify versioned hash
-            let calculated_versioned_hash = kzg_to_versioned_hash(commitment.as_slice());
+            let calculated_versioned_hash =
+                crate::eip4844::kzg_to_versioned_hash(commitment.as_slice());
             if *versioned_hash != calculated_versioned_hash {
                 return Err(BlobTransactionValidationError::WrongVersionedHash {
                     have: *versioned_hash,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Fix issue #2481: Remove unnecessary collection into Vec in `versioned_hashes` method.

The `versioned_hashes` method in `BlobTransactionSidecarVariant` was unnecessarily collecting the iterator results into a Vec, which could impact performance. Both implementations of the underlying method were doing the same operation on commitments.

## Solution

Created a common `VersionedHashIter` struct that implements the Iterator trait to handle versioned hash generation from commitments. This allows:

1. All related methods to return the same concrete type instead of `impl Iterator`
2. Removes the need for `.collect()` in `BlobTransactionSidecarVariant::versioned_hashes`
3. Maintains the same functionality while being more memory efficient

## PR Checklist

- [x] Added Tests (existing tests still pass)
- [x] Added Documentation (documented the new iterator type)
- [ ] Breaking changes (no breaking changes introduced) 