### PR TITLE
feat: add bincode compat support for BlobTransactionSidecarVariant

### DIFF
--- a/crates/eips/src/eip7594/mod.rs
+++ b/crates/eips/src/eip7594/mod.rs
@@ -32,3 +32,6 @@ pub use rlp::*;
 mod sidecar;
 #[cfg(feature = "kzg-sidecar")]
 pub use sidecar::*;
+
+#[cfg(all(feature = "kzg-sidecar", feature = "serde", feature = "serde-bincode-compat"))]
+pub use sidecar::serde_bincode_compat;

--- a/crates/eips/src/eip7594/sidecar.rs
+++ b/crates/eips/src/eip7594/sidecar.rs
@@ -796,6 +796,116 @@ impl Decodable7594 for BlobTransactionSidecarEip7594 {
     }
 }
 
+/// Bincode-compatible [`BlobTransactionSidecarVariant`] serde implementation.
+#[cfg(all(feature = "serde", feature = "serde-bincode-compat"))]
+pub mod serde_bincode_compat {
+    use crate::eip4844::{Blob, Bytes48};
+    use alloc::{borrow::Cow, vec::Vec};
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+    use serde_with::{DeserializeAs, SerializeAs};
+
+    /// Bincode-compatible [`super::BlobTransactionSidecarVariant`] serde implementation.
+    ///
+    /// Intended to use with the [`serde_with::serde_as`] macro in the following way:
+    /// ```rust
+    /// use alloy_eips::eip7594::{serde_bincode_compat, BlobTransactionSidecarVariant};
+    /// use serde::{Deserialize, Serialize};
+    /// use serde_with::serde_as;
+    ///
+    /// #[serde_as]
+    /// #[derive(Serialize, Deserialize)]
+    /// struct Data {
+    ///     #[serde_as(as = "serde_bincode_compat::BlobTransactionSidecarVariant")]
+    ///     sidecar: BlobTransactionSidecarVariant,
+    /// }
+    /// ```
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct BlobTransactionSidecarVariant<'a> {
+        /// The blob data (common to both variants).
+        pub blobs: Cow<'a, Vec<Blob>>,
+        /// The blob commitments (common to both variants).
+        pub commitments: Cow<'a, Vec<Bytes48>>,
+        /// The blob proofs (EIP-4844 only).
+        pub proofs: Option<Cow<'a, Vec<Bytes48>>>,
+        /// The cell proofs (EIP-7594 only).
+        pub cell_proofs: Option<Cow<'a, Vec<Bytes48>>>,
+    }
+
+    impl<'a> From<&'a super::BlobTransactionSidecarVariant> for BlobTransactionSidecarVariant<'a> {
+        fn from(value: &'a super::BlobTransactionSidecarVariant) -> Self {
+            match value {
+                super::BlobTransactionSidecarVariant::Eip4844(sidecar) => Self {
+                    blobs: Cow::Borrowed(&sidecar.blobs),
+                    commitments: Cow::Borrowed(&sidecar.commitments),
+                    proofs: Some(Cow::Borrowed(&sidecar.proofs)),
+                    cell_proofs: None,
+                },
+                super::BlobTransactionSidecarVariant::Eip7594(sidecar) => Self {
+                    blobs: Cow::Borrowed(&sidecar.blobs),
+                    commitments: Cow::Borrowed(&sidecar.commitments),
+                    proofs: None,
+                    cell_proofs: Some(Cow::Borrowed(&sidecar.cell_proofs)),
+                },
+            }
+        }
+    }
+
+    impl<'a> BlobTransactionSidecarVariant<'a> {
+        fn try_into_inner(self) -> Result<super::BlobTransactionSidecarVariant, &'static str> {
+            match (self.proofs, self.cell_proofs) {
+                (Some(proofs), None) => Ok(super::BlobTransactionSidecarVariant::Eip4844(
+                    crate::eip4844::BlobTransactionSidecar {
+                        blobs: self.blobs.into_owned(),
+                        commitments: self.commitments.into_owned(),
+                        proofs: proofs.into_owned(),
+                    },
+                )),
+                (None, Some(cell_proofs)) => Ok(super::BlobTransactionSidecarVariant::Eip7594(
+                    super::BlobTransactionSidecarEip7594 {
+                        blobs: self.blobs.into_owned(),
+                        commitments: self.commitments.into_owned(),
+                        cell_proofs: cell_proofs.into_owned(),
+                    },
+                )),
+                (None, None) => Err("Missing both 'proofs' and 'cell_proofs'"),
+                (Some(_), Some(_)) => Err("Both 'proofs' and 'cell_proofs' cannot be present"),
+            }
+        }
+    }
+
+    impl<'a> From<BlobTransactionSidecarVariant<'a>> for super::BlobTransactionSidecarVariant {
+        fn from(value: BlobTransactionSidecarVariant<'a>) -> Self {
+            value.try_into_inner().expect("Invalid BlobTransactionSidecarVariant")
+        }
+    }
+
+    impl SerializeAs<super::BlobTransactionSidecarVariant> for BlobTransactionSidecarVariant<'_> {
+        fn serialize_as<S>(
+            source: &super::BlobTransactionSidecarVariant,
+            serializer: S,
+        ) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            BlobTransactionSidecarVariant::from(source).serialize(serializer)
+        }
+    }
+
+    impl<'de> DeserializeAs<'de, super::BlobTransactionSidecarVariant>
+        for BlobTransactionSidecarVariant<'de>
+    {
+        fn deserialize_as<D>(
+            deserializer: D,
+        ) -> Result<super::BlobTransactionSidecarVariant, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            let value = BlobTransactionSidecarVariant::deserialize(deserializer)?;
+            value.try_into_inner().map_err(serde::de::Error::custom)
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/rpc-types-eth/src/transaction/request.rs
+++ b/crates/rpc-types-eth/src/transaction/request.rs
@@ -1396,7 +1396,7 @@ impl From<TxEnvelope> for TransactionRequest {
 pub(super) mod serde_bincode_compat {
     use crate::TransactionInput;
     use alloc::{borrow::Cow, vec::Vec};
-    use alloy_eips::{eip2930::AccessList, eip7594::BlobTransactionSidecarVariant};
+    use alloy_eips::eip2930::AccessList;
     use alloy_primitives::{Address, Bytes, ChainId, TxKind, B256, U256};
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
     use serde_with::{DeserializeAs, SerializeAs};
@@ -1449,7 +1449,8 @@ pub(super) mod serde_bincode_compat {
         /// Blob versioned hashes for EIP-4844 transactions.
         pub blob_versioned_hashes: Option<Cow<'a, Vec<B256>>>,
         /// Blob sidecar for EIP-4844 transactions.
-        pub sidecar: Option<Cow<'a, BlobTransactionSidecarVariant>>,
+        pub sidecar:
+            Option<alloy_eips::eip7594::serde_bincode_compat::BlobTransactionSidecarVariant<'a>>,
         /// Authorization list for EIP-7702 transactions.
         pub authorization_list:
             Option<Vec<alloy_eips::eip7702::serde_bincode_compat::SignedAuthorization<'a>>>,
@@ -1473,7 +1474,7 @@ pub(super) mod serde_bincode_compat {
                 access_list: value.access_list.as_ref().map(Cow::Borrowed),
                 transaction_type: value.transaction_type,
                 blob_versioned_hashes: value.blob_versioned_hashes.as_ref().map(Cow::Borrowed),
-                sidecar: value.sidecar.as_ref().map(Cow::Borrowed),
+                sidecar: value.sidecar.as_ref().map(Into::into),
                 authorization_list: value
                     .authorization_list
                     .as_ref()
@@ -1504,7 +1505,7 @@ pub(super) mod serde_bincode_compat {
                 blob_versioned_hashes: value
                     .blob_versioned_hashes
                     .map(|hashes| hashes.into_owned()),
-                sidecar: value.sidecar.map(|sidecar| sidecar.into_owned()),
+                sidecar: value.sidecar.map(Into::into),
                 authorization_list: value
                     .authorization_list
                     .map(|list| list.into_iter().map(Into::into).collect()),


### PR DESCRIPTION
Implements bincode-compatible serialization for `BlobTransactionSidecarVariant` by flattening the enum variants into optional fields, avoiding the use of untagged enums which are incompatible with bincode.

The implementation follows the existing pattern from `TransactionRequest` and uses `Cow` for efficient borrowing. The bincode-compatible struct has:
- `blobs` and `commitments` (common to both variants)
- `proofs` (optional, for EIP-4844 variant)
- `cell_proofs` (optional, for EIP-7594 variant)

The deserialization validates that exactly one of the proof fields is present and returns a proper serde error for invalid states instead of panicking. The `TransactionRequest` bincode-compat module now uses this new type for the `sidecar` field.