### PR TITLE
feat: Add `UnsupportedTransactionType` error

### DIFF
--- a/crates/consensus/src/error.rs
+++ b/crates/consensus/src/error.rs
@@ -1,6 +1,7 @@
 //! Helper errors.
 
 use alloc::{borrow::Cow, boxed::Box, string::ToString};
+use core::fmt::Display;
 
 /// Helper type that is [`core::error::Error`] and wraps a value and an error message.
 ///
@@ -14,7 +15,7 @@ pub struct ValueError<T> {
 
 impl<T> ValueError<T> {
     /// Creates a new error with the given value and error message.
-    pub fn new(value: T, msg: impl core::fmt::Display) -> Self {
+    pub fn new(value: T, msg: impl Display) -> Self {
         Self { msg: Cow::Owned(msg.to_string()), value: Box::new(value) }
     }
 
@@ -46,3 +47,9 @@ impl<T> ValueError<T> {
         &self.value
     }
 }
+
+/// The error for conversions or processing of transactions of type using components that lack the
+/// knowledge or capability to do so.
+#[derive(Debug, thiserror::Error)]
+#[error("Unsupported transaction type: {0}")]
+pub struct UnsupportedTransactionType<TxType: Display>(TxType);

--- a/crates/network/src/any/error.rs
+++ b/crates/network/src/any/error.rs
@@ -1,6 +1,9 @@
 //! Error types for converting between `Any` types.
 
+use crate::{Network, TransactionBuilderError};
+use alloy_consensus::error::UnsupportedTransactionType;
 use core::{error::Error, fmt};
+use std::fmt::{Debug, Display};
 
 /// A ConversionError that can capture any error type that implements the `Error` trait.
 pub struct AnyConversionError {
@@ -37,5 +40,13 @@ impl fmt::Display for AnyConversionError {
 impl Error for AnyConversionError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         self.inner.source()
+    }
+}
+
+impl<N: Network, TxType: Display + Debug + Sync + Send + 'static>
+    From<UnsupportedTransactionType<TxType>> for TransactionBuilderError<N>
+{
+    fn from(value: UnsupportedTransactionType<TxType>) -> Self {
+        Self::Custom(Box::new(value))
     }
 }


### PR DESCRIPTION
## Motivation

Custom nodes can deal with conversions or processing of transactions of a type that they can't deal with.

An error like this is usually defined locally in those projects.

## Solution

Add `UnsupportedTransactionType` error that can convert into `TransactionBuilderError`

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
