### PR TITLE
Ensure `convert_to_hashes` returns hash-only blocks

### DIFF
--- a/crates/provider/src/utils.rs
+++ b/crates/provider/src/utils.rs
@@ -134,7 +134,7 @@ pub(crate) fn convert_to_hashes<BlockResp: alloy_network::BlockResponse>(
     r: Option<BlockResp>,
 ) -> Option<BlockResp> {
     r.map(|mut block| {
-        if block.transactions().is_empty() {
+        if !block.transactions().is_hashes() {
             block.transactions_mut().convert_to_hashes();
         }
 


### PR DESCRIPTION


**Description:**
- fix `convert_to_hashes` so it always converts full transactions to hashes, matching the hashes-only request contract  
- keeps block responses lightweight and consistent for batching layers

