### PR TITLE
feat(mev): add support for `eth_sendBlobs` method to mev api

### DIFF
--- a/crates/provider/src/ext/mev/mod.rs
+++ b/crates/provider/src/ext/mev/mod.rs
@@ -3,7 +3,7 @@ mod with_auth;
 pub use self::with_auth::{sign_flashbots_payload, MevBuilder};
 use crate::Provider;
 use alloy_network::Network;
-use alloy_rpc_types_mev::{EthBundleHash, EthCancelBundle, EthSendBundle};
+use alloy_rpc_types_mev::{EthBundleHash, EthCancelBundle, EthSendBlobs, EthSendBundle};
 
 /// The HTTP header used for Flashbots signature authentication.
 pub const FLASHBOTS_SIGNATURE_HEADER: &str = "x-flashbots-signature";
@@ -21,6 +21,9 @@ pub trait MevApi<N>: Send + Sync {
 
     /// Cancels a previously sent MEV bundle using the `eth_cancelBundle` RPC method.
     fn cancel_bundle(&self, replacement_uuid: String) -> MevBuilder<(EthCancelBundle,), ()>;
+
+    /// Sends blob transaction permutations using the `eth_sendBlobs` RPC method.
+    fn send_blobs(&self, blobs: EthSendBlobs) -> MevBuilder<(EthSendBlobs,), ()>;
 }
 
 #[cfg_attr(target_family = "wasm", async_trait::async_trait(?Send))]
@@ -41,5 +44,9 @@ where
         MevBuilder::new_rpc(
             self.client().request("eth_cancelBundle", (EthCancelBundle { replacement_uuid },)),
         )
+    }
+
+    fn send_blobs(&self, blobs: EthSendBlobs) -> MevBuilder<(EthSendBlobs,), ()> {
+        MevBuilder::new_rpc(self.client().request("eth_sendBlobs", (blobs,)))
     }
 }

--- a/crates/rpc-types-mev/src/eth_calls.rs
+++ b/crates/rpc-types-mev/src/eth_calls.rs
@@ -431,6 +431,27 @@ impl PrivateTransactionPreferences {
     }
 }
 
+/// Bundle of blob transaction permutations for `eth_sendBlobs`
+///
+/// Sends multiple blob transaction permutations with the same nonce. These are conflicting
+/// transactions with different amounts of blobs where only one may be included.
+///
+/// For more details see:
+/// <https://docs.titanbuilder.xyz/api/eth_sendblobs>
+/// See also EIP-7925 draft:
+/// <https://ethereum-magicians.org/t/23333>
+#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EthSendBlobs {
+    /// A list of hex-encoded signed blob transactions (permutations with same nonce, different
+    /// blob counts)
+    pub txs: Vec<Bytes>,
+    /// Hex-encoded number string, optional. Highest block number in which one of the transactions
+    /// should be included.
+    #[serde(default, with = "alloy_serde::quantity::opt", skip_serializing_if = "Option::is_none")]
+    pub max_block_number: Option<u64>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::EthCallBundleResponse;


### PR DESCRIPTION
Adding support for `eth_sendBlobs` even with PeerDAS ahead.

See for details: https://docs.titanbuilder.xyz/api/eth_sendblobs
