### PR TITLE
refactor(rpc-client): replace impl Stream with dedicated PollerStream type

### DIFF
--- a/crates/rpc-client/Cargo.toml
+++ b/crates/rpc-client/Cargo.toml
@@ -28,7 +28,6 @@ alloy-json-rpc.workspace = true
 alloy-transport-http = { workspace = true, optional = true }
 alloy-transport.workspace = true
 
-async-stream.workspace = true
 futures.workspace = true
 pin-project.workspace = true
 serde_json.workspace = true
@@ -37,7 +36,6 @@ tokio = { workspace = true, features = ["sync"] }
 tokio-stream = { workspace = true, features = ["sync"] }
 tower.workspace = true
 tracing.workspace = true
-tracing-futures = { workspace = true, features = ["futures-03"] }
 
 alloy-pubsub = { workspace = true, optional = true }
 alloy-transport-ws = { workspace = true, optional = true }

--- a/crates/rpc-client/src/lib.rs
+++ b/crates/rpc-client/src/lib.rs
@@ -25,7 +25,7 @@ mod client;
 pub use client::{ClientRef, NoParams, RpcClient, RpcClientInner, WeakClient};
 
 mod poller;
-pub use poller::{PollChannel, PollerBuilder};
+pub use poller::{PollChannel, PollerBuilder, PollerStream};
 
 #[cfg(feature = "ws")]
 pub use alloy_transport_ws::WsConnect;


### PR DESCRIPTION
## Summary

This PR refactors the `PollerBuilder::into_stream()` method to return a concrete `PollerStream` type instead of an opaque `impl Stream`. This change provides better control over the polling behavior and enables future enhancements.

## Changes

- Replace `impl Stream` return type with dedicated `PollerStream<Resp, Output, Map>` struct
- Implement manual `Stream` trait with state machine for full control over polling
- Pre-serialize RPC params once during construction to avoid lifetime issues
- Add `map()` functionality similar to `EthCallMany` for transforming responses
- Remove unused dependencies: `async-stream` and `tracing-futures`

## Motivation

The previous implementation using `async-stream` macro provided limited control over the stream's behavior. With a dedicated struct, we can:
- Add pause/resume functionality in the future
- Implement dynamic polling intervals
- Add communication channels for stream control
- Better integrate with heartbeat mechanisms to address continuous polling issues

## Example Usage

```rust
// Basic usage remains the same
let stream = client
    .prepare_static_poller("eth_blockNumber", [])
    .into_stream();

// New map functionality for transforming responses
let stream = client
    .prepare_static_poller("eth_blockNumber", [])
    .into_stream()
    .map(|block_num: U64| block_num.to::<u64>());
```

## Breaking Changes

None. The public API remains unchanged, only the return type is now named instead of opaque.