### PR TITLE
feat: Add PollIntervalLayer for provider to customize client poll interval

### DIFF
--- a/crates/provider/src/builder.rs
+++ b/crates/provider/src/builder.rs
@@ -3,7 +3,7 @@ use crate::{
         CachedNonceManager, ChainIdFiller, FillerControlFlow, GasFiller, JoinFill, NonceFiller,
         NonceManager, RecommendedFillers, SimpleNonceManager, TxFiller, WalletFiller,
     },
-    layers::{CallBatchLayer, ChainLayer},
+    layers::{CallBatchLayer, ChainLayer, PollIntervalLayer},
     provider::SendableTx,
     Provider, RootProvider,
 };
@@ -12,7 +12,7 @@ use alloy_network::{Ethereum, IntoWallet, Network};
 use alloy_primitives::ChainId;
 use alloy_rpc_client::{ClientBuilder, RpcClient};
 use alloy_transport::{TransportError, TransportResult};
-use std::marker::PhantomData;
+use std::{marker::PhantomData, time::Duration};
 
 /// A layering abstraction in the vein of [`tower::Layer`]
 ///
@@ -230,6 +230,20 @@ impl<L, F, N> ProviderBuilder<L, F, N> {
     /// Does nothing to the client with a local transport.
     pub fn with_chain(self, chain: NamedChain) -> ProviderBuilder<Stack<ChainLayer, L>, F, N> {
         self.layer(ChainLayer::new(chain))
+    }
+
+    /// Sets a custom poll interval for the client.
+    ///
+    /// This overrides any default polling frequency, such as the one configured
+    /// by `with_chain()`.
+    ///
+    /// **Note:** If the poll interval is set multiple times, the last value
+    /// applied to the builder will be the one that is used.
+    pub fn with_poll_interval(
+        self,
+        poll_interval: Duration,
+    ) -> ProviderBuilder<Stack<PollIntervalLayer, L>, F, N> {
+        self.layer(PollIntervalLayer::new(poll_interval))
     }
 
     // --- Fillers ---

--- a/crates/provider/src/layers/mod.rs
+++ b/crates/provider/src/layers/mod.rs
@@ -11,6 +11,9 @@ pub use batch::{CallBatchLayer, CallBatchProvider};
 mod chain;
 pub use chain::ChainLayer;
 
+mod poll_interval;
+pub use poll_interval::PollIntervalLayer;
+
 #[cfg(not(target_family = "wasm"))]
 mod cache;
 #[cfg(not(target_family = "wasm"))]

--- a/crates/provider/src/layers/poll_interval.rs
+++ b/crates/provider/src/layers/poll_interval.rs
@@ -1,0 +1,32 @@
+use crate::{Provider, ProviderLayer};
+use alloy_network::Network;
+use std::time::Duration;
+
+/// Sets the poll interval for the client.
+///
+/// This has no effect if the client is using a local transport.
+#[derive(Debug, Clone, Copy)]
+pub struct PollIntervalLayer {
+    poll_interval: Duration,
+}
+
+impl PollIntervalLayer {
+    /// Create a new `PollIntervalLayer` from the given duration.
+    pub const fn new(poll_interval: Duration) -> Self {
+        Self { poll_interval }
+    }
+}
+
+impl<P, N> ProviderLayer<P, N> for PollIntervalLayer
+where
+    P: Provider<N>,
+    N: Network,
+{
+    type Provider = P;
+    fn layer(&self, inner: P) -> Self::Provider {
+        if !inner.client().is_local() {
+            inner.client().set_poll_interval(self.poll_interval);
+        }
+        inner
+    }
+}


### PR DESCRIPTION
Adds a provider layer to be able to customize poll interval.

There could be a problem when user writes for example:

```rust
ProviderBuilder::new()
  .with_chain(typedChain::BinanceSmartChain)
  .with_poll_interval(Duration::from_millis(100);
```
As that would override the poll interval set by the `with_chain()` and vice versa.
I added a comment for that, but not sure if this is something you would like to add.

The method would be for sure useful.


<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
Would be great to be able to change the poll interval.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
