### PR TITLE
feat: Add Erc7562Frame::is_revert method

### DIFF
--- a/crates/rpc-types-trace/src/geth/erc7562.rs
+++ b/crates/rpc-types-trace/src/geth/erc7562.rs
@@ -61,6 +61,16 @@ pub struct Erc7562Frame {
     pub calls: Vec<Self>,
 }
 
+impl Erc7562Frame {
+    /// Returns true if this call reverted.
+    pub fn is_revert(&self) -> bool {
+        if self.revert_reason.is_some() {
+            return true;
+        }
+        matches!(self.error.as_deref(), Some("execution reverted"))
+    }
+}
+
 /// The accessed slots.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]


### PR DESCRIPTION
Adds is_revert to Erc7562Frame for consistent revert detection, aligning behavior with CallFrame and handling Geth's "execution reverted" error when revertReason is null.