### PR TITLE
chore(network): remove outdated TODO about Ethereum-only block responses

### DIFF
--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -39,8 +39,6 @@ pub use alloy_network_primitives::{
 /// Captures type info for network-specific RPC requests/responses.
 ///
 /// Networks are only containers for types, so it is recommended to use ZSTs for their definition.
-// todo: block responses are ethereum only, so we need to include this in here too, or make `Block`
-// generic over tx/header type
 pub trait Network: Debug + Clone + Copy + Sized + Send + Sync + 'static {
     // -- Consensus types --
 


### PR DESCRIPTION
Removed a stale TODO in crates/network/src/lib.rs claiming block responses are Ethereum-only.
The Network trait already defines an associated BlockResponse type and AnyNetwork implements it via AnyRpcBlock, so the comment is misleading.