### PR TITLE
node-bindings: avoid panic in Drop for RethInstance

### DIFF
--- a/crates/node-bindings/src/nodes/reth.rs
+++ b/crates/node-bindings/src/nodes/reth.rs
@@ -122,7 +122,8 @@ impl RethInstance {
 
 impl Drop for RethInstance {
     fn drop(&mut self) {
-        self.pid.kill().expect("could not kill reth");
+        // Best-effort: the child process may already have exited; avoid panicking in Drop.
+        let _ = self.pid.kill();
     }
 }
 


### PR DESCRIPTION


### Description
- **Summary**: Replace `expect` in `Drop` with a best-effort `kill` to prevent panics during drop.
- **Rationale**: Panicking in `Drop` is an anti-pattern and can trigger double panics during unwinding, causing process aborts and flaky tests.
- **Change**: In `crates/node-bindings/src/nodes/reth.rs`, replace `self.pid.kill().expect(...)` with `let _ = self.pid.kill();` and add a short comment.


