### PR TITLE
transport: move alloy_primitives to dev-deps

### DIFF
--- a/crates/transport/Cargo.toml
+++ b/crates/transport/Cargo.toml
@@ -24,7 +24,6 @@ workspace = true
 
 [dependencies]
 alloy-json-rpc.workspace = true
-alloy-primitives.workspace = true
 
 base64.workspace = true
 futures-utils-wasm.workspace = true
@@ -42,6 +41,10 @@ futures.workspace = true
 parking_lot.workspace = true
 derive_more.workspace = true
 auto_impl.workspace = true
+
+# Test-only dependencies
+[dev-dependencies]
+alloy-primitives.workspace = true
 
 # non-WASM only
 [target.'cfg(not(target_family = "wasm"))'.dependencies]

--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -6,8 +6,6 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
-use alloy_primitives as _;
-
 mod boxed;
 pub use boxed::{BoxTransport, IntoBoxTransport};
 


### PR DESCRIPTION
 https://github.com/alloy-rs/alloy/pull/3094

reopened the changes from a fresh branch after push auth issues with the previous PR
required to unblock CI and satisfy the original review

remove the dummy use alloy_primitives as _; from alloy/crates/transport/src/lib.rs
move alloy-primitives from [dependencies] to [dev-dependencies] since only tests need it
