### PR TITLE
fix(provider): correct EthCallParams serialize length when no options set

### DIFF
--- a/crates/provider/src/provider/eth_call/params.rs
+++ b/crates/provider/src/provider/eth_call/params.rs
@@ -86,8 +86,10 @@ impl<N: Network> serde::Serialize for EthCallParams<N> {
             4
         } else if self.overrides().is_some() {
             3
-        } else {
+        } else if self.block().is_some() {
             2
+        } else {
+            1
         };
 
         let mut seq = serializer.serialize_seq(Some(len))?;


### PR DESCRIPTION
Previously reported seq length was 2 while emitting only 1 element when no block/overrides/block_overrides were set.
Now computes length as:
- 4 when block_overrides present
- 3 when overrides present
- 2 when only block present
- 1 when none present

Aligns with existing tests and avoids potential serde sequence length mismatches with non-JSON serializers.