### PR TITLE
chore: refine optional rpc-types features

### DIFF
--- a/crates/alloy/Cargo.toml
+++ b/crates/alloy/Cargo.toml
@@ -165,12 +165,18 @@ provider-anvil-api = [
 provider-debug-api = [
     "providers",
     "alloy-provider?/debug-api",
+    "rpc-types-debug",
     "rpc-types-trace",
 ]
 provider-engine-api = [
     "providers",
     "alloy-provider?/engine-api",
     "rpc-types-engine",
+]
+provider-mev-api = [
+    "providers",
+    "alloy-provider?/mev-api",
+    "rpc-types-mev",
 ]
 provider-net-api = ["providers", "alloy-provider?/net-api"]
 provider-trace-api = [
@@ -189,11 +195,6 @@ provider-anvil-node = [
     "alloy-provider?/anvil-node",
     "node-bindings",
 ]
-provider-mev-api = [
-    "providers",
-    "alloy-provider?/mev-api",
-    "rpc-types-mev",
-]
 
 # pubsub
 pubsub = [
@@ -210,36 +211,17 @@ rpc-client = ["rpc", "transports", "transport-http", "dep:alloy-rpc-client"]
 rpc-client-ws = ["rpc-client", "transport-ws", "alloy-rpc-client?/ws"]
 rpc-client-ipc = ["rpc-client", "transport-ipc", "alloy-rpc-client?/ipc"]
 rpc-types = ["rpc", "serde", "dep:alloy-rpc-types", "alloy-rpc-types?/eth"]
-rpc-types-admin = [
-    "rpc-types",
-    "alloy-rpc-types?/admin",
-    "alloy-provider?/admin-api",
-]
-rpc-types-anvil = [
-    "rpc-types",
-    "alloy-rpc-types?/anvil",
-    "alloy-provider?/anvil-api",
-]
+rpc-types-admin = ["rpc-types", "alloy-rpc-types?/admin"]
+rpc-types-anvil = ["rpc-types", "alloy-rpc-types?/anvil"]
+rpc-types-any = ["rpc-types", "alloy-rpc-types?/any"]
 rpc-types-beacon = ["rpc-types", "alloy-rpc-types?/beacon"]
-rpc-types-debug = ["rpc-types", "alloy-provider?/debug-api"]
-rpc-types-engine = [
-    "rpc-types",
-    "alloy-rpc-types?/engine",
-    "alloy-provider?/engine-api",
-]
+rpc-types-debug = ["rpc-types", "alloy-rpc-types?/debug"]
+rpc-types-engine = ["rpc-types", "alloy-rpc-types?/engine"]
 rpc-types-eth = ["rpc-types", "alloy-rpc-types?/eth"]
-rpc-types-mev = ["rpc-types", "alloy-rpc-types?/mev"]
 rpc-types-json = ["rpc-types", "alloy-rpc-types?/jsonrpsee-types"]
-rpc-types-trace = [
-    "rpc-types",
-    "alloy-rpc-types?/trace",
-    "alloy-provider?/trace-api",
-]
-rpc-types-txpool = [
-    "rpc-types",
-    "alloy-rpc-types?/txpool",
-    "alloy-provider?/txpool-api",
-]
+rpc-types-mev = ["rpc-types", "alloy-rpc-types?/mev"]
+rpc-types-trace = ["rpc-types", "alloy-rpc-types?/trace"]
+rpc-types-txpool = ["rpc-types", "alloy-rpc-types?/txpool"]
 
 # signers
 signers = ["dep:alloy-signer"]
@@ -311,10 +293,10 @@ eip712 = [
 ]
 
 arbitrary = [
-	"alloy-core/arbitrary",
-	"alloy-consensus?/arbitrary",
-	"alloy-eips?/arbitrary",
-	"alloy-rpc-types?/arbitrary",
-	"alloy-serde?/arbitrary"
+    "alloy-core/arbitrary",
+    "alloy-consensus?/arbitrary",
+    "alloy-eips?/arbitrary",
+    "alloy-rpc-types?/arbitrary",
+    "alloy-serde?/arbitrary",
 ]
 postgres = ["alloy-core/postgres"]

--- a/crates/rpc-types/Cargo.toml
+++ b/crates/rpc-types/Cargo.toml
@@ -27,6 +27,7 @@ alloy-primitives = { workspace = true, features = ["map"] }
 alloy-serde.workspace = true
 alloy-rpc-types-admin = { workspace = true, optional = true }
 alloy-rpc-types-anvil = { workspace = true, optional = true }
+alloy-rpc-types-any = { workspace = true, optional = true }
 alloy-rpc-types-beacon = { workspace = true, optional = true }
 alloy-rpc-types-debug = { workspace = true, optional = true }
 alloy-rpc-types-engine = { workspace = true, optional = true, features = [
@@ -52,6 +53,7 @@ default = [
 ]
 admin = ["dep:alloy-rpc-types-admin"]
 anvil = ["dep:alloy-rpc-types-anvil"]
+any = ["dep:alloy-rpc-types-any"]
 beacon = ["dep:alloy-rpc-types-beacon"]
 debug = ["dep:alloy-rpc-types-debug"]
 engine = ["dep:alloy-rpc-types-engine"]

--- a/crates/rpc-types/src/lib.rs
+++ b/crates/rpc-types/src/lib.rs
@@ -18,6 +18,9 @@ pub use alloy_rpc_types_admin as admin;
 #[cfg(feature = "anvil")]
 pub use alloy_rpc_types_anvil as anvil;
 
+#[cfg(feature = "any")]
+pub use alloy_rpc_types_any as any;
+
 #[cfg(feature = "beacon")]
 pub use alloy_rpc_types_beacon as beacon;
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Re-export some types from `alloy-rpc-types-any` crate in `alloy` crate level

## Solution

- add optional `rpc-types-any` feature in `alloy` crate level
- update `rpc-types-*` features to only depend on `rpc-types` and `alloy-rpc-types?/*` features

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
