### PR TITLE
chore: use fqs for tx_hash_with_type forwarding

### DIFF
--- a/crates/consensus/src/transaction/hashable.rs
+++ b/crates/consensus/src/transaction/hashable.rs
@@ -19,7 +19,22 @@ where
     T: RlpEcdsaEncodableTx,
 {
     /// Calculate the transaction hash for the given signature and type.
-    fn tx_hash_with_type(&self, signature: &Signature, ty: u8) -> alloy_primitives::TxHash {
-        self.tx_hash_with_type(signature, ty)
+    fn tx_hash_with_type(&self, signature: &Signature, ty: u8) -> TxHash {
+        RlpEcdsaEncodableTx::tx_hash_with_type(self, signature, ty)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Signed, TxLegacy};
+    use alloy_primitives::U256;
+
+    #[test]
+    fn hashable_signed() {
+        let tx = TxLegacy::default();
+        let signature = Signature::new(U256::from(1u64), U256::from(1u64), false);
+        let signed = Signed::new_unhashed(tx, signature);
+        let _hash = signed.hash();
     }
 }


### PR DESCRIPTION
both traits have the same name fn name so we should be explicit here