### PR TITLE
Drop dead_code allow on async_ci_only

### DIFF
--- a/crates/provider/src/ext/mod.rs
+++ b/crates/provider/src/ext/mod.rs
@@ -66,7 +66,6 @@ pub use mev::{
 
 #[cfg(test)]
 pub(crate) mod test {
-    #[allow(dead_code)] // dead only when all features off
     /// Run the given function only if we are in a CI environment.
     pub(crate) async fn async_ci_only<F, Fut>(f: F)
     where


### PR DESCRIPTION
Remove redundant #[allow(dead_code)] from ext::test::async_ci_only, which is referenced across provider tests and helpers. Ensures dead code lint will fire if the helper ever stops being used.