### PR TITLE
docs(provider): expand on filler documentation

### DIFF
--- a/crates/provider/src/fillers/join_fill.rs
+++ b/crates/provider/src/fillers/join_fill.rs
@@ -7,10 +7,12 @@ use alloy_network::Network;
 use alloy_transport::TransportResult;
 use futures::try_join;
 
-/// A layer that can fill in a [`TransactionRequest`] with additional information by joining two
+/// A filler that can fill in a [`TransactionRequest`] with additional information by joining two
 /// [`TxFiller`]s.
 ///
-/// This struct is itself a [`TxFiller`], and can be nested to compose any number of fill layers.
+/// This filler can be used to compose any number of fillers in layers by recursively joining them.
+///
+/// The left filler is called before the right filler.
 ///
 /// [`TransactionRequest`]: alloy_rpc_types_eth::TransactionRequest
 #[derive(Clone, Copy, Debug, Default)]

--- a/crates/provider/src/fillers/mod.rs
+++ b/crates/provider/src/fillers/mod.rs
@@ -1,8 +1,20 @@
-//! Transaction Fillers
+//! Transaction fillers.
 //!
 //! Fillers decorate a [`Provider`], filling transaction details before they
-//! are sent to the network. Fillers are used to set the nonce, gas price, gas
-//! limit, and other transaction details, and are called before any other layer.
+//! are sent to the network, like nonces, gas limits, and gas prices.
+//!
+//! Fillers are called before any other layer in the provider.
+//!
+//! # Implementing a filler
+//!
+//! Fillers implement the [`TxFiller`] trait. Before a filler is called, [`TxFiller::status`] is
+//! called to determine whether the filler has any work to do. If this function returns
+//! [`FillerControlFlow::Ready`], the filler will be called.
+//!
+//! # Composing fillers
+//!
+//! To layer fillers, a utility filler is provided called [`JoinFill`], which is a composition of
+//! two fillers, left and right. The left filler is called before the right filler.
 //!
 //! [`Provider`]: crate::Provider
 


### PR DESCRIPTION
## Motivation

The filler documentation wasn't clear on what the control flow was.

## Solution

Expand on the documentation.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
