### PR TITLE
fix: don't blow up header maps when using auth

### DIFF
--- a/crates/provider/src/ext/mev/with_auth.rs
+++ b/crates/provider/src/ext/mev/with_auth.rs
@@ -122,7 +122,7 @@ where
                 // Patch the existing RPC call with the new headers
                 let rpc_call = self.inner.map_meta(|meta| {
                     let mut meta = meta;
-                    meta.extensions_mut().insert(headers);
+                    meta.extensions_mut().get_or_insert_default::<HeaderMap>().extend(headers);
                     meta
                 });
 


### PR DESCRIPTION
Auth middleware is incorrectly blowing up any existing `HeaderMap` extensions, making it incompatible with other middleware that sets headers

## Motivation


## Solution


## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
