### PR TITLE
remove redundant double conversion in Filter::address

### DIFF
--- a/crates/contract/src/event.rs
+++ b/crates/contract/src/event.rs
@@ -2,7 +2,7 @@ use crate::Error;
 use alloy_network::Ethereum;
 use alloy_primitives::{Address, LogData, B256};
 use alloy_provider::{FilterPollerBuilder, Network, Provider};
-use alloy_rpc_types_eth::{BlockNumberOrTag, Filter, FilterBlockOption, Log, Topic, ValueOrArray};
+use alloy_rpc_types_eth::{BlockNumberOrTag, Filter, FilterBlockOption, FilterSet, Log, Topic};
 use alloy_sol_types::SolEvent;
 use alloy_transport::TransportResult;
 use futures::Stream;


### PR DESCRIPTION
Removes redundant double `.into()` conversion in `Filter::address()` and `Event::address()` methods by changing the generic constraint from `Into<ValueOrArray<Address>>` to `Into<FilterSet<Address>>