### PR TITLE
fix: use u128 type for BPO update fraction constants

### DIFF
--- a/crates/eips/src/eip7840.rs
+++ b/crates/eips/src/eip7840.rs
@@ -83,7 +83,7 @@ impl BlobParams {
         Self {
             target_blob_count: eip7892::BPO1_TARGET_BLOBS_PER_BLOCK,
             max_blob_count: eip7892::BPO1_MAX_BLOBS_PER_BLOCK,
-            update_fraction: eip7892::BPO1_BASE_UPDATE_FRACTION as u128,
+            update_fraction: eip7892::BPO1_BASE_UPDATE_FRACTION,
             ..Self::osaka()
         }
     }
@@ -93,7 +93,7 @@ impl BlobParams {
         Self {
             target_blob_count: eip7892::BPO2_TARGET_BLOBS_PER_BLOCK,
             max_blob_count: eip7892::BPO2_MAX_BLOBS_PER_BLOCK,
-            update_fraction: eip7892::BPO2_BASE_UPDATE_FRACTION as u128,
+            update_fraction: eip7892::BPO2_BASE_UPDATE_FRACTION,
             ..Self::osaka()
         }
     }

--- a/crates/eips/src/eip7892.rs
+++ b/crates/eips/src/eip7892.rs
@@ -10,7 +10,7 @@ pub const BPO1_TARGET_BLOBS_PER_BLOCK: u64 = 10;
 pub const BPO1_MAX_BLOBS_PER_BLOCK: u64 = 15;
 
 /// Update fraction for BPO1
-pub const BPO1_BASE_UPDATE_FRACTION: u64 = 8346193;
+pub const BPO1_BASE_UPDATE_FRACTION: u128 = 8346193;
 
 /// Targeted blob count with BPO2 activation
 pub const BPO2_TARGET_BLOBS_PER_BLOCK: u64 = 14;
@@ -19,7 +19,7 @@ pub const BPO2_TARGET_BLOBS_PER_BLOCK: u64 = 14;
 pub const BPO2_MAX_BLOBS_PER_BLOCK: u64 = 21;
 
 /// Update fraction for BPO2
-pub const BPO2_BASE_UPDATE_FRACTION: u64 = 11684671;
+pub const BPO2_BASE_UPDATE_FRACTION: u128 = 11684671;
 
 /// A scheduled blob parameter update entry.
 #[derive(Debug, Clone, PartialEq, Eq)]


### PR DESCRIPTION
Changed BPO1_BASE_UPDATE_FRACTION and BPO2_BASE_UPDATE_FRACTION from u64 to u128 to match the type used by all other update fraction constants and the BlobParams struct field.

This removes unnecessary type casts (as u128) in eip7840.rs and makes the code consistent with BLOB_GASPRICE_UPDATE_FRACTION and BLOB_GASPRICE_UPDATE_FRACTION_PECTRA which are already u128.

The values (8346193 and 11684671) fit comfortably in u32, so there's no reason to use u64 instead of u128 when the rest of the codebase expects u128.