### PR TITLE
fix(consensus): include EIP-7702 in ReceiptEnvelope Arbitrary range

### DIFF
--- a/crates/consensus/src/receipt/envelope.rs
+++ b/crates/consensus/src/receipt/envelope.rs
@@ -312,7 +312,7 @@ where
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         let receipt = ReceiptWithBloom::<Receipt<T>>::arbitrary(u)?;
 
-        match u.int_in_range(0..=3)? {
+        match u.int_in_range(0..=4)? {
             0 => Ok(Self::Legacy(receipt)),
             1 => Ok(Self::Eip2930(receipt)),
             2 => Ok(Self::Eip1559(receipt)),


### PR DESCRIPTION
The Arbitrary implementation was using range 0..=3, excluding EIP-7702
receipt envelopes (index 4) from property-based testing. Since EIP-7702
is fully supported, it should be included in testing.

Changes:
- Update int_in_range from 0..=3 to 0..=4

This ensures all 5 transaction types are equally tested.