### PR TITLE
chore: remove unused core::panic import

### DIFF
--- a/crates/rpc-client/src/call.rs
+++ b/crates/rpc-client/src/call.rs
@@ -3,7 +3,6 @@ use alloy_json_rpc::{
     RpcRecv, RpcResult, RpcSend,
 };
 use alloy_transport::{BoxTransport, IntoBoxTransport, RpcFut, TransportError, TransportResult};
-use core::panic;
 use futures::FutureExt;
 use serde_json::value::RawValue;
 use std::{


### PR DESCRIPTION
The panic! macro is used directly without needing to import core::panic.
This fixes an unused import warning.