### PR TITLE
chore: enable rustls by default

### DIFF
--- a/crates/alloy/Cargo.toml
+++ b/crates/alloy/Cargo.toml
@@ -68,7 +68,7 @@ alloy-trie = { workspace = true, optional = true }
 # ----------------------------------------- Configuration ---------------------------------------- #
 
 [features]
-default = ["std", "reqwest", "alloy-core/default", "essentials"]
+default = ["std", "reqwest", "reqwest-rustls-tls", "alloy-core/default", "essentials"]
 
 # std
 std = [


### PR DESCRIPTION
in https://github.com/alloy-rs/alloy/pull/2865 we removed tls by default because this was always enabling openssl by default with no easy way to opt out.

this restores tls support by default