### PR TITLE
refactor: replace impl Stream with dedicated BlockStream type

### DIFF
--- a/crates/provider/Cargo.toml
+++ b/crates/provider/Cargo.toml
@@ -51,7 +51,6 @@ alloy-primitives.workspace = true
 alloy-sol-types.workspace = true
 
 alloy-chains.workspace = true
-async-stream.workspace = true
 async-trait.workspace = true
 auto_impl.workspace = true
 dashmap = "6.0"


### PR DESCRIPTION
## Summary

Replaces the opaque `impl Stream` return type in `NewBlocks::into_block_stream()` with dedicated `BlockStream` and `NewBlocksStream` types, providing better control over the stream implementation.

This follows the same pattern established in #2695 for `PollerStream`, creating explicit stream types that can be extended with additional functionality in the future.

## Changes

- Created `BlockStream<N, S>` struct that implements the block fetching logic using a state machine
- Added `NewBlocksStream<N>` enum to handle both polling and WebSocket subscription cases
- Moved the async stream logic into a proper `Stream` implementation with explicit state transitions
- Preserved all existing functionality including retry logic and block caching

The implementation maintains backward compatibility while providing a foundation for future enhancements like pause/resume functionality for the heartbeat polling optimization.

🤖 Generated with [Claude Code](https://claude.ai/code)