### PR TITLE
feat: add orretrypolicyfn

### DIFF
--- a/crates/transport/src/layers/mod.rs
+++ b/crates/transport/src/layers/mod.rs
@@ -8,7 +8,9 @@ pub use throttle::{ThrottleLayer, ThrottleService};
 
 /// RetryBackoffLayer
 mod retry;
-pub use retry::{RateLimitRetryPolicy, RetryBackoffLayer, RetryBackoffService, RetryPolicy};
+pub use retry::{
+    OrRetryPolicyFn, RateLimitRetryPolicy, RetryBackoffLayer, RetryBackoffService, RetryPolicy,
+};
 
 /// FallbackLayer
 mod fallback;


### PR DESCRIPTION
this adds a new policy type that is intended to annotate the existing retry policy with a filter that checks the error message for example