### PR TITLE
feat: add better conversions for AnyRpcBlock

### DIFF
--- a/crates/consensus-any/Cargo.toml
+++ b/crates/consensus-any/Cargo.toml
@@ -37,6 +37,7 @@ serde = { workspace = true, features = ["derive"], optional = true }
 
 [dev-dependencies]
 arbitrary = { workspace = true, features = ["derive"] }
+alloy-consensus = { workspace = true, features = ["arbitrary"] }
 serde_json.workspace = true
 
 [features]

--- a/crates/consensus-any/src/block/header.rs
+++ b/crates/consensus-any/src/block/header.rs
@@ -1,5 +1,5 @@
 use alloy_consensus::{BlockHeader, Header};
-use alloy_primitives::{Address, BlockNumber, Bloom, Bytes, B256, B64, U256};
+use alloy_primitives::{Address, BlockNumber, Bloom, Bytes, Sealed, B256, B64, U256};
 
 /// Block header representation with certain fields made optional to account for possible
 /// differences in network implementations.
@@ -99,6 +99,14 @@ pub struct AnyHeader {
 }
 
 impl AnyHeader {
+    /// Seal the header with a known hash.
+    ///
+    /// WARNING: This method does not perform validation whether the hash is correct.
+    #[inline]
+    pub const fn seal(self, hash: B256) -> Sealed<Self> {
+        Sealed::new_unchecked(self, hash)
+    }
+
     /// Attempts to convert this header into a `Header`.
     ///
     /// This can fail if the header is missing required fields:

--- a/crates/network/src/any/error.rs
+++ b/crates/network/src/any/error.rs
@@ -1,0 +1,41 @@
+//! Error types for converting between `Any` types.
+
+use core::{error::Error, fmt};
+
+/// A ConversionError that can can capture any error type that implements the `Error` trait.
+pub struct AnyConversionError {
+    inner: Box<dyn Error + Send + Sync + 'static>,
+}
+
+impl AnyConversionError {
+    /// Creates a new `AnyError` wrapping the given error value.
+    pub fn new<E>(error: E) -> Self
+    where
+        E: Error + Send + Sync + 'static,
+    {
+        Self { inner: Box::new(error) }
+    }
+
+    /// Returns a reference to the underlying error value.
+    pub fn as_error(&self) -> &(dyn Error + Send + Sync + 'static) {
+        self.inner.as_ref()
+    }
+}
+
+impl fmt::Debug for AnyConversionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&self.inner, f)
+    }
+}
+
+impl fmt::Display for AnyConversionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.inner, f)
+    }
+}
+
+impl Error for AnyConversionError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        self.inner.source()
+    }
+}

--- a/crates/network/src/any/mod.rs
+++ b/crates/network/src/any/mod.rs
@@ -1,17 +1,20 @@
 mod builder;
-
 mod either;
+
+pub mod error;
+
 use alloy_consensus::TxEnvelope;
 use alloy_eips::{eip7702::SignedAuthorization, Typed2718};
 use alloy_primitives::{Bytes, ChainId, TxKind, B256, U256};
 pub use either::{AnyTxEnvelope, AnyTypedTransaction};
+use std::error::Error;
 
 mod unknowns;
 pub use unknowns::{AnyTxType, UnknownTxEnvelope, UnknownTypedTransaction};
 
 pub use alloy_consensus_any::{AnyHeader, AnyReceiptEnvelope};
 
