### PR TITLE
docs: fix incorrect type reference in as_eip4844 docstring

### DIFF
--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -388,7 +388,7 @@ impl<Eip4844: RlpEcdsaEncodableTx> EthereumTxEnvelope<Eip4844> {
         }
     }
 
-    /// Returns the EIP-4844 variant if the transaction is an EIP-4844 transaction.
+    /// Returns the [`Eip4844`] variant if the transaction is an EIP-4844 transaction.
     pub const fn as_eip4844(&self) -> Option<&Signed<Eip4844>> {
         match self {
             Self::Eip4844(tx) => Some(tx),


### PR DESCRIPTION
The docstring for `as_eip4844()` was referencing `TxEip4844Variant` specifically, but the function actually returns the generic `Eip4844` type parameter. This was confusing since `EthereumTxEnvelope<Eip4844>` can work with different concrete types (TxEip4844Variant, TxEip4844, TxEip4844WithSidecar)
