### PR TITLE
chore: expose WebSocketConfig in RPC client and provider for non-WASM builds

### DIFF
--- a/crates/provider/src/lib.rs
+++ b/crates/provider/src/lib.rs
@@ -56,6 +56,9 @@ pub use alloy_transport as transport;
 #[cfg(feature = "ws")]
 pub use alloy_rpc_client::WsConnect;
 
+#[cfg(all(feature = "ws", not(target_family = "wasm")))]
+pub use alloy_rpc_client::WebSocketConfig;
+
 #[cfg(feature = "ipc")]
 pub use alloy_rpc_client::IpcConnect;
 

--- a/crates/rpc-client/src/lib.rs
+++ b/crates/rpc-client/src/lib.rs
@@ -30,6 +30,9 @@ pub use poller::{PollChannel, PollerBuilder, PollerStream};
 #[cfg(feature = "ws")]
 pub use alloy_transport_ws::WsConnect;
 
+#[cfg(all(feature = "ws", not(target_family = "wasm")))]
+pub use alloy_transport_ws::WebSocketConfig;
+
 #[cfg(all(feature = "ipc", not(target_family = "wasm")))]
 pub use alloy_transport_ipc::IpcConnect;
 


### PR DESCRIPTION
Exposing the `WebSocketConfig` from the alloy-provider to not require any extra dependency to use it.

Re-export it to make it available from: `alloy_provider` -> `alloy_rpc_client` -> `alloy_transport_ws`

Example usage: `use alloy_provider::{WsConnect, WebSocketConfig};`
