### PR TITLE
chore: remove fulu blob constants

### DIFF
--- a/crates/eips/src/eip7594/mod.rs
+++ b/crates/eips/src/eip7594/mod.rs
@@ -22,12 +22,6 @@ pub const EIP_7594_WRAPPER_VERSION: u8 = 1;
 /// A commitment/proof serialized as 0x-prefixed hex string
 pub type Cell = FixedBytes<BYTES_PER_CELL>;
 
-/// CL-enforced target blobs per block after Fusaka hardfork activation.
-pub const TARGET_BLOBS_PER_BLOCK_FULU: u64 = 48;
-
-/// CL-enforced maximum blobs per block after Fusaka hardfork activation.
-pub const MAX_BLOBS_PER_BLOCK_FULU: u64 = 64;
-
 mod rlp;
 pub use rlp::*;
 

--- a/crates/eips/src/eip7840.rs
+++ b/crates/eips/src/eip7840.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     eip4844::{self, DATA_GAS_PER_BLOB},
-    eip7594, eip7691,
+    eip7691,
 };
 
 // helpers for serde
@@ -59,8 +59,8 @@ impl BlobParams {
     /// Returns [`BlobParams`] configuration activated with Osaka hardfork.
     pub const fn osaka() -> Self {
         Self {
-            target_blob_count: eip7594::TARGET_BLOBS_PER_BLOCK_FULU,
-            max_blob_count: eip7594::MAX_BLOBS_PER_BLOCK_FULU,
+            target_blob_count: eip7691::TARGET_BLOBS_PER_BLOCK_ELECTRA,
+            max_blob_count: eip7691::MAX_BLOBS_PER_BLOCK_ELECTRA,
             update_fraction: eip7691::BLOB_GASPRICE_UPDATE_FRACTION_PECTRA,
             min_blob_fee: eip4844::BLOB_TX_MIN_BLOB_GASPRICE,
         }


### PR DESCRIPTION
## Description

Remove `Fulu` blob constants as we are going to use `Prague` params and BPOs for further increases.