### PR TITLE
fix(pubsub): remove redundant shutdown try_recv check in recv_from_frontend

### DIFF
--- a/crates/pubsub/src/handle.rs
+++ b/crates/pubsub/src/handle.rs
@@ -113,10 +113,6 @@ impl ConnectionInterface {
             Err(TryRecvError::Empty) => {}
         }
 
-        if self.shutdown.try_recv().is_ok() {
-            return None;
-        }
-
         self.from_frontend.recv().await
     }
 


### PR DESCRIPTION
Remove the second shutdown try_recv() call which was redundant and had no effect.