### PR TITLE
feat: add block helper methods to EthCall and EthCallMany

### DIFF
--- a/crates/provider/src/provider/eth_call/call_many.rs
+++ b/crates/provider/src/provider/eth_call/call_many.rs
@@ -78,6 +78,48 @@ where
         self
     }
 
+    /// Set the block id to "pending".
+    pub fn pending(self) -> Self {
+        self.block(BlockId::pending())
+    }
+
+    /// Set the block id to "latest".
+    pub fn latest(self) -> Self {
+        self.block(BlockId::latest())
+    }
+
+    /// Set the block id to "earliest".
+    pub fn earliest(self) -> Self {
+        self.block(BlockId::earliest())
+    }
+
+    /// Set the block id to "finalized".
+    pub fn finalized(self) -> Self {
+        self.block(BlockId::finalized())
+    }
+
+    /// Set the block id to "safe".
+    pub fn safe(self) -> Self {
+        self.block(BlockId::safe())
+    }
+
+    /// Set the block id to a specific height.
+    pub fn number(self, number: u64) -> Self {
+        self.block(BlockId::number(number))
+    }
+
+    /// Set the block id to a specific hash, without requiring the hash be part
+    /// of the canonical chain.
+    pub fn hash(self, hash: alloy_primitives::B256) -> Self {
+        self.block(BlockId::hash(hash))
+    }
+
+    /// Set the block id to a specific hash and require the hash be part of the
+    /// canonical chain.
+    pub fn hash_canonical(self, hash: alloy_primitives::B256) -> Self {
+        self.block(BlockId::hash_canonical(hash))
+    }
+
     /// Set the [`TransactionIndex`] in the [`StateContext`].
     pub fn transaction_index(mut self, tx_index: TransactionIndex) -> Self {
         self.params = self.params.with_transaction_index(tx_index);

--- a/crates/provider/src/provider/eth_call/mod.rs
+++ b/crates/provider/src/provider/eth_call/mod.rs
@@ -287,6 +287,48 @@ where
         self.params.block = Some(block);
         self
     }
+
+    /// Set the block id to "pending".
+    pub const fn pending(self) -> Self {
+        self.block(BlockId::pending())
+    }
+
+    /// Set the block id to "latest".
+    pub const fn latest(self) -> Self {
+        self.block(BlockId::latest())
+    }
+
+    /// Set the block id to "earliest".
+    pub const fn earliest(self) -> Self {
+        self.block(BlockId::earliest())
+    }
+
+    /// Set the block id to "finalized".
+    pub const fn finalized(self) -> Self {
+        self.block(BlockId::finalized())
+    }
+
+    /// Set the block id to "safe".
+    pub const fn safe(self) -> Self {
+        self.block(BlockId::safe())
+    }
+
+    /// Set the block id to a specific height.
+    pub const fn number(self, number: u64) -> Self {
+        self.block(BlockId::number(number))
+    }
+
+    /// Set the block id to a specific hash, without requiring the hash be part
+    /// of the canonical chain.
+    pub const fn hash(self, hash: alloy_primitives::B256) -> Self {
+        self.block(BlockId::hash(hash))
+    }
+
+    /// Set the block id to a specific hash and require the hash be part of the
+    /// canonical chain.
+    pub const fn hash_canonical(self, hash: alloy_primitives::B256) -> Self {
+        self.block(BlockId::hash_canonical(hash))
+    }
 }
 
 impl<N> EthCall<N, Bytes>


### PR DESCRIPTION
Adds convenience methods for setting block IDs on `EthCall` and `EthCallMany`. These methods provide a more ergonomic API by delegating to the existing `block()` method with the appropriate `BlockId` variant.

## Added methods

- `pending()` - Set block to "pending"
- `latest()` - Set block to "latest"  
- `earliest()` - Set block to "earliest"
- `finalized()` - Set block to "finalized"
- `safe()` - Set block to "safe"
- `number(u64)` - Set block to a specific height
- `hash(B256)` - Set block to a specific hash (non-canonical)
- `hash_canonical(B256)` - Set block to a specific hash (canonical only)

All methods follow the same pattern as `BlockId` constructor methods and are const where possible.