### PR TITLE
docs: clarify MnemonicBuilder::phrase() does not accept file paths

### DIFF
--- a/crates/signer-local/src/mnemonic.rs
+++ b/crates/signer-local/src/mnemonic.rs
@@ -106,9 +106,11 @@ impl MnemonicBuilder<English> {
 }
 
 impl<W: Wordlist> MnemonicBuilder<W> {
-    /// Sets the phrase in the mnemonic builder. The phrase can either be a string or a path to
-    /// the file that contains the phrase. Once a phrase is provided, the key will be generated
-    /// deterministically by calling the `build` method.
+    /// Sets the phrase in the mnemonic builder. The phrase must be provided as a string
+    /// containing the BIP-39 mnemonic. This builder does not read from file paths
+    /// automatically; if your phrase is stored in a file, read the file contents yourself
+    /// and pass the resulting string here. Once a phrase is provided, the key will be
+    /// generated deterministically by calling the `build` method.
     ///
     /// # Examples
     ///
@@ -252,10 +254,10 @@ impl<W: Wordlist + Clone> IntoIterator for MnemonicBuilder<W> {
 /// Error produced by the mnemonic signer module.
 #[derive(Debug, Error)]
 pub enum MnemonicBuilderError {
-    /// Error suggests that a phrase (path or words) was expected but not found.
+    /// Error suggests that a phrase was expected but not found.
     #[error("expected phrase not found")]
     ExpectedPhraseNotFound,
-    /// Error suggests that a phrase (path or words) was not expected but found.
+    /// Error suggests that a phrase was not expected but found.
     #[error("unexpected phrase found")]
     UnexpectedPhraseFound,
 }


### PR DESCRIPTION
The previous docs for MnemonicBuilder::phrase() claimed the phrase could be provided as a string or a file path. The implementation only accepts a mnemonic string and never attempts to read from the filesystem; tests also demonstrate reading the file manually before passing the phrase. This change corrects the method docs to avoid implying file path support and instructs users to read the file themselves. Additionally, MnemonicBuilderError variant comments were updated to remove “(path or words)” to align with the actual API semantics and prevent confusion.