### PR TITLE
fix(pubsub): avoid BiBTreeMap remove/insert in SubscriptionManager::notify

### DIFF
--- a/crates/pubsub/src/managers/sub.rs
+++ b/crates/pubsub/src/managers/sub.rs
@@ -89,9 +89,8 @@ impl SubscriptionManager {
     /// exists, the notification is dropped.
     pub(crate) fn notify(&mut self, notification: EthNotification) {
         if let Some(local_id) = self.local_id_for(&notification.subscription) {
-            if let Some((_, sub)) = self.local_to_sub.remove_by_left(&local_id) {
+            if let Some(sub) = self.local_to_sub.get_by_left(&local_id) {
                 sub.notify(notification.result);
-                self.local_to_sub.insert(local_id, sub);
             }
         }
     }


### PR DESCRIPTION
Replace remove_by_left/insert with get_by_left in SubscriptionManager::notify().

ActiveSubscription::notify(&self, Box<RawValue>) does not require mutable or owned access to the subscription; borrowing via get_by_left is sufficient. EthNotification carries an owned Box<RawValue>, so passing it to notify remains correct.

This change eliminates unnecessary map removals/insertions (and potential allocations), reduces contention and churn on BiBTreeMap, and preserves behavior.