### PR TITLE
refactor(rpc-client): remove dead SerError state from BatchFuture 

### DIFF
--- a/crates/rpc-client/src/batch.rs
+++ b/crates/rpc-client/src/batch.rs
@@ -106,7 +106,6 @@ pub enum BatchFuture {
         requests: RequestPacket,
         channels: ChannelMap,
     },
-    SerError(Option<TransportError>),
     AwaitingResponse {
         channels: ChannelMap,
         #[pin]
@@ -244,20 +243,6 @@ impl BatchFuture {
         self.set(Self::Complete);
         Poll::Ready(Ok(()))
     }
-
-    fn poll_ser_error(
-        mut self: Pin<&mut Self>,
-        _cx: &mut task::Context<'_>,
-    ) -> Poll<<Self as Future>::Output> {
-        let e = if let CallStateProj::SerError(e) = self.as_mut().project() {
-            e.take().expect("no error")
-        } else {
-            unreachable!("Called poll_ser_error in incorrect state")
-        };
-
-        self.set(Self::Complete);
-        Poll::Ready(Err(e))
-    }
 }
 
 impl Future for BatchFuture {
@@ -270,10 +255,6 @@ impl Future for BatchFuture {
 
         if matches!(*self.as_mut(), Self::AwaitingResponse { .. }) {
             return self.poll_awaiting_response(cx);
-        }
-
-        if matches!(*self.as_mut(), Self::SerError(_)) {
-            return self.poll_ser_error(cx);
         }
 
         panic!("Called poll on BatchFuture in invalid state")


### PR DESCRIPTION
- Removed the unreachable BatchFuture::SerError state and its poll handler. This state was never constructed; serialization errors are surfaced earlier via map_err(TransportError::ser_err) during request serialization, and transport-level errors are returned from the transport future.
- Simplified the state machine by dropping an unused match branch, reducing maintenance surface and avoiding misleading code paths.