### PR TITLE
feat: add blocknumhash helper

### DIFF
--- a/crates/network-primitives/src/traits.rs
+++ b/crates/network-primitives/src/traits.rs
@@ -1,7 +1,7 @@
 use crate::BlockTransactions;
 use alloy_consensus::{BlockHeader, Transaction};
-use alloy_primitives::{Address, BlockHash, TxHash, B256};
 use alloy_eips::BlockNumHash;
+use alloy_primitives::{Address, BlockHash, TxHash, B256};
 use alloy_serde::WithOtherFields;
 
 /// Receipt JSON-RPC response.


### PR DESCRIPTION
add default helper for obtaining fields that are always both missing or present