### PR TITLE
feat: relax Clone bound for PollerBuilder and prepare_static_poller

### DIFF
--- a/crates/rpc-client/src/poller.rs
+++ b/crates/rpc-client/src/poller.rs
@@ -79,7 +79,7 @@ pub struct PollerBuilder<Params, Resp> {
 impl<Params, Resp> PollerBuilder<Params, Resp>
 where
     Params: RpcSend + 'static,
-    Resp: RpcRecv + Clone,
+    Resp: RpcRecv,
 {
     /// Create a new poller task.
     pub fn new(client: WeakClient, method: impl Into<Cow<'static, str>>, params: Params) -> Self {
@@ -145,13 +145,19 @@ where
     }
 
     /// Starts the poller in a new task, returning a channel to receive the responses on.
-    pub fn spawn(self) -> PollChannel<Resp> {
+    pub fn spawn(self) -> PollChannel<Resp>
+    where
+        Resp: Clone,
+    {
         let (tx, rx) = broadcast::channel(self.channel_size);
         self.into_future(tx).spawn_task();
         rx.into()
     }
 
-    async fn into_future(self, tx: broadcast::Sender<Resp>) {
+    async fn into_future(self, tx: broadcast::Sender<Resp>)
+    where
+        Resp: Clone,
+    {
         let mut stream = self.into_stream();
         while let Some(resp) = stream.next().await {
             if tx.send(resp).is_err() {


### PR DESCRIPTION
- Remove global Resp: Clone bound from PollerBuilder impl and RpcClient::prepare_static_poller; scope Clone to PollerBuilder::spawn (and its internal broadcast send path) only.
- Rationale: Clone is required by tokio::sync::broadcast used in spawn, but not by into_stream. The previous API over-constrained users by requiring Clone even when only using into_stream, preventing valid non-Clone response types.
- This change is backward compatible: spawn still requires Clone; into_stream now accepts broader types.