### PR TITLE
fix(consensus): silence unused generic param in Recovered::try_convert

### DIFF
--- a/crates/consensus/src/transaction/recovered.rs
+++ b/crates/consensus/src/transaction/recovered.rs
@@ -116,7 +116,7 @@ impl<T> Recovered<T> {
     }
 
     /// Converts the inner signed object to the given alternative that is `TryFrom<T>`
-    pub fn try_convert<Tx, _E>(self) -> Result<Recovered<Tx>, Tx::Error>
+    pub fn try_convert<Tx>(self) -> Result<Recovered<Tx>, Tx::Error>
     where
         Tx: TryFrom<T>,
     {
@@ -125,7 +125,7 @@ impl<T> Recovered<T> {
 
     /// Converts the transaction to the given alternative that is `TryFrom<T>`
     #[deprecated = "Use `try_convert` instead"]
-    pub fn try_convert_transaction<Tx, _E>(self) -> Result<Recovered<Tx>, Tx::Error>
+    pub fn try_convert_transaction<Tx>(self) -> Result<Recovered<Tx>, Tx::Error>
     where
         Tx: TryFrom<T>,
     {


### PR DESCRIPTION
Rename the unused generic parameter E to _E in Recovered::try_convert and the deprecated try_convert_transaction. This keeps behavior and the public API intact and aligns with similar try_convert methods elsewhere.