### PR TITLE
fix(consensus): correct ommers range in BlockBody arbitrary implementation

### DIFF
--- a/crates/consensus/src/block/mod.rs
+++ b/crates/consensus/src/block/mod.rs
@@ -386,7 +386,7 @@ where
             .collect::<arbitrary::Result<Vec<_>>>()?;
 
         // then generate up to 2 ommers
-        let ommers = (0..u.int_in_range(0..=1)?)
+        let ommers = (0..u.int_in_range(0..=2)?)
             .map(|_| H::arbitrary(u))
             .collect::<arbitrary::Result<Vec<_>>>()?;
 


### PR DESCRIPTION
Fix discrepancy between comment and implementation in BlockBody arbitrary test

The comment stated "generate up to 2 ommers" but the range was set to 0..=1, which only generated up to 1 ommer. This change corrects the range to 0..=2 to match both the comment and Ethereum protocol specification, which allows blocks to contain up to 2 ommers (uncles). 

This ensures proper test coverage for all valid ommer counts (0, 1, and 2) in property-based testing.