### PR TITLE
feat(rpc): Add generic `TxReq` to `SimBlock`

### DIFF
--- a/crates/rpc-types-eth/src/simulate.rs
+++ b/crates/rpc-types-eth/src/simulate.rs
@@ -13,7 +13,7 @@ pub const MAX_SIMULATE_BLOCKS: u64 = 256;
 #[derive(Clone, Debug, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
-pub struct SimBlock {
+pub struct SimBlock<TxReq = TransactionRequest> {
     /// Modifications to the default block characteristics.
     #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
     pub block_overrides: Option<BlockOverrides>,
@@ -22,10 +22,10 @@ pub struct SimBlock {
     pub state_overrides: Option<StateOverride>,
     /// A vector of transactions to be simulated.
     #[cfg_attr(feature = "serde", serde(default))]
-    pub calls: Vec<TransactionRequest>,
+    pub calls: Vec<TxReq>,
 }
 
-impl SimBlock {
+impl<TxReq> SimBlock<TxReq> {
     /// Enables state overrides
     pub fn with_state_overrides(mut self, overrides: StateOverride) -> Self {
         self.state_overrides = Some(overrides);
@@ -39,13 +39,13 @@ impl SimBlock {
     }
 
     /// Adds a call to the block.
-    pub fn call(mut self, call: TransactionRequest) -> Self {
+    pub fn call(mut self, call: TxReq) -> Self {
         self.calls.push(call);
         self
     }
 
     /// Adds multiple calls to the block.
-    pub fn extend_calls(mut self, calls: impl IntoIterator<Item = TransactionRequest>) -> Self {
+    pub fn extend_calls(mut self, calls: impl IntoIterator<Item = TxReq>) -> Self {
         self.calls.extend(calls);
         self
     }


### PR DESCRIPTION
## Motivation

The `TransactionRequest` is currently hard-coded to a concrete type. This means that the `SimBlock` and all components that depend on it will not work for custom transaction requests.

## Solution

Add generic `TxReq` with `TransactionRequest` as a default.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
