### PR TITLE
fix: align EIP1186AccountProofResponse::is_empty with EIP-161

### DIFF
--- a/crates/rpc-types-eth/src/account.rs
+++ b/crates/rpc-types-eth/src/account.rs
@@ -5,6 +5,7 @@ use alloy_primitives::{Address, Bytes, B256, B512, KECCAK256_EMPTY, U256};
 
 // re-export account type for `eth_getAccount`
 pub use alloy_consensus::Account;
+use alloy_consensus::EMPTY_ROOT_HASH;
 
 /// Account information.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]


### PR DESCRIPTION
EIP1186AccountProofResponse::is_empty was checking storage_hash.is_zero(), which never holds for a valid empty account, since empty storage uses the canonical EMPTY_ROOT_HASH instead of zero. This made the helper effectively always return false even when nonce == 0, balance == 0 and code_hash == KECCAK_EMPTY. The method now matches the EIP-161-style emptiness check (nonce, balance and code hash only), which is consistent with the existing comment and other account helpers in the crate.