### PR TITLE
feat: add missing gas_price setter to TransactionRequest

### DIFF
--- a/crates/rpc-types-eth/src/transaction/request.rs
+++ b/crates/rpc-types-eth/src/transaction/request.rs
@@ -217,6 +217,12 @@ impl TransactionRequest {
         self
     }
 
+    /// Sets the gas price for the transaction.
+    pub const fn gas_price(mut self, gas_price: u128) -> Self {
+        self.gas_price = Some(gas_price);
+        self
+    }
+
     /// Sets the maximum fee per gas for the transaction.
     pub const fn max_fee_per_gas(mut self, max_fee_per_gas: u128) -> Self {
         self.max_fee_per_gas = Some(max_fee_per_gas);


### PR DESCRIPTION
## Summary
- Add missing `gas_price()` builder method to `TransactionRequest`

## Changes
- Added `gas_price(gas_price: u128)` setter method following the same pattern as other fee-related setters
- Maintains consistency with existing methods like `max_fee_per_gas()` and `max_priority_fee_per_gas()`

## Usage
```rust
let request = TransactionRequest::default()
    .gas_price(20_000_000_000); // 20 gwei
```

Fixes #2565

🤖 Generated with [Claude Code](https://claude.ai/code)