### PR TITLE
refactor(json-rpc): improve `RequestPacket::is_empty` implementation

### DIFF
--- a/crates/json-rpc/src/packet.rs
+++ b/crates/json-rpc/src/packet.rs
@@ -95,7 +95,10 @@ impl RequestPacket {
 
     /// Check if the packet is empty.
     pub fn is_empty(&self) -> bool {
-        self.len() == 0
+        match self {
+            Self::Single(_) => false,
+            Self::Batch(batch) => batch.is_empty(),
+        }
     }
 
     /// Push a request into the packet.


### PR DESCRIPTION


## Description

The current `RequestPacket::is_empty` implementation uses `self.len() == 0` which is less idiomatic than using pattern matching and `Vec::is_empty()` directly.

## Solution

- Replace `self.len() == 0` with pattern matching on enum variants
- Use `batch.is_empty()` for `Batch` variant instead of computing length
- Maintain identical behavior while improving code clarity and following Rust idioms

