### PR TITLE
Avoid panic in AnvilInstance::drop; fail soft on kill error

### DIFF
--- a/crates/node-bindings/src/nodes/anvil.rs
+++ b/crates/node-bindings/src/nodes/anvil.rs
@@ -133,7 +133,9 @@ impl Drop for AnvilInstance {
                 }
             }
         }
-        self.child.kill().expect("could not kill anvil");
+        if let Err(err) = self.child.kill() {
+            eprintln!("alloy-node-bindings: failed to kill anvil process: {}", err);
+        }
     }
 }
 


### PR DESCRIPTION


### Summary
Make teardown more robust by preventing a panic in `Drop` when killing the Anvil process fails.

### Changes
- Replace `self.child.kill().expect("could not kill anvil")` with a fallible `kill()` and soft error logging via `eprintln!`.

### Rationale
- Panics in `Drop` can abort the process during unwinding and complicate shutdown. Soft-failing improves reliability and debuggability.

