### PR TITLE
fix(network): correct priority_fee_or_price field order in UnknownTypedTransaction

### DIFF
--- a/crates/network/src/any/unknowns.rs
+++ b/crates/network/src/any/unknowns.rs
@@ -157,7 +157,7 @@ impl alloy_consensus::Transaction for UnknownTypedTransaction {
 
     #[inline]
     fn priority_fee_or_price(&self) -> u128 {
-        self.gas_price().or(self.max_priority_fee_per_gas()).unwrap_or_default()
+        self.max_priority_fee_per_gas().or(self.gas_price()).unwrap_or_default()
     }
 
     fn effective_gas_price(&self, base_fee: Option<u64>) -> u128 {


### PR DESCRIPTION
The order of gas_price() and max_priority_fee_per_gas() was swapped in priority_fee_or_price(). 

For dynamic fee transactions (EIP-1559+), we should check max_priority_fee_per_gas first, then fall back to gas_price for legacy txs. The same logic (max_priority_fee_per_gas().or_else(|| gas_price())) is already used in either.rs in the same folder.