### PR TITLE
chore(rpc-types-eth): remove useless serde deny_unknown_fields on enums

### DIFF
--- a/crates/rpc-types-eth/src/filter.rs
+++ b/crates/rpc-types-eth/src/filter.rs
@@ -1321,7 +1321,6 @@ where
 /// Owned equivalent of a `SubscriptionId`
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 #[cfg_attr(feature = "serde", serde(untagged))]
 pub enum FilterId {
     /// Numeric id

--- a/crates/rpc-types-eth/src/pubsub.rs
+++ b/crates/rpc-types-eth/src/pubsub.rs
@@ -72,7 +72,6 @@ where
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
-#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 pub enum SubscriptionKind {
     /// New block headers subscription.
     ///


### PR DESCRIPTION
Remove serde(deny_unknown_fields) from SubscriptionKind and FilterId. This attribute has no effect at the enum container level (it applies to structs or struct-like enum variants), so keeping it is misleading. Behavior is unchanged; improves clarity and consistency.