### PR TITLE
Add EIP-2930 link and clarify access_list docs

### DIFF
--- a/crates/consensus/src/transaction/eip2930.rs
+++ b/crates/consensus/src/transaction/eip2930.rs
@@ -51,7 +51,7 @@ pub struct TxEip2930 {
     pub value: U256,
     /// The access list. See [EIP-2930](https://eips.ethereum.org/EIPS/eip-2930).
     ///
-    /// The `accessList` specifies a list of addresses and storage keys that the transaction
+    /// The `access_list` specifies a list of addresses and storage keys that the transaction
     /// plans to access. These addresses and storage keys are added into the `accessed_addresses`
     /// and `accessed_storage_keys` global sets (introduced in EIP-2929).
     /// A gas cost is charged, though at a discount relative to the cost of

--- a/crates/consensus/src/transaction/eip2930.rs
+++ b/crates/consensus/src/transaction/eip2930.rs
@@ -49,8 +49,10 @@ pub struct TxEip2930 {
     /// in the case of contract creation, as an endowment
     /// to the newly created account; formally Tv.
     pub value: U256,
-    /// The accessList specifies a list of addresses and storage keys;
-    /// these addresses and storage keys are added into the `accessed_addresses`
+    /// The access list. See [EIP-2930](https://eips.ethereum.org/EIPS/eip-2930).
+    ///
+    /// The `accessList` specifies a list of addresses and storage keys that the transaction
+    /// plans to access. These addresses and storage keys are added into the `accessed_addresses`
     /// and `accessed_storage_keys` global sets (introduced in EIP-2929).
     /// A gas cost is charged, though at a discount relative to the cost of
     /// accessing outside the list.


### PR DESCRIPTION

## Motivation


## Solution

The documentation for the `access_list` field in `TxEip2930` has been improved to provide better context and developer experience.

- A direct link to the EIP-2930 specification is now included in the documentation for the `access_list` field.
- The comment has been reformatted to follow standard Rustdoc style, with a concise summary line followed by a more detailed explanation.

This change makes it easier for developers to find the relevant specification and understand the purpose of the access list.
## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
