### PR TITLE
fix: make pollers and `Heartbeat` more reliable

### DIFF
--- a/crates/provider/src/blocks.rs
+++ b/crates/provider/src/blocks.rs
@@ -162,11 +162,11 @@ impl<N: Network> NewBlocks<N> {
                     }
                     Err(err) => {
                         error!(number, %err, "failed to fetch block");
-                        break 'task;
+                        break;
                     }
                     Ok(None) => {
                         error!(number, "failed to fetch block (doesn't exist)");
-                        break 'task;
+                        break;
                     }
                 };
                 self.known_blocks.put(number, block);

--- a/crates/rpc-client/src/poller.rs
+++ b/crates/rpc-client/src/poller.rs
@@ -1,5 +1,5 @@
 use crate::WeakClient;
-use alloy_json_rpc::{RpcError, RpcRecv, RpcSend};
+use alloy_json_rpc::{RpcRecv, RpcSend};
 use alloy_transport::utils::Spawnable;
 use async_stream::stream;
 use futures::{Stream, StreamExt};
@@ -20,9 +20,6 @@ use wasmtimer::tokio::sleep;
 
 #[cfg(not(target_family = "wasm"))]
 use tokio::time::sleep;
-
-/// The number of retries for polling a request.
-const MAX_RETRIES: usize = 3;
 
 /// A poller task builder.
 ///
@@ -176,8 +173,7 @@ where
         let span = debug_span!("poller", method = %self.method);
         stream! {
         let mut params = ParamsOnce::Typed(self.params);
-        let mut retries = MAX_RETRIES;
-        'outer: for _ in 0..self.limit {
+        for _ in 0..self.limit {
             let Some(client) = self.client.upgrade() else {
                 debug!("client dropped");
                 break;
@@ -192,21 +188,12 @@ where
                 }
             };
 
-            loop {
-                trace!("polling");
-                match client.request(self.method.clone(), params).await {
-                    Ok(resp) => yield resp,
-                    Err(RpcError::Transport(err)) if retries > 0 && err.recoverable() => {
-                        debug!(%err, "failed to poll, retrying");
-                        retries -= 1;
-                        continue;
-                    }
-                    Err(err) => {
-                        error!(%err, "failed to poll");
-                        break 'outer;
-                    }
+            trace!("polling");
+            match client.request(self.method.clone(), params).await {
+                Ok(resp) => yield resp,
+                Err(err) => {
+                    error!(%err, "failed to poll");
                 }
-                break;
             }
 
             trace!(duration=?self.poll_interval, "sleeping");


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

# Motivation

Changes pollers and heartbeat to be more tolerant to errors returned from client. Right now node going down for several seconds would cause pollers or heartbeat tasks to get terminated after several retries which might be critical and thus forces any user reliying on those to implement handling of such cases.

With this PR we're now enver ending the task and keep querying the node indefinitely instead

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
