### PR TITLE
fix(provider): use StateContext::default() placeholder in eth_callMany serialization

### DIFF
--- a/crates/provider/src/provider/eth_call/params.rs
+++ b/crates/provider/src/provider/eth_call/params.rs
@@ -196,7 +196,7 @@ impl serde::Serialize for EthCallManyParams<'_> {
         if let Some(context) = self.context() {
             seq.serialize_element(context)?;
         } else if self.overrides().is_some() {
-            seq.serialize_element(&StateOverride::default())?;
+            seq.serialize_element(&StateContext::default())?;
         }
 
         if let Some(overrides) = self.overrides() {


### PR DESCRIPTION
Previously, when context was absent but overrides present, EthCallManyParams::serialize inserted StateOverride::default() in the context position. This was semantically incorrect (context slot must be StateContext) and only worked incidentally because both defaults serialize to {}. This is fragile and violates the expected parameter ordering [bundles, context?, overrides?]. Replace the placeholder with StateContext::default() to align with the API contract and avoid future breakage if serde behavior diverges.