### PR TITLE
feat(beacon-types): `GetBlobsResponse`

### DIFF
--- a/crates/eips/src/eip4844/mod.rs
+++ b/crates/eips/src/eip4844/mod.rs
@@ -135,10 +135,11 @@ where
 
 /// Helper function to deserialize boxed blobs from a serde deserializer.
 #[cfg(all(debug_assertions, feature = "serde"))]
-pub(crate) fn deserialize_blobs<'de, D>(deserializer: D) -> Result<Vec<Blob>, D::Error>
+pub fn deserialize_blobs<'de, D>(deserializer: D) -> Result<alloc::vec::Vec<Blob>, D::Error>
 where
     D: serde::de::Deserializer<'de>,
 {
+    use alloc::vec::Vec;
     use serde::Deserialize;
 
     let raw_blobs = Vec::<alloy_primitives::Bytes>::deserialize(deserializer)?;
@@ -151,12 +152,11 @@ where
 
 #[cfg(all(not(debug_assertions), feature = "serde"))]
 #[inline(always)]
-pub(crate) fn deserialize_blobs<'de, D>(deserializer: D) -> Result<Vec<Blob>, D::Error>
+pub fn deserialize_blobs<'de, D>(deserializer: D) -> Result<alloc::vec::Vec<Blob>, D::Error>
 where
     D: serde::de::Deserializer<'de>,
 {
-    use serde::Deserialize;
-    Vec::<Blob>::deserialize(deserializer)
+    serde::Deserialize::deserialize(deserializer)
 }
 
 /// A heap allocated blob that serializes as 0x-prefixed hex string

--- a/crates/eips/src/eip4844/mod.rs
+++ b/crates/eips/src/eip4844/mod.rs
@@ -133,6 +133,19 @@ where
     Ok(blob)
 }
 
+/// Helper function to deserialize boxed blobs.
+#[cfg(feature = "serde")]
+pub fn deserialize_blobs<'de, D>(deserializer: D) -> Result<Vec<alloc::boxed::Box<Blob>>, D::Error>
+where
+    D: serde::de::Deserializer<'de>,
+{
+    use serde::Deserialize;
+    <Vec<alloy_primitives::Bytes>>::deserialize(deserializer)?
+        .into_iter()
+        .map(|blob| Blob::try_from(blob.as_ref()).map_err(serde::de::Error::custom))
+        .collect()
+}
+
 /// A heap allocated blob that serializes as 0x-prefixed hex string
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, alloy_rlp::RlpEncodableWrapper)]
 pub struct HeapBlob(Bytes);

--- a/crates/eips/src/eip4844/sidecar.rs
+++ b/crates/eips/src/eip4844/sidecar.rs
@@ -37,7 +37,7 @@ pub struct IndexedBlobHash {
 #[doc(alias = "BlobTxSidecar")]
 pub struct BlobTransactionSidecar {
     /// The blob data.
-    #[cfg_attr(feature = "serde", serde(deserialize_with = "deserialize_blobs"))]
+    #[cfg_attr(feature = "serde", serde(deserialize_with = "crate::eip4844::deserialize_blobs"))]
     pub blobs: Vec<Blob>,
     /// The blob commitments.
     pub commitments: Vec<Bytes48>,
@@ -477,32 +477,6 @@ impl Decodable7594 for BlobTransactionSidecar {
     fn decode_7594(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
         Self::rlp_decode_fields(buf)
     }
-}
-
-/// Helper function to deserialize boxed blobs from a serde deserializer.
-#[cfg(all(debug_assertions, feature = "serde"))]
-pub(crate) fn deserialize_blobs<'de, D>(deserializer: D) -> Result<Vec<Blob>, D::Error>
-where
-    D: serde::de::Deserializer<'de>,
-{
-    use serde::Deserialize;
-
-    let raw_blobs = Vec::<alloy_primitives::Bytes>::deserialize(deserializer)?;
-    let mut blobs = Vec::with_capacity(raw_blobs.len());
-    for blob in raw_blobs {
-        blobs.push(Blob::try_from(blob.as_ref()).map_err(serde::de::Error::custom)?);
-    }
-    Ok(blobs)
-}
-
-#[cfg(all(not(debug_assertions), feature = "serde"))]
-#[inline(always)]
-pub(crate) fn deserialize_blobs<'de, D>(deserializer: D) -> Result<Vec<Blob>, D::Error>
-where
-    D: serde::de::Deserializer<'de>,
-{
-    use serde::Deserialize;
-    Vec::<Blob>::deserialize(deserializer)
 }
 
 /// Helper function to deserialize boxed blobs from an existing [`MapAccess`]

--- a/crates/rpc-types-beacon/Cargo.toml
+++ b/crates/rpc-types-beacon/Cargo.toml
@@ -37,6 +37,7 @@ serde.workspace = true
 serde_json.workspace = true
 serde_with = { workspace = true, features = ["alloc"] }
 
+derive_more.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]

--- a/crates/rpc-types-beacon/src/sidecar.rs
+++ b/crates/rpc-types-beacon/src/sidecar.rs
@@ -50,7 +50,7 @@ pub struct GetBlobsResponse {
     /// Vec of individual blobs
     #[serde(deserialize_with = "deserialize_blobs")]
     #[into_iterator]
-    pub data: Vec<Box<Blob>>,
+    pub data: Vec<Blob>,
 }
 
 /// Intermediate type for BlobTransactionSidecar matching


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

`eth/v1/beacon/blob_sidecars` endpoint is now [deprecated](https://github.com/ethereum/beacon-APIs/pull/546) in favor of `eth/v1/beacon/blobs` which only returns blob bytes. This PR adds `GetBlobsResponse` type for it.

Not sure if `BeaconBlobBundle` is used for anything else but we might want to deprecate it as well

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
