### PR TITLE
fix(docs): correct typos in EIP and ENS references

### DIFF
--- a/crates/eips/README.md
+++ b/crates/eips/README.md
@@ -1,6 +1,6 @@
 # alloy-eips
 
-Ethereum Improvement Proprosal (EIP) implementations.
+Ethereum Improvement Proposal (EIP) implementations.
 
 Contains constants, helpers, and basic data structures for consensus EIPs.
 

--- a/crates/ens/src/lib.rs
+++ b/crates/ens/src/lib.rs
@@ -321,7 +321,7 @@ mod tests {
         let provider = ProviderBuilder::new()
             .connect_http("https://reth-ethereum.ithaca.xyz/rpc".parse().unwrap());
 
-        let name = "deployd.eth";
+        let name = "deployed.eth";
         let node = namehash(name);
         let res = provider.get_resolver(node, name).await;
         assert_eq!(*res.unwrap().address(), address!("0x231b0Ee14048e9dCcD1d247744d114a4EB5E8E63"));


### PR DESCRIPTION
Fixed typo in crates/eips/README.md:

- Replaced Proprosal with correct Proposal

Fixed ENS domain typo in crates/ens/src/lib.rs:

- Replaced "deployd.eth" with correct "deployed.eth"

Ensures proper naming and accurate documentation/tests.