### PR TITLE
chore: remove unnecessary Unpin bound on decoder in EthCall futures

### DIFF
--- a/crates/contract/src/eth_call.rs
+++ b/crates/contract/src/eth_call.rs
@@ -121,7 +121,7 @@ where
 
 impl<'coder, D, N> std::future::IntoFuture for EthCall<'coder, D, N>
 where
-    D: CallDecoder + Unpin,
+    D: CallDecoder,
     N: Network,
 {
     type Output = Result<D::CallOutput>;
@@ -149,7 +149,7 @@ where
 
 impl<D, N> std::future::Future for EthCallFut<'_, D, N>
 where
-    D: CallDecoder + Unpin,
+    D: CallDecoder,
     N: Network,
 {
     type Output = Result<D::CallOutput>;


### PR DESCRIPTION
The Unpin bound on the generic decoder type D in IntoFuture for EthCall and Future for EthCallFut was unnecessary because D is only ever referenced via &D and is neither pinned nor moved across await boundaries. The inner RPC future is the only pinned entity and is handled via pin! on the local binding. Removing the bound widens generic compatibility for non-Unpin decoders without affecting safety or behavior. Cross-checking provider’s EthCall implementation shows no analogous bound is required, confirming that this constraint was overly strict rather than intentional API design.