### PR TITLE
chore(rpc-types-trace): Re-export `CallKind`

### DIFF
--- a/crates/rpc-types-trace/src/geth/mod.rs
+++ b/crates/rpc-types-trace/src/geth/mod.rs
@@ -10,7 +10,7 @@ use serde::{de::DeserializeOwned, ser::SerializeMap, Deserialize, Serialize, Ser
 use std::{collections::BTreeMap, time::Duration};
 // re-exports
 pub use self::{
-    call::{CallConfig, CallFrame, CallLogFrame, FlatCallConfig},
+    call::{CallConfig, CallFrame, CallKind, CallLogFrame, FlatCallConfig},
     four_byte::FourByteFrame,
     noop::NoopFrame,
     pre_state::{


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
To import `CallKind` like `use alloy_rpc_types_trace::geth::CallKind` same as other public types such as `CallFrame`

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
