### PR TITLE
docs: fix error in unused_port function comment

### DIFF
--- a/crates/node-bindings/src/utils.rs
+++ b/crates/node-bindings/src/utils.rs
@@ -10,7 +10,7 @@ use tempfile::TempDir;
 
 /// A bit of hack to find an unused TCP port.
 ///
-/// Does not guarantee that the given port is unused after the function exists, just that it was
+/// Does not guarantee that the given port is unused after the function exits, just that it was
 /// unused before the function started (i.e., it does not reserve a port).
 pub(crate) fn unused_port() -> u16 {
     let listener = TcpListener::bind("127.0.0.1:0")


### PR DESCRIPTION
error in function documentation: `exists` -> `exits`

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
