### PR TITLE
Add transport-throttle feature

### DIFF
--- a/crates/alloy/Cargo.toml
+++ b/crates/alloy/Cargo.toml
@@ -282,6 +282,7 @@ transport-http = ["transports", "dep:alloy-transport-http"]
 transport-ipc = ["transports", "pubsub", "dep:alloy-transport-ipc"]
 transport-ipc-mock = ["alloy-transport-ipc?/mock"]
 transport-ws = ["transports", "pubsub", "dep:alloy-transport-ws"]
+transport-throttle = ["transports", "alloy-transport?/throttle"]
 
 # trie
 trie = ["dep:alloy-trie"]


### PR DESCRIPTION

## Motivation

The `alloy-transports` crate creates a convenient throttle layer to rate limit RPC requests on the client side, but it is only exposed with the `throttle` feature. This feature is not exposed in the `alloy` crate at all, so the user needs to import the `alloy-transports` separately to enable the feature. 

## Solution

Added the `transport-throttle` feature to the `alloy` crate to expose the `throttle` feature in the sub-crate.
