### PR TITLE
feat(eips): Add `MAX_TX_GAS_LIMIT_OSAKA` for EIP-7825

### DIFF
--- a/crates/eips/src/eip7825.rs
+++ b/crates/eips/src/eip7825.rs
@@ -1,0 +1,4 @@
+//! Contains constants for [EIP-7825](https://github.com/ethereum/EIPs/tree/master/EIPS/eip-7825.md)
+
+/// Maximum transaction gas limit as defined by [EIP-7825](https://eips.ethereum.org/EIPS/eip-7825) activated in `Osaka` hardfork.
+pub const MAX_TX_GAS_LIMIT_OSAKA: u64 = 2u64.pow(24);

--- a/crates/eips/src/lib.rs
+++ b/crates/eips/src/lib.rs
@@ -54,6 +54,9 @@ pub mod eip7702;
 pub mod eip7840;
 
 pub mod eip7892;
+
+pub mod eip7825;
+
 pub use eip7892::{BlobScheduleBlobParams, BlobScheduleEntry};
 
 pub mod eip7910;


### PR DESCRIPTION
## Motivation

This constant is defined in [reth](https://github.com/paradigmxyz/reth/blob/db04a19101c922965b8336d960f837537895defb/crates/primitives-traits/src/constants/mod.rs#L21), but not in `alloy`. We need it in alloy-evm https://github.com/alloy-rs/evm/pull/173

## Solution

Add `MAX_TX_GAS_LIMIT_OSAKA` constant for to `eip7825` module of `alloy-eips`.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
