### PR TITLE
docs: Correct typo 'implementor' to 'implementer

### DIFF
--- a/crates/pubsub/README.md
+++ b/crates/pubsub/README.md
@@ -30,7 +30,7 @@ The PubSub system here consists of 3 logical parts:
 This crate provides the following:
 
 - [`PubSubConnect`]: A trait for instantiating a PubSub service by connecting
-  to some **backend**. Implementors of this trait are responsible for
+  to some **backend**. Implementers of this trait are responsible for
   the precise connection details, and for spawning the **backend** task.
   Users should ALWAYS call [`PubSubConnect::into_service`] to get a running
   service with a running backend.

--- a/crates/rpc-client/src/client.rs
+++ b/crates/rpc-client/src/client.rs
@@ -417,7 +417,7 @@ mod pubsub_impl {
     }
 
     impl RpcClient {
-        /// Connect to a transport via a [`PubSubConnect`] implementor.
+        /// Connect to a transport via a [`PubSubConnect`] implementer.
         pub async fn connect_pubsub<C: PubSubConnect>(connect: C) -> TransportResult<Self> {
             ClientBuilder::default().pubsub(connect).await
         }


### PR DESCRIPTION


### Description:
This PR corrects a minor spelling mistake, changing `implementor` to `implementer` in the documentation and code comments.

This change affects the following files:
- `crates/pubsub/README.md`
- `crates/rpc-client/src/client.rs`