### PR TITLE
Prevent caching of non-deterministic (tag-based) RPC requests

### DIFF
--- a/crates/provider/src/layers/cache.rs
+++ b/crates/provider/src/layers/cache.rs
@@ -391,7 +391,9 @@ impl<Params: RpcSend> RequestType<Params> {
                 BlockId::Hash(_) | BlockId::Number(BlockNumberOrTag::Number(_))
             );
         }
-        false
+        // Treat absence of BlockId as tag-based (e.g., 'latest'), which is non-deterministic
+        // and should not be cached.
+        true
     }
 }
 


### PR DESCRIPTION


## Description

Previously, requests without an explicit `block_id` were treated as deterministic and cached, despite being executed with a tag (`latest`). This could serve stale data from the cache.

- Change: `has_block_tag()` now returns `true` when `block_id` is `None`, treating it as tag-based.
