### PR TITLE
docs: Document why sequential block fetching is preferred over join_all

### DIFF
--- a/crates/provider/src/blocks.rs
+++ b/crates/provider/src/blocks.rs
@@ -192,7 +192,11 @@ impl<N: Network> NewBlocks<N> {
             };
 
             // Then try to fill as many blocks as possible.
-            // TODO: Maybe use `join_all`
+            // We use sequential fetching instead of join_all for several reasons:
+            // 1. Better error handling with per-block retry logic
+            // 2. Respects cache size limits and can break early when cache is full
+            // 3. Avoids overwhelming RPC servers with too many concurrent requests
+            // 4. Maintains backpressure when consumer is slower than producer
             let mut retries = MAX_RETRIES;
             for number in self.next_yield..=block_number {
                 debug!(number, "fetching block");


### PR DESCRIPTION
While reviewing the code, I noticed a TODO suggesting` join_all` for concurrent block fetching and thought it could be a good performance optimization. After investigating, I found that while we do use `try_join_all `successfully elsewhere in the codebase (like `hashes_to_blocks` in utils.rs), this streaming context actually requires sequential fetching for proper per-block retry logic, cache size management, and RPC server backpressure control. I've replaced the ambiguous TODO with clear documentation explaining why the current approach is optimal, preventing future developers from going down the same investigation path.