### PR TITLE
json-rpc: propagate MapAccess::next_key errors in notification deserializer

### DIFF
--- a/crates/json-rpc/src/notification.rs
+++ b/crates/json-rpc/src/notification.rs
@@ -85,7 +85,7 @@ impl<'de> Deserialize<'de> for PubSubItem {
                 let mut error = None;
 
                 // Drain the map into the appropriate fields.
-                while let Ok(Some(key)) = map.next_key() {
+                while let Some(key) = map.next_key()? {
                     match key {
                         "id" => {
                             if id.is_some() {


### PR DESCRIPTION
Replace while let Ok(Some(key)) = map.next_key() with while let Some(key) = map.next_key()? in crates/json-rpc/src/notification.rs to avoid swallowing key deserialization errors. This improves error diagnostics on malformed input. The rest of the repository already uses the recommended pattern with immediate error propagation, so this change aligns the implementation with the established style.