### PR TITLE
fix(jwt): report parent directory path in try_create_random

### DIFF
--- a/crates/rpc-types-engine/src/jwt.rs
+++ b/crates/rpc-types-engine/src/jwt.rs
@@ -199,7 +199,7 @@ impl JwtSecret {
         if let Some(dir) = fpath.parent() {
             // Create parent directory
             fs::create_dir_all(dir)
-                .map_err(|err| JwtError::CreateDir { source: err, path: fpath.into() })?
+                .map_err(|err| JwtError::CreateDir { source: err, path: dir.into() })?
         }
 
         let secret = Self::random();


### PR DESCRIPTION
The CreateDir error in JwtSecret::try_create_random used the target file path instead of the parent directory, producing misleading diagnostics (“failed to create dir <file-path>”). Since the error variant and message explicitly refer to a directory, the path should be the actual directory that failed to be created. This change improves error clarity without affecting behavior or APIs.