### PR TITLE
fix(ens): use ENS_REVERSE_REGISTRAR_DOMAIN in get_reverse_registrar

### DIFF
--- a/crates/ens/src/lib.rs
+++ b/crates/ens/src/lib.rs
@@ -146,7 +146,7 @@ mod contract {
 mod provider {
     use crate::{
         namehash, reverse_address, EnsError, EnsRegistry, EnsResolver::EnsResolverInstance,
-        ReverseRegistrar::ReverseRegistrarInstance, ENS_ADDRESS,
+        ReverseRegistrar::ReverseRegistrarInstance, ENS_ADDRESS, ENS_REVERSE_REGISTRAR_DOMAIN,
     };
     use alloy_primitives::{Address, B256};
     use alloy_provider::{Network, Provider};
@@ -218,7 +218,7 @@ mod provider {
         async fn get_reverse_registrar(&self) -> Result<ReverseRegistrarInstance<&P, N>, EnsError> {
             let registry = EnsRegistry::new(ENS_ADDRESS, self);
             let address = registry
-                .owner(namehash("addr.reverse"))
+                .owner(namehash(ENS_REVERSE_REGISTRAR_DOMAIN))
                 .call()
                 .await
                 .map_err(EnsError::RevRegistrar)?;


### PR DESCRIPTION
Replace the hardcoded "addr.reverse" with ENS_REVERSE_REGISTRAR_DOMAIN in provider::get_reverse_registrar() to keep a single source of truth and maintain consistency with reverse_address(). This avoids drift and improves maintainability