### PR TITLE
feat: unbox BlockOverrides in TraceCallRequest

### DIFF
--- a/crates/rpc-types-trace/src/tracerequest.rs
+++ b/crates/rpc-types-trace/src/tracerequest.rs
@@ -19,7 +19,7 @@ pub struct TraceCallRequest<TxReq = TransactionRequest> {
     /// Optional: StateOverride
     pub state_overrides: Option<StateOverride>,
     /// Optional: BlockOverrides
-    pub block_overrides: Option<Box<BlockOverrides>>,
+    pub block_overrides: Option<BlockOverrides>,
 }
 
 impl<TxReq> TraceCallRequest<TxReq> {
@@ -50,7 +50,7 @@ impl<TxReq> TraceCallRequest<TxReq> {
 
     /// Sets the [`BlockOverrides`]
     /// Note: this is optional
-    pub fn with_block_overrides(mut self, block_overrides: Box<BlockOverrides>) -> Self {
+    pub fn with_block_overrides(mut self, block_overrides: BlockOverrides) -> Self {
         self.block_overrides = Some(block_overrides);
         self
     }


### PR DESCRIPTION
Changed replaces Option<Box> with Option in TraceCallRequest and updates the builder to accept BlockOverrides by value, removing an unnecessary heap allocation and aligning the API with the rest of the codebase where BlockOverrides is carried unboxed (EthCallParams, GethDebugTracingCallOptions, SimBlock). The serde shape is unchanged, and ergonomics improve by eliminating forced boxing. EvmOverrides remains intentionally boxed as documented, so this change targets only the TraceCallRequest inconsistency.