### PR TITLE
chore(rpc-types-mev): improve bundle API flexibility

### DIFF
--- a/crates/rpc-types-mev/src/eth_calls.rs
+++ b/crates/rpc-types-mev/src/eth_calls.rs
@@ -319,6 +319,15 @@ pub struct EthBundleHash {
     pub bundle_hash: Option<B256>,
 }
 
+/// Response from the matchmaker after sending a bundle.
+#[derive(Deserialize, Debug, Serialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+#[deprecated = "Use `EthBundleHash` instead"]
+pub struct SendBundleResponse {
+    /// Hash of the bundle bodies.
+    pub bundle_hash: B256,
+}
+
 /// Request for `eth_sendPrivateTransaction`
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]

--- a/crates/rpc-types-mev/src/eth_calls.rs
+++ b/crates/rpc-types-mev/src/eth_calls.rs
@@ -316,14 +316,6 @@ impl EthSendBundle {
 #[serde(rename_all = "camelCase")]
 pub struct EthBundleHash {
     /// Hash of the bundle bodies.
-    pub bundle_hash: B256,
-}
-
-/// Response from the matchmaker after sending a bundle.
-#[derive(Deserialize, Debug, Serialize, Clone, PartialEq, Eq)]
-#[serde(rename_all = "camelCase")]
-pub struct SendBundleResponse {
-    /// Hash of the bundle bodies.
     pub bundle_hash: Option<B256>,
 }
 

--- a/crates/rpc-types-mev/src/eth_calls.rs
+++ b/crates/rpc-types-mev/src/eth_calls.rs
@@ -312,21 +312,15 @@ impl EthSendBundle {
 }
 
 /// Response from the matchmaker after sending a bundle.
+#[deprecated = "Use `EthBundleHash` instead"]
+pub type SendBundleResponse = EthBundleHash;
+
+/// Response from the matchmaker after sending a bundle.
 #[derive(Deserialize, Debug, Serialize, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct EthBundleHash {
     /// Hash of the bundle bodies.
     pub bundle_hash: Option<B256>,
-}
-
-/// Response from the matchmaker after sending a bundle.
-#[derive(Deserialize, Debug, Serialize, Clone, PartialEq, Eq)]
-#[serde(rename_all = "camelCase")]
-#[deprecated = "Use `EthBundleHash` instead"]
-#[allow(deprecated)]
-pub struct SendBundleResponse {
-    /// Hash of the bundle bodies.
-    pub bundle_hash: B256,
 }
 
 /// Request for `eth_sendPrivateTransaction`

--- a/crates/rpc-types-mev/src/eth_calls.rs
+++ b/crates/rpc-types-mev/src/eth_calls.rs
@@ -323,6 +323,7 @@ pub struct EthBundleHash {
 #[derive(Deserialize, Debug, Serialize, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 #[deprecated = "Use `EthBundleHash` instead"]
+#[allow(deprecated)]
 pub struct SendBundleResponse {
     /// Hash of the bundle bodies.
     pub bundle_hash: B256,


### PR DESCRIPTION
Changes for `EthSendBundle`, `EthBundleHash` and removal of `SendBundleResponse`:
- `bundle_hash` in `EthBundleHash` is optional. Not all builders return such a bundle hash
- Remove duplicate struct `SendBundleResponse` in favor of `EthBundleHash`
- New `extra_fields` as known from `ChainConfig` allow the user to add builder specific fields 

Again a breaking change, but I have the feeling that it is worth it, for a better usability.

Update: Initially I replaced `Vec` with `HashSet` for fields like `reverting_tx_hashes`, but this would potentially lead to a non-deterministic bundle hash calculation. I reverted this change.