### PR TITLE
refactor(provider): simplify `HyperClient` init with `layer` method

### DIFF
--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -1484,28 +1484,14 @@ mod tests {
         crate::ext::test::async_ci_only(|| async move {
             use alloy_node_bindings::Reth;
             use alloy_rpc_types_engine::JwtSecret;
-            use alloy_transport_http::{AuthLayer, AuthService, Http, HyperClient};
+            use alloy_transport_http::{AuthLayer, Http, HyperClient};
 
             let secret = JwtSecret::random();
 
             let reth =
                 Reth::new().arg("--rpc.jwtsecret").arg(hex::encode(secret.as_bytes())).spawn();
 
-            let hyper_client =
-                Client::builder(TokioExecutor::new()).build_http::<Full<HyperBytes>>();
-
-            let service =
-                tower::ServiceBuilder::new().layer(AuthLayer::new(secret)).service(hyper_client);
-
-            let layer_transport: HyperClient<
-                Full<HyperBytes>,
-                AuthService<
-                    Client<
-                        alloy_transport_http::hyper_util::client::legacy::connect::HttpConnector,
-                        Full<HyperBytes>,
-                    >,
-                >,
-            > = HyperClient::with_service(service);
+            let layer_transport = HyperClient::new().layer(AuthLayer::new(secret));
 
             let http_hyper = Http::with_client(layer_transport, reth.endpoint_url());
 


### PR DESCRIPTION
## Motivation

Close #2988

Make `HyperClient` composable.

## Solution

- Introduced a new `layer` method in `HyperClient` to apply middleware layers, enhancing composability.
- Updated documentation for the new method with an example usage.
- Removed unnecessary service construction in provider tests which basically demonstrates the benefit of this new `layer` method.

## PR Checklist

- [x] Added Tests (Updated existing one)
- [x] Added Documentation
- [ ] Breaking changes
