### PR TITLE
consensus: remove deprecated `convert_transaction` and `try_convert_transaction` methods

### DIFF
--- a/crates/consensus/src/transaction/recovered.rs
+++ b/crates/consensus/src/transaction/recovered.rs
@@ -106,7 +106,6 @@ impl<T> Recovered<T> {
         self.map(Tx::from)
     }
 
-
     /// Converts the inner signed object to the given alternative that is `TryFrom<T>`
     pub fn try_convert<Tx, E>(self) -> Result<Recovered<Tx>, Tx::Error>
     where
@@ -114,7 +113,6 @@ impl<T> Recovered<T> {
     {
         self.try_map(Tx::try_from)
     }
-
 
     /// Applies the given closure to the inner signed object.
     pub fn map<Tx>(self, f: impl FnOnce(T) -> Tx) -> Recovered<Tx> {


### PR DESCRIPTION


### Description
- **Summary**: Remove deprecated methods that duplicate existing functionality in `Recovered<T>`.
- **Motivation**: The deprecated methods `convert_transaction` and `try_convert_transaction` are redundant wrappers around `convert` and `try_convert` respectively, creating API bloat.
- **Change**: Delete the deprecated methods entirely; users should use `convert` and `try_convert` instead.
