### PR TITLE
chore: set NO_COLOR for anvil

### DIFF
--- a/crates/node-bindings/src/nodes/anvil.rs
+++ b/crates/node-bindings/src/nodes/anvil.rs
@@ -399,7 +399,9 @@ impl Anvil {
         cmd.stdout(std::process::Stdio::piped()).stderr(std::process::Stdio::inherit());
 
         // disable nightly warning
-        cmd.env("FOUNDRY_DISABLE_NIGHTLY_WARNING", "");
+        cmd.env("FOUNDRY_DISABLE_NIGHTLY_WARNING", "")
+            // disable color in logs
+            .env("NO_COLOR", "1");
 
         // set additional environment variables
         cmd.envs(self.envs);


### PR DESCRIPTION
only prints raw text in logs