### PR TITLE
refactor(serde): remove unused Serialize import from ttd module

### DIFF
--- a/crates/serde/src/ttd.rs
+++ b/crates/serde/src/ttd.rs
@@ -13,7 +13,7 @@
 //! For non-human-readable formats, the default `serde` behavior for `Option<U256>` is used.
 
 use alloy_primitives::U256;
-use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+use serde::{de, Deserialize, Deserializer, Serializer};
 use serde_json::Value;
 
 /// Serializes an optional TTD as a JSON number.


### PR DESCRIPTION
Remove unused `Serialize` trait import from `alloy-serde/src/ttd.rs`.