### PR TITLE
chore: avoid temporary String allocation in anvil hardfork argument

### DIFF
--- a/crates/node-bindings/src/nodes/anvil.rs
+++ b/crates/node-bindings/src/nodes/anvil.rs
@@ -277,7 +277,8 @@ impl Anvil {
 
     /// Select the [`EthereumHardfork`] to start anvil with.
     pub fn hardfork(mut self, hardfork: EthereumHardfork) -> Self {
-        self = self.args(["--hardfork", hardfork.to_string().as_str()]);
+        let hardfork_str = hardfork.to_string();
+        self = self.args(["--hardfork", &hardfork_str]);
         self
     }
 


### PR DESCRIPTION
Replaces `.to_string().as_str()` with binding the String to a variable before borrowing in the hardfork method. This avoids allocating a temporary String that gets immediately dropped after being passed to args.