### PR TITLE
feat(provider): add mutable getters to fillers

### DIFF
--- a/crates/provider/src/builder.rs
+++ b/crates/provider/src/builder.rs
@@ -212,6 +212,11 @@ impl<L, F, N> ProviderBuilder<L, F, N> {
         }
     }
 
+    /// Returns a mutable reference to the transaction filler.
+    pub const fn filler_mut(&mut self) -> &mut F {
+        &mut self.filler
+    }
+
     /// Change the network.
     ///
     /// By default, the network is `Ethereum`. This method must be called to configure a different

--- a/crates/provider/src/fillers/join_fill.rs
+++ b/crates/provider/src/fillers/join_fill.rs
@@ -30,15 +30,18 @@ impl<L, R> JoinFill<L, R> {
         &self.left
     }
 
+    /// Get a mutable reference to the left filler.
+    pub const fn left_mut(&mut self) -> &mut L {
+        &mut self.left
+    }
+
     /// Get a reference to the right filler.
     pub const fn right(&self) -> &R {
         &self.right
     }
 
     /// Get a mutable reference to the left filler.
-    ///
-    /// NB: this function exists to enable the [`crate::WalletProvider`] impl.
-    pub(crate) const fn right_mut(&mut self) -> &mut R {
+    pub const fn right_mut(&mut self) -> &mut R {
         &mut self.right
     }
 }


### PR DESCRIPTION
## Motivation

Be able to modify the internal state of a filler by doing `provider_builder.filler_mut().right_mut().state = 1;`

## Solution

Add `ProviderBuilder::filler_mut`, `JoinFill::left_mut`, `JoinFill::right_mut` methods.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
