### PR TITLE
refactor(rpc-types-trace): remove redundant AddressFilter methods

### DIFF
--- a/crates/rpc-types-trace/src/filter.rs
+++ b/crates/rpc-types-trace/src/filter.rs
@@ -115,7 +115,6 @@ impl From<Vec<Address>> for AddressFilter {
     }
 }
 
-
 /// `TraceFilterMatcher` is a filter used for matching `TransactionTrace` based on it's action and
 /// result (if available).
 ///


### PR DESCRIPTION

Remove duplicate `AddressFilter::matches()` and `AddressFilter::is_empty()` methods that were simply wrapping the underlying `AddressHashSet` operations.

