### PR TITLE
feat(signer-local): add mnemonic builder helpers and iterator

### DIFF
--- a/crates/signer-local/src/lib.rs
+++ b/crates/signer-local/src/lib.rs
@@ -20,7 +20,7 @@ pub use error::LocalSignerError;
 #[cfg(feature = "mnemonic")]
 mod mnemonic;
 #[cfg(feature = "mnemonic")]
-pub use mnemonic::{MnemonicBuilder, MnemonicBuilderError};
+pub use mnemonic::{MnemonicBuilder, MnemonicBuilderError, MnemonicSignerIter};
 
 mod private_key;
 

--- a/crates/signer-local/src/mnemonic.rs
+++ b/crates/signer-local/src/mnemonic.rs
@@ -66,6 +66,43 @@ impl MnemonicBuilder<English> {
     pub fn from_phrase<P: Into<String>>(phrase: P) -> Self {
         Self::english().phrase(phrase)
     }
+
+    /// Creates a new [`MnemonicBuilder`] with the [`English`] wordlist and the given phrase and
+    /// returns the signer with the derivation path ` "m/44'/60'/0'/0/{index}"`
+    pub fn try_from_phrase_nth<P: Into<String>>(
+        phrase: P,
+        index: u32,
+    ) -> Result<PrivateKeySigner, LocalSignerError> {
+        Self::from_phrase(phrase).index(index)?.build()
+    }
+
+    /// Creates a new [`MnemonicBuilder`] with the [`English`] wordlist and the given phrase and
+    /// returns the signer with the derivation path ` "m/44'/60'/0'/0/{index}"`
+    ///
+    /// # Panics
+    ///
+    /// Panics if the derivation path cannot be parsed or the signer cannot be built.
+    pub fn from_phrase_nth<P: Into<String>>(phrase: P, index: u32) -> PrivateKeySigner {
+        Self::try_from_phrase_nth(phrase, index).unwrap()
+    }
+
+    /// Creates a new [`MnemonicBuilder`] with the [`English`] wordlist and the given phrase and
+    /// returns the first signer with the derivation path ` "m/44'/60'/0'/0/0"`
+    pub fn try_from_phrase_first<P: Into<String>>(
+        phrase: P,
+    ) -> Result<PrivateKeySigner, LocalSignerError> {
+        Self::try_from_phrase_nth(phrase, 0)
+    }
+
+    /// Creates a new [`MnemonicBuilder`] with the [`English`] wordlist and the given phrase and
+    /// returns the first signer with the derivation path ` "m/44'/60'/0'/0/0"`
+    ///
+    /// # Panics
+    ///
+    /// Panics if the derivation path cannot be parsed or the signer cannot be built.
+    pub fn from_phrase_first<P: Into<String>>(phrase: P) -> PrivateKeySigner {
+        Self::from_phrase_nth(phrase, 0)
+    }
 }
 
 impl<W: Wordlist> MnemonicBuilder<W> {
@@ -182,6 +219,36 @@ impl<W: Wordlist> MnemonicBuilder<W> {
     }
 }
 
+/// Iterator that generates signers from a mnemonic phrase by incrementing the derivation index.
+#[derive(Debug)]
+pub struct MnemonicSignerIter<W: Wordlist + Clone = English> {
+    builder: MnemonicBuilder<W>,
+    current_index: u32,
+}
+
+impl<W: Wordlist + Clone> Iterator for MnemonicSignerIter<W> {
+    type Item = Result<PrivateKeySigner, LocalSignerError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // Use the builder to generate signer at current index
+        let result = self.builder.clone().index(self.current_index).and_then(|b| b.build());
+
+        // Increment index for next iteration
+        self.current_index += 1;
+
+        Some(result)
+    }
+}
+
+impl<W: Wordlist + Clone> IntoIterator for MnemonicBuilder<W> {
+    type Item = Result<PrivateKeySigner, LocalSignerError>;
+    type IntoIter = MnemonicSignerIter<W>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        MnemonicSignerIter { builder: self, current_index: 0 }
+    }
+}
+
 /// Error produced by the mnemonic signer module.
 #[derive(Debug, Error)]
 pub enum MnemonicBuilderError {
@@ -271,5 +338,39 @@ mod tests {
         assert_eq!(signer1.address, signer2.address);
 
         dir.close().unwrap();
+    }
+
+    #[test]
+    fn mnemonic_iterator() {
+        let phrase =
+            "work man father plunge mystery proud hollow address reunion sauce theory bonus";
+
+        // Test that iterator generates different addresses
+        let builder = MnemonicBuilder::<English>::default().phrase(phrase);
+        let signers: Vec<_> = builder.into_iter().take(3).collect::<Result<Vec<_>, _>>().unwrap();
+
+        assert_eq!(signers.len(), 3);
+        // Verify each signer has a different address
+        assert_ne!(signers[0].address, signers[1].address);
+        assert_ne!(signers[1].address, signers[2].address);
+        assert_ne!(signers[0].address, signers[2].address);
+
+        // Verify addresses are deterministic (without password)
+        // First get the actual address for index 0 to verify
+        let first_signer =
+            MnemonicBuilder::<English>::default().phrase(phrase).index(0).unwrap().build().unwrap();
+        assert_eq!(signers[0].address, first_signer.address);
+
+        // Test with password
+        let builder_with_password =
+            MnemonicBuilder::<English>::default().phrase(phrase).password("TREZOR123");
+        let signers_with_password: Vec<_> =
+            builder_with_password.into_iter().take(1).collect::<Result<Vec<_>, _>>().unwrap();
+
+        // This should match the test case from mnemonic_deterministic
+        assert_eq!(
+            signers_with_password[0].address.to_string(),
+            "0x431a00DA1D54c281AeF638A73121B3D153e0b0F6"
+        );
     }
 }


### PR DESCRIPTION
Adds convenience methods and iterator support to `MnemonicBuilder` for easier signer generation from mnemonic phrases.

## Changes

- Added `from_phrase_nth` and `try_from_phrase_nth` for creating signers at specific derivation indices
- Added `from_phrase_first` and `try_from_phrase_first` convenience methods for the first signer (index 0)
- Implemented `IntoIterator` for `MnemonicBuilder` to generate multiple signers with incrementing indices
- Added `MnemonicSignerIter` iterator type that yields signers for derivation paths `m/44'/60'/0'/0/{index}`

## Usage

```rust
// Create signer at specific index
let signer = MnemonicBuilder::from_phrase_nth(phrase, 5);

// Create first signer (index 0)
let signer = MnemonicBuilder::from_phrase_first(phrase);

// Iterate over multiple signers
let builder = MnemonicBuilder::default().phrase(phrase);
for signer in builder.into_iter().take(10) {
    let signer = signer?;
    // Use signer...
}
```

The iterator requires `W: Wordlist + Clone` and generates signers deterministically from the same mnemonic phrase.