### PR TITLE
feat(provider): shorthand method to add multicall with allowFailure

### DIFF
--- a/crates/provider/src/provider/multicall/mod.rs
+++ b/crates/provider/src/provider/multicall/mod.rs
@@ -202,6 +202,23 @@ where
         self
     }
 
+    /// Add a dynamic call to the builder while specifying whether it is allowed to fail
+    ///
+    /// This is useful in combination with [`aggregate3`][MulticallBuilder::aggregate3].
+    pub fn add_dynamic3(
+        mut self,
+        item: impl MulticallItem<Decoder = D>,
+        allow_failure: bool,
+    ) -> Self {
+        let target = item.target();
+        let input = item.input();
+
+        let call = CallItem::<D>::new(target, input).allow_failure(allow_failure);
+
+        self.calls.push(call.to_call3_value());
+        self
+    }
+
     /// Add a dynamic [`CallItem`] to the builder
     pub fn add_call_dynamic(mut self, call: CallItem<D>) -> Self {
         self.calls.push(call.to_call3_value());
@@ -286,6 +303,28 @@ where
         let input = item.input();
 
         let call = CallItem::<Item::Decoder>::new(target, input);
+
+        self.add_call(call)
+    }
+
+    /// Appends a [`SolCall`] to the stack while specifying whether it is allowed to fail
+    ///
+    /// This is useful in combination with [`aggregate3`][MulticallBuilder::aggregate3].
+    #[expect(clippy::should_implement_trait)]
+    pub fn add3<Item: MulticallItem>(
+        self,
+        item: Item,
+        allow_failure: bool,
+    ) -> MulticallBuilder<T::Pushed, P, N>
+    where
+        Item::Decoder: 'static,
+        T: TuplePush<Item::Decoder>,
+        <T as TuplePush<Item::Decoder>>::Pushed: CallTuple,
+    {
+        let target = item.target();
+        let input = item.input();
+
+        let call = CallItem::<Item::Decoder>::new(target, input).allow_failure(allow_failure);
 
         self.add_call(call)
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

At the moment, adding a call to a `MulticallBuilder` while specifying that the call is allowed to revert when used in `aggregate3` is quite cumbersome:

```rust
use alloy::providers::{CallItem, MulticallItem as _};
// ...
let call = mycontract.someFunction(arg);
let mut multicall = provider.multicall().dynamic::<someFunctionCall>();
// add multiple calls
multicall = multicall.add_call_dynamic(CallItem::new(call.target(), call.input()).allow_failure(true));
// ...
let res = multicall.aggregate3().await?;
```

Notably, the `MulticallItem` trait must be in scope to use `.target()` and `.input()` on the call, and the dynamic multicall builder must be typed manually with the call's type.

## Solution

Add two methods: `add3` and `add_dynamic3` which take in a `impl MulticallItem` but have a second parameter to set whether the call can revert.

```rust
let mut multicall = provider.multicall().dynamic();
// add multiple calls
multicall = multicall.add_dynamic3(mycontract.someFunction(arg), true);
// ...
let res = muticall.aggregate3().await?;
```

This allows type inference to work its magic and doesn't require to construct a `CallItem` manually. 

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
