### PR TITLE
fix(eip1898): RpcBlockHash serde to use rename_all = \"camelCase\"

### DIFF
--- a/crates/eips/src/eip1898.rs
+++ b/crates/eips/src/eip1898.rs
@@ -35,7 +35,7 @@ impl BlockWithParent {
 /// <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1898.md#specification>
 #[derive(Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
-#[cfg_attr(feature = "serde", serde(rename = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct RpcBlockHash {
     /// A block hash
     pub block_hash: BlockHash,


### PR DESCRIPTION
The RpcBlockHash struct in crates/eips/src/eip1898.rs used serde(rename = "camelCase"), which renames the container type rather than its fields and therefore does not produce camelCase field names on serialization. This causes non-compliant output when RpcBlockHash is serialized directly, emitting block_hash and require_canonical instead of EIP-1898’s blockHash and requireCanonical. BlockId has custom serde and remains correct, but RpcBlockHash is public and re-exported, so consumers may serialize it directly. This change switches to serde(rename_all = "camelCase") to align RpcBlockHash field names with the EIP-1898 spec and the broader codebase convention, improving correctness without affecting BlockId’s existing behavior.