### PR TITLE
fix(transport-ipc): avoid false error on normal EOF

### DIFF
--- a/crates/transport-ipc/src/lib.rs
+++ b/crates/transport-ipc/src/lib.rs
@@ -80,7 +80,8 @@ impl IpcBackend {
                                 }
                             }
                             None => {
-                                error!("Read stream has failed.");
+                                // Stream ended; upstream already logged the cause (EOF or JSON error).
+                                debug!("IPC read stream ended");
                                 break true;
                             }
                         }


### PR DESCRIPTION
Normal IPC stream closures were logged as errors, creating false alerts and noisy logs. Downgrade the EOF path to debug and document that upstream already logged the cause.

