### PR TITLE
Bind geth HTTP/WS RPC to localhost by default

### DIFF
--- a/crates/node-bindings/src/nodes/geth.rs
+++ b/crates/node-bindings/src/nodes/geth.rs
@@ -447,11 +447,15 @@ impl Geth {
         // Open the HTTP API
         cmd.arg("--http");
         cmd.arg("--http.port").arg(&port_s);
+        // Bind explicitly to localhost to avoid exposing the API on all interfaces
+        cmd.arg("--http.addr").arg("127.0.0.1");
         cmd.arg("--http.api").arg(API);
 
         // Open the WS API
         cmd.arg("--ws");
         cmd.arg("--ws.port").arg(port_s);
+        // Bind explicitly to localhost to avoid exposing the API on all interfaces
+        cmd.arg("--ws.addr").arg("127.0.0.1");
         cmd.arg("--ws.api").arg(API);
 
         // pass insecure unlock flag if set


### PR DESCRIPTION


### Description
- Summary: Ensure `geth` RPC endpoints are not exposed publicly by default.
- Change: Add `--http.addr 127.0.0.1` and `--ws.addr 127.0.0.1` in `crates/node-bindings/src/nodes/geth.rs`.
- Rationale: Prevent unintended exposure of HTTP/WS RPC interfaces on `0.0.0.0`.
- Security: Reduces risk of external access to management APIs.
