### PR TITLE
feat: add environment variable support to Anvil builder

### DIFF
--- a/crates/node-bindings/src/nodes/anvil.rs
+++ b/crates/node-bindings/src/nodes/anvil.rs
@@ -160,6 +160,7 @@ pub struct Anvil {
     fork: Option<String>,
     fork_block_number: Option<u64>,
     args: Vec<OsString>,
+    envs: Vec<(OsString, OsString)>,
     timeout: Option<u64>,
     keep_stdout: bool,
 }
@@ -333,6 +334,29 @@ impl Anvil {
         self
     }
 
+    /// Adds an environment variable to pass to the `anvil`.
+    pub fn env<K, V>(mut self, key: K, value: V) -> Self
+    where
+        K: Into<OsString>,
+        V: Into<OsString>,
+    {
+        self.envs.push((key.into(), value.into()));
+        self
+    }
+
+    /// Adds multiple environment variables to pass to the `anvil`.
+    pub fn envs<I, K, V>(mut self, envs: I) -> Self
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: Into<OsString>,
+        V: Into<OsString>,
+    {
+        for (key, value) in envs {
+            self = self.env(key, value);
+        }
+        self
+    }
+
     /// Sets the timeout which will be used when the `anvil` instance is launched.
     pub const fn timeout(mut self, timeout: u64) -> Self {
         self.timeout = Some(timeout);
@@ -364,6 +388,9 @@ impl Anvil {
 
         // disable nightly warning
         cmd.env("FOUNDRY_DISABLE_NIGHTLY_WARNING", "");
+
+        // set additional environment variables
+        cmd.envs(self.envs);
 
         let mut port = self.port.unwrap_or_default();
         cmd.arg("-p").arg(port.to_string());


### PR DESCRIPTION
Added builder-style methods to set custom environment variables when spawning anvil instances.

## Summary

This PR adds `env()` and `envs()` methods to the `Anvil` builder, following the same pattern as the existing `arg()` and `args()` methods. This allows users to configure anvil's behavior through environment variables.

## Changes

- Added `envs: Vec<(OsString, OsString)>` field to store environment variables
- Added `env(key, value)` method to set a single environment variable
- Added `envs(pairs)` method to set multiple environment variables at once
- Applied environment variables in `try_spawn()` using `cmd.envs()`

## Usage

```rust
let anvil = Anvil::new()
    .env("RUST_LOG", "debug")
    .env("CUSTOM_VAR", "value")
    .envs([("VAR1", "value1"), ("VAR2", "value2")])
    .spawn();
```

This maintains consistency with the existing builder API while providing the flexibility to set any environment variables needed for anvil configuration.