### PR TITLE
refactor(rpc-types-mev): simplify `Inclusion::max_block_number` implementation

### DIFF
--- a/crates/rpc-types-mev/src/mev_calls.rs
+++ b/crates/rpc-types-mev/src/mev_calls.rs
@@ -184,7 +184,7 @@ impl Inclusion {
     /// Returns the block number of the last block the bundle is valid for.
     #[inline]
     pub fn max_block_number(&self) -> Option<u64> {
-        self.max_block.as_ref().map(|b| *b)
+        self.max_block.copied()
     }
 }
 


### PR DESCRIPTION
Replace manual `as_ref().map(|b| *b)` pattern with idiomatic `copied()` method in `Inclusion::max_block_number()`.