### PR TITLE
Clarify debug log on block height regression

### DIFF
--- a/crates/provider/src/blocks.rs
+++ b/crates/provider/src/blocks.rs
@@ -181,7 +181,7 @@ impl<N: Network> NewBlocks<N> {
                 // offset to the initial fetch so that we fetch tip - 1
                 self.next_yield = block_number.saturating_sub(1);
             } else if block_number < self.next_yield {
-                debug!(block_number, self.next_yield, "not advanced yet");
+                debug!(block_number, expected = self.next_yield, "block height regressed");
                 continue 'task;
             }
 


### PR DESCRIPTION
Adjust the debug log in the `NewBlocks` polling loop so that when `block_number < self.next_yield` it logs a “block height regressed” message with both current and expected heights. This makes it clear that the node returned an older block height (potential reorg or desync) instead of merely “not advancing”, improving observability and reducing confusion during incident analysis.