### PR TITLE
add `auto_impersonate` helper to anvil bindings

### DIFF
--- a/crates/node-bindings/src/nodes/anvil.rs
+++ b/crates/node-bindings/src/nodes/anvil.rs
@@ -312,6 +312,12 @@ impl Anvil {
         self
     }
 
+    /// Instantiate `anvil` with the `--auto-impersonate` flag.
+    pub fn auto_impersonate(mut self) -> Self {
+        self = self.arg("--auto-impersonate");
+        self
+    }
+
     /// Adds an argument to pass to the `anvil`.
     pub fn push_arg<T: Into<OsString>>(&mut self, arg: T) {
         self.args.push(arg.into());


### PR DESCRIPTION
adds a helper to the anvil node bindings for enabling the auto-impersonate mode

## Motivation

i think it's nicer to set options via helper methods rather than passing strings around

## Solution

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
