### PR TITLE
fix(geth): treat “execution reverted” as revert in CallFrame::is_revert

### DIFF
--- a/crates/rpc-types-trace/src/geth/call.rs
+++ b/crates/rpc-types-trace/src/geth/call.rs
@@ -55,8 +55,11 @@ impl CallFrame {
     }
 
     /// Returns true if this call reverted.
-    pub const fn is_revert(&self) -> bool {
-        self.revert_reason.is_some()
+    pub fn is_revert(&self) -> bool {
+        if self.revert_reason.is_some() {
+            return true;
+        }
+        matches!(self.error.as_deref(), Some("execution reverted"))
     }
 
     /// Returns true if this is a regular call


### PR DESCRIPTION
Adjust CallFrame::is_revert() to return true when Geth sets error to “execution reverted”, even if revertReason is None. This matches geth’s call tracer, which only populates revertReason when revert data decodes, but always sets error on revert. The function is no longer const to enable this check.