### PR TITLE
chore: clarify AWS KMS signer EIP-155 documentation

### DIFF
--- a/crates/signer-aws/src/signer.rs
+++ b/crates/signer-aws/src/signer.rs
@@ -182,7 +182,11 @@ impl AwsSigner {
         self.sign_digest_with_key(self.key_id.clone(), digest).await
     }
 
-    /// Sign a digest with this signer's key and applies EIP-155.
+    /// Sign a digest with this signer's key and recover a `Signature` with the
+    /// correct y-parity for the given public key.
+    ///
+    /// The digest is expected to already include any EIP-155 chain ID encoding
+    /// via the transaction's signature hash.
     #[instrument(err, skip(digest), fields(digest = %hex::encode(digest)))]
     async fn sign_digest_inner(&self, digest: &B256) -> Result<Signature, AwsSignerError> {
         let sig = self.sign_digest(digest).await?;


### PR DESCRIPTION
Updates `sign_digest_inner` documentation to clarify that `EIP-155` encoding is expected in the digest, not applied during signing.