### PR TITLE
feat: add provider-mev-api top level feature re-export

### DIFF
--- a/crates/alloy/Cargo.toml
+++ b/crates/alloy/Cargo.toml
@@ -189,6 +189,11 @@ provider-anvil-node = [
     "alloy-provider?/anvil-node",
     "node-bindings",
 ]
+provider-mev-api = [
+    "providers",
+    "alloy-provider?/mev-api",
+    "rpc-types-mev",
+]
 
 # pubsub
 pubsub = [


### PR DESCRIPTION
## Motivation
Using the mev-api feature today requires using alloy-provider instead of the alloy crate directly like this
alloy-provider = { version = "1.0.16", features = ["mev-api"] }

because the feature isn't re-exported into the alloy crate. For other features there is things like provider-anvil-api that are exposed apparently.

## Solution
Add the reexport so `provider-mev-api` feature can be used instead