### PR TITLE
chore(network): remove redundant EIP flags

### DIFF
--- a/crates/network/src/ethereum/builder.rs
+++ b/crates/network/src/ethereum/builder.rs
@@ -1,6 +1,5 @@
 use crate::{
-    BuildResult, Ethereum, Network, NetworkWallet, TransactionBuilder, TransactionBuilder7702,
-    TransactionBuilderError,
+    BuildResult, Ethereum, Network, NetworkWallet, TransactionBuilder, TransactionBuilderError,
 };
 use alloy_consensus::{TxType, TypedTransaction};
 use alloy_primitives::{Address, Bytes, ChainId, TxKind, U256};
@@ -140,14 +139,9 @@ impl TransactionBuilder<Ethereum> for TransactionRequest {
         let common = self.gas.is_some() && self.nonce.is_some();
 
         let legacy = self.gas_price.is_some();
-        let eip2930 = legacy && self.access_list().is_some();
-
         let eip1559 = self.max_fee_per_gas.is_some() && self.max_priority_fee_per_gas.is_some();
 
-        let eip4844 = eip1559 && self.sidecar.is_some() && self.to.is_some();
-
-        let eip7702 = eip1559 && self.authorization_list().is_some();
-        common && (legacy || eip2930 || eip1559 || eip4844 || eip7702)
+        common && (legacy || eip1559)
     }
 
     #[doc(alias = "output_transaction_type")]


### PR DESCRIPTION
- Replace common && (legacy || eip2930 || eip1559 || eip4844 || eip7702) with common && (legacy || eip1559).
- Remove unused local flags (eip2930, eip4844, eip7702) to avoid redundancy.

Rationale: Under current TransactionRequest semantics, EIP‑2930 implies legacy, and EIP‑4844/EIP‑7702 imply 1559 fields, so the coarse buildability reduces to legacy or 1559. Aligns with project style and avoids no‑op branches.