### PR TITLE
fix(cache): prevent caching for tag-based BlockId in get_block_receipts

### DIFF
--- a/crates/provider/src/layers/cache.rs
+++ b/crates/provider/src/layers/cache.rs
@@ -152,7 +152,7 @@ where
         &self,
         block: BlockId,
     ) -> ProviderCall<(BlockId,), Option<Vec<N::ReceiptResponse>>> {
-        let req = RequestType::new("eth_getBlockReceipts", (block,));
+        let req = RequestType::new("eth_getBlockReceipts", (block,)).with_block_id(block);
 
         let redirect = req.has_block_tag();
 


### PR DESCRIPTION
- Add .with_block_id(block) when building RequestType for eth_getBlockReceipts.
- Without setting block_id, has_block_tag() always returned false, causing tag-based requests (latest/pending/safe/finalized) to be cached and potentially serve stale data.
- This change aligns get_block_receipts with the layer’s documented policy and existing macros that avoid caching for non-deterministic block identifiers.