### PR TITLE
feat: `Eip2718DecodableReceipt`

### DIFF
--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -27,8 +27,8 @@ pub use constants::{EMPTY_OMMER_ROOT_HASH, EMPTY_ROOT_HASH};
 
 mod receipt;
 pub use receipt::{
-    Eip2718EncodableReceipt, Eip658Value, Receipt, ReceiptEnvelope, ReceiptWithBloom, Receipts,
-    RlpDecodableReceipt, RlpEncodableReceipt, TxReceipt,
+    Eip2718DecodableReceipt, Eip2718EncodableReceipt, Eip658Value, Receipt, ReceiptEnvelope,
+    ReceiptWithBloom, Receipts, RlpDecodableReceipt, RlpEncodableReceipt, TxReceipt,
 };
 
 pub mod conditional;

--- a/crates/consensus/src/receipt/mod.rs
+++ b/crates/consensus/src/receipt/mod.rs
@@ -12,7 +12,7 @@ pub use receipts::{Receipt, ReceiptWithBloom, Receipts};
 mod status;
 pub use status::Eip658Value;
 
-use alloy_eips::Typed2718;
+use alloy_eips::{eip2718::Eip2718Result, Typed2718};
 
 /// Bincode-compatible serde implementations for receipt types.
 #[cfg(all(feature = "serde", feature = "serde-bincode-compat"))]
@@ -127,6 +127,18 @@ pub trait Eip2718EncodableReceipt: RlpEncodableReceipt + Typed2718 {
 
     /// EIP-2718 encodes the receipt with the provided bloom filter.
     fn eip2718_encode_with_bloom(&self, bloom: &Bloom, out: &mut dyn BufMut);
+}
+
+/// Receipt type that knows how to decode itself along with bloom from EIP-2718 format.
+///
+/// This is used to support [`alloy_eips::eip2718::Decodable2718`] implementation for
+/// [`ReceiptWithBloom`].
+pub trait Eip2718DecodableReceipt: Sized {
+    /// EIP-2718 decodes the receipt and bloom from the buffer.
+    fn typed_decode_with_bloom(ty: u8, buf: &mut &[u8]) -> Eip2718Result<ReceiptWithBloom<Self>>;
+
+    /// EIP-2718 decodes the receipt and bloom from the buffer.
+    fn fallback_decode_with_bloom(buf: &mut &[u8]) -> Eip2718Result<ReceiptWithBloom<Self>>;
 }
 
 #[cfg(test)]

--- a/crates/consensus/src/receipt/receipts.rs
+++ b/crates/consensus/src/receipt/receipts.rs
@@ -1,8 +1,12 @@
 use crate::receipt::{
-    Eip2718EncodableReceipt, Eip658Value, RlpDecodableReceipt, RlpEncodableReceipt, TxReceipt,
+    Eip2718DecodableReceipt, Eip2718EncodableReceipt, Eip658Value, RlpDecodableReceipt,
+    RlpEncodableReceipt, TxReceipt,
 };
 use alloc::{vec, vec::Vec};
-use alloy_eips::{eip2718::Encodable2718, Typed2718};
+use alloy_eips::{
+    eip2718::{Eip2718Result, Encodable2718},
+    Decodable2718, Typed2718,
+};
 use alloy_primitives::{Bloom, Log};
 use alloy_rlp::{BufMut, Decodable, Encodable, Header};
 use core::fmt;
@@ -385,6 +389,19 @@ where
 
     fn encode_2718(&self, out: &mut dyn BufMut) {
         self.receipt.eip2718_encode_with_bloom(&self.logs_bloom, out);
+    }
+}
+
+impl<R> Decodable2718 for ReceiptWithBloom<R>
+where
+    R: Eip2718DecodableReceipt,
+{
+    fn typed_decode(ty: u8, buf: &mut &[u8]) -> Eip2718Result<Self> {
+        R::typed_decode_with_bloom(ty, buf)
+    }
+
+    fn fallback_decode(buf: &mut &[u8]) -> Eip2718Result<Self> {
+        R::fallback_decode_with_bloom(buf)
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Introduces `Eip2718DecodableReceipt` to support providing `Decodable2718` impl for `ReceiptWithBloom`

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
