### PR TITLE
chore(consensus): drop unused Debug import

### DIFF
--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -9,7 +9,6 @@ use crate::{
 };
 use alloy_eips::{eip2718::Encodable2718, eip7594::Encodable7594};
 use alloy_primitives::{Bytes, Signature, B256};
-use core::fmt::Debug;
 
 /// The Ethereum [EIP-2718] Transaction Envelope.
 ///


### PR DESCRIPTION
remove the unused core::fmt::Debug import from transaction/envelope.rs, keep the consensus crate warning-free under the workspace lint settings