### PR TITLE
fix: add defaults for blob response flags and drop unused serde_as

### DIFF
--- a/crates/rpc-types-beacon/src/sidecar.rs
+++ b/crates/rpc-types-beacon/src/sidecar.rs
@@ -8,7 +8,6 @@ use serde_with::{serde_as, DisplayFromStr};
 use std::vec::IntoIter;
 
 /// Bundle of blobs for a given block
-#[serde_as]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, derive_more::IntoIterator)]
 pub struct BeaconBlobBundle {
     /// Vec of individual blob data
@@ -42,10 +41,12 @@ impl BeaconBlobBundle {
 pub struct GetBlobsResponse {
     /// True if the response references an unverified execution payload. Optimistic information may
     /// be invalidated at a later time. If the field is not present, assume the False value.
+    #[serde(default)]
     pub execution_optimistic: bool,
     /// True if the response references the finalized history of the chain, as determined by fork
     /// choice. If the field is not present, additional calls are necessary to compare the epoch of
     /// the requested information with the finalized checkpoint.
+    #[serde(default)]
     pub finalized: bool,
     /// Vec of individual blobs
     #[serde(deserialize_with = "deserialize_blobs")]


### PR DESCRIPTION
The GetBlobsResponse fields execution_optimistic and finalized are documented as optional with a default of false when absent, but lacked #[serde(default)], making them effectively required and causing deserialization failures when BE nodes omit them. Added #[serde(default)] to align with the docs and Beacon API expectations. Also removed an unused #[serde_as] attribute from BeaconBlobBundle to reduce noise and match style used elsewhere in the crate.