### PR TITLE
fix: header Sealable hash_slow recursion

### DIFF
--- a/crates/consensus/src/block/header.rs
+++ b/crates/consensus/src/block/header.rs
@@ -168,7 +168,8 @@ impl Default for Header {
 
 impl Sealable for Header {
     fn hash_slow(&self) -> B256 {
-        self.hash_slow()
+        // Avoid trait-method recursion: call the inherent implementation directly.
+        Header::hash_slow(self)
     }
 }
 


### PR DESCRIPTION

Calling `hash_slow` via `Sealable` on `Header` recursed into itself, causing an immediate stack overflow.

