### PR TITLE
feat(mev): implement `send_end_of_block_bundle` method

### DIFF
--- a/crates/provider/src/ext/mev/mod.rs
+++ b/crates/provider/src/ext/mev/mod.rs
@@ -6,8 +6,8 @@ use alloy_network::Network;
 use alloy_primitives::{hex, TxHash};
 use alloy_rpc_types_mev::{
     EthBundleHash, EthCallBundle, EthCallBundleResponse, EthCancelBundle,
-    EthCancelPrivateTransaction, EthSendBlobs, EthSendBundle, EthSendPrivateTransaction,
-    PrivateTransactionPreferences,
+    EthCancelPrivateTransaction, EthSendBlobs, EthSendBundle, EthSendEndOfBlockBundle,
+    EthSendPrivateTransaction, PrivateTransactionPreferences,
 };
 
 /// The HTTP header used for Flashbots signature authentication.
@@ -55,6 +55,13 @@ pub trait MevApi<N>: Send + Sync {
         &self,
         tx_hash: TxHash,
     ) -> MevBuilder<(EthCancelPrivateTransaction,), bool>;
+
+    /// Sends end-of-block bundle using the `eth_sendEndOfBlockBundle` RPC method.
+    /// Returns the resulting bundle hash on success.
+    fn send_end_of_block_bundle(
+        &self,
+        bundle: EthSendEndOfBlockBundle,
+    ) -> MevBuilder<(EthSendEndOfBlockBundle,), Option<EthBundleHash>>;
 }
 
 #[cfg_attr(target_family = "wasm", async_trait::async_trait(?Send))]
@@ -116,5 +123,12 @@ where
                 (EthCancelPrivateTransaction { tx_hash },),
             ),
         )
+    }
+
+    fn send_end_of_block_bundle(
+        &self,
+        bundle: EthSendEndOfBlockBundle,
+    ) -> MevBuilder<(EthSendEndOfBlockBundle,), Option<EthBundleHash>> {
+        MevBuilder::new_rpc(self.client().request("eth_sendEndOfBlockBundle", (bundle,)))
     }
 }

--- a/crates/rpc-types-mev/src/eth_calls.rs
+++ b/crates/rpc-types-mev/src/eth_calls.rs
@@ -460,6 +460,27 @@ pub struct EthSendBlobs {
     pub max_block_number: Option<u64>,
 }
 
+/// Bundle of transactions for `eth_sendEndOfBlockBundle`
+///
+/// For more details see:
+/// <https://docs.titanbuilder.xyz/api/eth_sendendofblockbundle> or
+/// <https://docs.quasar.win/eth_sendendofblockbundle>
+#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EthSendEndOfBlockBundle {
+    /// A list of hex-encoded signed transactions
+    pub txs: Vec<Bytes>,
+    /// Hex-encoded block number for which this bundle is valid on
+    #[serde(default, with = "alloy_serde::quantity::opt", skip_serializing_if = "Option::is_none")]
+    pub block_number: Option<u64>,
+    /// List of hashes of possibly reverting txs
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub reverting_tx_hashes: Vec<TxHash>,
+    /// Pool addresses targeted by the bundle
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub target_pools: Vec<Address>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::EthCallBundleResponse;


### PR DESCRIPTION
Implement method for `eth_sendEndOfBlockBundle`.

Combining compatibility for both:

**Quasar** does not return a `bundle_hash` and does not support `targetPools`.
Docs: https://docs.quasar.win/eth_sendendofblockbundle

**Titan** returns a `bundle_hash` and requires `targetPools`.
Docs: https://docs.titanbuilder.xyz/api/eth_sendendofblockbundle