### PR TITLE
feat: add as_* helper methods to Delta<T>

### DIFF
--- a/crates/rpc-types-trace/src/parity.rs
+++ b/crates/rpc-types-trace/src/parity.rs
@@ -124,6 +124,30 @@ impl<T> Delta<T> {
     pub const fn is_changed(&self) -> bool {
         matches!(self, Self::Changed(_))
     }
+
+    /// Returns the value if the delta is [`Delta::Added`]
+    pub const fn as_added(&self) -> Option<&T> {
+        match self {
+            Self::Added(value) => Some(value),
+            _ => None,
+        }
+    }
+
+    /// Returns the value if the delta is [`Delta::Removed`]
+    pub const fn as_removed(&self) -> Option<&T> {
+        match self {
+            Self::Removed(value) => Some(value),
+            _ => None,
+        }
+    }
+
+    /// Returns the [`ChangedType`] if the delta is [`Delta::Changed`]
+    pub const fn as_changed(&self) -> Option<&ChangedType<T>> {
+        match self {
+            Self::Changed(changed) => Some(changed),
+            _ => None,
+        }
+    }
 }
 
 /// The diff of an account after a transaction


### PR DESCRIPTION
## Summary

Added missing helper methods to `Delta<T>` for accessing inner values. These methods follow the same pattern as the existing `is_*` methods and match the pattern used in other enums like `Action` and `TraceOutput` in the same file.

## Changes

Added three new const methods to `Delta<T>`:
- `as_added()` - Returns `Option<&T>` for the `Added` variant
- `as_removed()` - Returns `Option<&T>` for the `Removed` variant  
- `as_changed()` - Returns `Option<&ChangedType<T>>` for the `Changed` variant

Note: `as_unchanged()` was intentionally not added since the `Unchanged` variant contains no data.