### PR TITLE
feat(rpc): add cost() default function to ReceiptResponse trait

### DIFF
--- a/crates/network-primitives/src/traits.rs
+++ b/crates/network-primitives/src/traits.rs
@@ -36,6 +36,11 @@ pub trait ReceiptResponse {
     /// Effective gas price.
     fn effective_gas_price(&self) -> u128;
 
+    /// Total cost of this transaction = gas_used * effective_gas_price.
+    fn cost(&self) -> u128 {
+        self.gas_used() as u128 * self.effective_gas_price()
+    }
+
     /// Blob gas used by the eip-4844 transaction.
     fn blob_gas_used(&self) -> Option<u64>;
 


### PR DESCRIPTION
## Motivation
`ReceiptResponse` currently exposes `gas_used()` and `effective_gas_price()`, but computing the total transaction cost requires manual multiplication each time.  
Since this is a common operation, adding a default method improves ergonomics and readability.

## Solution
- Added a default `cost()` method to `ReceiptResponse` that returns:
  ```rust
  self.gas_used() as u128 * self.effective_gas_price()

closes #2807