### PR TITLE
feat: add connect_reqwest to ProviderBuilder, http_with_client to Cli…

### DIFF
--- a/crates/provider/src/builder.rs
+++ b/crates/provider/src/builder.rs
@@ -502,6 +502,18 @@ impl<L, F, N> ProviderBuilder<L, F, N> {
         self.connect_client(client)
     }
 
+    /// Build this provider with a pre-built Reqwest client.
+    #[cfg(any(test, feature = "reqwest"))]
+    pub fn connect_reqwest(self, client: reqwest::Client, url: reqwest::Url) -> F::Provider
+    where
+        L: ProviderLayer<crate::RootProvider<N>, N>,
+        F: TxFiller<N> + ProviderLayer<L::Provider, N>,
+        N: Network,
+    {
+        let client = ClientBuilder::default().http_with_client(client, url);
+        self.connect_client(client)
+    }
+
     /// Build this provider with an Reqwest HTTP transport.
     #[cfg(any(test, feature = "reqwest"))]
     #[deprecated(since = "0.12.6", note = "use `connect_http` instead")]

--- a/crates/rpc-client/src/builder.rs
+++ b/crates/rpc-client/src/builder.rs
@@ -61,6 +61,20 @@ impl<L> ClientBuilder<L> {
         self.transport(transport, is_local)
     }
 
+    /// Convenience function to create a new [`RpcClient`] with a [`reqwest`]
+    /// HTTP transport using a pre-built `reqwest::Client`.
+    #[cfg(feature = "reqwest")]
+    pub fn http_with_client(self, client: reqwest::Client, url: url::Url) -> RpcClient
+    where
+        L: Layer<alloy_transport_http::Http<reqwest::Client>>,
+        L::Service: IntoBoxTransport,
+    {
+        let transport = alloy_transport_http::Http::with_client(client, url);
+        let is_local = transport.guess_local();
+
+        self.transport(transport, is_local)
+    }
+
     /// Convenience function to create a new [`RpcClient`] with a `hyper` HTTP transport.
     #[cfg(all(not(target_family = "wasm"), feature = "hyper"))]
     pub fn hyper_http(self, url: url::Url) -> RpcClient

--- a/crates/rpc-client/src/client.rs
+++ b/crates/rpc-client/src/client.rs
@@ -71,6 +71,14 @@ impl RpcClient {
         Self::new(http, is_local)
     }
 
+    /// Create a new [`RpcClient`] with an HTTP transport using a pre-built [`reqwest::Client`].
+    #[cfg(feature = "reqwest")]
+    pub fn new_http_with_client(client: reqwest::Client, url: reqwest::Url) -> Self {
+        let http = alloy_transport_http::Http::with_client(client, url);
+        let is_local = http.guess_local();
+        Self::new(http, is_local)
+    }
+
     /// Creates a new [`RpcClient`] with the given transport and a `MaybePubsub`.
     fn new_maybe_pubsub(
         t: impl IntoBoxTransport,


### PR DESCRIPTION
…entBuilder, new_http_with_client to RpcClient

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
The default `reqwest::Client` implementation is not suitable for usage in high-performance applications due to the lack of connection pooling, low timeout and keepalive durations.

## Solution
Allows any user to pass a custom `reqwest::Client` at the time of `Provider` construction.

## PR Checklist

- [ ] Added Tests
- [X] Added Documentation
- [ ] Breaking changes
