### PR TITLE
refactor(network/any): remove redundant From<&AnyTxType> for u8 impl

### DIFF
--- a/crates/network/src/any/unknowns.rs
+++ b/crates/network/src/any/unknowns.rs
@@ -26,12 +26,6 @@ impl TryFrom<u8> for AnyTxType {
     }
 }
 
-impl From<&AnyTxType> for u8 {
-    fn from(value: &AnyTxType) -> Self {
-        value.0
-    }
-}
-
 impl From<AnyTxType> for u8 {
     fn from(value: AnyTxType) -> Self {
         value.0


### PR DESCRIPTION


Description
- What: Drop the duplicate conversion impl `From<&AnyTxType> for u8` from crates/network/src/any/unknowns.rs.
- Why: `AnyTxType` is Copy; having both by-value and by-ref conversions is redundant and bloats the API surface without added semantics.

