### PR TITLE
feat(rpc-types-eth): add PrunedHistory error code 4444

### DIFF
--- a/crates/rpc-types-eth/src/error.rs
+++ b/crates/rpc-types-eth/src/error.rs
@@ -16,6 +16,9 @@ pub enum EthRpcErrorCode {
     /// Thrown when querying for `finalized` or `safe` block before the merge transition is
     /// finalized, <https://github.com/ethereum/execution-apis/blob/6d17705a875e52c26826124c2a8a15ed542aeca2/src/schemas/block.yaml#L109>
     UnknownBlock,
+    /// Thrown when historical data is not available.
+    /// <https://eips.ethereum.org/EIPS/eip-4444#json-rpc-changes>
+    PrunedHistory,
 }
 
 impl EthRpcErrorCode {
@@ -27,6 +30,7 @@ impl EthRpcErrorCode {
             Self::InvalidInput => -32000,
             Self::ResourceNotFound => -32001,
             Self::UnknownBlock => -39001,
+            Self::PrunedHistory => 4444,
         }
     }
 }


### PR DESCRIPTION
## Summary

Add new  variant  with error code 4444 as specified in EIP-4444 for when historical data is not available.

## Changes

- Add  variant to  enum
- Map error code 4444 to the new variant

## Reference

- [EIP-4444 JSON-RPC Changes](https://eips.ethereum.org/EIPS/eip-4444#json-rpc-changes)

🤖 Generated with [Claude Code](https://claude.ai/code)