### PR TITLE
feat: add recover_signer_unchecked_with_buf to `SignerRecoverable` trait

### DIFF
--- a/crates/consensus/src/signed.rs
+++ b/crates/consensus/src/signed.rs
@@ -5,7 +5,7 @@ use crate::{
 use alloy_eips::{
     eip2718::Eip2718Result, eip2930::AccessList, eip7702::SignedAuthorization, Typed2718,
 };
-use alloy_primitives::{Bytes, Sealed, Signature, TxKind, B256, U256};
+use alloy_primitives::{keccak256, Bytes, Sealed, Signature, TxKind, B256, U256};
 use alloy_rlp::BufMut;
 use core::hash::{Hash, Hasher};
 #[cfg(not(feature = "std"))]
@@ -463,6 +463,15 @@ where
         &self,
     ) -> Result<alloy_primitives::Address, crate::crypto::RecoveryError> {
         let signature_hash = self.signature_hash();
+        crate::crypto::secp256k1::recover_signer_unchecked(self.signature(), signature_hash)
+    }
+
+    fn recover_signer_unchecked_with_buf(
+        &self,
+        buf: &mut Vec<u8>,
+    ) -> Result<alloy_primitives::Address, crate::crypto::RecoveryError> {
+        self.tx.encoded_for_signing();
+        let signature_hash = keccak256(buf);
         crate::crypto::secp256k1::recover_signer_unchecked(self.signature(), signature_hash)
     }
 }

--- a/crates/consensus/src/signed.rs
+++ b/crates/consensus/src/signed.rs
@@ -470,6 +470,7 @@ where
         &self,
         buf: &mut Vec<u8>,
     ) -> Result<alloy_primitives::Address, crate::crypto::RecoveryError> {
+        buf.clear();
         self.tx.encoded_for_signing();
         let signature_hash = keccak256(buf);
         crate::crypto::secp256k1::recover_signer_unchecked(self.signature(), signature_hash)

--- a/crates/consensus/src/signed.rs
+++ b/crates/consensus/src/signed.rs
@@ -5,7 +5,7 @@ use crate::{
 use alloy_eips::{
     eip2718::Eip2718Result, eip2930::AccessList, eip7702::SignedAuthorization, Typed2718,
 };
-use alloy_primitives::{keccak256, Bytes, Sealed, Signature, TxKind, B256, U256};
+use alloy_primitives::{Bytes, Sealed, Signature, TxKind, B256, U256};
 use alloy_rlp::BufMut;
 use core::hash::{Hash, Hasher};
 #[cfg(not(feature = "std"))]
@@ -468,11 +468,11 @@ where
 
     fn recover_signer_unchecked_with_buf(
         &self,
-        buf: &mut Vec<u8>,
+        buf: &mut alloc::vec::Vec<u8>,
     ) -> Result<alloy_primitives::Address, crate::crypto::RecoveryError> {
         buf.clear();
         self.tx.encoded_for_signing();
-        let signature_hash = keccak256(buf);
+        let signature_hash = alloy_primitives::keccak256(buf);
         crate::crypto::secp256k1::recover_signer_unchecked(self.signature(), signature_hash)
     }
 }

--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -483,6 +483,29 @@ where
             }
         }
     }
+
+    fn recover_signer_unchecked_with_buf(
+        &self,
+        buf: &mut Vec<u8>,
+    ) -> Result<alloy_primitives::Address, crate::crypto::RecoveryError> {
+        match self {
+            Self::Legacy(tx) => {
+                crate::transaction::SignerRecoverable::recover_signer_unchecked_with_buf(tx, buf)
+            }
+            Self::Eip2930(tx) => {
+                crate::transaction::SignerRecoverable::recover_signer_unchecked_with_buf(tx, buf)
+            }
+            Self::Eip1559(tx) => {
+                crate::transaction::SignerRecoverable::recover_signer_unchecked_with_buf(tx, buf)
+            }
+            Self::Eip4844(tx) => {
+                crate::transaction::SignerRecoverable::recover_signer_unchecked_with_buf(tx, buf)
+            }
+            Self::Eip7702(tx) => {
+                crate::transaction::SignerRecoverable::recover_signer_unchecked_with_buf(tx, buf)
+            }
+        }
+    }
 }
 
 impl<T> Encodable2718 for Signed<T>

