### PR TITLE
docs(rpc-types-eth): clarify EIP-4844 preferred_type docs to include blob_versioned_hashes

### DIFF
--- a/crates/rpc-types-eth/src/transaction/request.rs
+++ b/crates/rpc-types-eth/src/transaction/request.rs
@@ -797,7 +797,7 @@ impl TransactionRequest {
     ///
     /// Types are preferred as follows:
     /// - EIP-7702 if authorization_list is set
-    /// - EIP-4844 if sidecar or max_blob_fee_per_gas is set
+    /// - EIP-4844 if sidecar, blob_versioned_hashes, or max_blob_fee_per_gas is set
     /// - EIP-2930 if access_list is set
     /// - Legacy if gas_price is set and access_list is unset
     /// - EIP-1559 in all other cases


### PR DESCRIPTION

- What: Update a single docstring line in TransactionRequest::preferred_type to list all EIP-4844 triggers: sidecar, blob_versioned_hashes, or max_fee_per_blob_gas.
- Why: Align documentation with actual behavior (has_eip4844_fields), preventing confusion for users relying on docs.
