### PR TITLE
Fix misleading doc comment

### DIFF
--- a/crates/eips/src/eip1559/helpers.rs
+++ b/crates/eips/src/eip1559/helpers.rs
@@ -7,7 +7,7 @@ use crate::eip1559::{constants::GAS_LIMIT_BOUND_DIVISOR, BaseFeeParams};
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct Eip1559Estimation {
-    /// The base fee per gas.
+    /// The max fee per gas.
     #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
     pub max_fee_per_gas: u128,
     /// The max priority fee per gas.


### PR DESCRIPTION
EIP1559: `max_fee_per_gas` is not `base_fee_per_gas` (proofs: [1](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1559.md?plain=1#L212), [2](https://github.com/alloy-rs/alloy/blob/84bbfd79222361a07a8febc102e2844bb326e155/crates/provider/src/utils.rs#L119))
