### PR TITLE
fix: Convert static vectors to arrays

### DIFF
--- a/crates/provider/src/ext/tenderly.rs
+++ b/crates/provider/src/ext/tenderly.rs
@@ -183,7 +183,7 @@ mod test {
             StateOverridesBuilder::default().append(Address::ZERO, account_override).build();
 
         let _res = provider
-            .tenderly_simulate_bundle(&vec![tx.clone(), tx], block, Some(state_override), None)
+            .tenderly_simulate_bundle(&[tx.clone(), tx], block, Some(state_override), None)
             .await
             .unwrap();
     }

--- a/crates/rpc-types-trace/src/parity.rs
+++ b/crates/rpc-types-trace/src/parity.rs
@@ -796,7 +796,7 @@ mod tests {
 
     #[test]
     fn test_serialization_order() {
-        let test_cases = vec![
+        let test_cases = [
             TraceTestCase {
                 trace: LocalizedTransactionTrace {
                     trace: TransactionTrace {


### PR DESCRIPTION
## Motivation

Complies with clippy rules as of 1.92.0-nightly (caccb4d03 2025-09-24)

## Solution

Convert reported vectors to arrays by removing `vec!` prefix.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
