### PR TITLE
fix: guard 1-byte Eip658Value decode to avoid panic

### DIFF
--- a/crates/consensus/src/receipt/status.rs
+++ b/crates/consensus/src/receipt/status.rs
@@ -165,6 +165,9 @@ impl Decodable for Eip658Value {
         match h.payload_length {
             0 => Ok(Self::Eip658(false)),
             1 => {
+                if buf.remaining() < 1 {
+                    return Err(Error::InputTooShort);
+                }
                 let status = buf.get_u8() != 0;
                 Ok(status.into())
             }


### PR DESCRIPTION
Added a remaining-length check before reading the single byte in Eip658Value’s Decodable::decode when payload_length == 1. Without the guard, buf.get_u8() can panic on truncated input because Header::decode advances past the header without guaranteeing payload availability. The 32-byte branch already checks remaining() and returnsError::InputTooShort for underflow; this update mirrors that behavior for the 1-byte branch, aligns with existing patterns in the codebase (e.g., EIP-2718 decoders), and ensures malformed inputs return an error instead of panicking.