### PR TITLE
feat: switch parsing to split_once/strip_suffix to avoid allocations

### DIFF
--- a/crates/rpc-types-txpool/src/txpool.rs
+++ b/crates/rpc-types-txpool/src/txpool.rs
@@ -55,31 +55,28 @@ impl Visitor<'_> for TxpoolInspectSummaryVisitor {
     where
         E: de::Error,
     {
-        let addr_split: Vec<&str> = value.split(": ").collect();
-        if addr_split.len() != 2 {
-            return Err(de::Error::custom("invalid format for TxpoolInspectSummary: to"));
-        }
-        let value_split: Vec<&str> = addr_split[1].split(" wei + ").collect();
-        if value_split.len() != 2 {
-            return Err(de::Error::custom("invalid format for TxpoolInspectSummary: gasLimit"));
-        }
-        let gas_split: Vec<&str> = value_split[1].split(" gas × ").collect();
-        if gas_split.len() != 2 {
-            return Err(de::Error::custom("invalid format for TxpoolInspectSummary: gas"));
-        }
-        let gas_price_split: Vec<&str> = gas_split[1].split(" wei").collect();
-        if gas_price_split.len() != 2 {
-            return Err(de::Error::custom("invalid format for TxpoolInspectSummary: gas_price"));
-        }
-        let to = match addr_split[0] {
+        let (to_part, rest) = value
+            .split_once(": ")
+            .ok_or_else(|| de::Error::custom("invalid format for TxpoolInspectSummary: to"))?;
+        let (value_part, rest) = rest.split_once(" wei + ").ok_or_else(|| {
+            de::Error::custom("invalid format for TxpoolInspectSummary: gasLimit")
+        })?;
+        let (gas_part, rest) = rest
+            .split_once(" gas × ")
+            .ok_or_else(|| de::Error::custom("invalid format for TxpoolInspectSummary: gas"))?;
+        let gas_price_str = rest.strip_suffix(" wei").ok_or_else(|| {
+            de::Error::custom("invalid format for TxpoolInspectSummary: gas_price")
+        })?;
+
+        let to = match to_part {
             "" | "0x" | "contract creation" => None,
             addr => {
                 Some(Address::from_str(addr.trim_start_matches("0x")).map_err(de::Error::custom)?)
             }
         };
-        let value = U256::from_str(value_split[0]).map_err(de::Error::custom)?;
-        let gas = u64::from_str(gas_split[0]).map_err(de::Error::custom)?;
-        let gas_price = u128::from_str(gas_price_split[0]).map_err(de::Error::custom)?;
+        let value = U256::from_str(value_part).map_err(de::Error::custom)?;
+        let gas = u64::from_str(gas_part).map_err(de::Error::custom)?;
+        let gas_price = u128::from_str(gas_price_str).map_err(de::Error::custom)?;
 
         Ok(TxpoolInspectSummary { to, value, gas, gas_price })
     }


### PR DESCRIPTION
Replaced multiple split(...).collect::<Vec<_>>() usages in TxpoolInspectSummaryVisitor::visit_str() with split_once and strip_suffix, eliminating unnecessary intermediate Vec allocations and making the parsing intent explicit. The refactor preserves existing error messages and behavior while tightening validation by requiring the final segment to end exactly with " wei", which matches the serializer’s format and improves robustness without altering expected successful inputs or tests.