### PR TITLE
feat(rpc): add optional index field to CallLogFrame

### DIFF
--- a/crates/rpc-types-trace/src/geth/call.rs
+++ b/crates/rpc-types-trace/src/geth/call.rs
@@ -60,6 +60,9 @@ pub struct CallLogFrame {
     /// The position of the log relative to subcalls within the same trace.
     #[serde(default, with = "alloy_serde::quantity::opt", skip_serializing_if = "Option::is_none")]
     pub position: Option<u64>,
+    /// The index of the log in the trace.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub index: Option<u64>,
 }
 
 /// The configuration for the call tracer.


### PR DESCRIPTION
## Motivation

Resolve #2747

## Solution

Add optional `index` field to `CallLogFrame`, similar to `position` but not serialized with `alloy_serde::quantity::opt` as index is not prefixed with `0x`

## PR Checklist

- [ ] Added Tests (todo: use this https://github.com/paradigmxyz/reth/discussions/17629#discussioncomment-13906650 ?)
- [x] Added Documentation
- [ ] Breaking changes
