### PR TITLE
fix: ERC20 endpoints return type

### DIFF
--- a/crates/provider/Cargo.toml
+++ b/crates/provider/Cargo.toml
@@ -82,6 +82,7 @@ alloy-signer.workspace = true
 alloy-signer-local.workspace = true
 alloy-transport-http = { workspace = true, features = ["reqwest", "jwt-auth"] }
 alloy-serde.workspace = true
+alloy-dyn-abi.workspace = true
 
 itertools.workspace = true
 reqwest.workspace = true

--- a/crates/provider/src/ext/anvil.rs
+++ b/crates/provider/src/ext/anvil.rs
@@ -383,10 +383,12 @@ mod tests {
     };
     use alloy_eips::BlockNumberOrTag;
     use alloy_network::TransactionBuilder;
-    use alloy_primitives::B256;
+    use alloy_primitives::{address, B256};
     use alloy_rpc_types_eth::TransactionRequest;
+    use alloy_sol_types::{sol, SolCall};
 
     // use alloy_node_bindings::Anvil; (to be used in `test_anvil_reset`)
+    const FORK_URL: &str = "https://reth-ethereum.ithaca.xyz/rpc";
 
     #[tokio::test]
     async fn test_anvil_impersonate_account_stop_impersonating_account() {
@@ -1054,5 +1056,58 @@ mod tests {
         let res = provider.get_transaction_receipt(tx_hash).await.unwrap().unwrap();
         assert_eq!(res.from, alice);
         assert_eq!(res.to, Some(bob));
+    }
+
+    #[tokio::test]
+    async fn test_anvil_deal_erc20() {
+        let provider = ProviderBuilder::new().connect_anvil_with_config(|a| a.fork(FORK_URL));
+
+        let dai = address!("0x6B175474E89094C44Da98b954EedeAC495271d0F");
+        let user = Address::random();
+        let amount = U256::from(1e18 as u64);
+
+        let _res = provider.anvil_deal_erc20(user, dai, amount).await.unwrap();
+
+        sol! {
+            function balanceOf(address owner) view returns (uint256);
+        }
+
+        let balance_of_call = balanceOfCall::new((user,));
+        let input = balanceOfCall::abi_encode(&balance_of_call);
+
+        let result = provider
+            .call(TransactionRequest::default().with_to(dai).with_input(input))
+            .await
+            .unwrap();
+        let balance = balanceOfCall::abi_decode_returns(&result).unwrap();
+
+        assert_eq!(balance, amount);
+    }
+
+    #[tokio::test]
+    async fn test_anvil_set_erc20_allowance() {
+        let provider = ProviderBuilder::new().connect_anvil_with_config(|a| a.fork(FORK_URL));
+
+        let dai = address!("0x6B175474E89094C44Da98b954EedeAC495271d0F");
+        let owner = Address::random();
+        let spender = Address::random();
+        let amount = U256::from(1e18 as u64);
+
+        let _res = provider.anvil_set_erc20_allowance(owner, spender, dai, amount).await.unwrap();
+
+        sol! {
+            function allowance(address owner, address spender) view returns (uint256);
+        }
+
+        let allowance_call = allowanceCall::new((owner, spender));
+        let input = allowanceCall::abi_encode(&allowance_call);
+
+        let result = provider
+            .call(TransactionRequest::default().with_to(dai).with_input(input))
+            .await
+            .unwrap();
+        let allowance = allowanceCall::abi_decode_returns(&result).unwrap();
+
+        assert_eq!(allowance, amount);
     }
 }

--- a/crates/provider/src/ext/anvil.rs
+++ b/crates/provider/src/ext/anvil.rs
@@ -1066,7 +1066,7 @@ mod tests {
         let user = Address::random();
         let amount = U256::from(1e18 as u64);
 
-        let _res = provider.anvil_deal_erc20(user, dai, amount).await.unwrap();
+        provider.anvil_deal_erc20(user, dai, amount).await.unwrap();
 
         sol! {
             function balanceOf(address owner) view returns (uint256);
@@ -1093,7 +1093,7 @@ mod tests {
         let spender = Address::random();
         let amount = U256::from(1e18 as u64);
 
-        let _res = provider.anvil_set_erc20_allowance(owner, spender, dai, amount).await.unwrap();
+        provider.anvil_set_erc20_allowance(owner, spender, dai, amount).await.unwrap();
 
         sol! {
             function allowance(address owner, address spender) view returns (uint256);

--- a/crates/provider/src/ext/anvil.rs
+++ b/crates/provider/src/ext/anvil.rs
@@ -162,7 +162,7 @@ pub trait AnvilApi<N: Network>: Send + Sync {
         address: Address,
         token_address: Address,
         balance: U256,
-    ) -> TransportResult<TxHash>;
+    ) -> TransportResult<()>;
 
     /// Modifies the ERC20 allowance of an account.
     async fn anvil_set_erc20_allowance(
@@ -171,7 +171,7 @@ pub trait AnvilApi<N: Network>: Send + Sync {
         spender: Address,
         token: Address,
         allowance: U256,
-    ) -> TransportResult<TxHash>;
+    ) -> TransportResult<()>;
 }
 
 #[cfg_attr(target_family = "wasm", async_trait::async_trait(?Send))]
@@ -359,7 +359,7 @@ where
         address: Address,
         token_address: Address,
         balance: U256,
-    ) -> TransportResult<TxHash> {
+    ) -> TransportResult<()> {
         self.client().request("anvil_dealERC20", (address, token_address, balance)).await
     }
 
@@ -369,7 +369,7 @@ where
         spender: Address,
         token: Address,
         allowance: U256,
-    ) -> TransportResult<TxHash> {
+    ) -> TransportResult<()> {
         self.client().request("anvil_setERC20Allowance", (owner, spender, token, allowance)).await
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

In Foundry the ERC20 endpoints return `()`.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Make the ERC20 endpoints in alloy also return `()`, otherwise you get an error `Error("invalid type: null, expected 32 bytes, represented as a hex string of length 64, an array of u8, or raw bytes", line: 1, column: 4)`

Added tests to make sure it passes.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
