### PR TITLE
rpc-client: correct #[must_use] messages for BatchRequest/Waiter

### DIFF
--- a/crates/rpc-client/src/batch.rs
+++ b/crates/rpc-client/src/batch.rs
@@ -29,7 +29,7 @@ pub(crate) type ChannelMap = HashMap<Id, Channel>;
 /// A batch JSON-RPC request, used to bundle requests into a single transport
 /// call.
 #[derive(Debug)]
-#[must_use = "A BatchRequest does nothing unless sent via `send_batch` and `.await`"]
+#[must_use = "A BatchRequest does nothing unless sent (call `send()` or `.await` it)"]
 pub struct BatchRequest<'a> {
     /// The transport via which the batch will be sent.
     transport: ClientRef<'a>,
@@ -42,7 +42,7 @@ pub struct BatchRequest<'a> {
 }
 
 /// Awaits a single response for a request that has been included in a batch.
-#[must_use = "A Waiter does nothing unless the corresponding BatchRequest is sent via `send_batch` and `.await`, AND the Waiter is awaited."]
+#[must_use = "A Waiter does nothing unless the corresponding BatchRequest is sent (call `send()` or `.await` it), AND the Waiter is awaited."]
 #[pin_project]
 #[derive(Debug)]
 pub struct Waiter<Resp, Output = Resp, Map = fn(Resp) -> Output> {


### PR DESCRIPTION
The previous #[must_use] messages referenced a non-existent method name send_batch. The actual API uses send() and also supports awaiting BatchRequest directly via IntoFuture. This change updates the messages to avoid misleading guidance and align with the README usage and the public API, preventing confusion for users.