### PR TITLE
chore: rename ported fn

### DIFF
--- a/crates/consensus/src/signed.rs
+++ b/crates/consensus/src/signed.rs
@@ -466,7 +466,7 @@ where
         crate::crypto::secp256k1::recover_signer_unchecked(self.signature(), signature_hash)
     }
 
-    fn recover_signer_unchecked_with_buf(
+    fn recover_unchecked_with_buf(
         &self,
         buf: &mut alloc::vec::Vec<u8>,
     ) -> Result<alloy_primitives::Address, crate::crypto::RecoveryError> {

--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -484,25 +484,25 @@ where
         }
     }
 
-    fn recover_signer_unchecked_with_buf(
+    fn recover_unchecked_with_buf(
         &self,
         buf: &mut alloc::vec::Vec<u8>,
     ) -> Result<alloy_primitives::Address, crate::crypto::RecoveryError> {
         match self {
             Self::Legacy(tx) => {
-                crate::transaction::SignerRecoverable::recover_signer_unchecked_with_buf(tx, buf)
+                crate::transaction::SignerRecoverable::recover_unchecked_with_buf(tx, buf)
             }
             Self::Eip2930(tx) => {
-                crate::transaction::SignerRecoverable::recover_signer_unchecked_with_buf(tx, buf)
+                crate::transaction::SignerRecoverable::recover_unchecked_with_buf(tx, buf)
             }
             Self::Eip1559(tx) => {
-                crate::transaction::SignerRecoverable::recover_signer_unchecked_with_buf(tx, buf)
+                crate::transaction::SignerRecoverable::recover_unchecked_with_buf(tx, buf)
             }
             Self::Eip4844(tx) => {
-                crate::transaction::SignerRecoverable::recover_signer_unchecked_with_buf(tx, buf)
+                crate::transaction::SignerRecoverable::recover_unchecked_with_buf(tx, buf)
             }
             Self::Eip7702(tx) => {
-                crate::transaction::SignerRecoverable::recover_signer_unchecked_with_buf(tx, buf)
+                crate::transaction::SignerRecoverable::recover_unchecked_with_buf(tx, buf)
             }
         }
     }

--- a/crates/consensus/src/transaction/recovered.rs
+++ b/crates/consensus/src/transaction/recovered.rs
@@ -253,7 +253,7 @@ pub trait SignerRecoverable {
     /// allocating a new buffer for each transaction.
     ///
     /// Caution: it is expected that implementations clear this buffer.
-    fn recover_signer_unchecked_with_buf(
+    fn recover_unchecked_with_buf(
         &self,
         buf: &mut alloc::vec::Vec<u8>,
     ) -> Result<Address, RecoveryError> {
@@ -308,11 +308,11 @@ where
         self.1.recover_signer_unchecked()
     }
 
-    fn recover_signer_unchecked_with_buf(
+    fn recover_unchecked_with_buf(
         &self,
         buf: &mut alloc::vec::Vec<u8>,
     ) -> Result<Address, RecoveryError> {
-        self.1.recover_signer_unchecked_with_buf(buf)
+        self.1.recover_unchecked_with_buf(buf)
     }
 }
 
@@ -328,10 +328,10 @@ where
         self.inner().recover_signer_unchecked()
     }
 
-    fn recover_signer_unchecked_with_buf(
+    fn recover_unchecked_with_buf(
         &self,
         buf: &mut alloc::vec::Vec<u8>,
     ) -> Result<Address, RecoveryError> {
-        self.inner().recover_signer_unchecked_with_buf(buf)
+        self.inner().recover_unchecked_with_buf(buf)
     }
 }


### PR DESCRIPTION
avoid conflicts with reth