### PR TITLE
fix: don't use serde private API

### DIFF
--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -43,6 +43,7 @@ rand = { workspace = true, optional = true }
 # serde
 serde = { workspace = true, features = ["derive"], optional = true }
 serde_with = { workspace = true, optional = true }
+serde_json = { workspace = true, optional = true }
 
 # misc
 derive_more = { workspace = true, features = [
@@ -108,6 +109,7 @@ serde = [
 	"dep:serde",
 	"alloy-primitives/serde",
 	"dep:alloy-serde",
+    "dep:serde_json",
 	"alloy-eips/serde",
 	"alloy-trie/serde",
 	"c-kzg?/serde",

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -93,4 +93,6 @@ pub mod private {
     pub use arbitrary;
     #[cfg(feature = "serde")]
     pub use serde;
+    #[cfg(feature = "serde")]
+    pub use serde_json;
 }

--- a/crates/tx-macros/src/serde.rs
+++ b/crates/tx-macros/src/serde.rs
@@ -11,6 +11,7 @@ pub(crate) struct SerdeGenerator<'a> {
     variants: &'a GroupedVariants,
     alloy_consensus: &'a Path,
     serde: TokenStream,
+    serde_json: TokenStream,
     serde_cfg: &'a TokenStream,
 }
 
@@ -23,7 +24,8 @@ impl<'a> SerdeGenerator<'a> {
         serde_cfg: &'a TokenStream,
     ) -> Self {
         let serde = quote! { #alloy_consensus::private::serde };
-        Self { input_type_name, generics, variants, alloy_consensus, serde, serde_cfg }
+        let serde_json = quote! { #alloy_consensus::private::serde_json };
+        Self { input_type_name, generics, variants, alloy_consensus, serde, serde_json, serde_cfg }
     }
 
     /// Generate all serde-related code.
@@ -220,6 +222,7 @@ impl<'a> SerdeGenerator<'a> {
         let generics = self.generics;
         let unwrapped_generics = &generics.params;
         let serde = &self.serde;
+        let serde_json = &self.serde_json;
         let serde_bounds = self.generate_serde_bounds();
 
         let flattened_names = self.variants.flattened.iter().map(|v| &v.name);
@@ -232,15 +235,11 @@ impl<'a> SerdeGenerator<'a> {
                 where
                     D: #serde::Deserializer<'de>,
                 {
-                    let content = #serde::de::DeserializeSeed::deserialize(
-                        #serde::__private226::de::ContentVisitor::new(),
-                        deserializer
-                    )?;
-                    let deserializer =
-                        #serde::__private226::de::ContentRefDeserializer::<D::Error>::new(&content);
+                    let value = #serde_json::Value::deserialize(deserializer)?;
+                    let deserializer = &value;
 
                     let tagged_res =
-                        TaggedTxTypes::<#unwrapped_generics>::deserialize(deserializer).map(Self::Tagged);
+                        TaggedTxTypes::<#unwrapped_generics>::deserialize(deserializer).map(Self::Tagged).map_err(#serde::de::Error::custom);
 
                     if tagged_res.is_ok() {
                         // return tagged if successful


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->


Removes dependency on serde `Content` in favor of `serde_json::Value`. This allows to avoid usage of private APIs but means that we can't deseraize non-json data anymore

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
