### PR TITLE
feat: add helper methods to decode logs in TransactionReceipt

### DIFF
--- a/crates/rpc-types-eth/src/transaction/receipt.rs
+++ b/crates/rpc-types-eth/src/transaction/receipt.rs
@@ -242,6 +242,11 @@ impl<T: TxReceipt<Log: AsRef<alloy_primitives::Log>>> TransactionReceipt<T> {
     pub fn decode_nth_log<E: SolEvent>(&self, idx: usize) -> Option<alloy_primitives::Log<E>> {
         self.logs().get(idx).and_then(|log| E::decode_log(log.as_ref()).ok())
     }
+
+    /// Decode the last log in the receipt.
+    pub fn decode_last_log<E: SolEvent>(&self) -> Option<alloy_primitives::Log<E>> {
+        self.logs().last().and_then(|log| E::decode_log(log.as_ref()).ok())
+    }
 }
 
 impl<T: TxReceipt<Log = Log>> ReceiptResponse for TransactionReceipt<T> {


### PR DESCRIPTION
Adds helper methods to `TransactionReceipt` for easier log decoding:

- `decode_first_log<E: SolEvent>()` – decodes the first log.
- `decode_nth_log<E: SolEvent>(idx)` – decodes the log at a given index.

Both return `None` if decoding fails or index is out-of-bounds.  
Unit tests included for both methods.


closes #2810 