### PR TITLE
chore: forward std optional

### DIFF
--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -83,7 +83,7 @@ std = [
     "derive_more/std",
     "k256?/std",
     "serde?/std",
-    "serde_json/std",
+    "serde_json?/std",
     "serde_with?/std",
     "thiserror/std",
     "either/std",


### PR DESCRIPTION
only activate if enabled