### PR TITLE
expose alloy trie

### DIFF
--- a/crates/alloy/Cargo.toml
+++ b/crates/alloy/Cargo.toml
@@ -62,6 +62,9 @@ alloy-transport-http = { workspace = true, optional = true }
 alloy-transport-ipc = { workspace = true, optional = true }
 alloy-transport-ws = { workspace = true, optional = true }
 
+# trie
+alloy-trie = { workspace = true, optional = true }
+
 # ----------------------------------------- Configuration ---------------------------------------- #
 
 [features]
@@ -273,6 +276,9 @@ transport-http = ["transports", "dep:alloy-transport-http"]
 transport-ipc = ["transports", "pubsub", "dep:alloy-transport-ipc"]
 transport-ipc-mock = ["alloy-transport-ipc?/mock"]
 transport-ws = ["transports", "pubsub", "dep:alloy-transport-ws"]
+
+# trie
+trie = ["dep:alloy-trie"]
 
 # ---------------------------------------- Core re-exports --------------------------------------- #
 

--- a/crates/alloy/src/lib.rs
+++ b/crates/alloy/src/lib.rs
@@ -186,3 +186,10 @@ pub mod transports {
     #[doc(inline)]
     pub use alloy_transport_ws as ws;
 }
+
+/// Fast Merkle-Patricia Trie (MPT) state root calculator and proof generator
+/// for prefix-sorted nibbles.
+///
+/// See [`alloy_trie`] for more details.
+#[cfg(feature = "trie")]
+pub use alloy_trie as trie;

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -88,6 +88,7 @@ pub mod private {
     pub use alloy_eips;
     pub use alloy_primitives;
     pub use alloy_rlp;
+    pub use alloy_trie;
     #[cfg(feature = "arbitrary")]
     pub use arbitrary;
     #[cfg(feature = "serde")]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

`alloy-trie` is useful utility. However when a new minor version of `alloy-trie` is released and incorporated in patch version of `alloy` it causes a problem for example https://github.com/a16z/helios/issues/656, i.e. a repository could depend on an older version of `alloy-trie` but cargo installed version of `alloy` expects different `alloy-trie`.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

This problem can easily be solved if alloy-trie is re-exported in some way. 

- A feature is added `trie`  to the `alloy` crate
- If feature is activated then the `alloy-trie` module is available as `alloy::trie`.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
