### PR TITLE
fix(rpc-types-eth): correct build_7702 panic documentation

### DIFF
--- a/crates/rpc-types-eth/src/transaction/request.rs
+++ b/crates/rpc-types-eth/src/transaction/request.rs
@@ -593,10 +593,8 @@ impl TransactionRequest {
 
     /// Build an EIP-7702 transaction.
     ///
-    /// # Panics
-    ///
-    /// If required fields are missing. Use `complete_7702` to check if the
-    /// request can be built.
+    /// Returns an error if required fields are missing. Use `complete_7702` to
+    /// check if the request can be built.
     pub fn build_7702(self) -> Result<TxEip7702, ValueError<Self>> {
         let Some(to) = self.to else {
             return Err(ValueError::new(self, "Missing 'to' field for Eip7702 transaction."));


### PR DESCRIPTION
TransactionRequest::build_7702 returns a Result<TxEip7702, ValueError<Self>> and never panics on missing fields, unlike what the doc comment claimed via a # Panics section. This change updates the documentation to state that the function returns an error when required fields are missing and points to complete_7702 for pre-checks

