### PR TITLE
Avoid panic on TempDir cleanup in node-bindings utils

### DIFF
--- a/crates/node-bindings/src/utils.rs
+++ b/crates/node-bindings/src/utils.rs
@@ -73,7 +73,9 @@ pub fn run_with_tempdir_sync(prefix: &str, f: impl FnOnce(PathBuf)) {
     let temp_dir_path = temp_dir.path().to_path_buf();
     f(temp_dir_path);
     #[cfg(not(windows))]
-    temp_dir.close().unwrap();
+    {
+        let _ = temp_dir.close();
+    }
 }
 
 /// Runs the given async closure with a temporary directory.
@@ -86,7 +88,9 @@ where
     let temp_dir_path = temp_dir.path().to_path_buf();
     f(temp_dir_path).await;
     #[cfg(not(windows))]
-    temp_dir.close().unwrap();
+    {
+        let _ = temp_dir.close();
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION

- Replace `temp_dir.close().unwrap()` with best-effort `let _ = temp_dir.close();` on Unix.
- Prevents unexpected panics during temp directory cleanup in library code.
- Preserves existing function signatures and all call sites.
