### PR TITLE
feat: add with_failure_allowed

### DIFF
--- a/crates/provider/src/provider/multicall/inner_types.rs
+++ b/crates/provider/src/provider/multicall/inner_types.rs
@@ -87,6 +87,11 @@ impl<D: SolCall> CallItem<D> {
         self
     }
 
+    /// Convenience function for `allow_failure(true)`
+    pub const fn with_failure_allowed(self) -> Self {
+        self.allow_failure(true)
+    }
+
     /// Set the value to send with the call.
     pub const fn value(mut self, value: U256) -> Self {
         self.value = value;


### PR DESCRIPTION
accepting bool is a bit weird most of the time because false is always default so this ends up being called with true all the time

cc @joshieDo 