### PR TITLE
feat: add specialized debug trace methods

### DIFF
--- a/crates/provider/src/ext/debug.rs
+++ b/crates/provider/src/ext/debug.rs
@@ -724,13 +724,13 @@ mod test {
     {
       "failed": false,
       "gas": 21000,
-      "returnValue": "",
+      "returnValue": "0x",
       "structLogs": []
     },
     {
       "failed": false,
       "gas": 21000,
-      "returnValue": "",
+      "returnValue": "0x",
       "structLogs": []
     }
   ]


### PR DESCRIPTION
Adds specialized methods to the DebugApi trait for returning specific frame types from debug trace calls.

## Changes

### For `debug_trace_call`:
- Added `debug_trace_call_prestate()` for PreStateFrame results

### For `debug_trace_call_many`:  
- Added `debug_trace_call_many_as()` for generic type return
- Added `debug_trace_call_many_js()` for JSON values  
- Added `debug_trace_call_many_callframe()` for CallFrame results
- Added `debug_trace_call_many_prestate()` for PreStateFrame results

This provides consistency across the debug API by ensuring all trace methods have specialized variants for common frame types, similar to how `debug_trace_transaction` already has `debug_trace_transaction_js`, `debug_trace_transaction_call`, etc.