### PR TITLE
feat: auto-impl for transport connect types

### DIFF
--- a/crates/pubsub/Cargo.toml
+++ b/crates/pubsub/Cargo.toml
@@ -36,6 +36,7 @@ tokio-stream = { workspace = true, features = ["sync"] }
 tower.workspace = true
 tracing.workspace = true
 parking_lot.workspace = true
+auto_impl.workspace = true
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 wasmtimer.workspace = true

--- a/crates/pubsub/src/connect.rs
+++ b/crates/pubsub/src/connect.rs
@@ -5,6 +5,7 @@ use alloy_transport::{impl_future, TransportResult};
 ///
 /// Implementers should contain configuration options for the underlying
 /// transport.
+#[auto_impl::auto_impl(Box)]
 pub trait PubSubConnect: Sized + Send + Sync + 'static {
     /// Returns `true` if the transport connects to a local resource.
     fn is_local(&self) -> bool;

--- a/crates/transport/Cargo.toml
+++ b/crates/transport/Cargo.toml
@@ -41,6 +41,7 @@ governor = { version = "0.8.1", default-features = false, features = [
 futures.workspace = true
 parking_lot.workspace = true
 derive_more.workspace = true
+auto_impl.workspace = true
 
 # non-WASM only
 [target.'cfg(not(target_family = "wasm"))'.dependencies]

--- a/crates/transport/src/connect.rs
+++ b/crates/transport/src/connect.rs
@@ -13,6 +13,7 @@ use futures_utils_wasm::impl_future;
 /// - You need to provide special authentication information to a remote provider.
 /// - You have implemented a custom [`Transport`](crate::Transport).
 /// - You require a specific websocket reconnection strategy.
+#[auto_impl::auto_impl(&, &mut, Box, Arc)]
 pub trait TransportConnect: Sized + Send + Sync + 'static {
     /// Returns `true` if the transport connects to a local resource.
     fn is_local(&self) -> bool;


### PR DESCRIPTION
Adds auto-impl for all appropriate types to `TransportConnect` and `PubsubConnect`

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
