### PR TITLE
chore(rpc-types-mev): remove unused `#![allow(deprecated)]` directive

### DIFF
--- a/crates/rpc-types-mev/src/eth_calls.rs
+++ b/crates/rpc-types-mev/src/eth_calls.rs
@@ -1,6 +1,3 @@
-// Allow to keep the deprecated items for compatibility
-#![allow(deprecated)]
-
 use crate::{u256_numeric_string, Privacy, Validity};
 
 use alloy_eips::{eip2718::Encodable2718, BlockNumberOrTag};


### PR DESCRIPTION
Removes the unnecessary crate-level `#![allow(deprecated)]` attribute from `eth_calls.rs`.