### PR TITLE
ci: pin nextest to v0.9.98

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,9 @@ jobs:
       # Only run tests on latest stable and above
       - name: Install cargo-nextest
         if: ${{ matrix.rust != '1.85' }} # MSRV
-        uses: taiki-e/install-action@nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest@0.9.98
       - name: build
         if: ${{ matrix.rust == '1.85' }} # MSRV
         run: cargo build --workspace ${{ matrix.flags }}


### PR DESCRIPTION
Pin nextest version to avoid CI failures from latest release, following the same approach as https://github.com/paradigmxyz/reth/pull/16887.

This prevents potential CI breakage from automatic updates to newer nextest versions.