### PR TITLE
chore: enable rlp when consensus/eips are active

### DIFF
--- a/crates/alloy/Cargo.toml
+++ b/crates/alloy/Cargo.toml
@@ -151,14 +151,14 @@ contract = [
     "json",
     "sol-types",
 ]
-eips = ["dep:alloy-eips"]
+eips = ["dep:alloy-eips", "rlp"]
 ens = ["dep:alloy-ens"]
 genesis = ["dep:alloy-genesis"]
 network = ["dep:alloy-network"]
 node-bindings = ["dep:alloy-node-bindings", "alloy-provider?/anvil-node"]
 
 # consensus
-consensus = ["dep:alloy-consensus"]
+consensus = ["dep:alloy-consensus", "rlp"]
 consensus-secp256k1 = ["consensus", "alloy-consensus?/secp256k1"]
 
 # providers


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

`alloy-primitives/rlp` is enabled by both `alloy-consensus` and `alloy-eips` so we can trigger `alloy-core/rlp` as well here

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
