### PR TITLE
feat: add authorization list to CallBuilder

### DIFF
--- a/crates/contract/src/call.rs
+++ b/crates/contract/src/call.rs
@@ -4,12 +4,14 @@ use alloy_dyn_abi::{DynSolValue, JsonAbiExt};
 use alloy_json_abi::Function;
 use alloy_network::{
     eip2718::Encodable2718, Ethereum, IntoWallet, Network, TransactionBuilder,
-    TransactionBuilder4844, TransactionBuilderError, TxSigner,
+    TransactionBuilder4844, TransactionBuilder7702, TransactionBuilderError, TxSigner,
 };
 use alloy_network_primitives::ReceiptResponse;
 use alloy_primitives::{Address, Bytes, ChainId, Signature, TxKind, U256};
 use alloy_provider::{PendingTransactionBuilder, Provider};
-use alloy_rpc_types_eth::{state::StateOverride, AccessList, BlobTransactionSidecar, BlockId};
+use alloy_rpc_types_eth::{
+    state::StateOverride, AccessList, BlobTransactionSidecar, BlockId, SignedAuthorization,
+};
 use alloy_sol_types::SolCall;
 use std::{self, marker::PhantomData};
 
@@ -468,6 +470,15 @@ impl<P: Provider<N>, D: CallDecoder, N: Network> CallBuilder<P, D, N> {
         self
     }
 
+    /// Sets the `authorization_list` in the transaction to the provided value
+    pub fn authorization_list(mut self, authorization_list: Vec<SignedAuthorization>) -> Self
+    where
+        N::TransactionRequest: TransactionBuilder7702,
+    {
+        self.request.set_authorization_list(authorization_list);
+        self
+    }
+
     /// Sets the `value` field in the transaction to the provided value
     pub fn value(mut self, value: U256) -> Self {
         self.request.set_value(value);
@@ -621,7 +632,7 @@ mod tests {
     use alloy_node_bindings::Anvil;
     use alloy_primitives::{address, b256, bytes, hex, utils::parse_units, B256};
     use alloy_provider::{Provider, ProviderBuilder, WalletProvider};
-    use alloy_rpc_types_eth::AccessListItem;
+    use alloy_rpc_types_eth::{AccessListItem, Authorization};
     use alloy_signer_local::PrivateKeySigner;
     use alloy_sol_types::sol;
     use futures::Future;
@@ -718,6 +729,22 @@ mod tests {
             call_builder.request.max_fee_per_blob_gas.expect("max_fee_per_blob_gas should be set"),
             50,
             "max_fee_per_blob_gas of request should be '50'"
+        );
+    }
+
+    #[test]
+    fn change_authorization_list() {
+        let authorization_list = vec![SignedAuthorization::new_unchecked(
+            Authorization { chain_id: U256::from(1337), address: Address::ZERO, nonce: 0 },
+            0,
+            U256::ZERO,
+            U256::ZERO,
+        )];
+        let call_builder = build_call_builder().authorization_list(authorization_list.clone());
+        assert_eq!(
+            call_builder.request.authorization_list.expect("authorization_list should be set"),
+            authorization_list,
+            "Authorization list of the transaction should have been set to our authorization list"
         );
     }
 

--- a/crates/rpc-types-eth/src/transaction/mod.rs
+++ b/crates/rpc-types-eth/src/transaction/mod.rs
@@ -4,7 +4,7 @@ use alloy_consensus::{
     EthereumTxEnvelope, EthereumTypedTransaction, Signed, TxEip1559, TxEip2930, TxEip4844,
     TxEip4844Variant, TxEip7702, TxEnvelope, TxLegacy, Typed2718,
 };
-use alloy_eips::{eip2718::Encodable2718, eip7702::SignedAuthorization};
+use alloy_eips::eip2718::Encodable2718;
 use alloy_network_primitives::TransactionResponse;
 use alloy_primitives::{Address, BlockHash, Bytes, ChainId, TxKind, B256, U256};
 
@@ -16,7 +16,7 @@ pub use alloy_consensus::{
 pub use alloy_consensus_any::AnyReceiptEnvelope;
 pub use alloy_eips::{
     eip2930::{AccessList, AccessListItem, AccessListResult},
-    eip7702::Authorization,
+    eip7702::{Authorization, SignedAuthorization},
 };
 
 mod error;


### PR DESCRIPTION
## Motivation

`CallBuilder` is missing the option to set authorization list (introduced with EIP-7702).

## Solution

This PR adds te ability to set authorization list to the `CallBuilder`.

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
