### PR TITLE
Remove redundant Vec import from eip5792 call module

### DIFF
--- a/crates/eip5792/src/call.rs
+++ b/crates/eip5792/src/call.rs
@@ -1,5 +1,5 @@
 use alloy_primitives::{map::HashMap, Address, Bytes, ChainId, U256};
-use std::vec::Vec;
+
 
 /// Request that a wallet submits a batch of calls in `wallet_sendCalls`
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]


### PR DESCRIPTION
drop the unused std::vec::Vec import in crates/eip5792/src/call.rs, rely on the standard prelude for Vec