### PR TITLE
fix(provider): use correct admin_peerEvents subscription method

### DIFF
--- a/crates/provider/src/ext/admin.rs
+++ b/crates/provider/src/ext/admin.rs
@@ -76,7 +76,7 @@ where
     fn subscribe_peer_events(
         &self,
     ) -> GetSubscription<alloy_rpc_client::NoParams, alloy_rpc_types_admin::PeerEvent> {
-        let mut rpc_call = self.client().request_noparams("admin_peerEvents_subscribe");
+        let mut rpc_call = self.client().request_noparams("admin_peerEvents");
         rpc_call.set_is_subscription();
         GetSubscription::new(self.weak_client(), rpc_call)
     }


### PR DESCRIPTION
Switch subscription RPC from admin_peerEvents_subscribe to admin_peerEvents and mark it as a subscription via set_is_subscription(). Geth exposes the admin peer events stream as admin_peerEvents (without the “subscribe” suffix). This change aligns with upstream naming and our own pubsub README, ensuring compatibility and proper handling by the pubsub service.