### PR TITLE
feat(rpc-types): add `FillTransaction` response type

### DIFF
--- a/crates/rpc-types-eth/src/transaction/mod.rs
+++ b/crates/rpc-types-eth/src/transaction/mod.rs
@@ -26,7 +26,7 @@ mod receipt;
 pub use receipt::TransactionReceipt;
 
 pub mod request;
-pub use request::{TransactionInput, TransactionInputKind, TransactionRequest};
+pub use request::{FillTransaction, TransactionInput, TransactionInputKind, TransactionRequest};
 
 /// Serde-bincode-compat
 #[cfg(all(feature = "serde", feature = "serde-bincode-compat"))]

--- a/crates/rpc-types-eth/src/transaction/request.rs
+++ b/crates/rpc-types-eth/src/transaction/request.rs
@@ -1754,6 +1754,16 @@ pub struct BuildTransactionErr<T = TransactionRequest> {
 #[non_exhaustive]
 pub struct TransactionInputError;
 
+/// Response type for `eth_fillTransaction`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct FillTransaction<T = TypedTransaction> {
+    /// RLP-encoded signed transaction bytes.
+    pub raw: Bytes,
+    /// Filled transaction request with populated default values.
+    pub tx: T,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Motivation

https://github.com/foundry-rs/foundry/pull/12595 follow-up

## Solution

upstream `FillTransaction` response struct to `alloy-rpc-types-eth`

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
