### PR TITLE
fix(beacon): use u64 for gas equality errors

### DIFF
--- a/crates/rpc-types-beacon/src/relay.rs
+++ b/crates/rpc-types-beacon/src/relay.rs
@@ -697,21 +697,21 @@ pub mod error {
             /// The actual block hash
             actual: B256,
         },
-        /// Thrown if block hash mismatches
+        /// Thrown if gas limit mismatches
         #[error("incorrect GasLimit {actual}, expected {expected}")]
         IncorrectGasLimit {
             /// The expected gas limit
             expected: u64,
             /// The actual gas limit
-            actual: B256,
+            actual: u64,
         },
-        /// Thrown if block hash mismatches
+        /// Thrown if gas used mismatches
         #[error("incorrect GasUsed {actual}, expected {expected}")]
         IncorrectGasUsed {
             /// The expected gas used
             expected: u64,
             /// The actual gas used
-            actual: B256,
+            actual: u64,
         },
     }
 }


### PR DESCRIPTION
- Change IncorrectGasLimit.actual and IncorrectGasUsed.actual from B256 to u64, and update variant docs to reference gas limit/used.
- Gas fields are u64 across execution payloads and beacon serde (e.g., rpc-types-engine ExecutionPayloadV1/V2/V3), so using B256 was inconsistent and misleading.
- This prevents downstream type mismatches and makes error reporting accurate.