### PR TITLE
fix: use BlockHash for ForkedNetwork.fork_block_hash

### DIFF
--- a/crates/rpc-types-anvil/src/lib.rs
+++ b/crates/rpc-types-anvil/src/lib.rs
@@ -6,7 +6,7 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
-use alloy_primitives::{BlockHash, Bytes, ChainId, TxHash, B256, U256};
+use alloy_primitives::{BlockHash, Bytes, ChainId, B256, U256};
 use alloy_rpc_types_eth::TransactionRequest;
 use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::BTreeMap;
@@ -141,7 +141,7 @@ pub struct ForkedNetwork {
     /// Block number of the forked chain
     pub fork_block_number: u64,
     /// Block hash of the forked chain
-    pub fork_block_hash: TxHash,
+    pub fork_block_hash: BlockHash,
 }
 
 /// Additional `evm_mine` options


### PR DESCRIPTION
Align ForkedNetwork.fork_block_hash with Hardhat/Anvil semantics by switching its type from TxHash to BlockHash in 
crates/rpc-types-anvil/src/lib.rs. The field represents the hash of the block that the forked network was taken from per Hardhat’s hardhat_metadata spec, and our own docs already say “Block hash of the forked chain”. Other fields like latest_block_hash and current_block_hash already use BlockHash, so this change fixes an inconsistency and a semantic mismatch. Both TxHash and BlockHash are B256-sized aliases, so this doesn’t change the wire format and only corrects the API surface. Also removed the now-unused TxHash import.