### PR TITLE
docs: correct BlockOpcodeGas comment to block-level usage

### DIFF
--- a/crates/rpc-types-trace/src/opcode.rs
+++ b/crates/rpc-types-trace/src/opcode.rs
@@ -3,7 +3,7 @@
 use alloy_primitives::{BlockHash, TxHash};
 use serde::{Deserialize, Serialize};
 
-/// Opcode gas usage for a transaction.
+/// Opcode gas usage for a block.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BlockOpcodeGas {


### PR DESCRIPTION
The previous doc comment for BlockOpcodeGas claimed it was opcode gas usage for a transaction, which duplicates the 
TransactionOpcodeGas description and misrepresents the type. Updated the comment to describe block-level opcode gas usage, aligning the documentation with the actual structure