### PR TITLE
Chore(eip5792): remove redundant Vec import

### DIFF
--- a/crates/eip5792/src/call.rs
+++ b/crates/eip5792/src/call.rs
@@ -1,5 +1,4 @@
 use alloy_primitives::{map::HashMap, Address, Bytes, ChainId, U256};
-use std::vec::Vec;
 
 /// Request that a wallet submits a batch of calls in `wallet_sendCalls`
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]


### PR DESCRIPTION
Drop the explicit std::vec::Vec import, since Vec is already available from the Rust prelude