### PR TITLE
fix: remove ring spec and bump gcloud version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,7 +117,7 @@ futures-executor = "0.3"
 futures-utils-wasm = "0.1"
 wasmtimer = "0.4.0"
 
-gcloud-sdk = "0.27"
+gcloud-sdk = "0.27.4"
 hyper = { version = "1.2", default-features = false }
 hyper-util = "0.1"
 hyper-tls = "0.6.0"

--- a/crates/transport-ws/Cargo.toml
+++ b/crates/transport-ws/Cargo.toml
@@ -36,8 +36,6 @@ tracing.workspace = true
 http = "1.1"
 tokio = { workspace = true, features = ["sync", "rt", "time"] }
 tokio-tungstenite = { workspace = true, features = ["rustls-tls-webpki-roots"] }
-# choose ring as the default TLS backend
-rustls = { workspace = true, features = ["ring"] }
 
 # WASM only
 [target.'cfg(target_family = "wasm")'.dependencies]

--- a/crates/transport-ws/src/lib.rs
+++ b/crates/transport-ws/src/lib.rs
@@ -16,9 +16,6 @@ mod native;
 #[cfg(not(target_family = "wasm"))]
 pub use native::{WebSocketConfig, WsConnect};
 
-#[cfg(not(target_family = "wasm"))]
-use rustls as _;
-
 #[cfg(target_family = "wasm")]
 mod wasm;
 #[cfg(target_family = "wasm")]


### PR DESCRIPTION
## Motivation

Contrary to the comment, the ring feature does _not_ select ring as the default backend. instead it enables it in rustls, and then _if it is the only built-in backend enabled_ selects it by default. Unfortunately, if both built-ins are enabled there will be runtime errors in other peoples' binaries. When ring is enabled, binaries with the rustls features will crash when TLS is activated for the first time as [TLS backend inference](https://github.com/rustls/rustls/blob/v/0.23.31/rustls/src/crypto/mod.rs#L265-L286) is feature based and fails when both are enabled. Rustls @ 0.23.31 enables `aws-lc-rs` by default, ensuring that anyone using WS with a default-features rustls currently must either deliberately select a provider, or have runtime errors 

gcloud incorrectly enabled ring in older 0.27 versions, so this PR explicitly bumps it to 0.27.4

If we need ring for development, we can enable it as a dev-dep. 


I wanted to make a `Once` that checks for provider configuration before entering the WS connection logic for the first time, however, the rustls API makes that impossible :(

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
