### PR TITLE
fix: fix Typo in Function Name

### DIFF
--- a/crates/rpc-types-eth/src/block.rs
+++ b/crates/rpc-types-eth/src/block.rs
@@ -268,7 +268,7 @@ impl<T> Block<T> {
     }
 
     /// Returns a sealed reference of the header: `Sealed<&Header>`
-    pub const fn sealed_heder(&self) -> Sealed<&alloy_consensus::Header> {
+    pub const fn sealed_header(&self) -> Sealed<&alloy_consensus::Header> {
         Sealed::new_unchecked(&self.header.inner, self.header.hash)
     }
 


### PR DESCRIPTION


Description:  
This pull request corrects a typo in the function name from sealed_heder to sealed_header in the Block<T> implementation (crates/rpc-types-eth/src/block.rs). The change improves code readability and consistency. No logic or functionality has been altered.