### PR TITLE
Avoid redundant clones in StorageSlotFinder::find_slot

### DIFF
--- a/crates/contract/src/storage_slot.rs
+++ b/crates/contract/src/storage_slot.rs
@@ -130,27 +130,28 @@ where
     /// any encoding or hashing. For mappings, the actual storage location might be
     /// computed using keccak256 hashing.
     pub async fn find_slot(self) -> Result<Option<B256>, TransportError> {
-        let tx = self.base_request.clone().with_to(self.contract).with_input(self.calldata.clone());
-
+        let Self { provider, contract, calldata, expected_value, base_request, .. } = self;
+        let tx = base_request.with_to(contract).with_input(calldata);
+        
         // first collect all the slots that are used by the function call
-        let access_list_result = self.provider.create_access_list(&tx.clone()).await?;
+        let access_list_result = provider.create_access_list(&tx).await?;
         let access_list = access_list_result.access_list;
         // iterate over all the accessed slots and try to find the one that contains the
         // target value by overriding the slot and checking the function call result
         for item in access_list.0 {
-            if item.address != self.contract {
+            if item.address != contract {
                 continue;
             };
             for slot in &item.storage_keys {
                 let account_override = AccountOverride::default().with_state_diff(std::iter::once(
-                    (*slot, B256::from(self.expected_value.to_be_bytes())),
+                    (*slot, B256::from(expected_value.to_be_bytes())),
                 ));
 
                 let state_override = StateOverridesBuilder::default()
-                    .append(self.contract, account_override)
+                    .append(contract, account_override)
                     .build();
 
-                let Ok(result) = self.provider.call(tx.clone()).overrides(state_override).await
+                let Ok(result) = provider.call(tx.clone()).overrides(state_override).await
                 else {
                     // overriding this slot failed
                     continue;
@@ -161,7 +162,7 @@ where
                     continue;
                 };
 
-                if result_value == self.expected_value {
+                if result_value == expected_value {
                     return Ok(Some(*slot));
                 }
             }


### PR DESCRIPTION
inline destructure StorageSlotFinder state so the prepared TransactionRequest is reused without extra cloning reuse the shared request when creating the access list while keeping call semantics unchanged