### PR TITLE
doc: unhide `SendableTx`

### DIFF
--- a/crates/provider/src/provider/sendable.rs
+++ b/crates/provider/src/provider/sendable.rs
@@ -7,7 +7,7 @@ use alloy_network::Network;
 ///
 /// Users should NOT use this type directly. It should only be used as an
 /// implementation detail of [`Provider::send_transaction_internal`].
-#[doc(hidden, alias = "SendableTransaction")]
+#[doc(alias = "SendableTransaction")]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum SendableTx<N: Network> {
     /// A transaction that is not yet signed.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

I understand the doc was made `hidden` because as the doc comments suggest this should be considered an internal type. But this internal type is exposed in the `TxFiller` trait and `FillProvider` type and I think since it is already public type because being returned in public API the docs should still be accessible. The warning in the doc comment should be enough for the readers. 

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
