### PR TITLE
Remove heartbeat check and return Err on unsigned tx

### DIFF
--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -1059,15 +1059,9 @@ pub trait Provider<N: Network = Ethereum>: Send + Sync {
         &self,
         tx: SendableTx<N>,
     ) -> TransportResult<N::ReceiptResponse> {
-        // Make sure to initialize heartbeat before we submit transaction, so that
-        // we don't miss it if user will subscriber to it immediately after sending.
-        let _handle = self.root().get_heart();
-
         match tx {
-            SendableTx::Builder(mut tx) => {
-                alloy_network::TransactionBuilder::prep_for_submission(&mut tx);
-                let receipt = self.client().request("eth_sendTransactionSync", (tx,)).await?;
-                Ok(receipt)
+            SendableTx::Builder(_) => {
+               Err(RpcError::local_usage_str("unsigned tx not supported"))
             }
             SendableTx::Envelope(tx) => {
                 let encoded_tx = tx.encoded_2718();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

https://github.com/alloy-rs/alloy/pull/3177#discussion_r2544577731
https://github.com/alloy-rs/alloy/pull/3177#discussion_r2544666131

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
- Removed heartbeat check as no subscription is made with `sendRawTransactionSync`. Receipt is immediately returned from RPC.
- Removed call to `sendTransactionSync`. EIP-7966 does not support unsigned transactions. Return LocalUsage error instead.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
