### PR TITLE
fix(throttle): preserve Tower backpressure by swapping inner with mem::replace

### DIFF
--- a/crates/transport/src/layers/throttle.rs
+++ b/crates/transport/src/layers/throttle.rs
@@ -75,7 +75,8 @@ where
 
     fn call(&mut self, request: RequestPacket) -> Self::Future {
         let throttle = self.throttle.clone();
-        let mut inner = self.inner.clone();
+        let inner_clone = self.inner.clone();
+        let mut inner = std::mem::replace(&mut self.inner, inner_clone);
 
         Box::pin(async move {
             throttle.until_ready().await;


### PR DESCRIPTION
Use std::mem::replace instead of a clone in ThrottleService::call() so that the request executes exactly the same instance of inner on which poll_ready() was called. This preserves Tower backpressure and does not lose permits (unlike calling on a clone).