### PR TITLE
fix: add base_fee_per_gas validation in payload blob gas calculation

### DIFF
--- a/crates/rpc-types-engine/src/payload.rs
+++ b/crates/rpc-types-engine/src/payload.rs
@@ -1503,7 +1503,7 @@ impl ExecutionPayload {
         Some(blob_params.next_block_excess_blob_gas_osaka(
             self.excess_blob_gas()?,
             self.blob_gas_used()?,
-            self.as_v1().base_fee_per_gas.to(),
+            self.as_v1().base_fee_per_gas.try_into().ok()?,
         ))
     }
 


### PR DESCRIPTION
Fix potential panic when base_fee_per_gas is None in next_block_excess_blob_gas.

Replace .to() with .try_into().ok()? to safely handle missing base_fee_per_gas
and return None instead of panicking, consistent with consensus header implementation.