### PR TITLE
chore(`ci`): enable CodeQL as part of `ci.yml`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,6 +216,35 @@ jobs:
   deny:
     uses: ithacaxyz/ci/.github/workflows/deny.yml@main
 
+  codeql:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{matrix.language}}"
+
   ci-success:
     name: ci success
     runs-on: ubuntu-latest
@@ -232,6 +261,7 @@ jobs:
       - docs
       - fmt
       - deny
+      - codeql
     steps:
       - name: Decide whether the needed jobs succeeded or failed
         uses: re-actors/alls-green@release/v1


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

This PR introduces CodeQL code scanning as part of `ci.yml` initially just focused on Github actions as it is fast to run.

https://docs.github.com/en/code-security/code-scanning/introduction-to-code-scanning/about-code-scanning-with-codeql

Results are reported privately in the `security` tab.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

This workflow was derived from the default workflow example Github provides enhanced with concurrency cancel in progress, updated cron to run daily and allow workflow dispatch. Trigger on cron, pull requests and pushes to master.

This can later be expanded to cover Rust (currently in preview mode & will require custom build / caches to run efficiently).