### PR TITLE
fix(rpc-client): remove redundant into_box_transport

### DIFF
--- a/crates/rpc-client/src/client.rs
+++ b/crates/rpc-client/src/client.rs
@@ -251,7 +251,7 @@ impl RpcClientInner {
         Self {
             #[cfg(feature = "pubsub")]
             pubsub,
-            ..Self::new(t.into_box_transport(), is_local)
+            ..Self::new(t, is_local)
         }
     }
 


### PR DESCRIPTION
This change removes an unnecessary into_box_transport call in RpcClientInner::new_maybe_pubsub and delegates boxing to RpcClientInner::new, which already performs the conversion. The behavior remains identical because IntoBoxTransport specializes to avoid reboxing when the input is already a BoxTransport. The adjustment simplifies the code path and keeps boxing responsibilities centralized without altering runtime characteristics.