### PR TITLE
chore: add reqwest-default-tls feature

### DIFF
--- a/crates/alloy/Cargo.toml
+++ b/crates/alloy/Cargo.toml
@@ -106,6 +106,11 @@ reqwest = [
     "alloy-rpc-client?/reqwest",
     "alloy-provider?/reqwest",
     "alloy-transport-http?/reqwest",
+]
+reqwest-default-tls = [
+    "alloy-rpc-client?/reqwest",
+    "alloy-provider?/reqwest",
+    "alloy-transport-http?/reqwest",
     "alloy-transport-http?/reqwest-default-tls",
 ]
 reqwest-rustls-tls = [


### PR DESCRIPTION
the reqwest feature always pulls in openssl which is bad because there's no other way to just enable basic reqwest without default tls