### PR TITLE
Fix signer utils error message to avoid misleading

### DIFF
--- a/crates/signer/src/utils.rs
+++ b/crates/signer/src/utils.rs
@@ -32,7 +32,7 @@ pub fn public_key_to_address(pubkey: &VerifyingKey) -> Address {
 #[inline]
 #[track_caller]
 pub fn raw_public_key_to_address(pubkey: &[u8]) -> Address {
-    assert_eq!(pubkey.len(), 64, "raw public key must be 64 bytes");
+    assert_eq!(pubkey.len(), 64, "raw public key must be 32 bytes, which is 64 characters");
     let digest = keccak256(pubkey);
     Address::from_slice(&digest[12..])
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
The error message in raw_public_key_to_address is misleading for code readers.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Update the text message.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
