### PR TITLE
Adding support for signing 7702 authorizations

### DIFF
--- a/crates/signer-ledger/Cargo.toml
+++ b/crates/signer-ledger/Cargo.toml
@@ -26,7 +26,6 @@ workspace = true
 alloy-consensus = { workspace = true, features = ["std"] }
 alloy-primitives.workspace = true
 alloy-signer.workspace = true
-rlp = "0.5"
 
 async-trait.workspace = true
 coins-ledger = { version = "0.12", default-features = false }
@@ -40,6 +39,9 @@ alloy-sol-types = { workspace = true, optional = true }
 alloy-dyn-abi = { workspace = true, optional = true }
 alloy-network.workspace = true
 
+# eip7702
+alloy-eips = { workspace = true, optional = true }
+
 [dev-dependencies]
 alloy-consensus = { workspace = true, features = ["std"] }
 alloy-rlp.workspace = true
@@ -49,7 +51,7 @@ tracing-subscriber.workspace = true
 
 [features]
 eip712 = ["alloy-signer/eip712", "dep:alloy-sol-types", "dep:alloy-dyn-abi"]
-eip7702 = []
+eip7702 = ["alloy-eips"]
 
 # WASM support
 browser = ["coins-ledger/browser"]

--- a/crates/signer-ledger/Cargo.toml
+++ b/crates/signer-ledger/Cargo.toml
@@ -26,6 +26,7 @@ workspace = true
 alloy-consensus = { workspace = true, features = ["std"] }
 alloy-primitives.workspace = true
 alloy-signer.workspace = true
+rlp = "0.5"
 
 async-trait.workspace = true
 coins-ledger = { version = "0.12", default-features = false }
@@ -48,6 +49,7 @@ tracing-subscriber.workspace = true
 
 [features]
 eip712 = ["alloy-signer/eip712", "dep:alloy-sol-types", "dep:alloy-dyn-abi"]
+eip7702 = []
 
 # WASM support
 browser = ["coins-ledger/browser"]

--- a/crates/signer-ledger/Cargo.toml
+++ b/crates/signer-ledger/Cargo.toml
@@ -40,7 +40,7 @@ alloy-dyn-abi = { workspace = true, optional = true }
 alloy-network.workspace = true
 
 # eip7702
-alloy-eips = { workspace = true, optional = true }
+alloy-eip7702 = { workspace = true, optional = true }
 
 [dev-dependencies]
 alloy-consensus = { workspace = true, features = ["std"] }
@@ -51,7 +51,7 @@ tracing-subscriber.workspace = true
 
 [features]
 eip712 = ["alloy-signer/eip712", "dep:alloy-sol-types", "dep:alloy-dyn-abi"]
-eip7702 = ["alloy-eips"]
+eip7702 = ["alloy-eip7702"]
 
 # WASM support
 browser = ["coins-ledger/browser"]

--- a/crates/signer-ledger/src/lib.rs
+++ b/crates/signer-ledger/src/lib.rs
@@ -9,8 +9,8 @@
 #[macro_use]
 extern crate tracing;
 
-mod utils;
 mod signer;
+mod utils;
 pub use signer::LedgerSigner;
 
 mod types;

--- a/crates/signer-ledger/src/lib.rs
+++ b/crates/signer-ledger/src/lib.rs
@@ -10,7 +10,6 @@
 extern crate tracing;
 
 mod utils;
-use rlp as _;
 mod signer;
 pub use signer::LedgerSigner;
 

--- a/crates/signer-ledger/src/lib.rs
+++ b/crates/signer-ledger/src/lib.rs
@@ -9,6 +9,8 @@
 #[macro_use]
 extern crate tracing;
 
+mod utils;
+use rlp as _;
 mod signer;
 pub use signer::LedgerSigner;
 

--- a/crates/signer-ledger/src/signer.rs
+++ b/crates/signer-ledger/src/signer.rs
@@ -16,10 +16,6 @@ use alloy_dyn_abi::TypedData;
 #[cfg(feature = "eip712")]
 use alloy_sol_types::{Eip712Domain, SolStruct};
 
-#[cfg(feature = "eip7702")]
-use crate::utils::make_eip7702_tlv;
-#[cfg(feature = "eip7702")]
-use alloy_eips::eip7702::Authorization;
 
 /// A Ledger Ethereum signer.
 ///
