### PR TITLE
fix(transport): decrement request counter on retry limit exceeded

### DIFF
--- a/crates/transport/src/layers/retry.rs
+++ b/crates/transport/src/layers/retry.rs
@@ -255,6 +255,7 @@ where
                 if should_retry {
                     rate_limit_retry_number += 1;
                     if rate_limit_retry_number > this.max_rate_limit_retries {
+                        this.requests_enqueued.fetch_sub(1, Ordering::SeqCst);
                         return Err(TransportErrorKind::custom_str(&format!(
                             "Max retries exceeded {err}"
                         )));


### PR DESCRIPTION


The `RetryBackoffService` has a counter leak when retry attempts are exhausted. When `rate_limit_retry_number` exceeds `max_rate_limit_retries`, the service returns an error without decrementing the `requests_enqueued` counter. This causes the queue size metric to become inaccurate, leading to incorrect backoff calculations in subsequent requests.

Added `fetch_sub(1, Ordering::SeqCst)` before the early return when retry limit is exceeded. This ensures the counter is properly decremented in all error paths, maintaining accurate queue metrics and preventing excessive backoff delays.

