### PR TITLE
feat: Encodable2718:into_encoded

### DIFF
--- a/crates/consensus/src/block/mod.rs
+++ b/crates/consensus/src/block/mod.rs
@@ -11,7 +11,7 @@ pub(crate) use header::serde_bincode_compat;
 
 use crate::Transaction;
 use alloc::vec::Vec;
-use alloy_eips::{eip4895::Withdrawals, Typed2718};
+use alloy_eips::{eip2718::WithEncoded, eip4895::Withdrawals, Encodable2718, Typed2718};
 use alloy_primitives::B256;
 use alloy_rlp::{Decodable, Encodable, RlpDecodable, RlpEncodable};
 
@@ -118,6 +118,15 @@ impl<T, H> Block<T, H> {
                 withdrawals: self.body.withdrawals,
             },
         })
+    }
+
+    /// Converts the transactions in the block's body to `WithEncoded<T>` by encoding them via
+    /// [`Encodable2718`]
+    pub fn into_with_encoded2718(self) -> Block<WithEncoded<T>, H>
+    where
+        T: Encodable2718,
+    {
+        self.map_transactions(|tx| tx.into_encoded())
     }
 
     /// Returns the RLP encoded length of the block's header and body.

--- a/crates/eips/src/eip2718.rs
+++ b/crates/eips/src/eip2718.rs
@@ -232,6 +232,15 @@ pub trait Encodable2718: Typed2718 + Sized + Send + Sync {
         Sealed::new_unchecked(self, hash)
     }
 
+    /// A convenience function that encodes the value in the 2718 format and wraps it in a
+    /// [`WithEncoded`] wrapper.
+    ///
+    /// See also [`WithEncoded::from_2718_encodable`].
+    #[auto_impl(keep_default_for(&))]
+    fn into_encoded(self) -> WithEncoded<Self> {
+        WithEncoded::from_2718_encodable(self)
+    }
+
     /// The length of the 2718 encoded envelope in network format. This is the
     /// length of the header + the length of the type flag and inner encoding.
     fn network_len(&self) -> usize {


### PR DESCRIPTION
introduces a new default Encodable2718 trait functions that encodes the value directly into `WithEncoded` and map fn on the block type.