### PR TITLE
chore(consensus): remove dummy once_cell import from lib.rs

### DIFF
--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -12,8 +12,6 @@ extern crate alloc;
 #[cfg(feature = "arbitrary")]
 use rand as _;
 
-use once_cell as _;
-
 pub use alloy_trie::TrieAccount;
 
 #[deprecated(since = "0.7.3", note = "use TrieAccount instead")]


### PR DESCRIPTION


### Motivation
Remove a dummy import used solely to silence unused dependency warnings. This improves build hygiene and makes dependency usage explicit.

