### PR TITLE
feat(rpc-types-trace): add as_str method to GethDebugTracerType

### DIFF
--- a/crates/rpc-types-trace/src/geth/mod.rs
+++ b/crates/rpc-types-trace/src/geth/mod.rs
@@ -308,7 +308,7 @@ impl GethDebugTracerType {
         matches!(self, Self::JsTracer(_))
     }
 
-    /// Returns the the tracer type as a string.
+    /// Returns the tracer type as a string.
     ///
     /// If this is not a builtin tracer, it returns the captured string, which could be JavaScript code or a custom identifier such as `"tracer": "stylusTracer"`
     pub fn as_str(&self) -> &str {

--- a/crates/rpc-types-trace/src/geth/mod.rs
+++ b/crates/rpc-types-trace/src/geth/mod.rs
@@ -310,7 +310,8 @@ impl GethDebugTracerType {
 
     /// Returns the tracer type as a string.
     ///
-    /// If this is not a builtin tracer, it returns the captured string, which could be JavaScript code or a custom identifier such as `"tracer": "stylusTracer"`
+    /// If this is not a builtin tracer, it returns the captured string, which could be JavaScript
+    /// code or a custom identifier such as `"tracer": "stylusTracer"`
     pub fn as_str(&self) -> &str {
         match self {
             Self::BuiltInTracer(tracer) => match tracer {

--- a/crates/rpc-types-trace/src/geth/mod.rs
+++ b/crates/rpc-types-trace/src/geth/mod.rs
@@ -307,6 +307,23 @@ impl GethDebugTracerType {
     pub const fn is_js(&self) -> bool {
         matches!(self, Self::JsTracer(_))
     }
+
+    /// Returns the the tracer type as a string.
+    ///
+    /// If this is not a builtin tracer, it returns the captured string, which could be JavaScript code or a custom identifier such as `"tracer": "stylusTracer"`
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::BuiltInTracer(tracer) => match tracer {
+                GethDebugBuiltInTracerType::FourByteTracer => "4byteTracer",
+                GethDebugBuiltInTracerType::CallTracer => "callTracer",
+                GethDebugBuiltInTracerType::FlatCallTracer => "flatCallTracer",
+                GethDebugBuiltInTracerType::PreStateTracer => "prestateTracer",
+                GethDebugBuiltInTracerType::NoopTracer => "noopTracer",
+                GethDebugBuiltInTracerType::MuxTracer => "muxTracer",
+            },
+            Self::JsTracer(code) => code,
+        }
+    }
 }
 
 impl From<GethDebugBuiltInTracerType> for GethDebugTracerType {


### PR DESCRIPTION
## Summary

Add `as_str()` method to `GethDebugTracerType` that returns the tracer type as a string representation.

## Changes

- For built-in tracers, returns their standard names (e.g., "callTracer", "prestateTracer")
- For JS tracers, returns the captured string which could be JavaScript code or a custom identifier

This method provides a convenient way to get the string representation of any tracer type for use in RPC calls or logging.