### PR TITLE
refactor(consensus): remove Borsh skip attributes from tx structs

### DIFF
--- a/crates/consensus/src/transaction/eip1559.rs
+++ b/crates/consensus/src/transaction/eip1559.rs
@@ -57,8 +57,6 @@ pub struct TxEip1559 {
     /// The 160-bit address of the message call’s recipient or, for a contract creation
     /// transaction, ∅, used here to denote the only member of B0 ; formally Tt.
     #[cfg_attr(feature = "serde", serde(default))]
-    #[cfg_attr(feature = "borsh", borsh(skip))]
-    // TODO: Implement Borsh for TxKind in alloy_primitives
     pub to: TxKind,
     /// A scalar value equal to the number of Wei to
     /// be transferred to the message call’s recipient or,
@@ -75,8 +73,6 @@ pub struct TxEip1559 {
     // sometimes returning `null` instead of an empty array `[]`.
     // More details in <https://github.com/alloy-rs/alloy/pull/2450>.
     #[cfg_attr(feature = "serde", serde(deserialize_with = "alloy_serde::null_as_default"))]
-    #[cfg_attr(feature = "borsh", borsh(skip))]
-    // TODO: Implement Borsh for AccessList in alloy_eip2930
     pub access_list: AccessList,
     /// Input has two uses depending if `to` field is Create or Call.
     /// pub init: An unlimited size byte array specifying the

--- a/crates/consensus/src/transaction/eip2930.rs
+++ b/crates/consensus/src/transaction/eip2930.rs
@@ -44,8 +44,6 @@ pub struct TxEip2930 {
     /// The 160-bit address of the message call’s recipient or, for a contract creation
     /// transaction, ∅, used here to denote the only member of B0 ; formally Tt.
     #[cfg_attr(feature = "serde", serde(default))]
-    #[cfg_attr(feature = "borsh", borsh(skip))]
-    // TODO: Implement Borsh for TxKind in alloy_primitives
     pub to: TxKind,
     /// A scalar value equal to the number of Wei to
     /// be transferred to the message call’s recipient or,
@@ -59,8 +57,6 @@ pub struct TxEip2930 {
     /// and `accessed_storage_keys` global sets (introduced in EIP-2929).
     /// A gas cost is charged, though at a discount relative to the cost of
     /// accessing outside the list.
-    #[cfg_attr(feature = "borsh", borsh(skip))]
-    // TODO: Implement Borsh for AccessList in alloy_eip2930
     pub access_list: AccessList,
     /// Input has two uses depending if `to` field is Create or Call.
     /// pub init: An unlimited size byte array specifying the

--- a/crates/consensus/src/transaction/eip4844.rs
+++ b/crates/consensus/src/transaction/eip4844.rs
@@ -568,8 +568,6 @@ pub struct TxEip4844 {
     /// and `accessed_storage_keys` global sets (introduced in EIP-2929).
     /// A gas cost is charged, though at a discount relative to the cost of
     /// accessing outside the list.
-    #[cfg_attr(feature = "borsh", borsh(skip))]
-    // TODO: Implement Borsh for AccessList in alloy_eip2930
     pub access_list: AccessList,
 
     /// It contains a vector of fixed size hash(32 bytes)

--- a/crates/consensus/src/transaction/eip7702.rs
+++ b/crates/consensus/src/transaction/eip7702.rs
@@ -70,14 +70,10 @@ pub struct TxEip7702 {
     /// and `accessed_storage_keys` global sets (introduced in EIP-2929).
     /// A gas cost is charged, though at a discount relative to the cost of
     /// accessing outside the list.
-    #[cfg_attr(feature = "borsh", borsh(skip))]
-    // TODO: Implement Borsh for AccessList in alloy_eip2930
     pub access_list: AccessList,
     /// Authorizations are used to temporarily set the code of its signer to
     /// the code referenced by `address`. These also include a `chain_id` (which
     /// can be set to zero and not evaluated) as well as an optional `nonce`.
-    #[cfg_attr(feature = "borsh", borsh(skip))]
-    // TODO: Implement Borsh for SignedAuthorization in alloy_eip7702
     pub authorization_list: Vec<SignedAuthorization>,
     /// An unlimited size byte array specifying the
     /// input data of the message call, formally Td.

--- a/crates/eips/Cargo.toml
+++ b/crates/eips/Cargo.toml
@@ -125,4 +125,6 @@ arbitrary = [
 borsh = [
 	"dep:borsh",
 	"alloy-primitives/borsh",
+	"alloy-eip2930/borsh",
+	"alloy-eip7702/borsh",
 ]


### PR DESCRIPTION
## Motivation

Follow-up for #2946

Since core and eips were bumped we don't need anymore to skip Borsh on `TxKind` and `AccessList` and `SignedAuthorization` fields in the EIP-1559, EIP-2930, EIP-4844, and EIP-7702 transaction structs.



## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
