### PR TITLE
refactor(transport): remove variable shadowing in retry layer

### DIFF
--- a/crates/transport/src/layers/retry.rs
+++ b/crates/transport/src/layers/retry.rs
@@ -229,9 +229,9 @@ where
     }
 
     fn call(&mut self, request: RequestPacket) -> Self::Future {
-        let inner = self.inner.clone();
+        let cloned_inner = self.inner.clone();
         let this = self.clone();
-        let mut inner = std::mem::replace(&mut self.inner, inner);
+        let mut inner = std::mem::replace(&mut self.inner, cloned_inner);
         Box::pin(async move {
             let ahead_in_queue = this.requests_enqueued.fetch_add(1, Ordering::SeqCst) as u64;
             let mut rate_limit_retry_number: u32 = 0;


### PR DESCRIPTION

## Summary

Eliminate variable shadowing in retry service implementation to improve code readability and maintainability.

## Changes

- Rename first `inner` variable to `cloned_inner` in `RetryBackoffService::call`
- Remove variable shadowing that obscured which `inner` value was being used


