### PR TITLE
refactor: remove unused TurnkeySignatureNotFound error

### DIFF
--- a/crates/signer-turnkey/src/signer.rs
+++ b/crates/signer-turnkey/src/signer.rs
@@ -69,9 +69,6 @@ pub enum TurnkeySignerError {
     /// Invalid hex string in response.
     #[error("invalid hex string: {0}")]
     Hex(#[from] hex::FromHexError),
-    /// Signature not found in response.
-    #[error("signature not found in response")]
-    SignatureNotFound,
     /// Invalid signature format received from Turnkey.
     #[error("invalid signature format")]
     InvalidSignature,


### PR DESCRIPTION
The Turnkey signer never surfaces a “signature not found” condition independently of the SDK. Missing or malformed results are already handled inside TurnkeyClient as TurnkeyClientError, and malformed r/s/v values are mapped to Hex or InvalidSignature. The SignatureNotFound variant in TurnkeySignerError was therefore unreachable and misleading compared to the AWS signer, where the SDK can actually return a response without a signature.