### PR TITLE
feat(rpc-types-engine): add transaction helper methods to ExecutionPayload

### DIFF
--- a/crates/rpc-types-engine/src/payload.rs
+++ b/crates/rpc-types-engine/src/payload.rs
@@ -12,7 +12,7 @@ use alloy_consensus::{
 use alloy_eips::{
     calc_next_block_base_fee,
     eip1559::BaseFeeParams,
-    eip2718::{Decodable2718, Encodable2718},
+    eip2718::{Decodable2718, Encodable2718, Eip2718Result, WithEncoded},
     eip4844::BlobTransactionSidecar,
     eip4895::{Withdrawal, Withdrawals},
     eip7594::{BlobTransactionSidecarEip7594, CELLS_PER_EXT_BLOB},
@@ -1514,6 +1514,72 @@ impl ExecutionPayload {
     pub fn maybe_next_block_excess_blob_gas(&self, blob_params: Option<BlobParams>) -> Option<u64> {
         self.next_block_excess_blob_gas(blob_params?)
     }
+
+    /// Returns an iterator over the decoded transactions in this payload.
+    ///
+    /// This iterator will decode transactions on the fly.
+    pub fn decoded_transactions<T: Decodable2718>(
+        &self,
+    ) -> impl Iterator<Item = Eip2718Result<T>> + '_ {
+        self.transactions().iter().map(|tx_bytes| T::decode_2718_exact(tx_bytes.as_ref()))
+    }
+
+    /// Returns iterator over decoded transactions with their original encoded bytes.
+    ///
+    /// This iterator will decode transactions on the fly and return them with their bytes.
+    pub fn decoded_transactions_with_encoded<T: Decodable2718>(
+        &self,
+    ) -> impl Iterator<Item = Eip2718Result<WithEncoded<T>>> + '_
+    {
+        self.transactions().iter().cloned().zip(self.decoded_transactions()).map(
+            |(tx_bytes, result)| {
+                result.map(|tx| WithEncoded::new(tx_bytes, tx))
+            },
+        )
+    }
+
+    /// Returns an iterator over the recovered transactions in this payload.
+    ///
+    /// This iterator will decode and recover signer addresses for transactions on the fly.
+    pub fn recovered_transactions<T>(
+        &self,
+    ) -> impl Iterator<
+        Item = Result<
+            alloy_consensus::transaction::Recovered<T>,
+            alloy_consensus::crypto::RecoveryError,
+        >,
+    > + '_
+    where
+        T: Decodable2718 + alloy_consensus::transaction::SignerRecoverable,
+    {
+        self.decoded_transactions::<T>().map(|res| {
+            res.map_err(alloy_consensus::crypto::RecoveryError::from_source)
+                .and_then(|tx| tx.try_into_recovered())
+        })
+    }
+
+    /// Returns an iterator over the recovered transactions in this payload with their
+    /// original encoded bytes.
+    ///
+    /// This iterator will decode and recover signer addresses for transactions on the fly
+    /// and return them with their bytes.
+    pub fn recovered_transactions_with_encoded<T>(
+        &self,
+    ) -> impl Iterator<
+        Item = Result<
+            WithEncoded<alloy_consensus::transaction::Recovered<T>>,
+            alloy_consensus::crypto::RecoveryError,
+        >,
+    > + '_
+    where
+        T: Decodable2718 + alloy_consensus::transaction::SignerRecoverable,
+    {
+        self.transactions().iter().cloned().zip(self.recovered_transactions::<T>()).map(
+            |(tx_bytes, result)| {
+                result.map(|tx| WithEncoded::new(tx_bytes, tx))
+            },
+        )
+    }
 }
 
 impl From<ExecutionPayloadV1> for ExecutionPayload {
@@ -2854,6 +2920,42 @@ mod tests {
                 "Block hash mismatch in {:?}: expected {}, got {}",
                 path, expected_hash, actual_hash
             );
+        }
+    }
+
+    #[test]
+    fn test_decoded_transactions() {
+        // Use a valid transaction from one of the existing tests
+        let transaction = Bytes::from_static(&hex!("f86d0a8458b20efd825208946177843db3138ae69679a54b95cf345ed759450d8806f3e8d87878800080820a95a0f8bddb1dcc4558b532ff747760a6f547dd275afdbe7bdecc90680e71de105757a014f34ba38c180913c0543b0ac2eccfb77cc3f801a535008dc50e533fbe435f53"));
+        
+        let payload = ExecutionPayload::V1(ExecutionPayloadV1 {
+            parent_hash: B256::default(),
+            fee_recipient: Address::default(),
+            state_root: B256::default(),
+            receipts_root: B256::default(),
+            logs_bloom: Bloom::default(),
+            prev_randao: B256::default(),
+            block_number: 0,
+            gas_limit: 0,
+            gas_used: 0,
+            timestamp: 0,
+            extra_data: Bytes::default(),
+            base_fee_per_gas: U256::default(),
+            block_hash: B256::default(),
+            transactions: vec![transaction.clone()],
+        });
+
+        // Test decoded_transactions
+        let decoded: Vec<_> = payload.decoded_transactions::<TxEnvelope>().collect();
+        assert_eq!(decoded.len(), 1);
+        assert!(decoded[0].is_ok(), "Failed to decode transaction: {:?}", decoded[0]);
+
+        // Test decoded_transactions_with_encoded
+        let decoded_with_encoded: Vec<_> = payload.decoded_transactions_with_encoded::<TxEnvelope>().collect();
+        assert_eq!(decoded_with_encoded.len(), 1);
+        assert!(decoded_with_encoded[0].is_ok());
+        if let Ok(with_encoded) = &decoded_with_encoded[0] {
+            assert_eq!(with_encoded.encoded_bytes(), &transaction);
         }
     }
 }


### PR DESCRIPTION
Replicates the changes from https://github.com/alloy-rs/op-alloy/pull/597 to the `ExecutionPayload` type in alloy.

## Changes

Adds four generic helper methods for decoding and recovering transactions on `ExecutionPayload`:
- `decoded_transactions<T>()` - Decode transactions to any type implementing `Decodable2718`
- `decoded_transactions_with_encoded<T>()` - Same as above but includes original encoded bytes
- `recovered_transactions<T>()` - Recover signer addresses for types implementing both `Decodable2718` and `SignerRecoverable` (requires `k256` feature)
- `recovered_transactions_with_encoded<T>()` - Same as above but includes original encoded bytes (requires `k256` feature)

These methods provide the same functionality as the helpers added to `OpExecutionPayload` in op-alloy, but work directly with the base `ExecutionPayload` type.

## Example Usage

```rust
// Decode transactions
let transactions: Vec<_> = payload.decoded_transactions::<TxEnvelope>().collect();

// Decode with original bytes
let with_bytes: Vec<_> = payload.decoded_transactions_with_encoded::<TxEnvelope>().collect();

// Recover signer addresses (requires k256 feature)
#[cfg(feature = "k256")]
let recovered: Vec<_> = payload.recovered_transactions::<TxEnvelope>().collect();
```

Includes test coverage for the new methods.