### PR TITLE
node-bindings(geth): remove duplicate --miner.etherbase arg in Clique mode

### DIFF
--- a/crates/node-bindings/src/nodes/geth.rs
+++ b/crates/node-bindings/src/nodes/geth.rs
@@ -487,7 +487,6 @@ impl Geth {
                 let extra_data_bytes =
                     [&[0u8; 32][..], clique_addr.as_ref(), &[0u8; 65][..]].concat();
                 genesis.extra_data = extra_data_bytes.into();
-                // extra: etherbase is set once below after clique address resolution
             }
 
             let clique_addr = self.clique_address().ok_or_else(|| {


### PR DESCRIPTION


### Description
- Summary: Remove a duplicated CLI argument passed to geth when Clique is enabled.
- Motivation: The same `--miner.etherbase` flag was added twice, which is redundant and can confuse readers and tooling.
- Change: Keep a single `--miner.etherbase` assignment.

