### PR TITLE
chore: Avoid cloning EIP-4844 sidecar during request build

### DIFF
--- a/crates/rpc-types-eth/src/transaction/request.rs
+++ b/crates/rpc-types-eth/src/transaction/request.rs
@@ -577,7 +577,7 @@ impl TransactionRequest {
     pub fn build_4844_with_sidecar(mut self) -> Result<TxEip4844WithSidecar, ValueError<Self>> {
         self.populate_blob_hashes();
 
-        let Some(sidecar) = self.sidecar.clone() else {
+        let Some(sidecar) = self.sidecar.take() else {
             return Err(ValueError::new(self, "Missing 'sidecar' field for Eip4844 transaction."));
         };
 


### PR DESCRIPTION
Issue: build_4844_with_sidecar always cloned the BlobTransactionSidecar, triggering redundant allocation and violating redundant_clone. Fix: Move the sidecar out of self.sidecar with take(), preserving behavior while removing the unnecessary clone. Verification: cargo check (pending – cargo unavailable on this machine). Recommend running cargo check and cargo test -p alloy-rpc-types-eth once available.