### PR TITLE
Max retries

### DIFF
--- a/crates/transport-ws/src/native.rs
+++ b/crates/transport-ws/src/native.rs
@@ -40,7 +40,7 @@ impl WsConnect {
             url: url.into(),
             auth: None,
             config: None,
-            max_retries: 10,
+            max_retries: 0,
             retry_interval: Duration::from_secs(3),
         }
     }

--- a/crates/transport-ws/src/wasm.rs
+++ b/crates/transport-ws/src/wasm.rs
@@ -25,7 +25,7 @@ pub struct WsConnect {
 impl WsConnect {
     /// Creates a new websocket connection configuration.
     pub fn new<S: Into<String>>(url: S) -> Self {
-        Self { url: url.into(), max_retries: 10, retry_interval: Duration::from_secs(3) }
+        Self { url: url.into(), max_retries: 0, retry_interval: Duration::from_secs(3) }
     }
 
     /// Sets the max number of retries before failing and exiting the connection.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
max_retries for WsConnect::new should be 0, because it has unexpected consequences.

My case: I didn't know that max_retries = 10 by default. And there were background reconnections of the websocket, then the data integrity was destroyed. For a websocket, this is very important, because during the reconnection, data can be lost.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
