### PR TITLE
chore: add serde for `BlobScheduleBlobParams`

### DIFF
--- a/crates/eips/src/eip7892.rs
+++ b/crates/eips/src/eip7892.rs
@@ -17,6 +17,7 @@ pub enum BlobScheduleEntry {
 
 /// Blob parameters configuration for a chain, including scheduled updates.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BlobScheduleBlobParams {
     /// Configuration for blob-related calculations for the Cancun hardfork.
     pub cancun: BlobParams,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

The main motivation is to make `reth::ChainSpec` derive serde, so we can serialize it in the zkVM context. The ChainSpec however includes a `BlobScheduleBlobParams` field

## Solution

Derive serde for `BlobScheduleBlobParams`

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
