### PR TITLE
fix(batch.rs): reference BatchFuture in panic message

### DIFF
--- a/crates/rpc-client/src/batch.rs
+++ b/crates/rpc-client/src/batch.rs
@@ -276,6 +276,6 @@ impl Future for BatchFuture {
             return self.poll_ser_error(cx);
         }
 
-        panic!("Called poll on CallState in invalid state")
+        panic!("Called poll on BatchFuture in invalid state")
     }
 }


### PR DESCRIPTION
Replace "CallState" with "BatchFuture" in the panic! message for invalid poll state to match the enum name