### PR TITLE
docs: fix finalized checkpoint event topic name

### DIFF
--- a/crates/rpc-types-beacon/src/events/mod.rs
+++ b/crates/rpc-types-beacon/src/events/mod.rs
@@ -184,7 +184,7 @@ pub struct BlsToExecutionChangeMessage {
     pub to_execution_address: Address,
 }
 
-/// Event for the `Deposit` topic of the beacon API node event stream.
+/// Event for the `finalized_checkpoint` topic of the beacon API node event stream.
 ///
 /// Finalized checkpoint has been updated
 #[serde_as]


### PR DESCRIPTION
Updated the FinalizedCheckpointEvent doc comment to reference the finalized_checkpoint beacon node eventstream topic. The struct already models the finalized checkpoint event, but the comment incorrectly mentioned the deposit topic.