### PR TITLE
Ensure hash-only block responses strip transaction bodies

### DIFF
--- a/crates/provider/src/utils.rs
+++ b/crates/provider/src/utils.rs
@@ -134,10 +134,7 @@ pub(crate) fn convert_to_hashes<BlockResp: alloy_network::BlockResponse>(
     r: Option<BlockResp>,
 ) -> Option<BlockResp> {
     r.map(|mut block| {
-        if block.transactions().is_empty() {
-            block.transactions_mut().convert_to_hashes();
-        }
-
+        block.transactions_mut().convert_to_hashes();
         block
     })
 }


### PR DESCRIPTION
Always convert fetched blocks to the hashes variant when `full = false`, so lightweight calls never return full transaction payloads. Keeps the block stream contract consistent for downstream layers expecting hash-only transactions.


