### PR TITLE
feat(provider): include inner cause in DecodeError message

### DIFF
--- a/crates/provider/src/provider/multicall/inner_types.rs
+++ b/crates/provider/src/provider/multicall/inner_types.rs
@@ -196,7 +196,7 @@ pub enum MulticallError {
     #[error("batch contains a tx with a value, try using .send() instead")]
     ValueTx,
     /// Error decoding return data.
-    #[error("could not decode")]
+    #[error("could not decode: {0}")]
     DecodeError(alloy_sol_types::Error),
     /// No return data was found.
     #[error("no return data")]


### PR DESCRIPTION
Change MulticallError::DecodeError formatting from “could not decode” to “could not decode: {0}” to surface the underlying alloy_sol_types::Error.