### PR TITLE
feat: add from_block_unchecked to ExecutionData

### DIFF
--- a/crates/rpc-types-engine/src/payload.rs
+++ b/crates/rpc-types-engine/src/payload.rs
@@ -14,7 +14,7 @@ use alloy_eips::{
     eip4844::BlobTransactionSidecar,
     eip4895::{Withdrawal, Withdrawals},
     eip7594::{BlobTransactionSidecarEip7594, CELLS_PER_EXT_BLOB},
-    eip7685::Requests,
+    eip7685::{Requests, RequestsOrHash},
     BlockNumHash,
 };
 use alloy_primitives::{bytes::BufMut, Address, Bloom, Bytes, Sealable, B256, B64, U256};
@@ -1621,6 +1621,23 @@ impl ExecutionData {
     /// Creates new instance of [`ExecutionData`].
     pub const fn new(payload: ExecutionPayload, sidecar: ExecutionPayloadSidecar) -> Self {
         Self { payload, sidecar }
+    }
+
+    /// Conversion from [`alloy_consensus::Block`]. Also returns the [`ExecutionPayloadSidecar`]
+    /// extracted from the block.
+    ///
+    /// For the [`ExecutionPayloadSidecar`] this is expected to use just the requests hash, because
+    /// the [`Requests`] are not part of the block/header. See also
+    /// [`RequestsOrHash`](alloy_eips::eip4844::RequestsOrHash).
+    ///
+    /// See also [`ExecutionPayload::from_block_unchecked`].
+    pub fn from_block_unchecked<T, H>(block_hash: B256, block: &Block<T, H>) -> Self
+    where
+        T: Encodable2718 + Transaction,
+        H: BlockHeader,
+    {
+        let (payload, sidecar) = ExecutionPayload::from_block_unchecked(block_hash, block);
+        Self::new(payload, sidecar)
     }
 
     /// Returns the parent hash of the block.

--- a/crates/rpc-types-engine/src/payload.rs
+++ b/crates/rpc-types-engine/src/payload.rs
@@ -1628,7 +1628,7 @@ impl ExecutionData {
     ///
     /// For the [`ExecutionPayloadSidecar`] this is expected to use just the requests hash, because
     /// the [`Requests`] are not part of the block/header. See also
-    /// [`RequestsOrHash`].
+    /// [`RequestsOrHash`](alloy_eips::eip7685::RequestsOrHash).
     ///
     /// See also [`ExecutionPayload::from_block_unchecked`].
     pub fn from_block_unchecked<T, H>(block_hash: B256, block: &Block<T, H>) -> Self

--- a/crates/rpc-types-engine/src/payload.rs
+++ b/crates/rpc-types-engine/src/payload.rs
@@ -14,7 +14,7 @@ use alloy_eips::{
     eip4844::BlobTransactionSidecar,
     eip4895::{Withdrawal, Withdrawals},
     eip7594::{BlobTransactionSidecarEip7594, CELLS_PER_EXT_BLOB},
-    eip7685::{Requests, RequestsOrHash},
+    eip7685::Requests,
     BlockNumHash,
 };
 use alloy_primitives::{bytes::BufMut, Address, Bloom, Bytes, Sealable, B256, B64, U256};
@@ -1628,7 +1628,7 @@ impl ExecutionData {
     ///
     /// For the [`ExecutionPayloadSidecar`] this is expected to use just the requests hash, because
     /// the [`Requests`] are not part of the block/header. See also
-    /// [`RequestsOrHash`](alloy_eips::eip4844::RequestsOrHash).
+    /// [`RequestsOrHash`].
     ///
     /// See also [`ExecutionPayload::from_block_unchecked`].
     pub fn from_block_unchecked<T, H>(block_hash: B256, block: &Block<T, H>) -> Self


### PR DESCRIPTION
Adds a `from_block_unchecked` method to `ExecutionData` that creates an instance directly from a block.

This follows the same pattern used in op-alloy's implementation and provides a convenient way to construct `ExecutionData` with both payload and sidecar extracted from the block in a single call.

The method delegates to `ExecutionPayload::from_block_unchecked` which handles the version detection and sidecar extraction internally.