### PR TITLE
Restrict consensus transaction tests to the serde feature

### DIFF
--- a/crates/consensus/src/transaction/mod.rs
+++ b/crates/consensus/src/transaction/mod.rs
@@ -574,15 +574,13 @@ impl<T: TxHashRef> TxHashRef for alloy_eips::eip2718::WithEncoded<T> {
     }
 }
 
-#[cfg(test)]
-#[allow(unused_imports)]
+#[cfg(all(test, feature = "serde"))]
 mod tests {
     use crate::{Signed, TransactionEnvelope, TxEip1559, TxEnvelope, TxType};
     use alloy_primitives::Signature;
     use rand::Rng;
 
     #[test]
-    #[cfg(feature = "serde")]
     fn test_custom_envelope() {
         use serde::{Serialize, Serializer};
         fn serialize_with<S: Serializer>(


### PR DESCRIPTION
Gate the transaction test module behind cfg(all(test, feature = "serde"))
Drop the unused-import allowance and redundant function-level guard