### PR TITLE
docs: fix try_into_eip7702 documentation

### DIFF
--- a/crates/consensus/src/transaction/typed.rs
+++ b/crates/consensus/src/transaction/typed.rs
@@ -220,7 +220,7 @@ impl<Eip4844: RlpEcdsaEncodableTx> EthereumTypedTransaction<Eip4844> {
         }
     }
 
-    /// Consumes the type and returns the EIP-4844 if this transaction is of that type.
+    /// Consumes the type and returns the EIP-7702 if this transaction is of that type.
     pub fn try_into_eip7702(self) -> Result<TxEip7702, ValueError<Self>> {
         match self {
             Self::Eip7702(tx) => Ok(tx),


### PR DESCRIPTION
The documentation for `try_into_eip7702` incorrectly stated it returns `EIP-4844`, corrected to `EIP-7702` to match the function name and implementation.