### PR TITLE
Normalize active transport count in FallbackService to avoid zero-active configuration

### DIFF
--- a/crates/transport/src/layers/fallback.rs
+++ b/crates/transport/src/layers/fallback.rs
@@ -47,6 +47,14 @@ impl<S: Clone> FallbackService<S> {
             .map(|(id, transport)| ScoredTransport::new(id, transport))
             .collect::<Vec<_>>();
 
+        // Ensure a sane configuration: if there are transports, use at least one,
+        // and never exceed the available number of transports.
+        let active_transport_count = if scored_transports.is_empty() {
+            0
+        } else {
+            active_transport_count.max(1).min(scored_transports.len())
+        };
+
         Self { transports: Arc::new(scored_transports), active_transport_count }
     }
 


### PR DESCRIPTION


### Description
- **Summary**: Clamp `active_transport_count` to [1, transports.len()] when transports are present; 0 if empty.
- **Why**: Prevents a silent misconfiguration where no requests are dispatched if `active_transport_count` is 0.
- **How**: Normalize in `FallbackService::new` and add a brief comment.
