### PR TITLE
Avoid redundant allocation when ranking fallback transports 

### DIFF
--- a/crates/transport/src/layers/fallback.rs
+++ b/crates/transport/src/layers/fallback.rs
@@ -147,10 +147,11 @@ where
         // Default: parallel execution for methods with deterministic results
         // Get the top transports to use for this request
         let top_transports = {
-            // Clone the vec, sort it, and take the top `self.active_transport_count`
+            // Clone the vec, sort it, and keep only the top `self.active_transport_count`
             let mut transports_clone = (*self.transports).clone();
             transports_clone.sort_by(|a, b| b.cmp(a));
-            transports_clone.into_iter().take(self.active_transport_count).collect::<Vec<_>>()
+            transports_clone.truncate(self.active_transport_count);
+            transports_clone
         };
 
         // Create a collection of future requests


### PR DESCRIPTION
reuse the sorted transport vector instead of collecting into a second Vec, keep the existing ranking logic while eliminating an extra allocation