### PR TITLE
feat: add ensure_success method to ReceiptResponse

### DIFF
--- a/crates/network-primitives/src/lib.rs
+++ b/crates/network-primitives/src/lib.rs
@@ -10,7 +10,9 @@
 extern crate alloc;
 
 mod traits;
-pub use traits::{BlockResponse, HeaderResponse, ReceiptResponse, TransactionResponse};
+pub use traits::{
+    BlockResponse, HeaderResponse, ReceiptResponse, TransactionFailedError, TransactionResponse,
+};
 
 mod block;
 pub use block::{BlockTransactionHashes, BlockTransactions, BlockTransactionsKind};


### PR DESCRIPTION
Added a default trait method `ensure_success` to `ReceiptResponse` that verifies transaction success. Returns `Result<(), TransactionFailedError>` to provide a convenient way to check transaction status without manually inspecting the status field.

The `TransactionFailedError` includes the transaction hash for debugging and implements `core::error::Error`.