### PR TITLE
hore(provider): remove unused BlockHeader import

### DIFF
--- a/crates/provider/src/heart.rs
+++ b/crates/provider/src/heart.rs
@@ -1,7 +1,6 @@
 //! Block heartbeat and pending transaction watcher.
 
 use crate::{blocks::Paused, Provider, RootProvider};
-use alloy_consensus::BlockHeader;
 use alloy_json_rpc::RpcError;
 use alloy_network::{BlockResponse, Network};
 use alloy_primitives::{


### PR DESCRIPTION
drop the unused alloy_consensus::BlockHeader import from crates/provider/src/heart.rs
keeps the module free from redundant dependencies and the unused-import lint clean
