### PR TITLE
chore: deduplicate Either async_trait attribute

### DIFF
--- a/crates/signer/src/signer.rs
+++ b/crates/signer/src/signer.rs
@@ -135,7 +135,6 @@ pub trait SignerSync<Sig = Signature> {
 
 #[cfg_attr(target_family = "wasm", async_trait(?Send))]
 #[cfg_attr(not(target_family = "wasm"), async_trait)]
-#[async_trait]
 impl<A, B, Sig> Signer<Sig> for Either<A, B>
 where
     A: Signer<Sig> + Send + Sync,


### PR DESCRIPTION
cfg_attr already expands to async_trait, so the extra attribute was redundant and removed