### PR TITLE
chore: re-export transport

### DIFF
--- a/crates/provider/src/lib.rs
+++ b/crates/provider/src/lib.rs
@@ -51,6 +51,8 @@ pub mod utils;
 #[doc(no_inline)]
 pub use alloy_network::{self as network, Network};
 
+pub use alloy_transport as transport;
+
 #[cfg(feature = "ws")]
 pub use alloy_rpc_client::WsConnect;
 


### PR DESCRIPTION
a lot of api functions return TransportError/Result but these types arent reexported directly