### PR TITLE
fix: with_avg_unit_cost

### DIFF
--- a/crates/transport/src/layers/retry.rs
+++ b/crates/transport/src/layers/retry.rs
@@ -68,8 +68,9 @@ impl RetryBackoffLayer {
     /// (coming from forking mode) assuming here that storage request will be the
     /// driver for Rate limits we choose `17` as the average cost
     /// of any request
-    pub const fn with_avg_unit_cost(mut self, avg_cost: u64) {
+    pub const fn with_avg_unit_cost(mut self, avg_cost: u64) -> Self {
         self.avg_cost = avg_cost;
+        self
     }
 }
 


### PR DESCRIPTION
The current function takes ownership of `self` and never returns, making it unusable.

This fix simply returns `Self` so the caller can continue to use it