### PR TITLE
Add contract eth_call block overrides

### DIFF
--- a/crates/contract/src/eth_call.rs
+++ b/crates/contract/src/eth_call.rs
@@ -7,7 +7,7 @@ use alloy_network::Network;
 use alloy_primitives::{Address, Bytes};
 use alloy_rpc_types_eth::{
     state::{AccountOverride, StateOverride},
-    BlockId,
+    BlockId, BlockOverrides,
 };
 use alloy_sol_types::SolCall;
 
@@ -100,6 +100,12 @@ where
     /// Set the block to use for this call.
     pub fn block(mut self, block: BlockId) -> Self {
         self.inner = self.inner.block(block);
+        self
+    }
+
+    /// Sets the block overrides for this call.
+    pub fn with_block_overrides(mut self, overrides: BlockOverrides) -> Self {
+        self.inner = self.inner.with_block_overrides(overrides);
         self
     }
 }


### PR DESCRIPTION
## Motivation

It seems there's no way to set block overrides when doing a contract method `.call()` but only when building a call directly from the provider.

## Solution

Adds `with_block_overrides` to the contract `.call()` overrides, that similarly to the other methods just calls the underlying function