### PR TITLE
feat: add into_localized_trace method to RewardAction

### DIFF
--- a/crates/rpc-types-trace/src/parity.rs
+++ b/crates/rpc-types-trace/src/parity.rs
@@ -385,7 +385,7 @@ pub struct RewardAction {
 impl RewardAction {
     /// Helper to construct a [`LocalizedTransactionTrace`] that describes a reward to the block
     /// beneficiary.
-    pub fn into_localized_trace(self, block: BlockNumHash) -> LocalizedTransactionTrace {
+    pub const fn into_localized_trace(self, block: BlockNumHash) -> LocalizedTransactionTrace {
         LocalizedTransactionTrace {
             block_hash: Some(block.hash),
             block_number: Some(block.number),


### PR DESCRIPTION
Adds a helper method to construct a LocalizedTransactionTrace from a RewardAction and BlockNumHash. This is useful for creating traces that describe rewards to block beneficiaries.

The method takes ownership of the RewardAction and a BlockNumHash parameter containing the block number and hash, then constructs a complete LocalizedTransactionTrace with the reward action.

from 

https://github.com/paradigmxyz/reth/blob/fcb74930afd07269d0803ded1a81f1bee626f36c/crates/rpc/rpc/src/trace.rs#L715-L731