### PR TITLE
Add more mutable accessors

### DIFF
--- a/crates/json-rpc/src/packet.rs
+++ b/crates/json-rpc/src/packet.rs
@@ -122,7 +122,7 @@ impl RequestPacket {
         }
     }
 
-    /// Returns mutable reference to all [`SerializedRequest`].
+    /// Returns a mutable reference to all [`SerializedRequest`].
     pub fn requests_mut(&mut self) -> &mut [SerializedRequest] {
         match self {
             Self::Single(req) => std::slice::from_mut(req),

--- a/crates/json-rpc/src/packet.rs
+++ b/crates/json-rpc/src/packet.rs
@@ -114,11 +114,19 @@ impl RequestPacket {
         }
     }
 
-    /// Returns a all [`SerializedRequest`].
+    /// Returns all [`SerializedRequest`].
     pub fn requests(&self) -> &[SerializedRequest] {
         match self {
             Self::Single(req) => std::slice::from_ref(req),
             Self::Batch(req) => req.as_slice(),
+        }
+    }
+
+    /// Returns mutable reference to all [`SerializedRequest`].
+    pub fn requests_mut(&mut self) -> &mut [SerializedRequest] {
+        match self {
+            Self::Single(req) => std::slice::from_mut(req),
+            Self::Batch(req) => req.as_mut_slice(),
         }
     }
 

--- a/crates/json-rpc/src/request.rs
+++ b/crates/json-rpc/src/request.rs
@@ -349,6 +349,11 @@ impl SerializedRequest {
         &self.meta
     }
 
+    /// Returns a mutable reference to the request metadata (ID and Method).
+    pub const fn meta_mut(&mut self) -> &mut RequestMeta {
+        &mut self.meta
+    }
+
     /// Returns the request ID.
     pub const fn id(&self) -> &Id {
         &self.meta.id


### PR DESCRIPTION
## Motivation
fixes https://github.com/alloy-rs/alloy/issues/2670
TL;DR it would be very useful if transport layers could attach arbitrary metadata to each request. A `SerializedRequest` already has an `extensions` field which enables that but AFAICS there is no way to get a mutable reference to the `Extensions` from an owned `RequestPacket` (which is what the transport layers have access to).



## Solution
I added `SerializedRequest::meta_mut()` which provides is needed to get mutable access to the request `Extensions`.
Additionally I added `RequestPacket::requests_mut()` to give round out the mutable accessors for these types.

## PR Checklist
- [ ] Added Tests
    I didn't add any tests since I hope this change is trivial enough to not need any
- [ ] Added Documentation
    added doc comments on the 2 new functions
- [ ] Breaking changes
    no breaking change as this is only adding new functions
