### PR TITLE
refactor(consensus): unify try_get_provider body across std/no_std

### DIFF
--- a/crates/consensus/src/crypto.rs
+++ b/crates/consensus/src/crypto.rs
@@ -183,14 +183,7 @@ pub mod backend {
 
     /// Try to get the currently installed default provider, returning None if none is installed.
     pub(super) fn try_get_provider() -> Option<&'static dyn CryptoProvider> {
-        #[cfg(feature = "std")]
-        {
-            DEFAULT_PROVIDER.get().map(|arc| arc.as_ref())
-        }
-        #[cfg(not(feature = "std"))]
-        {
-            DEFAULT_PROVIDER.get().map(|arc| arc.as_ref())
-        }
+        DEFAULT_PROVIDER.get().map(|arc| arc.as_ref())
     }
 }
 


### PR DESCRIPTION
Remove redundant cfg branches; both OnceLock and OnceBox expose get() -> Option<&T>, so a single implementation is sufficient. Keep cfg in install_default_provider due to differing set signatures.