### PR TITLE
Chore(provider): remove redundant Debug import from WalletFillers

### DIFF
--- a/crates/provider/src/fillers/wallet.rs
+++ b/crates/provider/src/fillers/wallet.rs
@@ -1,5 +1,3 @@
-use std::fmt::Debug;
-
 use crate::{provider::SendableTx, Provider};
 use alloy_json_rpc::RpcError;
 use alloy_network::{Network, NetworkWallet, TransactionBuilder};


### PR DESCRIPTION
Remove the unused std::fmt::Debug import from WalletFiller keep compiler warnings clean without affecting behavior