### PR TITLE
refactor(contract): remove redundant PhantomData from StorageSlotFinder

### DIFF
--- a/crates/contract/src/storage_slot.rs
+++ b/crates/contract/src/storage_slot.rs
@@ -44,7 +44,6 @@ where
     calldata: Bytes,
     expected_value: U256,
     base_request: N::TransactionRequest,
-    _phantom: std::marker::PhantomData<N>,
 }
 
 impl<P, N> StorageSlotFinder<P, N>
@@ -69,7 +68,6 @@ where
             calldata,
             expected_value,
             base_request: N::TransactionRequest::default(),
-            _phantom: std::marker::PhantomData,
         }
     }
 
@@ -130,7 +128,7 @@ where
     /// any encoding or hashing. For mappings, the actual storage location might be
     /// computed using keccak256 hashing.
     pub async fn find_slot(self) -> Result<Option<B256>, TransportError> {
-        let Self { provider, contract, calldata, expected_value, base_request, _phantom: _ } = self;
+        let Self { provider, contract, calldata, expected_value, base_request } = self;
 
         let tx = base_request.with_to(contract).with_input(calldata);
 


### PR DESCRIPTION
StorageSlotFinder already carries N through base_request: N::TransactionRequest and P: Provider<N> bounds, so PhantomData<N> provided no additional type-carrying or auto-trait effect. Removing it simplifies the type and avoids needless field initialization and destructuring without impacting behavior or API.