### PR TITLE
chore(alloy): `consensus-secp256k1` feature

### DIFF
--- a/crates/alloy/Cargo.toml
+++ b/crates/alloy/Cargo.toml
@@ -143,7 +143,6 @@ wasm-bindgen = ["alloy-transport?/wasm-bindgen"]
 # ---------------------------------------- Main re-exports --------------------------------------- #
 
 # general
-consensus = ["dep:alloy-consensus"]
 contract = [
     "dep:alloy-contract",
     "providers",
@@ -157,6 +156,10 @@ ens = ["dep:alloy-ens"]
 genesis = ["dep:alloy-genesis"]
 network = ["dep:alloy-network"]
 node-bindings = ["dep:alloy-node-bindings", "alloy-provider?/anvil-node"]
+
+# consensus
+consensus = ["dep:alloy-consensus"]
+consensus-secp256k1 = ["consensus", "alloy-consensus?/secp256k1"]
 
 # providers
 providers = [


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Use `secp256k1` feature of `alloy-consensus` crate when using `alloy` crate without depending on `alloy-consensus` directly.

## Solution

Re-export `alloy-consensus/secp256k1` as `alloy/consensus-secp256k1`.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
