### PR TITLE
chore: remove outdated TODO about current-thread polling

### DIFF
--- a/crates/rpc-client/src/poller.rs
+++ b/crates/rpc-client/src/poller.rs
@@ -58,7 +58,6 @@ use tokio::time::{sleep, Sleep};
 /// # Ok(())
 /// # }
 /// ```
-// TODO: make this be able to be spawned on the current thread instead of forcing a task.
 #[derive(Debug)]
 #[must_use = "this builder does nothing unless you call `spawn` or `into_stream`"]
 pub struct PollerBuilder<Params, Resp> {


### PR DESCRIPTION
Remove misleading TODO in crates/rpc-client/src/poller.rs claiming lack of current-thread spawning.
PollerBuilder::into_stream already polls on the current thread as documented.