### PR TITLE
refactor(beacon-events): use BeaconBlockHeader in light client finality

### DIFF
--- a/crates/rpc-types-beacon/src/events/light_client_finality.rs
+++ b/crates/rpc-types-beacon/src/events/light_client_finality.rs
@@ -28,12 +28,18 @@ pub struct AttestedHeader {
     pub beacon: BeaconBlockHeader,
 }
 
+/// Backwards-compatible alias for the previously local `Beacon` header type.
+pub type Beacon = BeaconBlockHeader;
+
 /// Contains the `Beacon2` header that was finalized.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FinalizedHeader {
     /// The `Beacon2` object representing the block header.
     pub beacon: BeaconBlockHeader,
 }
+
+/// Backwards-compatible alias for the previously local `Beacon2` header type.
+pub type Beacon2 = BeaconBlockHeader;
 
 /// Contains the sync committee bits and signature.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]


### PR DESCRIPTION
- Replaced local Beacon and Beacon2 structs in LightClientFinalityData with crate::header::BeaconBlockHeader for both attested and finalized headers.
- Removed the now-unused Beacon and Beacon2 definitions and cleaned an unused B256 import.
- Ensures symmetry with LightClientOptimisticData, which already uses BeaconBlockHeader.
- Aligns with Beacon API schemas where both headers share the same structure.
- Reduces duplication, avoids confusing naming (Beacon2), and improves maintainability and type consistency.