### PR TITLE
chore: remove redundant std::self import from CallBuilder

### DIFF
--- a/crates/contract/src/call.rs
+++ b/crates/contract/src/call.rs
@@ -13,7 +13,7 @@ use alloy_rpc_types_eth::{
     state::StateOverride, AccessList, BlobTransactionSidecar, BlockId, SignedAuthorization,
 };
 use alloy_sol_types::SolCall;
-use std::{self, marker::PhantomData};
+use std::marker::PhantomData;
 
 // NOTE: The `T` generic here is kept to mitigate breakage with the `sol!` macro.
 // It should always be `()` and has no effect on the implementation.


### PR DESCRIPTION
drop the no-op std::self import from CallBuilder, keep only the PhantomData import that is actually used