### PR TITLE
fix(node-bindings): generalize ReadLineError output description

### DIFF
--- a/crates/node-bindings/src/node.rs
+++ b/crates/node-bindings/src/node.rs
@@ -25,8 +25,8 @@ pub enum NodeError {
     /// Encountered a fatal error.
     #[error("fatal error: {0}")]
     Fatal(String),
-    /// A line could not be read from the node stderr.
-    #[error("could not read line from node stderr: {0}")]
+    /// A line could not be read from the node output stream.
+    #[error("could not read line from node output: {0}")]
     ReadLineError(std::io::Error),
 
     /// The chain id was not set.


### PR DESCRIPTION
NodeError::ReadLineError was originally documented and formatted as reading from stderr only, but it is also used for stdout in the Reth and Anvil bindings. This patch updates the doc comment and error message to refer to the generic node output stream instead of stderr, aligning the error text with actual usage without changing the public API or behavior.