### PR TITLE
feat: add pagination support to watch_logs()

### DIFF
--- a/crates/provider/src/fillers/mod.rs
+++ b/crates/provider/src/fillers/mod.rs
@@ -483,6 +483,14 @@ where
         self.inner.watch_logs(filter).await
     }
 
+    fn watch_logs_paginated(
+        &self,
+        filter: &Filter,
+        page_size: u64,
+    ) -> crate::provider::PaginatedLogsPoller {
+        self.inner.watch_logs_paginated(filter, page_size)
+    }
+
     async fn watch_full_pending_transactions(
         &self,
     ) -> TransportResult<FilterPollerBuilder<N::TransactionResponse>> {

--- a/crates/provider/src/provider/mod.rs
+++ b/crates/provider/src/provider/mod.rs
@@ -16,7 +16,7 @@ mod sendable;
 pub use sendable::{SendableTx, SendableTxErr};
 
 mod r#trait;
-pub use r#trait::{FilterPollerBuilder, Provider};
+pub use r#trait::{FilterPollerBuilder, PaginatedLogsPoller, Provider};
 
 mod wallet;
 pub use wallet::WalletProvider;


### PR DESCRIPTION
Fixes #2889

Add `watch_logs_paginated()` method to prevent memory issues when fetching logs from large block ranges.

### Changes
- Add `PaginatedLogsPoller` that fetches logs in configurable page sizes
- Add `Provider::watch_logs_paginated(filter, page_size)` method
- Implement pagination logic that divides block ranges into smaller chunks