### PR TITLE
perf(rpc-types-eth): remove redundant Vec allocation in FilterSet::to_value_or_array

### DIFF
--- a/crates/rpc-types-eth/src/filter.rs
+++ b/crates/rpc-types-eth/src/filter.rs
@@ -191,11 +191,12 @@ impl<T: Clone + Eq + Hash> FilterSet<T> {
     /// - If the filter has only 1 value, it returns the single value
     /// - Otherwise it returns an array of values
     pub fn to_value_or_array(&self) -> Option<ValueOrArray<T>> {
-        let mut values = self.set.iter().cloned().collect::<Vec<T>>();
-        match values.len() {
+        match self.set.len() {
             0 => None,
-            1 => Some(ValueOrArray::Value(values.pop().expect("values length is one"))),
-            _ => Some(ValueOrArray::Array(values)),
+            1 => Some(ValueOrArray::Value(
+                self.set.iter().next().cloned().expect("values length is one"),
+            )),
+            _ => Some(ValueOrArray::Array(self.set.iter().cloned().collect())),
         }
     }
 }


### PR DESCRIPTION
Optimize `FilterSet::to_value_or_array` by eliminating unnecessary `Vec` allocation for empty and single-element cases.