### PR TITLE
feat(network): add tx type helper methods to AnyTxEnvelope and AnyRpcTransaction

### DIFF
--- a/crates/network/src/any/either.rs
+++ b/crates/network/src/any/either.rs
@@ -325,6 +325,36 @@ impl AnyTxEnvelope {
             _ => None,
         }
     }
+
+    /// Returns true if the transaction is a legacy transaction.
+    #[inline]
+    pub const fn is_legacy(&self) -> bool {
+        matches!(self.as_envelope(), Some(TxEnvelope::Legacy(_)))
+    }
+
+    /// Returns true if the transaction is an EIP-2930 transaction.
+    #[inline]
+    pub const fn is_eip2930(&self) -> bool {
+        matches!(self.as_envelope(), Some(TxEnvelope::Eip2930(_)))
+    }
+
+    /// Returns true if the transaction is an EIP-1559 transaction.
+    #[inline]
+    pub const fn is_eip1559(&self) -> bool {
+        matches!(self.as_envelope(), Some(TxEnvelope::Eip1559(_)))
+    }
+
+    /// Returns true if the transaction is an EIP-4844 transaction.
+    #[inline]
+    pub const fn is_eip4844(&self) -> bool {
+        matches!(self.as_envelope(), Some(TxEnvelope::Eip4844(_)))
+    }
+
+    /// Returns true if the transaction is an EIP-7702 transaction.
+    #[inline]
+    pub const fn is_eip7702(&self) -> bool {
+        matches!(self.as_envelope(), Some(TxEnvelope::Eip7702(_)))
+    }
 }
 
 impl Typed2718 for AnyTxEnvelope {

--- a/crates/network/src/any/mod.rs
+++ b/crates/network/src/any/mod.rs
@@ -3,7 +3,9 @@ mod either;
 
 pub mod error;
 
-use alloy_consensus::TxEnvelope;
+use alloy_consensus::{
+    Signed, TxEip1559, TxEip2930, TxEip4844Variant, TxEip7702, TxEnvelope, TxLegacy,
+};
 use alloy_eips::{eip7702::SignedAuthorization, Typed2718};
 use alloy_primitives::{Bytes, ChainId, TxKind, B256, U256};
 pub use either::{AnyTxEnvelope, AnyTypedTransaction};
@@ -242,6 +244,61 @@ impl AnyRpcTransaction {
     /// If the transaction is not an Ethereum transaction, it is returned as an error.
     pub fn try_into_envelope(self) -> Result<TxEnvelope, ValueError<AnyTxEnvelope>> {
         self.0.inner.inner.into_inner().try_into_envelope()
+    }
+
+    /// Returns the [`TxLegacy`] variant if the transaction is a legacy transaction.
+    pub fn as_legacy(&self) -> Option<&Signed<TxLegacy>> {
+        self.0.inner().inner.as_legacy()
+    }
+
+    /// Returns the [`TxEip2930`] variant if the transaction is an EIP-2930 transaction.
+    pub fn as_eip2930(&self) -> Option<&Signed<TxEip2930>> {
+        self.0.inner().inner.as_eip2930()
+    }
+
+    /// Returns the [`TxEip1559`] variant if the transaction is an EIP-1559 transaction.
+    pub fn as_eip1559(&self) -> Option<&Signed<TxEip1559>> {
+        self.0.inner().inner.as_eip1559()
+    }
+
+    /// Returns the [`TxEip4844Variant`] variant if the transaction is an EIP-4844 transaction.
+    pub fn as_eip4844(&self) -> Option<&Signed<TxEip4844Variant>> {
+        self.0.inner().inner.as_eip4844()
+    }
+
+    /// Returns the [`TxEip7702`] variant if the transaction is an EIP-7702 transaction.
+    pub fn as_eip7702(&self) -> Option<&Signed<TxEip7702>> {
+        self.0.inner().inner.as_eip7702()
+    }
+
+    /// Returns true if the transaction is a legacy transaction.
+    #[inline]
+    pub fn is_legacy(&self) -> bool {
+        self.0.inner().inner.is_legacy()
+    }
+
+    /// Returns true if the transaction is an EIP-2930 transaction.
+    #[inline]
+    pub fn is_eip2930(&self) -> bool {
+        self.0.inner().inner.is_eip2930()
+    }
+
+    /// Returns true if the transaction is an EIP-1559 transaction.
+    #[inline]
+    pub fn is_eip1559(&self) -> bool {
+        self.0.inner().inner.is_eip1559()
+    }
+
+    /// Returns true if the transaction is an EIP-4844 transaction.
+    #[inline]
+    pub fn is_eip4844(&self) -> bool {
+        self.0.inner().inner.is_eip4844()
+    }
+
+    /// Returns true if the transaction is an EIP-7702 transaction.
+    #[inline]
+    pub fn is_eip7702(&self) -> bool {
+        self.0.inner().inner.is_eip7702()
     }
 
     /// Attempts to convert the [`AnyRpcTransaction`] into `Either::Right` if this is an unknown


### PR DESCRIPTION
## Summary

Add missing helper methods from `TxEnvelope` to `AnyTxEnvelope` and `AnyRpcTransaction` for checking and accessing specific transaction types. These methods provide a consistent API across the different transaction envelope types.

## Changes

**AnyTxEnvelope** - Added methods that delegate to the underlying EthereumTxEnvelope:
- `is_legacy()`, `is_eip2930()`, `is_eip1559()`, `is_eip4844()`, `is_eip7702()` - Check transaction type

**AnyRpcTransaction** - Added methods that forward through the inner transaction:
- `as_legacy()`, `as_eip2930()`, `as_eip1559()`, `as_eip4844()`, `as_eip7702()` - Access typed variants
- `is_legacy()`, `is_eip2930()`, `is_eip1559()`, `is_eip4844()`, `is_eip7702()` - Check transaction type

These additions provide feature parity with `TxEnvelope` and make it easier to work with the `Any` network types.