### PR TITLE
feat: BlobParams::max_blobs_per_tx

### DIFF
--- a/crates/eips/src/eip7840.rs
+++ b/crates/eips/src/eip7840.rs
@@ -5,34 +5,29 @@ use crate::{
     eip7691,
 };
 
-// helpers for serde
-#[cfg(feature = "serde")]
-const DEFAULT_BLOB_FEE_GETTER: fn() -> u128 = || eip4844::BLOB_TX_MIN_BLOB_GASPRICE;
-#[cfg(feature = "serde")]
-const IS_DEFAULT_BLOB_FEE: fn(&u128) -> bool = |&x| x == eip4844::BLOB_TX_MIN_BLOB_GASPRICE;
-
 /// Configuration for the blob-related calculations.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "serde",
+    serde(from = "serde_impl::SerdeHelper", into = "serde_impl::SerdeHelper")
+)]
 pub struct BlobParams {
     /// Target blob count for the block.
-    #[cfg_attr(feature = "serde", serde(rename = "target"))]
     pub target_blob_count: u64,
     /// Max blob count for the block.
-    #[cfg_attr(feature = "serde", serde(rename = "max"))]
     pub max_blob_count: u64,
     /// Update fraction for excess blob gas calculation.
-    #[cfg_attr(feature = "serde", serde(rename = "baseFeeUpdateFraction"))]
     pub update_fraction: u128,
     /// Minimum gas price for a data blob.
     ///
     /// Not required per EIP-7840 and assumed to be the default
     /// [`eip4844::BLOB_TX_MIN_BLOB_GASPRICE`] if not set.
-    #[cfg_attr(
-        feature = "serde",
-        serde(default = "DEFAULT_BLOB_FEE_GETTER", skip_serializing_if = "IS_DEFAULT_BLOB_FEE")
-    )]
     pub min_blob_fee: u128,
+    /// Maximum number of blobs per transaction.
+    ///
+    /// If not specified, defaults to `max_blob_count` during deserialization.
+    pub max_blobs_per_tx: u64,
 }
 
 impl BlobParams {
@@ -43,6 +38,7 @@ impl BlobParams {
             max_blob_count: eip4844::MAX_BLOBS_PER_BLOCK_DENCUN as u64,
             update_fraction: eip4844::BLOB_GASPRICE_UPDATE_FRACTION,
             min_blob_fee: eip4844::BLOB_TX_MIN_BLOB_GASPRICE,
+            max_blobs_per_tx: eip4844::MAX_BLOBS_PER_BLOCK_DENCUN as u64,
         }
     }
 
@@ -53,6 +49,7 @@ impl BlobParams {
             max_blob_count: eip7691::MAX_BLOBS_PER_BLOCK_ELECTRA,
             update_fraction: eip7691::BLOB_GASPRICE_UPDATE_FRACTION_PECTRA,
             min_blob_fee: eip4844::BLOB_TX_MIN_BLOB_GASPRICE,
+            max_blobs_per_tx: eip7691::MAX_BLOBS_PER_BLOCK_ELECTRA,
         }
     }
 
@@ -63,6 +60,7 @@ impl BlobParams {
             max_blob_count: eip7691::MAX_BLOBS_PER_BLOCK_ELECTRA,
             update_fraction: eip7691::BLOB_GASPRICE_UPDATE_FRACTION_PECTRA,
             min_blob_fee: eip4844::BLOB_TX_MIN_BLOB_GASPRICE,
+            max_blobs_per_tx: eip7691::MAX_BLOBS_PER_BLOCK_ELECTRA,
         }
     }
 
@@ -96,5 +94,64 @@ impl BlobParams {
     #[inline]
     pub const fn calc_blob_fee(&self, excess_blob_gas: u64) -> u128 {
         eip4844::fake_exponential(self.min_blob_fee, excess_blob_gas as u128, self.update_fraction)
+    }
+}
+
+#[cfg(feature = "serde")]
+mod serde_impl {
+    use crate::{eip4844, eip7840::BlobParams};
+
+    #[derive(serde::Serialize, serde::Deserialize, Clone, Copy)]
+    #[serde(rename_all = "camelCase")]
+    pub(crate) struct SerdeHelper {
+        #[serde(rename = "target")]
+        target_blob_count: u64,
+        #[serde(rename = "max")]
+        max_blob_count: u64,
+        #[serde(rename = "baseFeeUpdateFraction")]
+        update_fraction: u128,
+        min_blob_fee: Option<u128>,
+        max_blobs_per_tx: Option<u64>,
+    }
+
+    impl From<BlobParams> for SerdeHelper {
+        fn from(params: BlobParams) -> Self {
+            let BlobParams {
+                target_blob_count,
+                max_blob_count,
+                update_fraction,
+                min_blob_fee,
+                max_blobs_per_tx,
+            } = params;
+
+            SerdeHelper {
+                target_blob_count,
+                max_blob_count,
+                update_fraction,
+                min_blob_fee: (min_blob_fee != eip4844::BLOB_TX_MIN_BLOB_GASPRICE)
+                    .then_some(min_blob_fee),
+                max_blobs_per_tx: Some(max_blobs_per_tx),
+            }
+        }
+    }
+
+    impl From<SerdeHelper> for BlobParams {
+        fn from(helper: SerdeHelper) -> Self {
+            let SerdeHelper {
+                target_blob_count,
+                max_blob_count,
+                update_fraction,
+                min_blob_fee,
+                max_blobs_per_tx,
+            } = helper;
+
+            BlobParams {
+                target_blob_count,
+                max_blob_count,
+                update_fraction,
+                min_blob_fee: min_blob_fee.unwrap_or(eip4844::BLOB_TX_MIN_BLOB_GASPRICE),
+                max_blobs_per_tx: max_blobs_per_tx.unwrap_or(max_blob_count),
+            }
+        }
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Implements https://github.com/ethereum/EIPs/pull/9623

The new field defaults to max blob count per block making the change not breaking. This required introducing a manual serde impl which is now also handling the `minBlobFee`deserialization

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
