### PR TITLE
docs: Remove redundant comment in BlockBody arbitrary implementation

### DIFF
--- a/crates/consensus/src/block/mod.rs
+++ b/crates/consensus/src/block/mod.rs
@@ -343,7 +343,6 @@ where
 {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         // first generate up to 100 txs
-        // first generate a reasonable amount of txs
         let transactions = (0..u.int_in_range(0..=100)?)
             .map(|_| T::arbitrary(u))
             .collect::<arbitrary::Result<Vec<_>>>()?;


### PR DESCRIPTION
Removed a duplicate and less informative comment in the BlockBody arbitrary implementation. The remaining comment accurately describes the code, specifying that up to 100 transactions are generated. This change improves code clarity and avoids confusion for future maintainers.