### PR TITLE
chore(provider): remove unnecessary dead_code allow on async_ci_only

### DIFF
--- a/crates/provider/src/ext/mod.rs
+++ b/crates/provider/src/ext/mod.rs
@@ -66,7 +66,6 @@ pub use mev::{
 
 #[cfg(test)]
 pub(crate) mod test {
-    #[allow(dead_code)] // dead only when all features off
     /// Run the given function only if we are in a CI environment.
     pub(crate) async fn async_ci_only<F, Fut>(f: F)
     where


### PR DESCRIPTION
Removes the `#[allow(dead_code)]` attribute from the `async_ci_only` test helper function in `crates/provider/src/ext/mod.rs`.