### PR TITLE
chore(signer-gcp): remove unused fmt::Debug import

### DIFF
--- a/crates/signer-gcp/src/signer.rs
+++ b/crates/signer-gcp/src/signer.rs
@@ -15,7 +15,7 @@ use gcloud_sdk::{
 };
 use k256::ecdsa::{self, VerifyingKey};
 use spki::DecodePublicKey;
-use std::{fmt, fmt::Debug};
+use std::fmt;
 use thiserror::Error;
 
 type Client = GoogleApi<KeyManagementServiceClient<GoogleAuthMiddleware>>;


### PR DESCRIPTION
Drop redundant fmt::Debug from imports in signer.rs.
Aligns with actual usage (custom Debug impl) and reduces noise.