### PR TITLE
fix: incorrect debug log message in heartbeat transaction watcher

### DIFF
--- a/crates/provider/src/heart.rs
+++ b/crates/provider/src/heart.rs
@@ -527,7 +527,7 @@ impl<N: Network, S: Stream<Item = N::BlockResponse> + Unpin + 'static> Heartbeat
         }
     }
 
-    /// Reap transactions overridden by the reorg.
+    /// Reap transactions overridden by a chain gap (true reorg or resync after a pause).
     /// Accepts new chain height as an argument, and drops any subscriptions
     /// that were received in blocks affected by the reorg (e.g. >= new_height).
     fn move_reorg_to_unconfirmed(&mut self, new_height: u64) {
@@ -537,7 +537,7 @@ impl<N: Network, S: Stream<Item = N::BlockResponse> + Unpin + 'static> Heartbeat
                     // All blocks after and _including_ the new height are reaped.
                     if received_at_block >= new_height {
                         let hash = watcher.config.tx_hash;
-                        debug!(tx=%hash, %received_at_block, %new_height, "return to unconfirmed due to reorg");
+                        debug!(tx=%hash, %received_at_block, %new_height, "return to unconfirmed after chain gap");
                         self.unconfirmed.insert(hash, watcher);
                         return None;
                     }


### PR DESCRIPTION


Fixes misleading debug log message that incorrectly attributes transaction state changes to reorgs when they can also occur during heartbeat resync after a pause.

The `move_reorg_to_unconfirmed` function is called in two scenarios:
1. **True chain reorg** - when block heights are discontinuous
2. **Heartbeat resync** - when the heartbeat resumes after being paused

Previously, the debug log message always stated `"return to unconfirmed due to reorg"`, which was misleading in the second case. This could cause confusion during debugging and incident investigation.

