### PR TITLE
feat: add methods to build EIP-7594 sidecars with default and custom settings

### DIFF
--- a/crates/eips/src/eip4844/builder.rs
+++ b/crates/eips/src/eip4844/builder.rs
@@ -449,27 +449,7 @@ impl<T: SidecarCoder> SidecarBuilder<T> {
         self,
         settings: &c_kzg::KzgSettings,
     ) -> Result<BlobTransactionSidecarEip7594, c_kzg::Error> {
-        let mut commitments = Vec::with_capacity(self.inner.blobs.len());
-        let mut proofs = Vec::with_capacity(self.inner.blobs.len());
-        for blob in &self.inner.blobs {
-            // SAFETY: same size
-            let blob = unsafe { core::mem::transmute::<&Blob, &c_kzg::Blob>(blob) };
-            let commitment = settings.blob_to_kzg_commitment(blob)?;
-            let (_cells, kzg_proofs) = settings.compute_cells_and_kzg_proofs(blob)?;
-
-            // SAFETY: same size
-            unsafe {
-                commitments
-                    .push(core::mem::transmute::<c_kzg::Bytes48, Bytes48>(commitment.to_bytes()));
-                for kzg_proof in kzg_proofs.iter() {
-                    proofs.push(core::mem::transmute::<c_kzg::Bytes48, Bytes48>(
-                        kzg_proof.to_bytes(),
-                    ));
-                }
-            }
-        }
-
-        Ok(BlobTransactionSidecarEip7594::new(self.inner.blobs, commitments, proofs))
+        self.build_7594_with_settings(settings)
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
sidecar builder was lacking a method to build for 7594 with default kzg settings

## Solution

- new fn to build with default kzg(mainnet) moved old functionality to a helper fn that accepts settings
- mark old fn as deprecated


<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
