### PR TITLE
feat(rpc-types-engine): custom ssz decode to distinguish Fulu and Electra payload

### DIFF
--- a/crates/rpc-types-engine/src/payload.rs
+++ b/crates/rpc-types-engine/src/payload.rs
@@ -2054,6 +2054,7 @@ mod tests {
 
     #[test]
     #[cfg(feature = "ssz")]
+    #[cfg(not(debug_assertions))]
     fn ssz_blobsbundlev2_roundtrip() {
         let commitments = vec![Bytes48::default(), Bytes48::default()];
         let num_blobs = commitments.len();
@@ -2072,6 +2073,7 @@ mod tests {
 
     #[test]
     #[cfg(feature = "ssz")]
+    #[cfg(not(debug_assertions))]
     fn ssz_blobsbundlev2_invalid_proofs_length() {
         let commitments = vec![Bytes48::default()];
 
@@ -2090,6 +2092,7 @@ mod tests {
 
     #[test]
     #[cfg(feature = "ssz")]
+    #[cfg(not(debug_assertions))]
     fn ssz_blobsbundlev2_mismatched_commitments_blobs() {
         let blobs_bundle_v2 = BlobsBundleV2 {
             commitments: vec![Bytes48::default(), Bytes48::default()],
@@ -2106,6 +2109,7 @@ mod tests {
 
     #[test]
     #[cfg(feature = "ssz")]
+    #[cfg(not(debug_assertions))]
     fn ssz_blobsbundlev2_empty() {
         let blobs_bundle_v2 = BlobsBundleV2 { commitments: vec![], proofs: vec![], blobs: vec![] };
 


### PR DESCRIPTION
For SSZ when using `SubmitBlockRequest::from_ssz_bytes(...)`, the enum default to `Fulu` without the custom deserialization for an `Electra` payload. Same as for the serde it compares the amount of proofs/commits to determine the version.

https://github.com/alloy-rs/alloy/blob/fe4bfe2be3d78345d32c8bbd542123e2c099a146/crates/rpc-types-beacon/src/relay.rs#L205-L209

Test with `#[cfg(not(debug_assertions))]` are not executed in the CI, locally they are fine. Same concept as the serde tests. Run:
`cargo test -p alloy-rpc-types-engine --features ssz ssz_blobsbundlev2 --release`