### PR TITLE
refactor: name the stream type in PollChannel::into_stream

### DIFF
--- a/crates/rpc-client/src/lib.rs
+++ b/crates/rpc-client/src/lib.rs
@@ -25,7 +25,7 @@ mod client;
 pub use client::{ClientRef, NoParams, RpcClient, RpcClientInner, WeakClient};
 
 mod poller;
-pub use poller::{PollChannel, PollerBuilder, PollerStream};
+pub use poller::{PollChannel, PollerBuilder, PollerStream, PollStream};
 
 #[cfg(feature = "ws")]
 pub use alloy_transport_ws::WsConnect;


### PR DESCRIPTION
Closes the TODO on line 462. 

The `into_stream()` method now returns a named `PollStream<T>` type instead of `impl Stream`, so you can actually use it in type signatures.