### PR TITLE
docs: fix EIP-2930 transaction handling documentation

### DIFF
--- a/crates/provider/src/fillers/gas.rs
+++ b/crates/provider/src/fillers/gas.rs
@@ -35,10 +35,11 @@ pub enum GasFillable {
 /// ## Note:
 ///
 /// The layer will populate gas fields based on the following logic:
-/// - if `gas_price` is set, it will process as a legacy tx and populate the `gas_limit` field if
-///   unset.
-/// - if `access_list` is set, it will process as a 2930 tx and populate the `gas_limit` and
-///   `gas_price` field if unset.
+/// - if `gas_price` is set, it will process as a legacy tx (or EIP-2930 if `access_list` is also
+///   set) and populate the `gas_limit` field if unset, and `gas_price` if unset for EIP-2930.
+/// - if `access_list` is set but `gas_price` is not set, it will process as an EIP-1559 tx (which
+///   can also have an access_list) and populate the `gas_limit`, `max_fee_per_gas` and
+///   `max_priority_fee_per_gas` fields if unset.
 /// - if `blob_sidecar` is set, it will process as an EIP-4844 tx and populate the `gas_limit`,
 ///   `max_fee_per_gas`, and `max_priority_fee_per_gas` fields if unset. The `max_fee_per_blob_gas`
 ///   is populated by [`BlobGasFiller`].


### PR DESCRIPTION
Clarify that EIP-2930 transactions require both gas_price and access_list.

When only access_list is set (without gas_price), the transaction is processed as EIP-1559, which also supports access lists.