### PR TITLE
chore(provider): remove unused Debug import from WalletFiller

### DIFF
--- a/crates/provider/src/fillers/wallet.rs
+++ b/crates/provider/src/fillers/wallet.rs
@@ -1,5 +1,3 @@
-use std::fmt::Debug;
-
 use crate::{provider::SendableTx, Provider};
 use alloy_json_rpc::RpcError;
 use alloy_network::{Network, NetworkWallet, TransactionBuilder};


### PR DESCRIPTION
Drop the redundant std::fmt::Debug import in crates/provider/src/fillers/wallet.rs; the Debug derive already brings the trait into scope.
Keeps the module free of unused imports per the “focus on removing unused code” guideline.
