### PR TITLE
chore(deps): internal dep bumps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ c-kzg = { version = "2.1.1", default-features = false }
 elliptic-curve = { version = "0.13", default-features = false }
 k256 = { version = "0.13", default-features = false, features = ["ecdsa"] }
 sha2 = { version = "0.10", default-features = false }
-secp256k1 = { version = "0.30", default-features = false }
+secp256k1 = { version = "0.31", default-features = false }
 spki = { version = "0.7", default-features = false }
 zeroize = { version = "1.8.1", default-features = false }
 
@@ -158,11 +158,12 @@ home = "0.5"
 http = "1.1.0"
 itertools = { version = ">=0.13, <=0.14", default-features = false }
 jsonwebtoken = "9.3.0"
-lru = "0.13"
+lru = "0.16"
 once_cell = { version = "1.21", default-features = false }
 parking_lot = "0.12.3"
 pin-project = "1.1"
 rand = "0.8"
+rand_09 = { package = "rand", version = "0.9" }
 reqwest = { version = "0.12", default-features = false }
 semver = "1.0"
 strum = { version = "0.27", default-features = false }

--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -55,17 +55,27 @@ auto_impl.workspace = true
 thiserror.workspace = true
 either.workspace = true
 once_cell = { workspace = true, features = ["race", "alloc"] }
-secp256k1 = { workspace = true, optional = true, features = ["recovery", "global-context", "std"] }
+secp256k1 = { workspace = true, optional = true, features = [
+    "recovery",
+    "global-context",
+    "std",
+] }
 
 [dev-dependencies]
 alloy-eips = { workspace = true, features = ["arbitrary", "kzg", "serde"] }
 alloy-primitives = { workspace = true, features = ["arbitrary", "rand"] }
-secp256k1 = { workspace = true, features = ["recovery", "global-context", "std", "rand"] }
+secp256k1 = { workspace = true, features = [
+    "recovery",
+    "global-context",
+    "std",
+    "rand",
+] }
 
 arbitrary = { workspace = true, features = ["derive"] }
 bincode = { workspace = true, features = ["serde"] }
 k256.workspace = true
 rand.workspace = true
+rand_09.workspace = true
 serde_json.workspace = true
 tokio = { workspace = true, features = ["macros"] }
 assert_matches.workspace = true
@@ -87,34 +97,34 @@ std = [
     "thiserror/std",
     "either/std",
     "once_cell/std",
-    "secp256k1?/std"
+    "secp256k1?/std",
 ]
 k256 = ["dep:k256", "alloy-primitives/k256", "alloy-eips/k256"]
 secp256k1 = ["dep:secp256k1"]
 crypto-backend = []
 kzg = ["dep:c-kzg", "alloy-eips/kzg", "std"]
 arbitrary = [
-	"std",
-	"dep:rand",
-	"dep:arbitrary",
-	"alloy-eips/arbitrary",
-	"alloy-primitives/arbitrary",
-	"alloy-serde?/arbitrary",
-	"alloy-trie/arbitrary",
-	"c-kzg?/arbitrary",
-	"alloy-tx-macros/arbitrary"
+    "std",
+    "dep:rand",
+    "dep:arbitrary",
+    "alloy-eips/arbitrary",
+    "alloy-primitives/arbitrary",
+    "alloy-serde?/arbitrary",
+    "alloy-trie/arbitrary",
+    "c-kzg?/arbitrary",
+    "alloy-tx-macros/arbitrary",
 ]
 serde = [
-	"dep:serde",
-	"alloy-primitives/serde",
-	"dep:alloy-serde",
-	"alloy-eips/serde",
-	"alloy-trie/serde",
-	"c-kzg?/serde",
-	"either/serde",
-	"k256?/serde",
-	"rand?/serde",
-	"secp256k1?/serde",
-	"alloy-tx-macros/serde"
+    "dep:serde",
+    "alloy-primitives/serde",
+    "dep:alloy-serde",
+    "alloy-eips/serde",
+    "alloy-trie/serde",
+    "c-kzg?/serde",
+    "either/serde",
+    "k256?/serde",
+    "rand?/serde",
+    "secp256k1?/serde",
+    "alloy-tx-macros/serde",
 ]
 serde-bincode-compat = ["alloy-eips/serde-bincode-compat", "serde_with"]

