### PR TITLE
chore: remove redundant clone

### DIFF
--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -1820,7 +1820,7 @@ mod tests {
         };
 
         let _receipt =
-            provider.send_transaction_sync(tx.clone()).await.expect("failed to send tx sync");
+            provider.send_transaction_sync(tx).await.expect("failed to send tx sync");
     }
 
     #[tokio::test]


### PR DESCRIPTION
Removes unnecessary clone in test_send_tx_sync, the transaction is only used once.