### PR TITLE
docs: update version in installation example from 1.0.1 to 1.0.27

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ cargo add alloy --features full
 Alternatively, you can add the following to your `Cargo.toml` file:
 
 ```toml
-alloy = { version = "1.0.1", features = ["full"] }
+alloy = { version = "1.0.27", features = ["full"] }
 ```
 
 For a more fine-grained control over the features you wish to include, you can add the individual crates to your `Cargo.toml` file, or use the `alloy` crate with the features you need.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ cargo add alloy --features full
 Alternatively, you can add the following to your `Cargo.toml` file:
 
 ```toml
-alloy = { version = "1.0.27", features = ["full"] }
+alloy = { version = "1", features = ["full"] }
 ```
 
 For a more fine-grained control over the features you wish to include, you can add the individual crates to your `Cargo.toml` file, or use the `alloy` crate with the features you need.


### PR DESCRIPTION
Update the version number in the README installation example to match the current workspace version (1.0.27) instead of the outdated 1.0.1. 

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
