### PR TITLE
docs: add MEV API limitations and timing warnings

### DIFF
--- a/crates/provider/src/ext/mev/mod.rs
+++ b/crates/provider/src/ext/mev/mod.rs
@@ -14,6 +14,20 @@ use alloy_rpc_types_mev::{
 pub const FLASHBOTS_SIGNATURE_HEADER: &str = "x-flashbots-signature";
 
 /// This module provides support for interacting with non-standard MEV-related RPC endpoints.
+///
+/// # Important Notes
+///
+/// MEV operations are extremely time-sensitive and should be executed as quickly as possible.
+/// Bundle submissions have strict timing requirements and may fail if submitted too late.
+///
+/// ## Common Limitations
+///
+/// - Bundle size limits vary by relay (typically 1-10 transactions)
+/// - Timeout constraints apply to simulation and execution
+/// - Rate limiting may be enforced by MEV relays
+/// - Authentication is required for most operations
+///
+/// See [Flashbots documentation](https://docs.flashbots.net/flashbots-auction/searchers/advanced/rpc-endpoint) for detailed limitations.
 #[cfg_attr(target_family = "wasm", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_family = "wasm"), async_trait::async_trait)]
 pub trait MevApi<N>: Send + Sync {
@@ -25,6 +39,11 @@ pub trait MevApi<N>: Send + Sync {
 
     /// Sends a MEV bundle using the `eth_sendBundle` RPC method.
     /// Returns the resulting bundle hash on success.
+    ///
+    /// # Timing Critical
+    ///
+    /// Bundle submission is extremely time-sensitive. Submit as early as possible
+    /// in the block interval to maximize inclusion probability.
     fn send_bundle(
         &self,
         bundle: EthSendBundle,
@@ -65,6 +84,11 @@ pub trait MevApi<N>: Send + Sync {
 
     /// Sends a MEV bundle using the `mev_sendBundle` RPC method.
     /// Returns the resulting bundle hash on success.
+    ///
+    /// # Timing Critical
+    ///
+    /// Bundle submission is extremely time-sensitive. Submit as early as possible
+    /// in the block interval to maximize inclusion probability.
     fn send_mev_bundle(
         &self,
         bundle: MevSendBundle,


### PR DESCRIPTION
Added documentation to MEV API trait covering timing constraints, bundle size limits, and rate limiting. 
Included warnings about critical timing requirements for bundle submissions to help developers avoid common pitfalls when using MEV operations.
