### PR TITLE
fix: correct SyncInfo.stages doc to list of  Stage  entries

### DIFF
--- a/crates/rpc-types-eth/src/syncing.rs
+++ b/crates/rpc-types-eth/src/syncing.rs
@@ -16,8 +16,8 @@ pub struct SyncInfo {
     pub warp_chunks_amount: Option<U256>,
     /// Warp sync snapshot chunks processed.
     pub warp_chunks_processed: Option<U256>,
-    /// The details of the sync stages as an hashmap
-    /// where the key is the name of the stage and the value is the block number.
+    /// The details of the sync stages as a list of entries; each `Stage` contains the
+    /// stage name and the latest processed block for that stage.
     #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
     pub stages: Option<Vec<Stage>>,
 }


### PR DESCRIPTION
he previous comment incorrectly described SyncInfo.stages as a hashmap keyed by stage name to block number, which contradicted the actual type Option<Vec<Stage>> and the serde model that aliases stage_name and block_number. The corrected description reflects the intended JSON shape as a list of stage objects, aligns with the field type and existing serde/unit tests, and removes the grammar issue. This avoids misleading API consumers and ensures the docs match the real wire format.