### PR TITLE
chore(network): remove redundant trait bounds from Network::TxType

### DIFF
--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -39,7 +39,7 @@ pub use alloy_network_primitives::{
 /// Captures type info for network-specific RPC requests/responses.
 ///
 /// Networks are only containers for types, so it is recommended to use ZSTs for their definition.
-pub trait Network: Debug + Clone + Copy + Sized + Send + Sync + 'static {
+pub trait Network: Debug + Copy + Sized + Send + Sync + 'static {
     // -- Consensus types --
 
     /// The network transaction type enum.
@@ -49,12 +49,10 @@ pub trait Network: Debug + Clone + Copy + Sized + Send + Sync + 'static {
     #[doc(alias = "TransactionType")]
     type TxType: Typed2718
         + Into<u8>
-        + PartialEq
         + Eq
         + TryFrom<u8, Error = Eip2718Error>
         + Debug
         + Display
-        + Clone
         + Copy
         + Send
         + Sync


### PR DESCRIPTION
Removes redundant trait bounds from `Network::TxType` associated type: removed `Clone` bound (implied by `Copy`), removed `PartialEq` bound (implied by `Eq`)