-use crate::Network;
+use crate::{any::error::AnyConversionError, Network};
 use alloy_consensus::{
     error::ValueError,
     transaction::{Either, Recovered},
@@ -98,6 +101,24 @@ impl AnyRpcBlock {
         self.0.into_inner()
     }
 
+    /// Attempts to convert the inner RPC [`Block`] into a consensus block.
+    ///
+    /// Returns an [`AnyConversionError`] if any of the conversions fail.
+    pub fn try_into_consensus<T, H>(
+        self,
+    ) -> Result<alloy_consensus::Block<T, H>, AnyConversionError>
+    where
+        T: TryFrom<AnyRpcTransaction, Error: Error + Send + Sync + 'static>,
+        H: TryFrom<AnyRpcHeader, Error: Error + Send + Sync + 'static>,
+    {
+        self.into_inner()
+            .try_convert_header()
+            .map_err(AnyConversionError::new)?
+            .try_convert_transactions()
+            .map_err(AnyConversionError::new)
+            .map(Block::into_consensus_block)
+    }
+
     /// Tries to convert inner transactions into a vector of [`AnyRpcTransaction`].
     ///
     /// Returns an error if the block contains only transaction hashes or if it is an uncle block.
@@ -174,6 +195,18 @@ impl From<AnyRpcBlock> for Block<AnyRpcTransaction, AnyRpcHeader> {
 impl From<AnyRpcBlock> for WithOtherFields<Block<AnyRpcTransaction, AnyRpcHeader>> {
     fn from(value: AnyRpcBlock) -> Self {
         value.0
+    }
+}
+
+impl<T, H> TryFrom<AnyRpcBlock> for alloy_consensus::Block<T, H>
+where
+    T: TryFrom<AnyRpcTransaction, Error: Error + Send + Sync + 'static>,
+    H: TryFrom<AnyRpcHeader, Error: Error + Send + Sync + 'static>,
+{
+    type Error = AnyConversionError;
+
+    fn try_from(value: AnyRpcBlock) -> Result<Self, Self::Error> {
+        value.try_into_consensus()
     }
 }
 
@@ -437,5 +470,23 @@ impl TransactionResponse for AnyRpcTransaction {
 impl Typed2718 for AnyRpcTransaction {
     fn ty(&self) -> u8 {
         self.inner.ty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn convert_any_block() {
+        let block = AnyRpcBlock::new(
+            Block::new(
+                AnyRpcHeader::from_sealed(AnyHeader::default().seal(B256::ZERO)),
+                BlockTransactions::Full(vec![]),
+            )
+            .into(),
+        );
+
+        let _block: alloy_consensus::Block<TxEnvelope, AnyRpcHeader> = block.try_into().unwrap();
     }
 }

--- a/crates/network/src/any/mod.rs
+++ b/crates/network/src/any/mod.rs
@@ -109,9 +109,10 @@ impl AnyRpcBlock {
     ) -> Result<alloy_consensus::Block<T, H>, AnyConversionError>
     where
         T: TryFrom<AnyRpcTransaction, Error: Error + Send + Sync + 'static>,
-        H: TryFrom<AnyRpcHeader, Error: Error + Send + Sync + 'static>,
+        H: TryFrom<AnyHeader, Error: Error + Send + Sync + 'static>,
     {
         self.into_inner()
+            .map_header(|h| h.into_consensus())
             .try_convert_header()
             .map_err(AnyConversionError::new)?
             .try_convert_transactions()
@@ -201,7 +202,7 @@ impl From<AnyRpcBlock> for WithOtherFields<Block<AnyRpcTransaction, AnyRpcHeader
 impl<T, H> TryFrom<AnyRpcBlock> for alloy_consensus::Block<T, H>
 where
     T: TryFrom<AnyRpcTransaction, Error: Error + Send + Sync + 'static>,
-    H: TryFrom<AnyRpcHeader, Error: Error + Send + Sync + 'static>,
+    H: TryFrom<AnyHeader, Error: Error + Send + Sync + 'static>,
 {
     type Error = AnyConversionError;
 
@@ -487,6 +488,7 @@ mod tests {
             .into(),
         );
 
-        let _block: alloy_consensus::Block<TxEnvelope, AnyRpcHeader> = block.try_into().unwrap();
+        let _block: alloy_consensus::Block<TxEnvelope, alloy_consensus::Header> =
+            block.try_into().unwrap();
     }
 }


### PR DESCRIPTION
This adds a `TryFrom<AnyRpcBlock> for alloy_consensus::Block<T, H>` impl and missing functions required for this.

```
        let _block: alloy_consensus::Block<TxEnvelope, alloy_consensus::Header> = block.try_into().unwrap();
```

This also changes the try_into_header return value, which is technically breaking but imo this is fine here.

cc @cakevm 