### PR TITLE
fix(consensus): replace redundant set_chain_id call with comment in set_chain_id_checked

### DIFF
--- a/crates/consensus/src/transaction/mod.rs
+++ b/crates/consensus/src/transaction/mod.rs
@@ -257,7 +257,7 @@ pub trait SignableTransaction<Signature>: Transaction {
                 if tx_chain_id != chain_id {
                     return false;
                 }
-                self.set_chain_id(chain_id);
+                // Chain ID already matches, no need to set it again
             }
             None => {
                 self.set_chain_id(chain_id);


### PR DESCRIPTION
Fix logical error in set_chain_id_checked method that was calling set_chain_id()  even when chain_id already matched the required value.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
