### PR TITLE
docs: fix swapped filter doc comments

### DIFF
--- a/crates/rpc-types-eth/src/filter.rs
+++ b/crates/rpc-types-eth/src/filter.rs
@@ -642,7 +642,7 @@ impl Filter {
         self.block_option.get_from_block().and_then(|b| b.as_number())
     }
 
-    /// Returns the numeric value of the `fromBlock` field
+    /// Returns the value of the `blockHash` field
     pub const fn get_block_hash(&self) -> Option<B256> {
         match self.block_option {
             FilterBlockOption::AtBlockHash(hash) => Some(hash),

--- a/crates/rpc-types-trace/src/filter.rs
+++ b/crates/rpc-types-trace/src/filter.rs
@@ -72,7 +72,7 @@ impl TraceFilter {
         self
     }
 
-    /// Sets the `from_address` field of the struct
+    /// Sets the `mode` field of the struct
     pub const fn mode(mut self, mode: TraceFilterMode) -> Self {
         self.mode = mode;
         self


### PR DESCRIPTION
get_block_hash docs said fromBlock instead of blockHash, mode docs said from_address instead of mode.