### PR TITLE
feat: include DecodeError in SszDecodeError display

### DIFF
--- a/crates/rpc-types-beacon/src/requests.rs
+++ b/crates/rpc-types-beacon/src/requests.rs
@@ -169,8 +169,8 @@ mod ssz_requests_conversions {
         #[error("unknown request_type prefix: {0}")]
         UnknownRequestType(u8),
         /// Remaining bytes could not be decoded as SSZ requests_data.
-        #[error("ssz error decoding request_type {0}: {1}")]
-        SszDecodeError(u8, #[source] DecodeError),
+        #[error("ssz decode error for request_type {0}: {1:?}")]
+        SszDecodeError(u8, DecodeError),
         /// Requests of request_type exceeds Electra size limits
         #[error("requests_data payload for request_type {0} exceeds Electra size limit {1}")]
         RequestPayloadSizeExceeded(u8, usize),


### PR DESCRIPTION
SszDecodeError previously formatted only the request_type and omitted the underlying ssz::DecodeError from the display output and error chaining, which made diagnosing SSZ decoding issues difficult. This change updates the error message to include the inner cause and annotates the second field with #[source] so that Error::source() returns the underlying DecodeError. The wording is also adjusted from “requests_type” to “request_type” for consistency with the surrounding enum. This aligns with existing practices in the codebase where inner causes are surfaced (e.g., Multicall DecodeError) and improves observability without altering the variant shape or call sites.