### PR TITLE
chore(beacon): remove redundant DisplayFromStr on header.block_number

### DIFF
--- a/crates/rpc-types-beacon/src/payload.rs
+++ b/crates/rpc-types-beacon/src/payload.rs
@@ -121,8 +121,9 @@ pub struct ExecutionPayloadHeader {
     pub logs_bloom: Bloom,
     /// The previous Randao value of the execution payload.
     pub prev_randao: B256,
-    /// The block number of the execution payload, represented as a string.
-    pub block_number: String,
+    /// The block number of the execution payload, represented as a `u64`.
+    #[serde_as(as = "DisplayFromStr")]
+    pub block_number: u64,
     /// The gas limit of the execution payload, represented as a `u64`.
     #[serde_as(as = "DisplayFromStr")]
     pub gas_limit: u64,

--- a/crates/rpc-types-beacon/src/payload.rs
+++ b/crates/rpc-types-beacon/src/payload.rs
@@ -122,7 +122,6 @@ pub struct ExecutionPayloadHeader {
     /// The previous Randao value of the execution payload.
     pub prev_randao: B256,
     /// The block number of the execution payload, represented as a string.
-    #[serde_as(as = "DisplayFromStr")]
     pub block_number: String,
     /// The gas limit of the execution payload, represented as a `u64`.
     #[serde_as(as = "DisplayFromStr")]


### PR DESCRIPTION
- Remove #[serde_as(as = "DisplayFromStr")] from ExecutionPayloadHeader.block_number (type String).
- For String this adapter is a no-op: serde already serializes/deserializes JSON strings natively. Keeping it adds noise and suggests a conversion that does not occur.
- All other DisplayFromStr uses remain on numeric/bignum types to enforce beacon “quoted decimal” semantics.