### PR TITLE
Remove unused Debug import in transport error module

### DIFF
--- a/crates/transport/src/error.rs
+++ b/crates/transport/src/error.rs
@@ -1,7 +1,7 @@
 use alloy_json_rpc::{ErrorPayload, Id, RpcError, RpcResult};
 use serde::Deserialize;
 use serde_json::value::RawValue;
-use std::{error::Error as StdError, fmt::Debug};
+use std::error::Error as StdError;
 use thiserror::Error;
 
 /// A transport error is an [`RpcError`] containing a [`TransportErrorKind`].


### PR DESCRIPTION
The crates/transport/src/error.rs module derives Debug on its types, so the explicit std::fmt::Debug import was unused and flagged during review.
Change: Dropped the redundant fmt::Debug import; the derive-generated impls remain untouched.