### PR TITLE
fix: the bundle hash is null on root level, not the value

### DIFF
--- a/crates/provider/src/ext/mev/mod.rs
+++ b/crates/provider/src/ext/mev/mod.rs
@@ -14,7 +14,10 @@ pub const FLASHBOTS_SIGNATURE_HEADER: &str = "x-flashbots-signature";
 pub trait MevApi<N>: Send + Sync {
     /// Sends a MEV bundle using the `eth_sendBundle` RPC method.
     /// Returns the resulting bundle hash on success.
-    fn send_bundle(&self, bundle: EthSendBundle) -> MevBuilder<(EthSendBundle,), EthBundleHash>;
+    fn send_bundle(
+        &self,
+        bundle: EthSendBundle,
+    ) -> MevBuilder<(EthSendBundle,), Option<EthBundleHash>>;
 }
 
 #[cfg_attr(target_family = "wasm", async_trait::async_trait(?Send))]
@@ -24,7 +27,10 @@ where
     N: Network,
     P: Provider<N>,
 {
-    fn send_bundle(&self, bundle: EthSendBundle) -> MevBuilder<(EthSendBundle,), EthBundleHash> {
+    fn send_bundle(
+        &self,
+        bundle: EthSendBundle,
+    ) -> MevBuilder<(EthSendBundle,), Option<EthBundleHash>> {
         MevBuilder::new_rpc(self.client().request("eth_sendBundle", (bundle,)))
     }
 }

--- a/crates/rpc-types-mev/src/eth_calls.rs
+++ b/crates/rpc-types-mev/src/eth_calls.rs
@@ -320,7 +320,7 @@ pub type SendBundleResponse = EthBundleHash;
 #[serde(rename_all = "camelCase")]
 pub struct EthBundleHash {
     /// Hash of the bundle bodies.
-    pub bundle_hash: Option<B256>,
+    pub bundle_hash: B256,
 }
 
 /// Request for `eth_sendPrivateTransaction`


### PR DESCRIPTION
Sorry my bad, in #2583 I changed the bundle hash to allow `None`. But this was not correct. I checked now for all builders, they return: 

`{"id":0,"jsonrpc":"2.0","result":null}`
or
 `{"id":0,"jsonrpc":"2.0","result":{"bundleHash":"0x1234...."}}`