### PR TITLE
fix(provider): skip cache for eth_getLogs with dynamic block tags

### DIFF
--- a/crates/provider/src/layers/cache.rs
+++ b/crates/provider/src/layers/cache.rs
@@ -197,15 +197,15 @@ where
     }
 
     async fn get_logs(&self, filter: &Filter) -> TransportResult<Vec<Log>> {
-        if filter.block_hash.is_none() {
+        if filter.block_option.as_block_hash().is_none() {
+            // if block options have dynamic range we can't cache them
             let from_is_number = filter
-                .from_block
+                .block_option
+                .get_from_block()
                 .as_ref()
-                .is_some_and(|block| matches!(block, BlockNumberOrTag::Number(_)));
-            let to_is_number = filter
-                .to_block
-                .as_ref()
-                .is_some_and(|block| matches!(block, BlockNumberOrTag::Number(_)));
+                .is_some_and(|block| block.is_number());
+            let to_is_number =
+                filter.block_option.get_to_block().as_ref().is_some_and(|block| block.is_number());
 
             if !from_is_number || !to_is_number {
                 return self.inner.get_logs(filter).await;


### PR DESCRIPTION


The `CacheProvider::get_logs` method was caching responses for all `eth_getLogs` requests, including those with dynamic block tags (`latest`, `pending`, `finalized`, `safe`). This caused clients to receive stale log data when querying for recent events, breaking event monitoring and notification systems.

Other cache-aware methods (`get_code_at`, `get_proof`, `get_storage_at`) already skip caching for dynamic block identifiers, but `get_logs` was missing this check.


