### PR TITLE
docs: fix typo and standardize crate descriptions

### DIFF
--- a/crates/eip5792/Cargo.toml
+++ b/crates/eip5792/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alloy-eip5792"
-description = "Types for the 'wallet' Ethereum JSON-RPC namespace"
+description = "Types for the `wallet_` Ethereum JSON-RPC namespace"
 
 version.workspace = true
 edition.workspace = true

--- a/crates/eips/Cargo.toml
+++ b/crates/eips/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alloy-eips"
-description = "Ethereum Improvement Proprosal (EIP) implementations"
+description = "Ethereum Improvement Proposal (EIP) implementations"
 
 version.workspace = true
 edition.workspace = true

--- a/crates/rpc-types-admin/Cargo.toml
+++ b/crates/rpc-types-admin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alloy-rpc-types-admin"
-description = "Ethereum RPC admin types"
+description = "Types for the `admin` Ethereum JSON-RPC namespace"
 
 version.workspace = true
 edition.workspace = true

--- a/crates/rpc-types-debug/Cargo.toml
+++ b/crates/rpc-types-debug/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alloy-rpc-types-debug"
-description = "Ethereum RPC debug types"
+description = "Types for the `debug` Ethereum JSON-RPC namespace"
 
 version.workspace = true
 edition.workspace = true

--- a/crates/rpc-types-mev/Cargo.toml
+++ b/crates/rpc-types-mev/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alloy-rpc-types-mev"
-description = "Types for the MEV JSON-RPC namespace"
+description = "Types for the MEV bundle JSON-RPC namespace"
 
 version.workspace = true
 edition.workspace = true


### PR DESCRIPTION
 - Fixes 'Proprosal' typo in alloy-eips.
 - Corrects wallet_ namespace in alloy-eip5792.
 - Standardizes rpc-types-* description format.
 - Adds 'bundle' to MEV description for clarity.