### PR TITLE
docs(local-signer): add `with_chain_id` to match crate docs example

### DIFF
--- a/crates/signer-local/src/lib.rs
+++ b/crates/signer-local/src/lib.rs
@@ -161,6 +161,15 @@ impl<C: PrehashSigner<(ecdsa::Signature, RecoveryId)>> LocalSigner<C> {
     pub const fn chain_id(&self) -> Option<ChainId> {
         self.chain_id
     }
+
+    /// Returns a new signer with the given chain ID (builder-style).
+    ///
+    /// This matches the usage in the crate-level docs.
+    #[inline]
+    pub fn with_chain_id(mut self, chain_id: Option<ChainId>) -> Self {
+        self.chain_id = chain_id;
+        self
+    }
 }
 
 // do not log the signer


### PR DESCRIPTION
### description

The crate-level docs demonstrate using `with_chain_id(Some(...))` on `LocalSigner`, but the method didn’t exist on the type. This PR adds a minimal builder-style helper:

```rust
pub fn with_chain_id(mut self, chain_id: Option<ChainId>) -> Self
```

It aligns the API with the docs, improves ergonomics, and doesn’t alter existing behavior (the mutable `set_chain_id` remains available).
