### PR TITLE
docs: clarify RpcClient::with_poll_interval behavior

### DIFF
--- a/crates/rpc-client/src/client.rs
+++ b/crates/rpc-client/src/client.rs
@@ -147,8 +147,8 @@ impl RpcClient {
 
     /// Sets the poll interval for the client in milliseconds.
     ///
-    /// Note: This will only set the poll interval for the client if it is the only reference to the
-    /// inner client. If the reference is held by many, then it will not update the poll interval.
+    /// Note: `RpcClient` internally wraps an `Arc<RpcClientInner>`, so updating the poll interval
+    /// changes it for all `RpcClient` handles that share the same inner client.
     pub fn with_poll_interval(self, poll_interval: Duration) -> Self {
         self.inner().set_poll_interval(poll_interval);
         self


### PR DESCRIPTION
with_poll_interval always updates the shared RpcClientInner poll interval for all RpcClient handles that reference it. The previous rustdoc incorrectly claimed that the interval would only be updated when this handle was the sole reference to the inner client. This change updates the documentation to match the actual behavior and make the sharing semantics via Arc<RpcClientInner> explicit.