### PR TITLE
refactor: remove redundant trait bounds in CloneTransport impl

### DIFF
--- a/crates/transport/src/boxed.rs
+++ b/crates/transport/src/boxed.rs
@@ -78,7 +78,7 @@ trait CloneTransport: Transport + std::any::Any {
 
 impl<T> CloneTransport for T
 where
-    T: Transport + Clone + Send + Sync,
+      T: Transport + Clone,
 {
     #[inline]
     fn clone_box(&self) -> Box<dyn CloneTransport + Send + Sync> {


### PR DESCRIPTION
What Changed
File: crates/transport/src/boxed.rs
Lines: 79-82
Removed + Send + Sync from the where clause of impl<T> CloneTransport for T
The Transport trait already includes Send + Sync + 'static as supertraits (defined in trait.rs:36-44), making these bounds redundant when specified again in the implementation block.