### PR TITLE
fix: clarify KMS signer EIP-155 documentation

### DIFF
--- a/crates/signer-gcp/src/signer.rs
+++ b/crates/signer-gcp/src/signer.rs
@@ -221,8 +221,11 @@ impl GcpSigner {
         request_sign_digest(&self.client, &self.key_name, digest).await.and_then(decode_signature)
     }
 
-    /// Sign a digest with this signer's key and add the eip155 `v` value
-    /// corresponding to the input chain_id
+    /// Sign a digest with this signer's key and recover a `Signature` with the
+    /// correct y-parity for the given public key.
+    ///
+    /// The digest is expected to already include any EIP-155 chain ID encoding
+    /// via the transaction's signature hash.
     #[instrument(err, skip(digest), fields(digest = %hex::encode(digest)))]
     async fn sign_digest_inner(&self, digest: &B256) -> Result<Signature, GcpSignerError> {
         let sig = self.sign_digest(digest).await?;


### PR DESCRIPTION
Previously the documentation for sign_digest_inner in the GCP and AWS KMS signers claimed that the function applied EIP-155 v based on the chain ID. In reality these helpers only recover the correct y-parity for a given (r, s, digest, pubkey), while the EIP-155 encoding of v is handled by the transaction types during encoding. This change updates the comments to describe the actual behavior and explicitly note that the digest is expected to already include any EIP-155 chain ID encoding via the transaction’s signature hash.