### PR TITLE
fix!(provider): use Option<Account> for get_account

### DIFF
--- a/crates/provider/src/fillers/mod.rs
+++ b/crates/provider/src/fillers/mod.rs
@@ -426,7 +426,10 @@ where
         self.inner.get_account_info(address)
     }
 
-    fn get_account(&self, address: Address) -> RpcWithBlock<Address, alloy_consensus::Account> {
+    fn get_account(
+        &self,
+        address: Address,
+    ) -> RpcWithBlock<Address, Option<alloy_consensus::Account>> {
         self.inner.get_account(address)
     }
 

--- a/crates/provider/src/provider/erased.rs
+++ b/crates/provider/src/provider/erased.rs
@@ -141,7 +141,10 @@ impl<N: Network> Provider<N> for DynProvider<N> {
         self.0.get_account_info(address)
     }
 
-    fn get_account(&self, address: Address) -> RpcWithBlock<Address, alloy_consensus::Account> {
+    fn get_account(
+        &self,
+        address: Address,
+    ) -> RpcWithBlock<Address, Option<alloy_consensus::Account>> {
         self.0.get_account(address)
     }
 

--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -330,7 +330,10 @@ pub trait Provider<N: Network = Ethereum>: Send + Sync {
 
     /// Retrieves account information ([Account](alloy_consensus::Account)) for the given [Address]
     /// at the particular [BlockId].
-    fn get_account(&self, address: Address) -> RpcWithBlock<Address, alloy_consensus::Account> {
+    fn get_account(
+        &self,
+        address: Address,
+    ) -> RpcWithBlock<Address, Option<alloy_consensus::Account>> {
         self.client().request("eth_getAccount", address).into()
     }
 


### PR DESCRIPTION
## Motivation

This endpoint actually returns an option, ie the account can be `null` if not found.

## Solution

Use `Option<Account>` instead of `Account`

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
