### PR TITLE
feat: default into_logs fn

### DIFF
--- a/crates/consensus-any/src/lib.rs
+++ b/crates/consensus-any/src/lib.rs
@@ -7,7 +7,6 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#[cfg(feature = "serde")]
 extern crate alloc;
 
 mod block;

--- a/crates/consensus-any/src/receipt/envelope.rs
+++ b/crates/consensus-any/src/receipt/envelope.rs
@@ -1,3 +1,4 @@
+use alloc::vec::Vec;
 use alloy_consensus::{Eip658Value, Receipt, ReceiptWithBloom, TxReceipt};
 use alloy_eips::{
     eip2718::{Decodable2718, Eip2718Result, Encodable2718},
@@ -117,7 +118,14 @@ where
     }
 
     fn logs(&self) -> &[T] {
-        self.logs()
+        Self::logs(self)
+    }
+
+    fn into_logs(self) -> Vec<Self::Log>
+    where
+        Self::Log: Clone,
+    {
+        self.inner.receipt.logs
     }
 }
 

--- a/crates/consensus/src/receipt/envelope.rs
+++ b/crates/consensus/src/receipt/envelope.rs
@@ -199,6 +199,13 @@ where
     fn logs(&self) -> &[T] {
         &self.as_receipt().unwrap().logs
     }
+
+    fn into_logs(self) -> Vec<Self::Log>
+    where
+        Self::Log: Clone,
+    {
+        self.into_receipt().logs
+    }
 }
 
 impl ReceiptEnvelope {

--- a/crates/consensus/src/receipt/mod.rs
+++ b/crates/consensus/src/receipt/mod.rs
@@ -1,3 +1,4 @@
+use alloc::vec::Vec;
 use alloy_primitives::Bloom;
 use alloy_rlp::BufMut;
 use core::fmt;
@@ -81,6 +82,15 @@ pub trait TxReceipt: Clone + fmt::Debug + PartialEq + Eq + Send + Sync {
 
     /// Returns the logs emitted by this transaction.
     fn logs(&self) -> &[Self::Log];
+
+    /// Consumes the type and returns the logs emitted by this transaction as a vector.
+    #[auto_impl(keep_default_for(&, Arc))]
+    fn into_logs(self) -> Vec<Self::Log>
+    where
+        Self::Log: Clone,
+    {
+        self.logs().to_vec()
+    }
 }
 
 /// Receipt type that knows how to encode itself with a [`Bloom`] value.

--- a/crates/consensus/src/receipt/receipts.rs
+++ b/crates/consensus/src/receipt/receipts.rs
@@ -92,6 +92,13 @@ where
     fn logs(&self) -> &[Self::Log] {
         &self.logs
     }
+
+    fn into_logs(self) -> Vec<Self::Log>
+    where
+        Self::Log: Clone,
+    {
+        self.logs
+    }
 }
 
 impl<T: Encodable> Receipt<T> {


### PR DESCRIPTION
this is often useful when converting something that is `TxReceipt` into rpc Log object which requires taking ownership of the logs

we can make this default by simply calling to_vec but can specialize this in the impls