### PR TITLE
fix(rpc-types): correct BeaconExecutionPayloadV3 doc

### DIFF
--- a/crates/rpc-types-beacon/src/payload.rs
+++ b/crates/rpc-types-beacon/src/payload.rs
@@ -383,7 +383,7 @@ pub mod beacon_payload_v2 {
 #[serde_as]
 #[derive(Debug, Serialize, Deserialize)]
 struct BeaconExecutionPayloadV3<'a> {
-    /// Inner V1 payload
+    /// Inner V2 payload
     #[serde(flatten)]
     payload_inner: BeaconExecutionPayloadV2<'a>,
     #[serde_as(as = "DisplayFromStr")]

--- a/crates/rpc-types-engine/src/payload.rs
+++ b/crates/rpc-types-engine/src/payload.rs
@@ -667,7 +667,7 @@ pub struct ExecutionPayloadV3 {
     /// See <https://github.com/ethereum/execution-apis/blob/fe8e13c288c592ec154ce25c534e26cb7ce0530d/src/engine/cancun.md#ExecutionPayloadV3>
     #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
     pub blob_gas_used: u64,
-    /// Array of hex[`u64`] representing excess blob gas, enabled with V3
+    /// Array of hex [`u64`] representing excess blob gas, enabled with V3
     /// See <https://github.com/ethereum/execution-apis/blob/fe8e13c288c592ec154ce25c534e26cb7ce0530d/src/engine/cancun.md#ExecutionPayloadV3>
     #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
     pub excess_blob_gas: u64,


### PR DESCRIPTION
Fixes BeaconExecutionPayloadV3 doc comment that incorrectly stated "Inner V1 payload" when the field type is BeaconExecutionPayloadV2 and adds missing space in excess_blob_gas field doc.
