### PR TITLE
test: Test display of `UnsupportedTransactionType` error and its conversion into `TransactionBuilderError`

### DIFF
--- a/crates/network/src/any/error.rs
+++ b/crates/network/src/any/error.rs
@@ -2,8 +2,11 @@
 
 use crate::{Network, TransactionBuilderError};
 use alloy_consensus::error::UnsupportedTransactionType;
-use core::{error::Error, fmt};
-use std::fmt::{Debug, Display};
+use core::{
+    error::Error,
+    fmt,
+    fmt::{Debug, Display},
+};
 
 /// A ConversionError that can capture any error type that implements the `Error` trait.
 pub struct AnyConversionError {
@@ -48,5 +51,22 @@ impl<N: Network, TxType: Display + Debug + Sync + Send + 'static>
 {
     fn from(value: UnsupportedTransactionType<TxType>) -> Self {
         Self::Custom(Box::new(value))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::AnyNetwork;
+    use alloy_consensus::TxType;
+
+    #[test]
+    fn test_tx_builder_error_from_unsupported_tx_type_displays_it() {
+        let error = UnsupportedTransactionType::new(TxType::Eip2930);
+        let error = TransactionBuilderError::<AnyNetwork>::from(error);
+        let actual_msg = error.to_string();
+        let expected_msg = "Unsupported transaction type: EIP-2930";
+
+        assert_eq!(actual_msg, expected_msg);
     }
 }


### PR DESCRIPTION
## Motivation

The `UnsupportedTransactionType` error lacks a constructor and conversions except into `TransactionBuilderError`, which is untested.

## Solution

Add a constructor and more conversions for `UnsupportedTransactionType`.

Test display of `UnsupportedTransactionType` error and its conversion into `TransactionBuilderError`

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
