### PR TITLE
fix: correct broken doc links

### DIFF
--- a/crates/network/README.md
+++ b/crates/network/README.md
@@ -19,7 +19,7 @@ networking. The core model is as follows:
   types to define the input and output types of the RPC methods.
 - `TransactionBuilder` - A trait for constructing and validating network-specific transaction requests. Used to build typed transactions for signing and submission. See [`TransactionBuilder`](./src/transaction/builder.rs).
 - `NetworkWallet` - A trait for wallets that can sign transactions for a given network. Used to abstract over different signing backends. See [`NetworkWallet`](./src/transaction/signer.rs).
-- `BlockResponse`, `TransactionResponse`, `ReceiptResponse`, `HeaderResponse` - Traits (from `alloy-network-primitives`) that define the structure of block, transaction, receipt, and header types used in RPC responses. These are associated types in the `Network` trait and are implemented by network-specific types. See [`alloy-network-primitives`]([https://docs.rs/alloy-network-primitives/](https://docs.rs/alloy-network-primitives/)).
+- `BlockResponse`, `TransactionResponse`, `ReceiptResponse`, `HeaderResponse` - Traits (from `alloy-network-primitives`) that define the structure of block, transaction, receipt, and header types used in RPC responses. These are associated types in the `Network` trait and are implemented by network-specific types. See [`alloy-network-primitives`](https://docs.rs/alloy-network-primitives/).
 
 ## Usage
 

--- a/crates/provider/src/ext/trace/with_block.rs
+++ b/crates/provider/src/ext/trace/with_block.rs
@@ -227,7 +227,7 @@ impl<Params: RpcSend> TraceParams<Params> {
     /// Create a new `TraceParams` with the given parameters.
     ///
     /// The `method` is used to determine which parameters to ignore according to the `trace_*` api
-    /// spec. See <https://reth.rs/jsonrpc/trace.html>.
+    /// spec. See <https://reth.rs/jsonrpc/trace>.
     pub fn new(
         method: &String,
         params: Params,


### PR DESCRIPTION
## Description

Hi! Just a small cleanup to fix a couple of broken or malformed links in the docs:

- Fixed the Markdown formatting for the `alloy-network-primitives` link in `crates/network/README.md`. The extra brackets were breaking the rendering.
- Updated a stale `.html` suffix in the URL in `crates/provider/src/ext/trace/with_block.rs` — current link returns 404.

## Motivation

Spotted these while reading through the docs. It’s minor, but broken links are annoying and worth cleaning up.

## Solution

Simple changes.

## PR Checklist

- [ ] Added Tests  
- [x] Added Documentation  
- [ ] Breaking changes