### PR TITLE
fix(eip7547): InclusionListStatusV1 serialize_map size hint

### DIFF
--- a/crates/eip7547/src/summary.rs
+++ b/crates/eip7547/src/summary.rs
@@ -58,7 +58,7 @@ impl Serialize for InclusionListStatusV1 {
     where
         S: Serializer,
     {
-        let mut map = serializer.serialize_map(Some(3))?;
+        let mut map = serializer.serialize_map(Some(2))?;
         map.serialize_entry("status", self.status.as_str())?;
         map.serialize_entry("validationError", &self.status.validation_error())?;
         map.end()


### PR DESCRIPTION
The custom Serialize for InclusionListStatusV1 emits exactly two entries: status and validationError, but the serializer was initialized with serialize_map(Some(3)). This mismatch is incorrect and may cause unnecessary allocations. Aligning the size hint to 2 matches the actual output and mirrors patterns used elsewhere (e.g., PayloadStatus, JSON-RPC Response), ensuring accurate serialization behavior and clearer intent.