### PR TITLE
feat: add headerinfo helper type

### DIFF
--- a/crates/consensus/src/block/header.rs
+++ b/crates/consensus/src/block/header.rs
@@ -1,4 +1,5 @@
 use crate::{
+    block::HeaderInfo,
     constants::{EMPTY_OMMER_ROOT_HASH, EMPTY_ROOT_HASH},
     Block, BlockBody,
 };
@@ -15,7 +16,6 @@ use alloy_primitives::{
 };
 use alloy_rlp::{length_of_length, BufMut, Decodable, Encodable};
 use core::mem;
-use crate::block::HeaderInfo;
 
 /// Ethereum Block header
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -562,7 +562,6 @@ impl<'a> arbitrary::Arbitrary<'a> for Header {
 /// Trait for extracting specific Ethereum block data from a header
 #[auto_impl::auto_impl(&, Arc)]
 pub trait BlockHeader {
-
     /// Extracts essential information into one container type.
     fn header_info(&self) -> HeaderInfo {
         HeaderInfo {
@@ -571,6 +570,8 @@ pub trait BlockHeader {
             timestamp: self.timestamp(),
             gas_limit: self.gas_limit(),
             base_fee_per_gas: self.base_fee_per_gas(),
+            excess_blob_gas: self.excess_blob_gas(),
+            blob_gas_used: self.blob_gas_used(),
             difficulty: self.difficulty(),
             mix_hash: self.mix_hash(),
         }

--- a/crates/consensus/src/block/header.rs
+++ b/crates/consensus/src/block/header.rs
@@ -15,6 +15,7 @@ use alloy_primitives::{
 };
 use alloy_rlp::{length_of_length, BufMut, Decodable, Encodable};
 use core::mem;
+use crate::block::HeaderInfo;
 
 /// Ethereum Block header
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -561,6 +562,20 @@ impl<'a> arbitrary::Arbitrary<'a> for Header {
 /// Trait for extracting specific Ethereum block data from a header
 #[auto_impl::auto_impl(&, Arc)]
 pub trait BlockHeader {
+
+    /// Extracts essential information into one container type.
+    fn header_info(&self) -> HeaderInfo {
+        HeaderInfo {
+            number: self.number(),
+            beneficiary: self.beneficiary(),
+            timestamp: self.timestamp(),
+            gas_limit: self.gas_limit(),
+            base_fee_per_gas: self.base_fee_per_gas(),
+            difficulty: self.difficulty(),
+            mix_hash: self.mix_hash(),
+        }
+    }
+
     /// Retrieves the parent hash of the block
     fn parent_hash(&self) -> B256;
 

--- a/crates/consensus/src/block/meta.rs
+++ b/crates/consensus/src/block/meta.rs
@@ -1,4 +1,4 @@
-//! Commonly used types that contain metadata of a block
+//! Commonly used types that contain metadata of a block.
 
 use alloy_primitives::{Address, B256, U256};
 
@@ -19,9 +19,17 @@ pub struct HeaderInfo {
     ///
     /// [EIP-1559]: https://eips.ethereum.org/EIPS/eip-1559
     pub base_fee_per_gas: Option<u64>,
+    /// A running total of blob gas consumed in excess of the target, prior to the block. Blocks
+    /// with above-target blob gas consumption increase this value, blocks with below-target blob
+    /// gas consumption decrease it (bounded at 0). This was added in EIP-4844.
+    pub excess_blob_gas: Option<u64>,
+    /// The total amount of blob gas consumed by the transactions within the block, added in
+    /// EIP-4844.
+    pub blob_gas_used: Option<u64>,
     /// The difficulty of the block
     ///
-    /// Unused after the Paris (AKA the merge) upgrade and replaced by `prevrandao` and expected to be 0.
+    /// Unused after the Paris (AKA the merge) upgrade and replaced by `prevrandao` and expected to
+    /// be 0.
     pub difficulty: U256,
     /// The output of the randomness beacon provided by the beacon chain
     ///

--- a/crates/consensus/src/block/meta.rs
+++ b/crates/consensus/src/block/meta.rs
@@ -1,0 +1,34 @@
+//! Commonly used types that contain metadata of a block
+
+use alloy_primitives::{Address, B256, U256};
+
+/// Essential info extracted from a header.
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq)]
+pub struct HeaderInfo {
+    /// The number of ancestor blocks of this block (block height).
+    pub number: u64,
+    /// Beneficiary (Coinbase or miner) is a address that have signed the block.
+    ///
+    /// This is the receiver address of all the gas spent in the block.
+    pub beneficiary: Address,
+    /// The timestamp of the block in seconds since the UNIX epoch
+    pub timestamp: u64,
+    /// The gas limit of the block
+    pub gas_limit: u64,
+    /// The base fee per gas, added in the London upgrade with [EIP-1559]
+    ///
+    /// [EIP-1559]: https://eips.ethereum.org/EIPS/eip-1559
+    pub base_fee_per_gas: Option<u64>,
+    /// The difficulty of the block
+    ///
+    /// Unused after the Paris (AKA the merge) upgrade and replaced by `prevrandao` and expected to be 0.
+    pub difficulty: U256,
+    /// The output of the randomness beacon provided by the beacon chain
+    ///
+    /// Replaces `difficulty` after the Paris (AKA the merge) upgrade with [EIP-4399].
+    ///
+    /// Note: `prevrandao` can be found in a block in place of `mix_hash`.
+    ///
+    /// [EIP-4399]: https://eips.ethereum.org/EIPS/eip-4399
+    pub mix_hash: Option<B256>,
+}

--- a/crates/consensus/src/block/mod.rs
+++ b/crates/consensus/src/block/mod.rs
@@ -6,6 +6,9 @@ pub use header::{BlockHeader, Header};
 mod traits;
 pub use traits::EthBlock;
 
+mod meta;
+pub use meta::HeaderInfo;
+
 #[cfg(all(feature = "serde", feature = "serde-bincode-compat"))]
 pub(crate) use header::serde_bincode_compat;
 

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -20,7 +20,7 @@ pub use alloy_trie::TrieAccount;
 pub use alloy_trie::TrieAccount as Account;
 
 mod block;
-pub use block::{Block, BlockBody, BlockHeader, EthBlock, Header};
+pub use block::{Block, BlockBody, BlockHeader, EthBlock, Header, HeaderInfo};
 
 pub mod constants;
 pub use constants::{EMPTY_OMMER_ROOT_HASH, EMPTY_ROOT_HASH};

--- a/crates/rpc-types-engine/src/payload.rs
+++ b/crates/rpc-types-engine/src/payload.rs
@@ -5,10 +5,7 @@ use alloc::{
     string::{String, ToString},
     vec::Vec,
 };
-use alloy_consensus::{
-    constants::MAXIMUM_EXTRA_DATA_SIZE, Blob, Block, BlockBody, BlockHeader, Bytes48, Header,
-    Transaction, EMPTY_OMMER_ROOT_HASH,
-};
+use alloy_consensus::{constants::MAXIMUM_EXTRA_DATA_SIZE, Blob, Block, BlockBody, BlockHeader, Bytes48, Header, HeaderInfo, Transaction, EMPTY_OMMER_ROOT_HASH};
 use alloy_eips::{
     eip2718::{Decodable2718, Encodable2718},
     eip4844::BlobTransactionSidecar,
@@ -302,6 +299,20 @@ pub struct ExecutionPayloadV1 {
 }
 
 impl ExecutionPayloadV1 {
+
+    /// Extracts essential information into one container type.
+    pub fn header_info(&self) -> HeaderInfo {
+        HeaderInfo {
+            number: self.block_number,
+            beneficiary: self.fee_recipient,
+            timestamp: self.timestamp,
+            gas_limit: self.gas_limit,
+            base_fee_per_gas: Some(self.base_fee_per_gas.saturating_to()),
+            difficulty: U256::ZERO,
+            mix_hash: Some(self.prev_randao),
+        }
+    }
+    
     /// Returns the block number and hash as a [`BlockNumHash`].
     pub const fn block_num_hash(&self) -> BlockNumHash {
         BlockNumHash::new(self.block_number, self.block_hash)
@@ -1167,6 +1178,12 @@ pub enum ExecutionPayload {
 }
 
 impl ExecutionPayload {
+
+    /// Extracts essential information into one container type.
+    pub fn header_info(&self) -> HeaderInfo {
+       self.as_v1().header_info()
+    }
+    
     /// Converts [`alloy_consensus::Block`] to [`ExecutionPayload`] and also returns the
     /// [`ExecutionPayloadSidecar`] extracted from the block.
     ///


### PR DESCRIPTION
This is the bare minimum we can extract without additional context (e.g. specid, blobcontext)

but is almost identical to the evm `BlockEnv`,

with this we can make it easier to fill the BlockEnv that we need for the evm,

with the specid as additional context this can be easily converted into the full blockenv then

this is an additional header trait fn but is default impl'ed, so this doesnt break.