### PR TITLE
perf(rpc-types-eth): remove redundant clones in FilterSet and tests

### DIFF
--- a/crates/rpc-types-eth/src/filter.rs
+++ b/crates/rpc-types-eth/src/filter.rs
@@ -191,11 +191,12 @@ impl<T: Clone + Eq + Hash> FilterSet<T> {
     /// - If the filter has only 1 value, it returns the single value
     /// - Otherwise it returns an array of values
     pub fn to_value_or_array(&self) -> Option<ValueOrArray<T>> {
-        let mut values = self.set.iter().cloned().collect::<Vec<T>>();
-        match values.len() {
+        match self.set.len() {
             0 => None,
-            1 => Some(ValueOrArray::Value(values.pop().expect("values length is one"))),
-            _ => Some(ValueOrArray::Array(values)),
+            1 => Some(ValueOrArray::Value(
+                self.set.iter().next().cloned().expect("values length is one"),
+            )),
+            _ => Some(ValueOrArray::Array(self.set.iter().cloned().collect())),
         }
     }
 }
@@ -1745,12 +1746,12 @@ mod tests {
         }
 
         let item = Item { value: ValueOrArray::Value(U256::from(1u64)) };
-        let json = serde_json::to_value(item.clone()).unwrap();
+        let json = serde_json::to_value(&item).unwrap();
         let deserialized: Item = serde_json::from_value(json).unwrap();
         assert_eq!(item, deserialized);
 
         let item = Item { value: ValueOrArray::Array(vec![U256::from(1u64), U256::ZERO]) };
-        let json = serde_json::to_value(item.clone()).unwrap();
+        let json = serde_json::to_value(&item).unwrap();
         let deserialized: Item = serde_json::from_value(json).unwrap();
         assert_eq!(item, deserialized);
     }


### PR DESCRIPTION
This PR removes unnecessary allocations and clones in alloy-rpc-types-eth, specifically targeting the FilterSet::to_value_or_array method and test serialization code.