### PR TITLE
refactor(node-bindings): remove redundant bounds checks in extract_value

### DIFF
--- a/crates/node-bindings/src/utils.rs
+++ b/crates/node-bindings/src/utils.rs
@@ -42,18 +42,14 @@ pub(crate) fn extract_value<'a>(key: &str, line: &'a str) -> Option<&'a str> {
     if let Some(pos) = line.find(key_equal.as_ref()) {
         let start = pos + key_equal.len();
         let end = line[start..].find(' ').map(|i| start + i).unwrap_or(line.len());
-        if start <= line.len() && end <= line.len() {
-            return Some(line[start..end].trim());
-        }
+        return Some(line[start..end].trim());
     }
 
     // If not found, try to find the key with ': '
     if let Some(pos) = line.find(key_colon.as_ref()) {
         let start = pos + key_colon.len();
         let end = line[start..].find(',').map(|i| start + i).unwrap_or(line.len()); // Assuming comma or end of line
-        if start <= line.len() && end <= line.len() {
-            return Some(line[start..end].trim());
-        }
+        return Some(line[start..end].trim());
     }
 
     // If neither variant matches, return None


### PR DESCRIPTION

## Changes
- Removed unnecessary `start <= line.len() && end <= line.len()` bounds checks in `extract_value` utility function
- Simplified control flow by directly returning the trimmed slice

## Motivation
The bounds checks are redundant because:
- `start` is always valid (derived from `find()` position + key length)
- `end` is always valid (via `find().map().unwrap_or(line.len())`)


