### PR TITLE
feat: re-export `serde-bincode-compat`

### DIFF
--- a/crates/alloy/Cargo.toml
+++ b/crates/alloy/Cargo.toml
@@ -291,6 +291,7 @@ serde = [
     "alloy-consensus?/serde",
     "dep:alloy-serde",
 ]
+serde-bincode-compat = ["alloy-consensus/serde-bincode-compat"]
 ssz = ["alloy-rpc-types?/ssz", "alloy-eips?/ssz"]
 k256 = [
     "alloy-core/k256",


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Re-export `serde-bincode-compat` from `alloy-consensus` in the `alloy` meta-crate

Fixes #2686 

## Solution

A new optional `serde-bincode-compat` feature in `alloy` meta-crate that enables the corresponding `alloy-consensus` feature

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
