### PR TITLE
feat: make Uncle branch unreachable in serializer to enforce invariant

### DIFF
--- a/crates/rpc-types-trace/src/otterscan.rs
+++ b/crates/rpc-types-trace/src/otterscan.rs
@@ -10,7 +10,6 @@ use alloy_rpc_types_eth::{
 };
 use serde::{
     de::{self, Unexpected},
-    ser::SerializeSeq,
     Deserialize, Deserializer, Serialize, Serializer,
 };
 


### PR DESCRIPTION
In OtsBlock's custom serializer we mark the transactions field with skip_serializing_if = BlockTransactions::is_uncle, which guarantees the field is not serialized for uncle blocks and the custom serializer is never invoked for that variant. The existing Uncle arm returned an empty array, which would silently produce an incorrect shape if the attribute were ever removed or the function reused elsewhere. Replace it with unreachable!() to encode the invariant directly and fail fast on misuse, aligning with the RPC contract where uncle blocks omit the transactions field entirely.