### PR TITLE
Avoid unnecessary String allocation in serde display serialization

### DIFF
--- a/crates/serde/src/displayfromstr.rs
+++ b/crates/serde/src/displayfromstr.rs
@@ -22,7 +22,7 @@
 //! assert_eq!(val, deserialized);
 //! ```
 
-use crate::alloc::string::{String, ToString};
+use crate::alloc::string::String;
 use core::{fmt, str::FromStr};
 use serde::{Deserialize, Deserializer, Serializer};
 


### PR DESCRIPTION


### Description
- Replace `to_string()` + `collect_str(&...)` with direct `collect_str(value)` in `crates/serde/src/displayfromstr.rs`.
- This removes a temporary allocation and copy in a hot serialization path with no behavior change.

- Impact: minor performance win, zero API or output differences.
- Risk: none — relies on the same `Display` bound and serde’s `collect_str`.