--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -486,7 +486,7 @@ where
 
     fn recover_signer_unchecked_with_buf(
         &self,
-        buf: &mut Vec<u8>,
+        buf: &mut alloc::vec::Vec<u8>,
     ) -> Result<alloy_primitives::Address, crate::crypto::RecoveryError> {
         match self {
             Self::Legacy(tx) => {

--- a/crates/consensus/src/transaction/recovered.rs
+++ b/crates/consensus/src/transaction/recovered.rs
@@ -248,6 +248,14 @@ pub trait SignerRecoverable {
     /// Returns an error if the transaction's signature is invalid.
     fn recover_signer_unchecked(&self) -> Result<Address, RecoveryError>;
 
+    /// Same as [`SignerRecoverable::recover_signer_unchecked`] but receives a buffer to operate on
+    /// for encoding. This is useful during batch recovery of historical transactions to avoid
+    /// allocating a new buffer for each transaction.
+    fn recover_signer_unchecked_with_buf(
+        &self,
+        buf: &mut Vec<u8>,
+    ) -> Result<Address, RecoveryError>;
+
     /// Recover the signer via [`SignerRecoverable::recover_signer`] and returns a
     /// `Recovered<Self>`
     fn try_into_recovered(self) -> Result<Recovered<Self>, RecoveryError>
@@ -294,6 +302,13 @@ where
     fn recover_signer_unchecked(&self) -> Result<Address, RecoveryError> {
         self.1.recover_signer_unchecked()
     }
+
+    fn recover_signer_unchecked_with_buf(
+        &self,
+        buf: &mut Vec<u8>,
+    ) -> Result<Address, RecoveryError> {
+        self.1.recover_signer_unchecked_with_buf(buf)
+    }
 }
 
 impl<T> SignerRecoverable for Sealed<T>
@@ -306,5 +321,12 @@ where
 
     fn recover_signer_unchecked(&self) -> Result<Address, RecoveryError> {
         self.inner().recover_signer_unchecked()
+    }
+
+    fn recover_signer_unchecked_with_buf(
+        &self,
+        buf: &mut Vec<u8>,
+    ) -> Result<Address, RecoveryError> {
+        self.inner().recover_signer_unchecked_with_buf(buf)
     }
 }

--- a/crates/consensus/src/transaction/recovered.rs
+++ b/crates/consensus/src/transaction/recovered.rs
@@ -251,6 +251,8 @@ pub trait SignerRecoverable {
     /// Same as [`SignerRecoverable::recover_signer_unchecked`] but receives a buffer to operate on
     /// for encoding. This is useful during batch recovery of historical transactions to avoid
     /// allocating a new buffer for each transaction.
+    ///
+    /// Caution: it is expected that implementations clear this buffer.
     fn recover_signer_unchecked_with_buf(
         &self,
         buf: &mut alloc::vec::Vec<u8>,

--- a/crates/consensus/src/transaction/recovered.rs
+++ b/crates/consensus/src/transaction/recovered.rs
@@ -253,7 +253,7 @@ pub trait SignerRecoverable {
     /// allocating a new buffer for each transaction.
     fn recover_signer_unchecked_with_buf(
         &self,
-        buf: &mut Vec<u8>,
+        buf: &mut alloc::vec::Vec<u8>,
     ) -> Result<Address, RecoveryError>;
 
     /// Recover the signer via [`SignerRecoverable::recover_signer`] and returns a
@@ -305,7 +305,7 @@ where
 
     fn recover_signer_unchecked_with_buf(
         &self,
-        buf: &mut Vec<u8>,
+        buf: &mut alloc::vec::Vec<u8>,
     ) -> Result<Address, RecoveryError> {
         self.1.recover_signer_unchecked_with_buf(buf)
     }
@@ -325,7 +325,7 @@ where
 
     fn recover_signer_unchecked_with_buf(
         &self,
-        buf: &mut Vec<u8>,
+        buf: &mut alloc::vec::Vec<u8>,
     ) -> Result<Address, RecoveryError> {
         self.inner().recover_signer_unchecked_with_buf(buf)
     }

--- a/crates/consensus/src/transaction/recovered.rs
+++ b/crates/consensus/src/transaction/recovered.rs
@@ -254,7 +254,10 @@ pub trait SignerRecoverable {
     fn recover_signer_unchecked_with_buf(
         &self,
         buf: &mut alloc::vec::Vec<u8>,
-    ) -> Result<Address, RecoveryError>;
+    ) -> Result<Address, RecoveryError> {
+        let _ = buf;
+        self.recover_signer()
+    }
 
     /// Recover the signer via [`SignerRecoverable::recover_signer`] and returns a
     /// `Recovered<Self>`


### PR DESCRIPTION
## Motivation

Closes https://github.com/paradigmxyz/reth/issues/17068.

## Solution

- Add `recover_signer_unchecked_with_buf` to `SignerRecoverable` 
- Add `recover_signer_unchecked_with_buf` impls for `Signed<T>` and `EthereumTxEnvelope<Eip4844>`

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
