### PR TITLE
fix(provider): use fillable parameter in ChainIdFiller::fill

### DIFF
--- a/crates/provider/src/fillers/chain_id.rs
+++ b/crates/provider/src/fillers/chain_id.rs
@@ -93,10 +93,14 @@ impl<N: Network> TxFiller<N> for ChainIdFiller {
 
     async fn fill(
         &self,
-        _fillable: Self::Fillable,
+        fillable: Self::Fillable,
         mut tx: SendableTx<N>,
     ) -> TransportResult<SendableTx<N>> {
-        self.fill_sync(&mut tx);
+        if let Some(builder) = tx.as_mut_builder() {
+            if builder.chain_id().is_none() {
+                builder.set_chain_id(fillable);
+            }
+        }
         Ok(tx)
     }
 }


### PR DESCRIPTION
ChainIdFiller::fill now uses the fillable parameter directly instead of calling fill_sync again. 

This matches the pattern used by other fillers and ensures the prepare() result is properly utilized.