### PR TITLE
feat(json-rpc): add request extensions

### DIFF
--- a/crates/json-rpc/Cargo.toml
+++ b/crates/json-rpc/Cargo.toml
@@ -29,3 +29,4 @@ serde_json = { workspace = true, features = ["std", "raw_value"] }
 thiserror = { workspace = true, features = ["std"] }
 tracing.workspace = true
 alloy-sol-types.workspace = true
+http.workspace = true

--- a/crates/json-rpc/src/request.rs
+++ b/crates/json-rpc/src/request.rs
@@ -1,5 +1,6 @@
 use crate::{common::Id, RpcBorrow, RpcSend};
 use alloy_primitives::{keccak256, B256};
+use http::Extensions;
 use serde::{
     de::{DeserializeOwned, MapAccess},
     ser::SerializeMap,
@@ -9,7 +10,7 @@ use serde_json::value::RawValue;
 use std::{borrow::Cow, marker::PhantomData, mem::MaybeUninit};
 
 /// `RequestMeta` contains the [`Id`] and method name of a request.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug)]
 pub struct RequestMeta {
     /// The method name.
     pub method: Cow<'static, str>,
@@ -17,12 +18,14 @@ pub struct RequestMeta {
     pub id: Id,
     /// Whether the request is a subscription, other than `eth_subscribe`.
     is_subscription: bool,
+    /// Optional HTTP extensions for the request.
+    extensions: Extensions,
 }
 
 impl RequestMeta {
     /// Create a new `RequestMeta`.
-    pub const fn new(method: Cow<'static, str>, id: Id) -> Self {
-        Self { method, id, is_subscription: false }
+    pub fn new(method: Cow<'static, str>, id: Id) -> Self {
+        Self { method, id, is_subscription: false, extensions: Extensions::new() }
     }
 
     /// Returns `true` if the request is a subscription.
@@ -41,7 +44,27 @@ impl RequestMeta {
     pub fn set_subscription_status(&mut self, sub: bool) {
         self.is_subscription = sub;
     }
+
+    /// Returns a reference to the request extensions.
+    pub const fn extensions(&self) -> &Extensions {
+        &self.extensions
+    }
+
+    /// Add an extension to the request.
+    pub fn add_extension<T: Clone + Send + Sync + 'static>(&mut self, ext: T) {
+        self.extensions.insert(ext);
+    }
 }
+
+impl PartialEq for RequestMeta {
+    fn eq(&self, other: &Self) -> bool {
+        self.method == other.method
+            && self.id == other.id
+            && self.is_subscription == other.is_subscription
+    }
+}
+
+impl Eq for RequestMeta {}
 
 /// A JSON-RPC 2.0 request object.
 ///


### PR DESCRIPTION
## Motivation

Diving into alloy json-rpc I found that the Tower traits are all implemented for the type [`RequestPacket`](https://github.com/alloy-rs/alloy/blob/main/crates/json-rpc/src/packet.rs#L13).

One big difference that I can see with the regular `http::Request` is the lack of [http extensions](https://docs.rs/http/latest/http/request/struct.Request.html#method.extensions) which can be nice to write custom layers that use request-specific metadata.

One example use case would be a custom redundancy layer (e.g. as an expansion to [`FallbackService`](https://github.com/alloy-rs/alloy/blob/main/crates/transport/src/layers/fallback.rs#L31)) that allows per-request redundancy criteria, for instance to require consensus between N transports, or to use the "highest value" returned by N transports.

## Solution

I've added an optional `extensions` field to the `RequestMeta` inside each request packet. 
It should be enough for any Tower layer to query this to define its extra behavior.
