### PR TITLE
feat: Add lenient_block_number_or_tag to support raw integers

### DIFF
--- a/crates/eips/src/eip1898.rs
+++ b/crates/eips/src/eip1898.rs
@@ -241,6 +241,18 @@ impl fmt::Debug for BlockNumberOrTag {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
 pub struct LenientBlockNumberOrTag(BlockNumberOrTag);
 
+impl LenientBlockNumberOrTag {
+    /// Creates a new [`LenientBlockNumberOrTag`] from a [`BlockNumberOrTag`].
+    pub const fn new(block_number_or_tag: BlockNumberOrTag) -> Self {
+        Self(block_number_or_tag)
+    }
+
+    /// Returns the inner [`BlockNumberOrTag`].
+    pub const fn into_inner(self) -> BlockNumberOrTag {
+        self.0
+    }
+}
+
 impl From<LenientBlockNumberOrTag> for BlockNumberOrTag {
     fn from(value: LenientBlockNumberOrTag) -> Self {
         value.0

--- a/crates/eips/src/eip1898.rs
+++ b/crates/eips/src/eip1898.rs
@@ -232,14 +232,26 @@ impl fmt::Debug for BlockNumberOrTag {
     }
 }
 
+/// This is a helper
+/// Various block number representations
+#[derive(Clone, Copy, Debug, Default)]
+pub struct LenientBlockNumberOrTag(BlockNumberOrTag);
+
+impl From<LenientBlockNumberOrTag> for BlockNumberOrTag {
+    fn from(value: LenientBlockNumberOrTag) -> Self {
+        value.0
+    }
+}
+
 /// A module that deserializes either a BlockNumberOrTag, or a simple number.
+#[cfg(feature = "serde")]
 pub mod lenient_block_number_or_tag {
-    use crate::BlockNumberOrTag;
+    use super::{BlockNumberOrTag, LenientBlockNumberOrTag};
     use serde::{
         de::{self, Visitor},
         Deserialize, Deserializer,
     };
-    use std::fmt;
+    use core::fmt;
 
     /// Following the spec the block parameter is either:
     ///
@@ -258,18 +270,12 @@ pub mod lenient_block_number_or_tag {
     ///
     /// EIP-1898 does not all calls that use `BlockNumber` like `eth_getBlockByNumber` and doesn't
     /// list raw integers as supported.
-    pub fn lenient_block_number_or_tag<'de, D>(
-        deserializer: D,
-    ) -> Result<BlockNumberOrTag, D::Error>
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<BlockNumberOrTag, D::Error>
     where
         D: Deserializer<'de>,
     {
         LenientBlockNumberOrTag::deserialize(deserializer).map(Into::into)
     }
-
-    /// Various block number representations, See [`lenient_block_number_or_tag()`]
-    #[derive(Clone, Copy, Debug)]
-    pub struct LenientBlockNumberOrTag(pub BlockNumberOrTag);
 
     impl<'de> Deserialize<'de> for LenientBlockNumberOrTag {
         fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
@@ -308,12 +314,6 @@ pub mod lenient_block_number_or_tag {
             }
 
             deserializer.deserialize_any(LenientBlockNumberVisitor)
-        }
-    }
-
-    impl From<LenientBlockNumberOrTag> for BlockNumberOrTag {
-        fn from(value: LenientBlockNumberOrTag) -> Self {
-            value.0
         }
     }
 }

--- a/crates/eips/src/lib.rs
+++ b/crates/eips/src/lib.rs
@@ -15,8 +15,8 @@ pub use eip1559::calc_next_block_base_fee;
 
 pub mod eip1898;
 pub use eip1898::{
-    BlockHashOrNumber, BlockId, BlockNumHash, BlockNumberOrTag, ForkBlock, HashOrNumber, NumHash,
-    RpcBlockHash,
+    lenient_block_number_or_tag, BlockHashOrNumber, BlockId, BlockNumHash, BlockNumberOrTag,
+    ForkBlock, HashOrNumber, NumHash, RpcBlockHash,
 };
 
 pub mod eip2124;

--- a/crates/eips/src/lib.rs
+++ b/crates/eips/src/lib.rs
@@ -15,8 +15,8 @@ pub use eip1559::calc_next_block_base_fee;
 
 pub mod eip1898;
 pub use eip1898::{
-    BlockHashOrNumber, BlockId, BlockNumHash, BlockNumberOrTag,
-    ForkBlock, HashOrNumber, NumHash, RpcBlockHash,
+    BlockHashOrNumber, BlockId, BlockNumHash, BlockNumberOrTag, ForkBlock, HashOrNumber, NumHash,
+    RpcBlockHash,
 };
 
 pub mod eip2124;

--- a/crates/eips/src/lib.rs
+++ b/crates/eips/src/lib.rs
@@ -15,7 +15,7 @@ pub use eip1559::calc_next_block_base_fee;
 
 pub mod eip1898;
 pub use eip1898::{
-    lenient_block_number_or_tag, BlockHashOrNumber, BlockId, BlockNumHash, BlockNumberOrTag,
+    BlockHashOrNumber, BlockId, BlockNumHash, BlockNumberOrTag,
     ForkBlock, HashOrNumber, NumHash, RpcBlockHash,
 };
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

BlockNumberOrTag supports only:
- HEX String - an integer block number
- String "latest" - for the latest mined block
- String "finalized" - for the finalized block
- String "safe" - for the safe head block
- String "earliest" for the earliest/genesis block
- String "pending" - for the pending state/transactions

And EIP-1898 does not all calls that use `BlockNumber` like `eth_getBlockByNumber` and doesn't list raw integers as supported.

## Solution

Added a module that deserializes either a BlockNumberOrTag, or a simple number

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
