### PR TITLE
refactor(json-rpc): remove unnecessary copying

### DIFF
--- a/crates/json-rpc/src/response/mod.rs
+++ b/crates/json-rpc/src/response/mod.rs
@@ -44,7 +44,7 @@ impl BorrowedResponse<'_> {
     /// Convert this borrowed response to an owned response by copying the data
     /// from the deserializer (if necessary).
     pub fn into_owned(self) -> Response {
-        Response { id: self.id.clone(), payload: self.payload.into_owned() }
+        Response { id: self.id, payload: self.payload.into_owned() }
     }
 }
 


### PR DESCRIPTION
BorrowedResponse::into_owned consumes self, so there is no need to clone the Id field when constructing the owned Response. Moving the Id instead avoids an unnecessary allocation in the String case while keeping the API and behavior unchanged.