### PR TITLE
Multicall send support

### DIFF
--- a/crates/provider/src/provider/multicall/mod.rs
+++ b/crates/provider/src/provider/multicall/mod.rs
@@ -624,6 +624,7 @@ where
         let tryBlockAndAggregateReturn { blockNumber, blockHash, returnData } = output;
         Ok((blockNumber.to::<u64>(), blockHash, T::decode_return_results(&returnData)?))
     }
+
     /// Sends the `tryBlockAndAggregate` function as a transaction  
     pub async fn send_try_block_and_aggregate(
         &self,
@@ -632,6 +633,7 @@ where
         let call = self.to_try_block_and_aggregate_call(require_success);
         self.build_and_send(call, None).await
     }
+
     /// Helper for building the transaction request for the given call type input.
     fn build_request<M: SolCall>(
         &self,


### PR DESCRIPTION
## Summary

Adds `send_*` methods to `MulticallBuilder` to support sending multicall operations as transactions instead of just read-only calls.

## Changes

- Add `send_aggregate()`
- Add `send_try_aggregate()` 
- Add `send_aggregate3()`
- Add `send_aggregate3_value()`
- Add `send_block_and_aggregate()`
- Add `send_try_block_and_aggregate()`

## Usage
Users can now send multicall operations as transactions:

```rust
let multicall = provider.multicall()
    .add_call(contract_a.method1(...))
    .add_call(contract_b.method2(...));

// Send as a single on-chain transaction
let pending_tx = multicall.send_aggregate().await?;
```
Closes #2733