@@ -288,10 +284,10 @@ impl LedgerSigner {
     #[cfg(feature = "eip7702")]
     pub async fn sign_auth(
     &self,
-    auth: &Authorization,
+    auth: &alloy_eip7702::Authorization,
 ) -> Result<Signature, LedgerError> {
     let path_bytes = Self::path_to_bytes(&self.derivation);
-    let tlv_payload = make_eip7702_tlv(auth.chain_id, &auth.address, auth.nonce);
+    let tlv_payload = crate::utils::make_eip7702_tlv(auth.chain_id, &auth.address, auth.nonce);
 
     let tlv_length = (tlv_payload.len() as u16).to_be_bytes();
 
@@ -512,7 +508,7 @@ mod tests {
         let delegate: Address = address!("0x4Cd241E8d1510e30b2076397afc7508Ae59C66c9");
         let nonce: u64 = 72;
         
-        let auth: Authorization = Authorization{
+        let auth: alloy_eip7702::Authorization = alloy_eip7702::Authorization{
             chain_id: U256::from(chain_id),
             address: delegate,
             nonce: nonce

--- a/crates/signer-ledger/src/types.rs
+++ b/crates/signer-ledger/src/types.rs
@@ -60,7 +60,8 @@ pub enum LedgerError {
     },
 }
 
-pub(crate) const P1_FIRST: u8 = 0x00;
+pub(crate) const P1_FIRST_0: u8 = 0x00;
+pub(crate) const P1_FIRST_1: u8 = 0x01;
 
 #[repr(u8)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -72,6 +73,7 @@ pub(crate) enum INS {
     GET_APP_CONFIGURATION = 0x06,
     SIGN_PERSONAL_MESSAGE = 0x08,
     SIGN_ETH_EIP_712 = 0x0C,
+    SIGN_EIP7702_AUTHORIZATION = 0x34,
 }
 
 impl fmt::Display for INS {
@@ -82,6 +84,7 @@ impl fmt::Display for INS {
             Self::GET_APP_CONFIGURATION => write!(f, "GET_APP_CONFIGURATION"),
             Self::SIGN_PERSONAL_MESSAGE => write!(f, "SIGN_PERSONAL_MESSAGE"),
             Self::SIGN_ETH_EIP_712 => write!(f, "SIGN_ETH_EIP_712"),
+            Self::SIGN_EIP7702_AUTHORIZATION => write!(f, "SIGN_EIP7702_AUTHORIZATION"),
         }
     }
 }

--- a/crates/signer-ledger/src/utils.rs
+++ b/crates/signer-ledger/src/utils.rs
@@ -11,8 +11,12 @@ pub(crate) fn be_varint(n: u64) -> Vec<u8> {
 
 // Tlv encoding for the 7702 authorization list
 #[cfg(feature = "eip7702")]
-pub(crate) fn make_eip7702_tlv(chain_id: alloy_primitives::U256, delegate: &[u8; 20], nonce: u64) -> Vec<u8> {
-    let mut tlv = Vec::new();
+pub(crate) fn make_eip7702_tlv(
+    chain_id: alloy_primitives::U256,
+    delegate: &[u8; 20],
+    nonce: u64,
+) -> Vec<u8> {
+    let mut tlv = Vec::with_capacity(9 + 20);
 
     // STRUCT_VERSION tag=0x00, one-byte version=1
     tlv.push(0x00);
@@ -35,7 +39,6 @@ pub(crate) fn make_eip7702_tlv(chain_id: alloy_primitives::U256, delegate: &[u8;
     tlv.push(0x03);
     tlv.push(nn.len() as u8);
     tlv.extend_from_slice(&nn);
-    
 
     tlv
 }

--- a/crates/signer-ledger/src/utils.rs
+++ b/crates/signer-ledger/src/utils.rs
@@ -1,0 +1,43 @@
+
+
+// Helper to encode a big-endian varint (no leading zeroes)
+// Nonce limit is 2**64 - 1 https://eips.ethereum.org/EIPS/eip-2681
+#[cfg(feature = "eip7702")]
+pub(crate) fn be_varint(n: u64) -> Vec<u8> {
+    let mut buf = n.to_be_bytes().to_vec();
+    while buf.first() == Some(&0) && buf.len() > 1 {
+        buf.remove(0);
+    }
+    buf
+}
+
+// Tlv encoding for the 7702 authorization list
+#[cfg(feature = "eip7702")]
+pub(crate) fn make_eip7702_tlv(chain_id: u64, delegate: &[u8; 20], nonce: u64) -> Vec<u8> {
+    let mut tlv = Vec::new();
+
+    // STRUCT_VERSION tag=0x00, one-byte version=1
+    tlv.push(0x00);
+    tlv.push(1);
+    tlv.push(1);
+
+    // DELEGATE_ADDR tag=0x01
+    tlv.push(0x01);
+    tlv.push(20);
+    tlv.extend_from_slice(delegate);
+
+    // CHAIN_ID tag=0x02
+    let ci = be_varint(chain_id);
+    tlv.push(0x02);
+    tlv.push(ci.len() as u8);
+    tlv.extend_from_slice(&ci);
+
+    // NONCE tag=0x03
+    let nn = be_varint(nonce);
+    tlv.push(0x03);
+    tlv.push(nn.len() as u8);
+    tlv.extend_from_slice(&nn);
+    
+
+    tlv
+}

--- a/crates/signer-ledger/src/utils.rs
+++ b/crates/signer-ledger/src/utils.rs
@@ -1,6 +1,3 @@
-#[cfg(feature = "eip7702")]
-use alloy_primitives::{U256};
-
 // Helper to encode a big-endian varint (no leading zeroes)
 // Nonce limit is 2**64 - 1 https://eips.ethereum.org/EIPS/eip-2681
 #[cfg(feature = "eip7702")]
@@ -14,7 +11,7 @@ pub(crate) fn be_varint(n: u64) -> Vec<u8> {
 
 // Tlv encoding for the 7702 authorization list
 #[cfg(feature = "eip7702")]
-pub(crate) fn make_eip7702_tlv(chain_id: U256, delegate: &[u8; 20], nonce: u64) -> Vec<u8> {
+pub(crate) fn make_eip7702_tlv(chain_id: alloy_primitives::U256, delegate: &[u8; 20], nonce: u64) -> Vec<u8> {
     let mut tlv = Vec::new();
 
     // STRUCT_VERSION tag=0x00, one-byte version=1

--- a/crates/signer-ledger/src/utils.rs
+++ b/crates/signer-ledger/src/utils.rs
@@ -1,4 +1,5 @@
-
+#[cfg(feature = "eip7702")]
+use alloy_primitives::{U256};
 
 // Helper to encode a big-endian varint (no leading zeroes)
 // Nonce limit is 2**64 - 1 https://eips.ethereum.org/EIPS/eip-2681
@@ -13,7 +14,7 @@ pub(crate) fn be_varint(n: u64) -> Vec<u8> {
 
 // Tlv encoding for the 7702 authorization list
 #[cfg(feature = "eip7702")]
-pub(crate) fn make_eip7702_tlv(chain_id: u64, delegate: &[u8; 20], nonce: u64) -> Vec<u8> {
+pub(crate) fn make_eip7702_tlv(chain_id: U256, delegate: &[u8; 20], nonce: u64) -> Vec<u8> {
     let mut tlv = Vec::new();
 
     // STRUCT_VERSION tag=0x00, one-byte version=1
@@ -27,7 +28,7 @@ pub(crate) fn make_eip7702_tlv(chain_id: u64, delegate: &[u8; 20], nonce: u64) -
     tlv.extend_from_slice(delegate);
 
     // CHAIN_ID tag=0x02
-    let ci = be_varint(chain_id);
+    let ci = be_varint(chain_id.to::<u64>());
     tlv.push(0x02);
     tlv.push(ci.len() as u8);
     tlv.extend_from_slice(&ci);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

EIP-7702 introduces a new delegation flow that lets an EOA authorize a separate delegate to act on its behalf.  
To support this, the Ledger signer needs to be able to encode the TLV-style payload and send it to the device for signing. 


## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
- Add a new function `sign_auth` which does the following :
  - Internally builds the TLV payload  
  - Then streams it over the APDU `SIGN_EIP7702_AUTHORIZATION` instruction.


## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
