### PR TITLE
docs(rpc-types-engine): correct ExecutionPayloadV3 spec URL and Execu…

### DIFF
--- a/crates/rpc-types-engine/src/payload.rs
+++ b/crates/rpc-types-engine/src/payload.rs
@@ -653,7 +653,7 @@ impl ssz::Encode for ExecutionPayloadV2 {
 
 /// This structure maps on the ExecutionPayloadV3 structure of the beacon chain spec.
 ///
-/// See also: <https://github.com/ethereum/execution-apis/blob/6709c2a795b707202e93c4f2867fa0bf2640a84f/src/engine/shanghai.md#executionpayloadv2>
+/// See also: <https://github.com/ethereum/execution-apis/blob/fe8e13c288c592ec154ce25c534e26cb7ce0530d/src/engine/cancun.md#executionpayloadv3>
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
@@ -1277,7 +1277,7 @@ impl ExecutionPayload {
         Ok(base_block)
     }
 
-    /// Converts [`ExecutionPayloadV1`] to [`Block`].
+    /// Converts [`ExecutionPayload`] to [`Block`].
     ///
     /// Caution: This does not set fields that are not part of the payload and only part of the
     /// [`ExecutionPayloadSidecar`]:


### PR DESCRIPTION
Corrects `ExecutionPayloadV3` doc to reference the Cancun V3 spec instead of Shanghai V2 spec, as V3 was introduced in the Cancun hardfork 
Fixes `ExecutionPayload::try_into_block` doc that incorrectly referenced `ExecutionPayloadV1` when the method operates on the `ExecutionPayload` enum.