### PR TITLE
chore: fix typo 'proprosal' -> 'proposal'

### DIFF
--- a/crates/eips/Cargo.toml
+++ b/crates/eips/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alloy-eips"
-description = "Ethereum Improvement Proprosal (EIP) implementations"
+description = "Ethereum Improvement Proposal (EIP) implementations"
 
 version.workspace = true
 edition.workspace = true

--- a/crates/eips/README.md
+++ b/crates/eips/README.md
@@ -1,6 +1,6 @@
 # alloy-eips
 
-Ethereum Improvement Proprosal (EIP) implementations.
+Ethereum Improvement Proposal (EIP) implementations.
 
 Contains constants, helpers, and basic data structures for consensus EIPs.
 


### PR DESCRIPTION
fixed in Cargo.toml and README.md
'proprosal' -> 'proposal'