### PR TITLE
Replace redundant ok().unwrap() with explicit invariant in ConvertRuint

### DIFF
--- a/crates/serde/src/quantity.rs
+++ b/crates/serde/src/quantity.rs
@@ -314,12 +314,12 @@ mod private {
 
         #[inline]
         fn into_ruint(self) -> Self::Ruint {
-            self.try_into().ok().unwrap()
+            self.try_into().unwrap_or_else(|_| unreachable!("infallible ConvertRuint::into_ruint conversion failed"))
         }
 
         #[inline]
         fn from_ruint(ruint: Self::Ruint) -> Self {
-            ruint.try_into().ok().unwrap()
+            ruint.try_into().unwrap_or_else(|_| unreachable!("infallible ConvertRuint::from_ruint conversion failed"))
         }
     }
 


### PR DESCRIPTION

Clarify intent and remove redundancy in `quantity.rs` conversions.

- Replace `try_into().ok().unwrap()` with `unwrap_or_else(|_| unreachable!(...))` in:
  - `ConvertRuint::into_ruint`
  - `ConvertRuint::from_ruint`


- Eliminates unnecessary `Option` hop and improves diagnostics.
- Communicates the invariant without requiring a `Debug` bound on the error (which `expect` would need).

