### PR TITLE
chore: remove redundant clone in provider test

### DIFF
--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -1865,7 +1865,7 @@ mod tests {
             ..Default::default()
         };
 
-        let builder = provider.send_transaction(tx.clone()).await.expect("failed to send tx");
+        let builder = provider.send_transaction(tx).await.expect("failed to send tx");
         let hash1 = *builder.tx_hash();
 
         // Wait until tx is confirmed.


### PR DESCRIPTION
Removes redundant `.clone()`, variable is not used.