### PR TITLE
chore(rpc-client): remove duplicate localhost:8545 parsing assertion

### DIFF
--- a/crates/rpc-client/src/builtin.rs
+++ b/crates/rpc-client/src/builtin.rs
@@ -218,10 +218,6 @@ mod test {
             BuiltInConnectionString::Http("https://localhost:8545".parse::<Url>().unwrap())
         );
         assert_eq!(
-            BuiltInConnectionString::from_str("localhost:8545").unwrap(),
-            BuiltInConnectionString::Http("http://localhost:8545".parse::<Url>().unwrap())
-        );
-        assert_eq!(
             BuiltInConnectionString::from_str("http://127.0.0.1:8545").unwrap(),
             BuiltInConnectionString::Http("http://127.0.0.1:8545".parse::<Url>().unwrap())
         );


### PR DESCRIPTION
- Removed a redundant assertion in test_parsing_urls that duplicated the exact same case for "localhost:8545".
- Parsing logic for "localhost:8545" is unambiguous: try_as_http prepends http:// and validates scheme; the behavior is already covered once.