### PR TITLE
feat(mev-api): add support for eth_cancelBundle

### DIFF
--- a/crates/provider/src/ext/mev/mod.rs
+++ b/crates/provider/src/ext/mev/mod.rs
@@ -3,7 +3,7 @@ mod with_auth;
 pub use self::with_auth::{sign_flashbots_payload, MevBuilder};
 use crate::Provider;
 use alloy_network::Network;
-use alloy_rpc_types_mev::{EthBundleHash, EthSendBundle};
+use alloy_rpc_types_mev::{EthBundleHash, EthCancelBundle, EthSendBundle};
 
 /// The HTTP header used for Flashbots signature authentication.
 pub const FLASHBOTS_SIGNATURE_HEADER: &str = "x-flashbots-signature";
@@ -18,6 +18,9 @@ pub trait MevApi<N>: Send + Sync {
         &self,
         bundle: EthSendBundle,
     ) -> MevBuilder<(EthSendBundle,), Option<EthBundleHash>>;
+
+    /// Cancels a previously sent MEV bundle using the `eth_cancelBundle` RPC method.
+    fn cancel_bundle(&self, replacement_uuid: String) -> MevBuilder<(EthCancelBundle,), ()>;
 }
 
 #[cfg_attr(target_family = "wasm", async_trait::async_trait(?Send))]
@@ -32,5 +35,11 @@ where
         bundle: EthSendBundle,
     ) -> MevBuilder<(EthSendBundle,), Option<EthBundleHash>> {
         MevBuilder::new_rpc(self.client().request("eth_sendBundle", (bundle,)))
+    }
+
+    fn cancel_bundle(&self, replacement_uuid: String) -> MevBuilder<(EthCancelBundle,), ()> {
+        MevBuilder::new_rpc(
+            self.client().request("eth_cancelBundle", (EthCancelBundle { replacement_uuid },)),
+        )
     }
 }

--- a/crates/rpc-types-mev/src/eth_calls.rs
+++ b/crates/rpc-types-mev/src/eth_calls.rs
@@ -1,3 +1,6 @@
+// Allow to keep the deprecated items for compatibility
+#![allow(deprecated)]
+
 use crate::{u256_numeric_string, Privacy, Validity};
 
 use alloy_eips::{eip2718::Encodable2718, BlockNumberOrTag};
@@ -208,6 +211,15 @@ pub struct EthCallBundleTransactionResult {
 }
 
 /// Request for `eth_cancelBundle`
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct EthCancelBundle {
+    /// The replacement UUID of the bundle to be canceled
+    pub replacement_uuid: String,
+}
+
+/// Request for `eth_cancelBundle`
+#[deprecated = "Use `EthCancelBundle` instead"]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct CancelBundleRequest {


### PR DESCRIPTION
Supporting `eth_cancelBundle` for the mev-api.

Changes:
- Add `fn cancel_bundle(replacement_uuid: String)`
  - I have choosen to pass just the string and not the struct for simplicity.
- Deprecated `CancelBundleRequest` in favor of `EthCancelBundle`
  - Following the naming schema like `EthSendBundle` 
  - Instead of the `bundleHash`, `replacementUuid` is required. See: https://docs.flashbots.net/flashbots-auction/advanced/bundle-cancellations#canceling-bundles
- Added `#![allow(deprecated)]` to the file to make clippy happy. But when importing the deprecated warning is active.

PS: I didn't use the uuid crate here to let users choose their preferred UUID implementation.