### PR TITLE
docs: fix SendableTx::try_into_request documentation

### DIFF
--- a/crates/provider/src/provider/sendable.rs
+++ b/crates/provider/src/provider/sendable.rs
@@ -61,9 +61,9 @@ impl<N: Network> SendableTx<N> {
         }
     }
 
-    /// Returns the envelope if this variant is an [`SendableTx::Builder`].
+    /// Returns the request if this variant is an [`SendableTx::Builder`].
     ///
-    /// Returns a [`SendableTxErr`] with the request object otherwise.
+    /// Returns a [`SendableTxErr`] with the envelope object otherwise.
     pub fn try_into_request(self) -> Result<N::TransactionRequest, SendableTxErr<N::TxEnvelope>> {
         match self {
             Self::Builder(req) => Ok(req),


### PR DESCRIPTION
The documentation for SendableTx::try_into_request incorrectly described the successful case as returning an envelope and the error as carrying a request, which contradicts both the enum definition and the actual implementation.

This change updates the comment to state that the method returns the request or the Builder variant and a SendableTxErr containing the envelope otherwise, making the docs consistent with the code and its usage in the fillers layer.