### PR TITLE
fix(rpc-types-engine): remove const from CancunPayloadFields::new

### DIFF
--- a/crates/rpc-types-engine/src/cancun.rs
+++ b/crates/rpc-types-engine/src/cancun.rs
@@ -22,7 +22,8 @@ pub struct CancunPayloadFields {
 
 impl CancunPayloadFields {
     /// Returns a new [`CancunPayloadFields`] instance.
-    pub const fn new(parent_beacon_block_root: B256, versioned_hashes: Vec<B256>) -> Self {
+    #[allow(clippy::missing_const_for_fn)]
+    pub fn new(parent_beacon_block_root: B256, versioned_hashes: Vec<B256>) -> Self {
         Self { parent_beacon_block_root, versioned_hashes }
     }
 }


### PR DESCRIPTION
Remove const modifier from CancunPayloadFields::new since Vec parameters cannot be used in const fn contexts. Add clippy allow attribute to suppress the false positive warning about making the function const.


