### PR TITLE
fix: with_poll_interval doc to reflect shared atomic behavior

### DIFF
--- a/crates/rpc-client/src/client.rs
+++ b/crates/rpc-client/src/client.rs
@@ -147,8 +147,9 @@ impl RpcClient {
 
     /// Sets the poll interval for the client in milliseconds.
     ///
-    /// Note: This will only set the poll interval for the client if it is the only reference to the
-    /// inner client. If the reference is held by many, then it will not update the poll interval.
+    /// Note: This updates the shared poll interval on the underlying client and is visible to all
+    /// clones of this client. Existing pollers created via `prepare_static_poller(...)`
+    /// snapshot the interval at construction time and will not pick up subsequent changes.
     pub fn with_poll_interval(self, poll_interval: Duration) -> Self {
         self.inner().set_poll_interval(poll_interval);
         self


### PR DESCRIPTION
The with_poll_interval documentation incorrectly stated that the poll interval would only be set if this client held unique ownership of the inner client. In practice, with_poll_interval uses set_poll_interval, which stores to an AtomicU64 inside Arc, so the change is visible to all clones. This commit corrects the note to describe the shared atomic behavior and clarifies that PollerBuilder and PollerStream snapshot the poll interval at construction time and therefore will not observe subsequent changes, while future pollers created after the change will.