### PR TITLE
test: Fix typo in test function name in receipts.rs

### DIFF
--- a/crates/consensus/src/receipt/receipts.rs
+++ b/crates/consensus/src/receipt/receipts.rs
@@ -556,7 +556,7 @@ mod test {
     }
 
     #[test]
-    fn rountrip_encodable_eip1559() {
+    fn roundtrip_encodable_eip1559() {
         let receipts =
             Receipts { receipt_vec: vec![vec![ReceiptEnvelope::Eip1559(Default::default())]] };
 


### PR DESCRIPTION


Description:  
This pull request corrects a typo in the test function name from rountrip_encodable_eip1559 to roundtrip_encodable_eip1559 in the file crates/consensus/src/receipt/receipts.rs. No other changes were made. This improves code readability and consistency.