### PR TITLE
feat(envelope): add try_into_* consuming helpers for EthereumTxEnvelope and tests

### DIFF
--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -1487,7 +1487,7 @@ mod tests {
             Signature::test_signature(),
             Default::default(),
         ));
-        
+
         let result = legacy_tx.try_into_legacy();
         assert!(result.is_ok());
     }
@@ -1499,7 +1499,7 @@ mod tests {
             Signature::test_signature(),
             Default::default(),
         ));
-        
+
         let result = eip1559_tx.try_into_legacy();
         assert!(result.is_err());
         let error = result.unwrap_err();
@@ -1516,7 +1516,7 @@ mod tests {
             Signature::test_signature(),
             Default::default(),
         ));
-        
+
         let result = eip2930_tx.try_into_eip2930();
         assert!(result.is_ok());
     }
@@ -1528,7 +1528,7 @@ mod tests {
             Signature::test_signature(),
             Default::default(),
         ));
-        
+
         let result = legacy_tx.try_into_eip2930();
         assert!(result.is_err());
         let error = result.unwrap_err();
@@ -1544,7 +1544,7 @@ mod tests {
             Signature::test_signature(),
             Default::default(),
         ));
-        
+
         let result = eip1559_tx.try_into_eip1559();
         assert!(result.is_ok());
     }
@@ -1556,7 +1556,7 @@ mod tests {
             Signature::test_signature(),
             Default::default(),
         ));
-        
+
         let result = eip2930_tx.try_into_eip1559();
         assert!(result.is_err());
         let error = result.unwrap_err();
@@ -1572,7 +1572,7 @@ mod tests {
             Signature::test_signature(),
             Default::default(),
         ));
-        
+
         let result = eip4844_tx.try_into_eip4844();
         assert!(result.is_ok());
     }
@@ -1584,7 +1584,7 @@ mod tests {
             Signature::test_signature(),
             Default::default(),
         ));
-        
+
         let result = eip1559_tx.try_into_eip4844();
         assert!(result.is_err());
         let error = result.unwrap_err();
@@ -1600,7 +1600,7 @@ mod tests {
             Signature::test_signature(),
             Default::default(),
         ));
-        
+
         let result = eip7702_tx.try_into_eip7702();
         assert!(result.is_ok());
     }
@@ -1612,7 +1612,7 @@ mod tests {
             Signature::test_signature(),
             Default::default(),
         ));
-        
+
         let result = eip4844_tx.try_into_eip7702();
         assert!(result.is_err());
         let error = result.unwrap_err();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
closes https://github.com/alloy-rs/alloy/issues/3061

## Solution

Add try_into_legacy, try_into_eip2930, try_into_eip1559, try_into_eip4844 and try_into_eip7702 that consume the envelope and return the matching Signed<T> or a ValueError preserving the original envelope. Include unit tests for each success and failure case, asserting error messages and that the original envelope can be recovered from the ValueError.


<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
