### PR TITLE
fix(provider): correct TxFiller rustdoc link

### DIFF
--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -933,7 +933,7 @@ pub trait Provider<N: Network = Ethereum>: Send + Sync {
     ///
     /// [`send_transaction`]: Self::send_transaction
     /// [`ProviderLayer`]: crate::ProviderLayer
-    /// [`TxFiller`]: crate::TxFiller
+    /// [`TxFiller`]: crate::fillers::TxFiller
     #[doc(hidden)]
     async fn send_transaction_internal(
         &self,


### PR DESCRIPTION
## Motivation
- cargo doc in CI was failing because the [`TxFiller`] link pointed to crate::TxFiller
- the type lives under crate::fillers, so every PR was hitting a rustdoc::broken-intra-doc-links error
- updated the doc comment so the doc job turns green again

## Testing
- cargo doc --workspace --all-features --no-deps --document-private-items