### PR TITLE
feat: implement CallBuilder::legacy() to prefer legacy by setting gas_price

### DIFF
--- a/crates/contract/src/call.rs
+++ b/crates/contract/src/call.rs
@@ -424,16 +424,6 @@ impl<P: Provider<N>, D: CallDecoder, N: Network> CallBuilder<P, D, N> {
         self
     }
 
-    /// Uses a Legacy transaction instead of an EIP-1559 one to execute the call
-    pub fn legacy(mut self) -> Self {
-        if self.request.gas_price().is_none() {
-            if let Some(max_fee) = self.request.max_fee_per_gas() {
-                self.request.set_gas_price(max_fee);
-            }
-        }
-        self
-    }
-
     /// Sets the `gas` field in the transaction to the provided value
     pub fn gas(mut self, gas: u64) -> Self {
         self.request.set_gas_limit(gas);


### PR DESCRIPTION
Implement CallBuilder::legacy() so that it prefers building legacy transactions without breaking abstractions. The method sets gas_price when it is not present using max_fee_per_gas as a reasonable fallback and returns self, letting the underlying transaction request handle type selection and conflict trimming. This keeps behavior consistent with preferred_type and provider gas filling logic and respects EIP-2930, 4844, and 7702 semantics.