### PR TITLE
Gate TxKind import while dropping unused allowance

### DIFF
--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -1067,8 +1067,9 @@ mod tests {
         eip4844::BlobTransactionSidecar,
         eip7702::Authorization,
     };
-    #[allow(unused_imports)]
-    use alloy_primitives::{b256, Bytes, TxKind};
+    use alloy_primitives::b256;
+    #[cfg(feature = "k256")]
+    use alloy_primitives::TxKind;
     use alloy_primitives::{hex, Address, Signature, U256};
     use alloy_rlp::Decodable;
     use std::{fs, path::PathBuf, str::FromStr, vec};


### PR DESCRIPTION
remove the blanket #[allow(unused_imports)] and unused Bytes import from the consensus envelope tests
keep b256 always, but gate TxKind behind #[cfg(feature = "k256")] so only the k256-specific test pulls it in
leaves the module warning-free when k256 is disabled