### PR TITLE
docs: add examples for TransactionRequest::preferred_type()

### DIFF
--- a/crates/rpc-types-eth/src/transaction/request.rs
+++ b/crates/rpc-types-eth/src/transaction/request.rs
@@ -641,8 +641,7 @@ impl TransactionRequest {
     ///
     /// This function is intended for building and eventually signing transactions client-side.
     /// Unlike [`Self::minimal_tx_type`] which returns the minimal required type, this function
-    /// prefers [`TxType::Eip1559`] when no conflicting fields are set, making it ideal for
-    /// modern transaction building workflows.
+    /// prefers [`TxType::Eip1559`] when no conflicting fields are set.
     ///
     /// Types are preferred as follows:
     /// - EIP-7702 if authorization_list is set
@@ -654,62 +653,56 @@ impl TransactionRequest {
     /// # Examples
     ///
     /// ```rust
-    /// use alloy_rpc_types_eth::TransactionRequest;
     /// use alloy_consensus::TxType;
     /// use alloy_eips::eip2930::AccessList;
-    /// 
+    /// use alloy_rpc_types_eth::TransactionRequest;
+    ///
     /// // EIP-7702 (highest priority)
     /// let mut request = TransactionRequest::default();
     /// request.authorization_list = Some(vec![]);
     /// assert_eq!(request.preferred_type(), TxType::Eip7702);
-    /// 
+    ///
     /// // EIP-4844 with max_fee_per_blob_gas
-    /// let request = TransactionRequest::default()
-    ///     .max_fee_per_blob_gas(1000000000);
+    /// let request = TransactionRequest::default().max_fee_per_blob_gas(1000000000);
     /// assert_eq!(request.preferred_type(), TxType::Eip4844);
-    /// 
+    ///
     /// // EIP-2930 with both access_list and gas_price
-    /// let request = TransactionRequest::default()
-    ///     .access_list(AccessList::default())
-    ///     .gas_price(20000000000);
+    /// let request =
+    ///     TransactionRequest::default().access_list(AccessList::default()).gas_price(20000000000);
     /// assert_eq!(request.preferred_type(), TxType::Eip2930);
-    /// 
+    ///
     /// // Legacy with only gas_price (no access_list)
-    /// let request = TransactionRequest::default()
-    ///     .gas_price(20000000000);
+    /// let request = TransactionRequest::default().gas_price(20000000000);
     /// assert_eq!(request.preferred_type(), TxType::Legacy);
-    /// 
+    ///
     /// // EIP-1559 as default for modern transactions
     /// let request = TransactionRequest::default();
     /// assert_eq!(request.preferred_type(), TxType::Eip1559);
-    /// 
+    ///
     /// // EIP-1559 even with access_list but no gas_price
-    /// let request = TransactionRequest::default()
-    ///     .access_list(AccessList::default());
+    /// let request = TransactionRequest::default().access_list(AccessList::default());
     /// assert_eq!(request.preferred_type(), TxType::Eip1559);
     /// ```
     ///
-    /// # Key Differences from `minimal_tx_type()`
+    /// # Key Differences from [`Self::minimal_tx_type`]
     ///
     /// ```rust
-    /// use alloy_rpc_types_eth::TransactionRequest;
     /// use alloy_consensus::TxType;
     /// use alloy_eips::eip2930::AccessList;
-    /// 
+    /// use alloy_rpc_types_eth::TransactionRequest;
+    ///
     /// // Empty request - preferred_type prefers EIP-1559, minimal_tx_type falls back to Legacy
     /// let request = TransactionRequest::default();
-    /// assert_eq!(request.preferred_type(), TxType::Eip1559);    // Preferred for new txs
-    /// assert_eq!(request.minimal_tx_type(), TxType::Legacy);    // Minimal requirement
-    /// 
+    /// assert_eq!(request.preferred_type(), TxType::Eip1559); // Preferred for new txs
+    /// assert_eq!(request.minimal_tx_type(), TxType::Legacy); // Minimal requirement
+    ///
     /// // Access list only - different behavior
-    /// let request = TransactionRequest::default()
-    ///     .access_list(AccessList::default());
-    /// assert_eq!(request.preferred_type(), TxType::Eip1559);    // Still prefers EIP-1559
-    /// assert_eq!(request.minimal_tx_type(), TxType::Eip2930);   // Minimal is EIP-2930
-    /// 
+    /// let request = TransactionRequest::default().access_list(AccessList::default());
+    /// assert_eq!(request.preferred_type(), TxType::Eip1559); // Still prefers EIP-1559
+    /// assert_eq!(request.minimal_tx_type(), TxType::Eip2930); // Minimal is EIP-2930
+    ///
     /// // Gas price only - both agree on Legacy
-    /// let request = TransactionRequest::default()
-    ///     .gas_price(20000000000);
+    /// let request = TransactionRequest::default().gas_price(20000000000);
     /// assert_eq!(request.preferred_type(), TxType::Legacy);
     /// assert_eq!(request.minimal_tx_type(), TxType::Legacy);
     /// ```

--- a/crates/rpc-types-eth/src/transaction/request.rs
+++ b/crates/rpc-types-eth/src/transaction/request.rs
@@ -639,12 +639,80 @@ impl TransactionRequest {
 
     /// Check this builder's preferred type, based on the fields that are set.
     ///
+    /// This function is intended for building and eventually signing transactions client-side.
+    /// Unlike [`Self::minimal_tx_type`] which returns the minimal required type, this function
+    /// prefers [`TxType::Eip1559`] when no conflicting fields are set, making it ideal for
+    /// modern transaction building workflows.
+    ///
     /// Types are preferred as follows:
     /// - EIP-7702 if authorization_list is set
     /// - EIP-4844 if sidecar or max_blob_fee_per_gas is set
     /// - EIP-2930 if access_list is set
     /// - Legacy if gas_price is set and access_list is unset
     /// - EIP-1559 in all other cases
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use alloy_rpc_types_eth::TransactionRequest;
+    /// use alloy_consensus::TxType;
+    /// use alloy_eips::eip2930::AccessList;
+    /// 
+    /// // EIP-7702 (highest priority)
+    /// let mut request = TransactionRequest::default();
+    /// request.authorization_list = Some(vec![]);
+    /// assert_eq!(request.preferred_type(), TxType::Eip7702);
+    /// 
+    /// // EIP-4844 with max_fee_per_blob_gas
+    /// let request = TransactionRequest::default()
+    ///     .max_fee_per_blob_gas(1000000000);
+    /// assert_eq!(request.preferred_type(), TxType::Eip4844);
+    /// 
+    /// // EIP-2930 with both access_list and gas_price
+    /// let request = TransactionRequest::default()
+    ///     .access_list(AccessList::default())
+    ///     .gas_price(20000000000);
+    /// assert_eq!(request.preferred_type(), TxType::Eip2930);
+    /// 
+    /// // Legacy with only gas_price (no access_list)
+    /// let request = TransactionRequest::default()
+    ///     .gas_price(20000000000);
+    /// assert_eq!(request.preferred_type(), TxType::Legacy);
+    /// 
+    /// // EIP-1559 as default for modern transactions
+    /// let request = TransactionRequest::default();
+    /// assert_eq!(request.preferred_type(), TxType::Eip1559);
+    /// 
+    /// // EIP-1559 even with access_list but no gas_price
+    /// let request = TransactionRequest::default()
+    ///     .access_list(AccessList::default());
+    /// assert_eq!(request.preferred_type(), TxType::Eip1559);
+    /// ```
+    ///
+    /// # Key Differences from `minimal_tx_type()`
+    ///
+    /// ```rust
+    /// use alloy_rpc_types_eth::TransactionRequest;
+    /// use alloy_consensus::TxType;
+    /// use alloy_eips::eip2930::AccessList;
+    /// 
+    /// // Empty request - preferred_type prefers EIP-1559, minimal_tx_type falls back to Legacy
+    /// let request = TransactionRequest::default();
+    /// assert_eq!(request.preferred_type(), TxType::Eip1559);    // Preferred for new txs
+    /// assert_eq!(request.minimal_tx_type(), TxType::Legacy);    // Minimal requirement
+    /// 
+    /// // Access list only - different behavior
+    /// let request = TransactionRequest::default()
+    ///     .access_list(AccessList::default());
+    /// assert_eq!(request.preferred_type(), TxType::Eip1559);    // Still prefers EIP-1559
+    /// assert_eq!(request.minimal_tx_type(), TxType::Eip2930);   // Minimal is EIP-2930
+    /// 
+    /// // Gas price only - both agree on Legacy
+    /// let request = TransactionRequest::default()
+    ///     .gas_price(20000000000);
+    /// assert_eq!(request.preferred_type(), TxType::Legacy);
+    /// assert_eq!(request.minimal_tx_type(), TxType::Legacy);
+    /// ```
     pub const fn preferred_type(&self) -> TxType {
         if self.authorization_list.is_some() {
             TxType::Eip7702


### PR DESCRIPTION
## Summary
- Add comprehensive documentation examples for the `preferred_type()` function in `TransactionRequest`
- Highlight key differences between `preferred_type()` and `minimal_tx_type()`

## Changes
- Added detailed examples showing client-side transaction building use case
- Demonstrated EIP-1559 preference for modern transactions when no conflicting fields are set
- Included side-by-side comparisons showing behavioral differences from `minimal_tx_type()`
- Covered all transaction type detection scenarios with builder API usage patterns

## Dependencies
- **Blocked by:** #2567 (gas_price setter method)
- This PR includes examples using the `.gas_price()` builder method added in #2567

The examples help developers understand when to use `preferred_type()` vs `minimal_tx_type()` and their nuanced behavioral differences.

🤖 Generated with [Claude Code](https://claude.ai/code)