### PR TITLE
feat: re-export signer dep crates

### DIFF
--- a/crates/signer-aws/Cargo.toml
+++ b/crates/signer-aws/Cargo.toml
@@ -29,6 +29,7 @@ alloy-primitives.workspace = true
 alloy-signer.workspace = true
 
 async-trait.workspace = true
+aws-config = { version = "1", default-features = false }
 aws-sdk-kms = { version = "1", default-features = false }
 k256.workspace = true
 spki = { workspace = true, features = ["std"] }
@@ -37,7 +38,6 @@ tracing.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
-aws-config = { version = "1", default-features = false }
 
 [features]
 eip712 = ["alloy-signer/eip712"]

--- a/crates/signer-aws/src/lib.rs
+++ b/crates/signer-aws/src/lib.rs
@@ -11,3 +11,6 @@ extern crate tracing;
 
 mod signer;
 pub use signer::{AwsSigner, AwsSignerError};
+
+pub use aws_config;
+pub use aws_sdk_kms;

--- a/crates/signer-gcp/src/lib.rs
+++ b/crates/signer-gcp/src/lib.rs
@@ -11,3 +11,5 @@ extern crate tracing;
 
 mod signer;
 pub use signer::{GcpKeyRingRef, GcpSigner, GcpSignerError, KeySpecifier};
+
+pub use gcloud_sdk;

--- a/crates/signer-ledger/src/lib.rs
+++ b/crates/signer-ledger/src/lib.rs
@@ -19,3 +19,5 @@ pub use types::{DerivationType as HDPath, LedgerError};
 #[doc(hidden)]
 #[deprecated(note = "use `LedgerSigner` instead")]
 pub type Ledger = LedgerSigner;
+
+pub use coins_ledger;


### PR DESCRIPTION
Allows re-using aws, gcloud, ledger directly from alloy instead of having to match the version in users. We already depend on them in our public API so it doesn't change.
