### PR TITLE
fix(node-bindings): parse key=value correctly with comma delimiter

### DIFF
--- a/crates/node-bindings/src/utils.rs
+++ b/crates/node-bindings/src/utils.rs
@@ -24,8 +24,8 @@ pub(crate) fn unused_port() -> u16 {
 /// Extracts the value for the given key from the line of text.
 ///
 /// It supports keys that end with '=' or ': '.
-/// For keys end with '=', find value until ' ' is encountered or end of line
-/// For keys end with ':', find value until ',' is encountered or end of line
+/// For keys ending with '=', find value until ',' or ' ' is encountered, or end of line.
+/// For keys ending with ':', find value until ',' is encountered, or end of line.
 pub(crate) fn extract_value<'a>(key: &str, line: &'a str) -> Option<&'a str> {
     let mut key_equal = Cow::from(key);
     let mut key_colon = Cow::from(key);
@@ -41,7 +41,10 @@ pub(crate) fn extract_value<'a>(key: &str, line: &'a str) -> Option<&'a str> {
     // Try to find the key with '='
     if let Some(pos) = line.find(key_equal.as_ref()) {
         let start = pos + key_equal.len();
-        let end = line[start..].find(' ').map(|i| start + i).unwrap_or(line.len());
+        let end = line[start..]
+            .find(|c: char| c == ',' || c == ' ')
+            .map(|i| start + i)
+            .unwrap_or(line.len());
         if start <= line.len() && end <= line.len() {
             return Some(line[start..end].trim());
         }


### PR DESCRIPTION
## Summary

Fix value extraction for `key=value` format to stop at comma delimiter, preventing parsing errors when multiple key-value pairs are present.

## Problem

The `extract_value` function for `key=value` format only stopped at space characters, causing it to capture subsequent key-value pairs when parsing lines like `endpoint=127.0.0.1:8545,other=value`.


