### PR TITLE
deps: bump alloy-trie to 0.9.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ alloy-primitives = { version = "1.2.0", default-features = false }
 alloy-sol-types = { version = "1.2.0", default-features = false }
 
 alloy-rlp = { version = "0.3.9", default-features = false }
-alloy-trie = { version = "0.8.0", default-features = false }
+alloy-trie = { version = "0.9.0", default-features = false }
 
 alloy-chains = { version = "0.2", default-features = false }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

New version of alloy-trie was released https://crates.io/crates/alloy-trie/0.9.0

## Solution

Bump alloy-trie to v0.9.0

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
