### PR TITLE
chore: gate Vec import in rpc account module

### DIFF
--- a/crates/rpc-types-eth/src/account.rs
+++ b/crates/rpc-types-eth/src/account.rs
@@ -1,6 +1,6 @@
-#![allow(unused_imports)]
-
-use alloc::{string::String, vec::Vec};
+use alloc::string::String;
+#[cfg(feature = "serde")]
+use alloc::vec::Vec;
 use alloy_primitives::{Address, Bytes, B256, B512, KECCAK256_EMPTY, U256};
 
 // re-export account type for `eth_getAccount`


### PR DESCRIPTION
## Solution

Inline Vec behind serde and drop the global unused-import allow in account.rs

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
