### PR TITLE
refactor: simplify PreStateConfig initialization in tests

### DIFF
--- a/crates/rpc-types-trace/src/geth/pre_state.rs
+++ b/crates/rpc-types-trace/src/geth/pre_state.rs
@@ -297,13 +297,13 @@ mod tests {
 
     #[test]
     fn test_disable_code() {
-        assert!(PreStateConfig { ..Default::default() }.code_enabled());
+        assert!(PreStateConfig::default().code_enabled());
         assert!(PreStateConfig { disable_code: Some(false), ..Default::default() }.code_enabled());
         assert!(!PreStateConfig { disable_code: Some(true), ..Default::default() }.code_enabled());
     }
     #[test]
     fn test_disable_storage() {
-        assert!(PreStateConfig { ..Default::default() }.storage_enabled());
+        assert!(PreStateConfig::default().storage_enabled());
         assert!(
             PreStateConfig { disable_storage: Some(false), ..Default::default() }.storage_enabled()
         );


### PR DESCRIPTION
Change replaces verbose struct initialization syntax with the more idiomatic Default::default() method for PreStateConfig in test cases. These are the only instances in the codebase where this simplification applies - other usages properly set explicit fields.
