### PR TITLE
docs: fix incorrect type flag doc for EIP-4844 + minor grammar in CI config

### DIFF
--- a/.config/zepter.yaml
+++ b/.config/zepter.yaml
@@ -13,9 +13,9 @@ workflows:
         "propagate-feature",
         # These are the features to check:
         "--features=arbitrary,std,serde,ssz",
-        # Do not try to add a new section into `[features]` of `A` only because `B` expose that feature. There are edge-cases where this is still needed, but we can add them manually.
+        # Do not try to add a new section into `[features]` of `A` only because `B` exposes that feature. There are edge-cases where this is still needed, but we can add them manually.
         "--left-side-feature-missing=ignore",
-        # Ignore the case that `A` it outside of the workspace. Otherwise it will report errors in external dependencies that we have no influence on.
+        # Ignore the case that `A` is outside of the workspace. Otherwise it will report errors in external dependencies that we have no influence on.
         "--left-side-outside-workspace=ignore",
         # Only check normal dependencies. 
         # Propagating to dev-dependencies leads to compilation issues: https://github.com/alloy-rs/alloy/pull/2144#issuecomment-2702291349

--- a/crates/consensus/src/receipt/envelope.rs
+++ b/crates/consensus/src/receipt/envelope.rs
@@ -39,7 +39,7 @@ pub enum ReceiptEnvelope<T = Log> {
     /// [EIP-1559]: https://eips.ethereum.org/EIPS/eip-1559
     #[cfg_attr(feature = "serde", serde(rename = "0x2", alias = "0x02"))]
     Eip1559(ReceiptWithBloom<Receipt<T>>),
-    /// Receipt envelope with type flag 2, containing a [EIP-4844] receipt.
+    /// Receipt envelope with type flag 3, containing a [EIP-4844] receipt.
     ///
     /// [EIP-4844]: https://eips.ethereum.org/EIPS/eip-4844
     #[cfg_attr(feature = "serde", serde(rename = "0x3", alias = "0x03"))]


### PR DESCRIPTION
crates/consensus/src/receipt/envelope.rs
 type flag 2 → type flag 3
Why: EIP-4844 uses type ID 3. Docs were wrong, now fixed.

.config/zepter.yaml
expose → exposes

A it outside → A is outside
Why: Grammar fixes for clarity in CI config comments.
