### PR TITLE
fix: Use injected #alloy_rlp path in generated typed_decode error mapping

### DIFF
--- a/crates/tx-macros/src/expand.rs
+++ b/crates/tx-macros/src/expand.rs
@@ -568,7 +568,7 @@ impl Expander {
                 #(#variant_types: #alloy_eips::Decodable2718),*
             {
                 fn typed_decode(ty: u8, buf: &mut &[u8]) -> #alloy_eips::eip2718::Eip2718Result<Self> {
-                    match ty.try_into().map_err(|_| alloy_rlp::Error::Custom("unexpected tx type"))? {
+                    match ty.try_into().map_err(|_| #alloy_rlp::Error::Custom("unexpected tx type"))? {
                         #(#typed_decode_arms,)*
                     }
                 }


### PR DESCRIPTION
Replaced bare reference to alloy_rlp::Error::Custom with the injected #alloy_rlp::Error::Custom in the TransactionEnvelope derive expansion. This aligns with how other paths are injected and prevents potential resolution issues for downstream crates that don’t directly depend on alloy-rlp under the alloy_rlp name. Ensures consistency and robustness of the generated code across varying dependency configurations.