### PR TITLE
refactor: remove redundant struct update syntax in AnyHeader construction

### DIFF
--- a/crates/network/src/any/mod.rs
+++ b/crates/network/src/any/mod.rs
@@ -180,11 +180,9 @@ impl DerefMut for AnyRpcBlock {
 
 impl From<Block> for AnyRpcBlock {
     fn from(value: Block) -> Self {
-        let block = value
-            .map_header(|h| h.map(|h| alloy_consensus_any::AnyHeader { ..h.into() }))
-            .map_transactions(|tx| {
-                AnyRpcTransaction::new(WithOtherFields::new(tx.map(AnyTxEnvelope::Ethereum)))
-            });
+        let block = value.map_header(|h| h.map(|h| h.into())).map_transactions(|tx| {
+            AnyRpcTransaction::new(WithOtherFields::new(tx.map(AnyTxEnvelope::Ethereum)))
+        });
 
         Self(WithOtherFields::new(block))
     }


### PR DESCRIPTION
Replace `AnyHeader { ..h.into() }` with direct `h.into()` call since From<Header> implementation already exists, improving readability and performance.

Before: .map_header(|h| h.map(|h| alloy_consensus_any::AnyHeader { ..h.into() }))
After:  .map_header(|h| h.map(|h| h.into()))