### PR TITLE
fix: encode TraceFilter after/count as QUANTITY

### DIFF
--- a/crates/rpc-types-trace/src/filter.rs
+++ b/crates/rpc-types-trace/src/filter.rs
@@ -28,8 +28,10 @@ pub struct TraceFilter {
     #[serde(default)]
     pub mode: TraceFilterMode,
     /// Output offset
+    #[serde(with = "alloy_serde::quantity::opt")]
     pub after: Option<u64>,
     /// Output amount
+    #[serde(with = "alloy_serde::quantity::opt")]
     pub count: Option<u64>,
 }
 


### PR DESCRIPTION
This change updates the TraceFilter fields after and count to use Ethereum JSON-RPC QUANTITY (hex) encoding via alloy_serde::quantity::opt. OpenEthereum/Parity trace_filter expects these pagination fields as hex quantities; previously they were serialized as decimal JSON numbers and would fail to parse hex input, leading to incompatibilities with nodes. Aligning these fields with the existing fromBlock/toBlock handling ensures correct wire format for both serialization and deserialization and brings consistency across the RPC types.