### PR TITLE
fix(contract): correct event filter test assertions

### DIFF
--- a/crates/contract/src/event.rs
+++ b/crates/contract/src/event.rs
@@ -364,10 +364,10 @@ mod tests {
             .await
             .expect("no receipt");
 
-        // we sent the wrong event
-        // so no events should be returned when querying event.query() (MyEvent)
+        // The wrong event is not matched, but the previously emitted MyEvent remains
         let all = event.query().await.unwrap();
-        assert_eq!(all.len(), 0);
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].0, expected_event);
 
         #[cfg(feature = "pubsub")]
         {
@@ -405,10 +405,10 @@ mod tests {
                 .await
                 .expect("no receipt");
 
-            // we sent the wrong event
-            // so no events should be returned when querying event.query() (MyEvent)
+            // The wrong event is not matched, but the previously emitted MyEvent remains
             let all = event.query().await.unwrap();
-            assert_eq!(all.len(), 0);
+            assert_eq!(all.len(), 1);
+            assert_eq!(all[0].0, expected_event);
         }
     }
 
@@ -470,10 +470,10 @@ mod tests {
             .await
             .expect("no receipt");
 
-        // we sent the wrong event
-        // so no events should be returned when querying event.query() (MyEvent)
+        // The wrong event is not matched, but the previously emitted MyEvent remains
         let all = event.query().await.unwrap();
-        assert_eq!(all.len(), 0);
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].0, expected_event);
 
         #[cfg(feature = "pubsub")]
         {
@@ -513,10 +513,10 @@ mod tests {
                 .await
                 .expect("no receipt");
 
-            // we sent the wrong event
-            // so no events should be returned when querying event.query() (MyEvent)
+            // The wrong event is not matched, but the previously emitted MyEvent remains
             let all = event.query().await.unwrap();
-            assert_eq!(all.len(), 0);
+            assert_eq!(all.len(), 1);
+            assert_eq!(all[0].0, expected_event);
         }
     }
 }


### PR DESCRIPTION
The event filter tests have wrong assertions since commit 23429c62.

After emitting WrongEvent, the test expects query() to return 0 logs. But MyEvent from block 2 is still in the blockchain, so query() returns 1. The filter works correctly - it ignores WrongEvent. The test just expects the wrong result. Historical logs don't disappear.
Fixed 4 assertions: changed `assert_eq!(all.len(), 0)` to `assert_eq!(all.len(), 1)`.