### PR TITLE
remove unused itertools import from wallet provider tests

### DIFF
--- a/crates/provider/src/provider/wallet.rs
+++ b/crates/provider/src/provider/wallet.rs
@@ -93,7 +93,6 @@ where
 mod test {
     use super::*;
     use crate::ProviderBuilder;
-    use itertools::Itertools;
 
     #[test]
     fn basic_usage() {


### PR DESCRIPTION
drop the dangling `itertools::Itertools` import from the wallet provider test module keep the test suite free from `unused_imports` warnings enforced by the workspace lints