### PR TITLE
refactor(transport): remove redundant trait bounds in compile-time check

### DIFF
--- a/crates/transport/src/boxed.rs
+++ b/crates/transport/src/boxed.rs
@@ -132,7 +132,7 @@ mod test {
     const fn _compile_check() {
         const fn inner<T>()
         where
-            T: Transport + CloneTransport + Send + Sync + Clone + IntoBoxTransport + 'static,
+            T: CloneTransport + Send + Sync + IntoBoxTransport + 'static,
         {
         }
         inner::<BoxTransport>();


### PR DESCRIPTION
Removes redundant Transport and Clone trait bounds from the _compile_check const function in boxed.rs.