### PR TITLE
perf(serde): avoid allocation in B256 hex serialization

### DIFF
--- a/crates/serde/src/lib.rs
+++ b/crates/serde/src/lib.rs
@@ -8,6 +8,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate alloc;
+
 use alloy_primitives::{hex, B256};
 use serde::Serializer;
 

--- a/crates/serde/src/lib.rs
+++ b/crates/serde/src/lib.rs
@@ -8,8 +8,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate alloc;
-
-use alloc::format;
 use alloy_primitives::{hex, B256};
 use serde::Serializer;
 
@@ -46,5 +44,5 @@ pub fn serialize_b256_hex_string_no_prefix<S>(x: &B256, s: S) -> Result<S::Ok, S
 where
     S: Serializer,
 {
-    s.serialize_str(&format!("{x:x}"))
+    s.collect_str(&format_args!("{x:x}"))
 }


### PR DESCRIPTION


Description
- What: Replace serialize_str(&format!("{x:x}")) with collect_str(&format_args!("{x:x}")) in crates/serde/src/lib.rs.
- Why: Eliminates an intermediate String allocation on a hot serialization path, improving performance and reducing allocator pressure.
- How: Use Serializer::collect_str with format_args! to write directly to the serializer without allocating.

