### PR TITLE
refactor: Change `op` in `StructLog` from `String` to Cow<'static, str>

### DIFF
--- a/crates/rpc-types-trace/src/geth/mod.rs
+++ b/crates/rpc-types-trace/src/geth/mod.rs
@@ -108,6 +108,13 @@ pub struct StructLog {
     pub refund_counter: Option<u64>,
 }
 
+impl StructLog {
+    /// Returns the name of the opcode.
+    pub fn opcode(&self) -> &str {
+        self.op.as_ref()
+    }
+}
+
 /// Tracing response objects
 ///
 /// Note: This deserializes untagged, so it's possible that a custom javascript tracer response


### PR DESCRIPTION
## Motivation

Closes https://github.com/alloy-rs/alloy/issues/2729.
and finally https://github.com/paradigmxyz/revm-inspectors/issues/322.

## Solution

Replace op in StructLog from String to Cow<'static, str>

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [x] Breaking changes
