### PR TITLE
feat(provider): add block_number_for_id helper method

### DIFF
--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -145,7 +145,10 @@ pub trait Provider<N: Network = Ethereum>: Send + Sync {
     ///
     /// This is a convenience function that fetches the full block when the block identifier is not
     /// a number.
-    async fn block_number_for_id(&self, block_id: BlockId) -> TransportResult<Option<BlockNumber>> {
+    async fn get_block_number_by_id(
+        &self,
+        block_id: BlockId,
+    ) -> TransportResult<Option<BlockNumber>> {
         match block_id {
             BlockId::Number(BlockNumberOrTag::Number(num)) => Ok(Some(num)),
             BlockId::Number(BlockNumberOrTag::Latest) => self.get_block_number().await.map(Some),
@@ -1701,19 +1704,21 @@ mod tests {
         let provider = ProviderBuilder::new().connect_anvil();
 
         let block_num = provider
-            .block_number_for_id(BlockId::Number(BlockNumberOrTag::Number(0)))
+            .get_block_number_by_id(BlockId::Number(BlockNumberOrTag::Number(0)))
             .await
             .unwrap();
         assert_eq!(block_num, Some(0));
 
-        let block_num =
-            provider.block_number_for_id(BlockId::Number(BlockNumberOrTag::Latest)).await.unwrap();
+        let block_num = provider
+            .get_block_number_by_id(BlockId::Number(BlockNumberOrTag::Latest))
+            .await
+            .unwrap();
         assert_eq!(block_num, Some(0));
 
         let block =
             provider.get_block_by_number(BlockNumberOrTag::Number(0)).await.unwrap().unwrap();
         let hash = block.header.hash;
-        let block_num = provider.block_number_for_id(BlockId::Hash(hash.into())).await.unwrap();
+        let block_num = provider.get_block_number_by_id(BlockId::Hash(hash.into())).await.unwrap();
         assert_eq!(block_num, Some(0));
     }
 

--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -141,6 +141,21 @@ pub trait Provider<N: Network = Ethereum>: Send + Sync {
             .into()
     }
 
+    /// Get the block number for a given block identifier.
+    ///
+    /// This is a convenience function that fetches the full block when the block identifier is not
+    /// a number.
+    async fn block_number_for_id(&self, block_id: BlockId) -> TransportResult<Option<BlockNumber>> {
+        match block_id {
+            BlockId::Number(BlockNumberOrTag::Number(num)) => Ok(Some(num)),
+            BlockId::Number(BlockNumberOrTag::Latest) => self.get_block_number().await.map(Some),
+            _ => {
+                let block = self.get_block(block_id).await?;
+                Ok(block.map(|b| b.header().number()))
+            }
+        }
+    }
+
     /// Execute a smart contract call with a transaction request and state
     /// overrides, without publishing a transaction.
     ///
@@ -1679,6 +1694,27 @@ mod tests {
         let provider = ProviderBuilder::new().connect_anvil();
         let num = provider.get_block_number().await.unwrap();
         assert_eq!(0, num)
+    }
+
+    #[tokio::test]
+    async fn gets_block_number_for_id() {
+        let provider = ProviderBuilder::new().connect_anvil();
+
+        let block_num = provider
+            .block_number_for_id(BlockId::Number(BlockNumberOrTag::Number(0)))
+            .await
+            .unwrap();
+        assert_eq!(block_num, Some(0));
+
+        let block_num =
+            provider.block_number_for_id(BlockId::Number(BlockNumberOrTag::Latest)).await.unwrap();
+        assert_eq!(block_num, Some(0));
+
+        let block =
+            provider.get_block_by_number(BlockNumberOrTag::Number(0)).await.unwrap().unwrap();
+        let hash = block.header.hash;
+        let block_num = provider.block_number_for_id(BlockId::Hash(hash.into())).await.unwrap();
+        assert_eq!(block_num, Some(0));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Add `block_number_for_id` helper method to the Provider trait
- Returns block number directly for numeric BlockId values
- Fetches full block for hash and tag identifiers to extract the block number
- Returns None if block doesn't exist

## Motivation
This helper method provides a convenient way to resolve block numbers from any `BlockId`, which is useful when you need to work with block numbers but receive a `BlockId` as input (e.g., from user input or other APIs).