### PR TITLE
fix: correct self-comparison in EIP-4844 transaction test

### DIFF
--- a/crates/rpc-types-eth/src/transaction/request.rs
+++ b/crates/rpc-types-eth/src/transaction/request.rs
@@ -2031,7 +2031,7 @@ mod tests {
 
             let maybe_eip4844_tx: Result<TypedTransaction, _> =
                 eip4844_request.build_consensus_tx();
-            assert_matches!(maybe_eip4844_tx, Ok(TypedTransaction::Eip4844(TxEip4844Variant::TxEip4844(TxEip4844 { max_fee_per_blob_gas, .. }))) if max_fee_per_blob_gas == max_fee_per_blob_gas);
+            assert_matches!(maybe_eip4844_tx, Ok(TypedTransaction::Eip4844(TxEip4844Variant::TxEip4844(TxEip4844 { max_fee_per_blob_gas: blob_gas_fee, .. }))) if blob_gas_fee == max_fee_per_blob_gas);
 
             // Negative case
             let eip4844_request_incorrect_to = TransactionRequest {


### PR DESCRIPTION
Fixed a tautological assertion where max_fee_per_blob_gas was compared to itself instead of the expected value. While this didn't cause test failures, it made the assertion meaningless since it always passes.

The test now properly validates that max_fee_per_blob_gas is correctly set in EIP-4844 transactions, matching the pattern used in other transaction type tests in the same file.