### PR TITLE
feat(rpc-client): add connect convenience method

### DIFF
--- a/crates/rpc-client/src/builtin.rs
+++ b/crates/rpc-client/src/builtin.rs
@@ -45,6 +45,25 @@ impl TransportConnect for BuiltInConnectionString {
 }
 
 impl BuiltInConnectionString {
+    /// Parse a connection string and connect to it in one go.
+    ///
+    /// This is a convenience method that combines `from_str` and `connect_boxed`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// use alloy_rpc_client::BuiltInConnectionString;
+    ///
+    /// let transport = BuiltInConnectionString::parse_and_connect("http://localhost:8545").await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn parse_and_connect(s: &str) -> Result<BoxTransport, TransportError> {
+        let connection = Self::from_str(s)?;
+        connection.connect_boxed().await
+    }
+
     /// Connect with the given connection string.
     ///
     /// # Notes

--- a/crates/rpc-client/src/builtin.rs
+++ b/crates/rpc-client/src/builtin.rs
@@ -55,11 +55,11 @@ impl BuiltInConnectionString {
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// use alloy_rpc_client::BuiltInConnectionString;
     ///
-    /// let transport = BuiltInConnectionString::parse_and_connect("http://localhost:8545").await?;
+    /// let transport = BuiltInConnectionString::connect("http://localhost:8545").await?;
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn parse_and_connect(s: &str) -> Result<BoxTransport, TransportError> {
+    pub async fn connect(s: &str) -> Result<BoxTransport, TransportError> {
         let connection = Self::from_str(s)?;
         connection.connect_boxed().await
     }


### PR DESCRIPTION
## Summary

Adds a new convenience method `connect` to `BuiltInConnectionString` that combines parsing a connection string and connecting to it in a single async call.

## Changes

- Added `connect` async method that:
  - Takes a connection string as `&str`
  - Parses it using `from_str`
  - Immediately connects using `connect_boxed`
  - Returns `Result<BoxTransport, TransportError>`

This simplifies the common pattern:
```rust
// Before
BuiltInConnectionString::from_str(s)?.connect_boxed().await?

// After
BuiltInConnectionString::connect(s).await?
```