--- a/crates/consensus/src/crypto.rs
+++ b/crates/consensus/src/crypto.rs
@@ -270,15 +270,15 @@ mod impl_secp256k1 {
         let sig =
             RecoverableSignature::from_compact(&sig[0..64], RecoveryId::try_from(sig[64] as i32)?)?;
 
-        let public = SECP256K1.recover_ecdsa(&Message::from_digest(*msg), &sig)?;
+        let public = SECP256K1.recover_ecdsa(Message::from_digest(*msg), &sig)?;
         Ok(public_key_to_address(public))
     }
 
     /// Signs message with the given secret key.
     /// Returns the corresponding signature.
     pub fn sign_message(secret: B256, message: B256) -> Result<Signature, Error> {
-        let sec = SecretKey::from_slice(secret.as_ref())?;
-        let s = SECP256K1.sign_ecdsa_recoverable(&Message::from_digest(message.0), &sec);
+        let sec = SecretKey::from_byte_array(secret.0)?;
+        let s = SECP256K1.sign_ecdsa_recoverable(Message::from_digest(message.0), &sec);
         let (rec_id, data) = s.serialize_compact();
 
         let signature = Signature::new(
@@ -350,14 +350,13 @@ mod impl_k256 {
 
 #[cfg(test)]
 mod tests {
-
     #[cfg(feature = "secp256k1")]
     #[test]
     fn sanity_ecrecover_call_secp256k1() {
         use super::impl_secp256k1::*;
         use alloy_primitives::B256;
 
-        let (secret, public) = secp256k1::generate_keypair(&mut rand::thread_rng());
+        let (secret, public) = secp256k1::generate_keypair(&mut rand_09::rng());
         let signer = public_key_to_address(public);
 
         let message = b"hello world";
@@ -402,8 +401,7 @@ mod tests {
         use super::{impl_k256, impl_secp256k1};
         use alloy_primitives::B256;
 
-        let (secp256k1_secret, secp256k1_public) =
-            secp256k1::generate_keypair(&mut rand::thread_rng());
+        let (secp256k1_secret, secp256k1_public) = secp256k1::generate_keypair(&mut rand_09::rng());
         let k256_secret = k256::ecdsa::SigningKey::from_slice(&secp256k1_secret.secret_bytes())
             .expect("k256 secret");
         let k256_public = *k256_secret.verifying_key();

--- a/crates/transport/Cargo.toml
+++ b/crates/transport/Cargo.toml
@@ -34,7 +34,7 @@ thiserror = { workspace = true, features = ["std"] }
 tower.workspace = true
 url.workspace = true
 tracing.workspace = true
-governor = { version = "0.8.1", default-features = false, features = [
+governor = { version = "0.10", default-features = false, features = [
     "std",
     "quanta",
 ], optional = true }
@@ -45,7 +45,7 @@ auto_impl.workspace = true
 
 # non-WASM only
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-tokio = { workspace = true, features = ["rt", "time","sync","macros"] }
+tokio = { workspace = true, features = ["rt", "time", "sync", "macros"] }
 
 # WASM only
 [target.'cfg(target_family = "wasm")'.dependencies]

--- a/crates/tx-macros/Cargo.toml
+++ b/crates/tx-macros/Cargo.toml
@@ -29,14 +29,10 @@ workspace = true
 syn = "2.0"
 quote = "1.0"
 proc-macro2 = "1.0"
-darling = "0.20"
+darling = "0.21"
 
 alloy-primitives.workspace = true
 
 [features]
-arbitrary = [
-	"alloy-primitives/arbitrary"
-]
-serde = [
-	"alloy-primitives/serde"
-]
+arbitrary = ["alloy-primitives/arbitrary"]
+serde = ["alloy-primitives/serde", "darling/serde"]


### PR DESCRIPTION
Breaking bumps for internal deps, not a breaking API change.

Remaining:
```
alloy-hardforks   0.2.0   -> 0.3.0 
gcloud-sdk        0.27    -> 0.28.1
tokio-tungstenite 0.26    -> 0.27.0
rand              0.8     -> 0.9.2 
jsonrpsee         0.25    -> 0.26.0
jsonrpsee-types   0.25    -> 0.26.0
coins-ledger      0.12    -> 0.13.0
coins-bip32       0.12    -> 0.13.0
coins-bip39       0.12    -> 0.13.0
```