### PR TITLE
feat(network): Add method to remove nonce from transaction using `TransactionBuilder`

### DIFF
--- a/crates/network/src/any/builder.rs
+++ b/crates/network/src/any/builder.rs
@@ -24,6 +24,10 @@ impl TransactionBuilder<AnyNetwork> for WithOtherFields<TransactionRequest> {
         self.deref_mut().set_nonce(nonce)
     }
 
+    fn take_nonce(&mut self) -> Option<u64> {
+        self.deref_mut().nonce.take()
+    }
+
     fn input(&self) -> Option<&Bytes> {
         self.deref().input()
     }

--- a/crates/network/src/ethereum/builder.rs
+++ b/crates/network/src/ethereum/builder.rs
@@ -23,6 +23,10 @@ impl TransactionBuilder<Ethereum> for TransactionRequest {
         self.nonce = Some(nonce);
     }
 
+    fn take_nonce(&mut self) -> Option<u64> {
+        self.nonce.take()
+    }
+
     fn input(&self) -> Option<&Bytes> {
         self.input.input()
     }

--- a/crates/network/src/transaction/builder.rs
+++ b/crates/network/src/transaction/builder.rs
@@ -84,9 +84,18 @@ pub trait TransactionBuilder<N: Network>: Default + Sized + Send + Sync + 'stati
     /// Set the nonce for the transaction.
     fn set_nonce(&mut self, nonce: u64);
 
+    /// Takes the nonce out of the transaction, clearing it.
+    fn take_nonce(&mut self) -> Option<u64>;
+
     /// Builder-pattern method for setting the nonce.
     fn with_nonce(mut self, nonce: u64) -> Self {
         self.set_nonce(nonce);
+        self
+    }
+
+    /// Takes the nonce out of the transaction, clearing it.
+    fn without_nonce(mut self) -> Self {
+        self.take_nonce();
         self
     }
 


### PR DESCRIPTION
## Motivation

To remove reliance on concrete type `TransactionRequest` and use only the abstraction `TransactionBuilder` in its place, currently there is no way to remove the nonce.

This feature is required for RPC methods like `eth_call`. Lack of nonce makes the EVM set it.

## Solution

Add methods to `TransactionBuilder` that take the nonce out of the transaction.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
