### PR TITLE
feat(LocalSigner): add `public_key` method to LocalSigner

### DIFF
--- a/crates/signer-local/src/private_key.rs
+++ b/crates/signer-local/src/private_key.rs
@@ -87,7 +87,8 @@ impl LocalSigner<SigningKey> {
         self.credential.to_bytes()
     }
 
-    /// Returns this signer's public key as a hex string prefixed with "0x".
+    /// Convenience function that returns this signer's ethereum public key as a [`B512`] byte
+    /// array.
     #[inline]
     pub fn public_key(&self) -> B512 {
         B512::from_slice(&self.credential.verifying_key().to_encoded_point(false).as_bytes()[1..])


### PR DESCRIPTION

## Motivation

Resolve #2555, by implementing a helper providing a straightforward way to display the public key. See foundry-rs/foundry#10600.

## Solution

* Implemented a `public_key()` method in `LocalSigner` that returns the signer's public key as a hex string prefixed with "0x".
* Added a unit test to verify the functionality of the `public_key()` method.

This method is specifically implemented for `LocalSigner<SigningKey>` and leverages its `verifying_key` method to directly obtain the pubkey without the risk of triggering an error. This contrasts with foundry's "cast wallet pubkey" command implementation, which instantiates a `k256::SecretKey`.
https://github.com/foundry-rs/foundry/blob/365cbb43b67707fdbe594ae212bd7b718079b70f/crates/cast/src/cmd/wallet/mod.rs#L426-L440


## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [x] Breaking changes
