### PR TITLE
refactor: remove unnecessary Encode bound in parse_request_payload

### DIFF
--- a/crates/rpc-types-beacon/src/requests.rs
+++ b/crates/rpc-types-beacon/src/requests.rs
@@ -95,7 +95,7 @@ mod ssz_requests_conversions {
                     request_type: u8,
                 ) -> Result<Vec<T>, TryFromRequestsError>
                 where
-                    Vec<T>: Decode + Encode,
+                    T: Decode,
                 {
                     let list: Vec<T> = Vec::from_ssz_bytes(payload)
                         .map_err(|e| SszDecodeError(request_type, e))?;


### PR DESCRIPTION
Tightened the generic bound in crates/rpc-types-beacon/src/requests.rs for parse_request_payload from Vec<T>: Decode + Encode to T: Decode because the function only calls Vec::::from_ssz_bytes and never encodes, making Encode redundant; this reduces unnecessary constraints and improves clarity without changing behavior, since Vec<T> implements Decode when T: Decode.