### PR TITLE
chore: add Recovered::copied

### DIFF
--- a/crates/consensus/src/transaction/recovered.rs
+++ b/crates/consensus/src/transaction/recovered.rs
@@ -183,6 +183,11 @@ impl<T> Recovered<&T> {
         let Self { inner, signer } = self;
         Recovered::new_unchecked(inner.clone(), signer)
     }
+
+    /// Helper function to explicitly create a new copy of `Recovered<&T>`
+    pub const fn copied(&self) -> Self {
+        *self
+    }
 }
 
 impl<T: Encodable> Encodable for Recovered<T> {


### PR DESCRIPTION
this is helpful to guide borrow checker when a copy should be created