### PR TITLE
fix: misleading debug log in transaction watcher

### DIFF
--- a/crates/provider/src/heart.rs
+++ b/crates/provider/src/heart.rs
@@ -380,8 +380,8 @@ struct TxWatcher {
 impl TxWatcher {
     /// Notify the waiter.
     fn notify(self, result: Result<(), WatchTxError>) {
-        debug!(tx=%self.config.tx_hash, "notifying");
-        let _ = self.tx.send(result);
+        let sent = self.tx.send(result).is_ok();
+        debug!(tx=%self.config.tx_hash, sent, "notifying watcher");
     }
 }
 


### PR DESCRIPTION
Updated `TxWatcher::notify` to log whether the notification was actually delivered, instead of unconditionally logging that it was sent. Previously the debug log claimed the watcher was notified even when the `oneshot::Sender` had already been dropped, which could mislead debugging of missed notifications.  


