### PR TITLE
fix(json-rpc): propagate map key deserialization errors

### DIFF
--- a/crates/json-rpc/src/notification.rs
+++ b/crates/json-rpc/src/notification.rs
@@ -85,7 +85,7 @@ impl<'de> Deserialize<'de> for PubSubItem {
                 let mut error = None;
 
                 // Drain the map into the appropriate fields.
-                while let Ok(Some(key)) = map.next_key() {
+                while let Some(key) = map.next_key()? {
                     match key {
                         "id" => {
                             if id.is_some() {


### PR DESCRIPTION
Switch visit_map in PubSubItem from while let Ok(Some(key)) = map.next_key() to while let Some(key) = map.next_key()?. This ensures deserialization errors from MapAccess::next_key are not suppressed, improving error reporting and matching serde’s recommended pattern. The change also brings the implementation in line with Request/Response visitors in this crate.