### PR TITLE
fix(rpc-types): remove const from RpcModules::new

### DIFF
--- a/crates/rpc-types/src/rpc.rs
+++ b/crates/rpc-types/src/rpc.rs
@@ -13,7 +13,8 @@ pub struct RpcModules {
 
 impl RpcModules {
     /// Create a new instance of `RPCModules`
-    pub const fn new(module_map: HashMap<String, String>) -> Self {
+    #[allow(clippy::missing_const_for_fn)]
+    pub fn new(module_map: HashMap<String, String>) -> Self {
         Self { module_map }
     }
 


### PR DESCRIPTION
HashMap cannot be created in const context, so marking the function as const was semantically incorrect. The function now correctly reflects that it cannot be called in const contexts.
