### PR TITLE
feat: from tx for withotherfields

### DIFF
--- a/crates/rpc-types-eth/src/transaction/request.rs
+++ b/crates/rpc-types-eth/src/transaction/request.rs
@@ -860,6 +860,13 @@ impl TransactionBuilder7702 for TransactionRequest {
     }
 }
 
+#[cfg(feature = "serde")]
+impl From<TransactionRequest> for alloy_serde::WithOtherFields<TransactionRequest> {
+    fn from(tx: TransactionRequest) -> Self {
+        Self::new(tx)
+    }
+}
+
 impl From<Transaction> for TransactionRequest {
     fn from(tx: Transaction) -> Self {
         tx.into_request()


### PR DESCRIPTION
missing from impl, allows us to get rid of some wrappers in foundry and can just call .into()