### PR TITLE
fix(eip7547): correct InclusionListSummaryEntryV1 Display name

### DIFF
--- a/crates/eip7547/src/summary.rs
+++ b/crates/eip7547/src/summary.rs
@@ -88,7 +88,11 @@ pub struct InclusionListSummaryEntryV1 {
 
 impl fmt::Display for InclusionListSummaryEntryV1 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "InclusionListEntryV1 {{ address: {}, nonce: {} }}", self.address, self.nonce)
+        write!(
+            f,
+            "InclusionListSummaryEntryV1 {{ address: {}, nonce: {} }}",
+            self.address, self.nonce
+        )
     }
 }
 


### PR DESCRIPTION
The Display implementation for InclusionListSummaryEntryV1 used the wrong type name in its format string (InclusionListEntryV1). This could confuse log parsing and debugging, especially when grepping by type name. Update the string to match the actual type name so logs remain consistent with the code.