### PR TITLE
fix: correct gas field types in Header::size() method

### DIFF
--- a/crates/consensus/src/block/header.rs
+++ b/crates/consensus/src/block/header.rs
@@ -249,8 +249,8 @@ impl Header {
         mem::size_of::<Bloom>() + // logs bloom
         mem::size_of::<U256>() + // difficulty
         mem::size_of::<BlockNumber>() + // number
-        mem::size_of::<u128>() + // gas limit
-        mem::size_of::<u128>() + // gas used
+        mem::size_of::<u64>() + // gas limit
+        mem::size_of::<u64>() + // gas used
         mem::size_of::<u64>() + // timestamp
         mem::size_of::<B256>() + // mix hash
         mem::size_of::<u64>() + // nonce


### PR DESCRIPTION
Fix incorrect memory size calculation for gas_limit and gas_used fields in Header::size() method. 

These fields are defined as u64 in the struct but were being calculated as u128, causing inaccurate memory size estimates.