### PR TITLE
chore(eip5792): drop redundant Vec import

### DIFF
--- a/crates/eip5792/src/call.rs
+++ b/crates/eip5792/src/call.rs
@@ -1,5 +1,4 @@
 use alloy_primitives::{map::HashMap, Address, Bytes, ChainId, U256};
-use std::vec::Vec;
 
 /// Request that a wallet submits a batch of calls in `wallet_sendCalls`
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]


### PR DESCRIPTION
rely on the Rust prelude for Vec, removing the extra use std::vec::Vec in eip5792::call, keeps the module leaner by trimming an unused import while retaining the same behavior