### PR TITLE
Remove unnecessary Copy bound in contract interface mapping

### DIFF
--- a/crates/contract/src/interface.rs
+++ b/crates/contract/src/interface.rs
@@ -119,7 +119,7 @@ fn create_mapping<const N: usize, T, F>(
     signature: F,
 ) -> FbHashMap<N, (String, usize)>
 where
-    F: Fn(&T) -> FixedBytes<N> + Copy,
+    F: Fn(&T) -> FixedBytes<N>,
 {
     elements
         .iter()
@@ -127,7 +127,7 @@ where
             sub_elements
                 .iter()
                 .enumerate()
-                .map(move |(index, element)| (signature(element), (name.to_owned(), index)))
+                .map(|(index, element)| (signature(element), (name.to_owned(), index)))
         })
         .collect()
 }


### PR DESCRIPTION
drop the Copy constraint from create_mapping by letting the inner closure borrow, keep the mapping logic intact while allowing non-Copy signature functions to be used