### PR TITLE
fix: trezor derivation path

### DIFF
--- a/crates/signer-trezor/src/types.rs
+++ b/crates/signer-trezor/src/types.rs
@@ -21,7 +21,7 @@ pub enum DerivationType {
 impl fmt::Display for DerivationType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match self {
-            Self::TrezorLive(index) => write!(f, "m/44'/60'/{index}'/0/0"),
+            Self::TrezorLive(index) => write!(f, "m/44'/60'/0'/0/{index}"),
             Self::Other(inner) => f.write_str(inner),
         }
     }


### PR DESCRIPTION
fixed the use of index in derivation path to comply with usual address discovery with trezor (eg in Rabby).
Usually, index refers to the address index in the account 0, cc [Trezor blog](https://trezor.io/learn/advanced/standards-proposals/what-is-bip44)

## Motivation

Tried to interact with trezor signer using an address generated through Rabby at an index > 0, which failed, specifying the index in the `DerivationType::TrezorLive`. Noticed it is because current implementation uses the `index` as a BIP44 account, while in my interpretation it refers to address index in account 0. This seems to be the standard interpretation as this is also how Rabby generates addresses from Trezor device.

## Solution

Moved the `index` from the position of the account to the position of the address index. Alternative solution is to have two variables: one for the account and one for the address index. I don t know how common it is to use an account > 0.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [x] Breaking changes
