### PR TITLE
Feat/poller reconnect

### DIFF
--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -1336,7 +1336,6 @@ mod tests {
     use alloy_rpc_types_eth::{request::TransactionRequest, Block};
     use alloy_signer_local::PrivateKeySigner;
     use alloy_transport::layers::{RetryBackoffLayer, RetryPolicy};
-    use futures::StreamExt;
     use std::{io::Read, str::FromStr, time::Duration};
 
     // For layer transport tests


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
Resolves #3150 
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

This is how I imagine the flow to be

```txt

    Poller starts with params: (filter_id_123,)
    Makes RPC calls: eth_getFilterChanges(filter_id_123)
    Server responds: "filter not found"
    Poller says: "Let me get new params"
    Poller calls reconnection logic: (old_filter_id) → (new_filter_id)
    Poller continues with new params: (filter_id_456,)

```
In terms of code, I imagine it to look like this
```
let poller = PollerBuilder::new(client, "eth_getFilterChanges", (filter_id,))
     .with_reconnect(|weak_client| async move {
        let client = weak_client.upgrade().ok_or("client dropped")?;
        let new_filter = client.request_noparams("eth_newBlockFilter").await?;
        serde_json::value::to_raw_value(&(new_filter,))
         .map_err(TransportError::ser_err)
 });
```
PS: I kinda tested this, I wasn't able to recreate the filter dropping, couldn't get the right amount of time to wait such that it drops but I did try if it does enter the error if it updates the params with the ```with_reconnect``` function. And it does.
## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
