### PR TITLE
Fix incorrect debug log timing in RPC call preparation

### DIFF
--- a/crates/rpc-client/src/call.rs
+++ b/crates/rpc-client/src/call.rs
@@ -78,9 +78,9 @@ where
 
                     let request = request.take().expect("no request");
                     if tracing::enabled!(tracing::Level::TRACE) {
-                        trace!(?request, "sending request");
+                        trace!(?request, "preparing request");
                     } else {
-                        debug!(method=%request.meta.method, id=%request.meta.id, "sending request");
+                        debug!(method=%request.meta.method, id=%request.meta.id, "serializing request");
                     }
                     let request = request.serialize();
                     let fut = match request {


### PR DESCRIPTION


The debug log message "sending request" was emitted before the request was actually serialized and sent. This could mislead developers during debugging, as the log would indicate a request was sent even when serialization failed locally, making it harder to distinguish between network issues and serialization errors.

