### PR TITLE
fix: bpo config parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ alloy-eip2930 = { version = "0.2.0", default-features = false }
 alloy-eip7702 = { version = "0.6.1", default-features = false }
 
 # hardforks
-alloy-hardforks = "0.2.0"
+alloy-hardforks = "0.3.5"
 
 # ethereum
 ethereum_ssz_derive = "0.9"

--- a/crates/genesis/Cargo.toml
+++ b/crates/genesis/Cargo.toml
@@ -27,6 +27,7 @@ alloy-eips = { workspace = true, features = ["serde"] }
 alloy-primitives.workspace = true
 alloy-serde.workspace = true
 alloy-trie = { workspace = true, features = ["ethereum"] }
+alloy-hardforks.workspace = true
 
 # serde
 serde.workspace = true

--- a/crates/genesis/src/lib.rs
+++ b/crates/genesis/src/lib.rs
@@ -17,6 +17,7 @@ use alloy_eips::{
     eip7840::{self, BlobParams},
     BlobScheduleBlobParams,
 };
+use alloy_hardforks::EthereumHardfork;
 use alloy_primitives::{keccak256, Address, Bytes, B256, U256};
 use alloy_serde::{storage::deserialize_storage_map, OtherFields};
 use alloy_trie::{TrieAccount, EMPTY_ROOT_HASH, KECCAK_EMPTY};
@@ -871,28 +872,28 @@ impl ChainConfig {
                 .with_max_blobs_per_tx(eip7594::MAX_BLOBS_PER_TX_FUSAKA);
 
             match key.as_str() {
-                "osaka" => osaka = Some(params),
-                "bpo1" => {
+                val if val == EthereumHardfork::Osaka.name() => osaka = Some(params),
+                val if val == EthereumHardfork::Bpo1.name() => {
                     if let Some(timestamp) = self.bpo1_time {
                         scheduled.push((timestamp, params));
                     }
                 }
-                "bpo2" => {
+                val if val == EthereumHardfork::Bpo2.name() => {
                     if let Some(timestamp) = self.bpo2_time {
                         scheduled.push((timestamp, params));
                     }
                 }
-                "bpo3" => {
+                val if val == EthereumHardfork::Bpo3.name() => {
                     if let Some(timestamp) = self.bpo3_time {
                         scheduled.push((timestamp, params));
                     }
                 }
-                "bpo4" => {
+                val if val == EthereumHardfork::Bpo4.name() => {
                     if let Some(timestamp) = self.bpo4_time {
                         scheduled.push((timestamp, params));
                     }
                 }
-                "bpo5" => {
+                val if val == EthereumHardfork::Bpo5.name() => {
                     if let Some(timestamp) = self.bpo5_time {
                         scheduled.push((timestamp, params));
                     }


### PR DESCRIPTION
## Description

In `alloy-genesis`, the bpo hardforks are matched by incorrect literal strings which broke the computation of the `blob_schedule_blob_params`. This PR fixes that by ensuring we're matching against the names provided by the `alloy-hardforks` crate.