### PR TITLE
fix: make responses_by_ids accept HashSet keys Borrow<Id>

### DIFF
--- a/crates/json-rpc/src/packet.rs
+++ b/crates/json-rpc/src/packet.rs
@@ -6,7 +6,7 @@ use serde::{
     Deserialize, Serialize,
 };
 use serde_json::value::RawValue;
-use std::{fmt, marker::PhantomData};
+use std::{borrow::Borrow, fmt, hash::Hash, marker::PhantomData};
 
 /// A [`RequestPacket`] is a [`SerializedRequest`] or a batch of serialized
 /// request.
@@ -370,7 +370,10 @@ impl<Payload, ErrData> ResponsePacket<Payload, ErrData> {
     /// - Responses are not guaranteed to be in the same order.
     /// - Responses are not guaranteed to be in the set.
     /// - If the packet contains duplicate IDs, both will be found.
-    pub fn responses_by_ids(&self, ids: &HashSet<Id>) -> Vec<&Response<Payload, ErrData>> {
+    pub fn responses_by_ids<K>(&self, ids: &HashSet<K>) -> Vec<&Response<Payload, ErrData>>
+    where
+        K: Borrow<Id> + Eq + Hash,
+    {
         match self {
             Self::Single(single) if ids.contains(&single.id) => vec![single],
             Self::Batch(batch) => batch.iter().filter(|res| ids.contains(&res.id)).collect(),


### PR DESCRIPTION
Change responses_by_ids to accept a HashSet of keys that Borrow<Id> (K: Borrow<Id> + Eq + Hash). This makes it interoperable with RequestPacket::subscription_request_ids(), which returns HashSet<&Id>, without forcing unnecessary Id clones, and also supports existing HashSet<Id> callers.