### PR TITLE
Use is_subscription() in RequestPacket::subscription_request_ids

### DIFF
--- a/crates/json-rpc/src/packet.rs
+++ b/crates/json-rpc/src/packet.rs
@@ -76,14 +76,12 @@ impl RequestPacket {
     pub fn subscription_request_ids(&self) -> HashSet<&Id> {
         match self {
             Self::Single(single) => {
-                let id = (single.method() == "eth_subscribe").then(|| single.id());
+                let id = single.is_subscription().then(|| single.id());
                 HashSet::from_iter(id)
             }
-            Self::Batch(batch) => batch
-                .iter()
-                .filter(|req| req.method() == "eth_subscribe")
-                .map(|req| req.id())
-                .collect(),
+            Self::Batch(batch) => {
+                batch.iter().filter(|req| req.is_subscription()).map(|req| req.id()).collect()
+            }
         }
     }
 


### PR DESCRIPTION
Switch subscription detection from hardcoded method == "eth_subscribe" to SerializedRequest::is_subscription() for both Single and Batch cases. This aligns with the documented API and pubsub behavior, ensuring non-standard subscriptions marked via set_is_subscription() are correctly included when collecting subscription request IDs.