### PR TITLE
refactor(transport): remove redundant Send + Sync bounds in CloneTransport

### DIFF
--- a/crates/transport/src/boxed.rs
+++ b/crates/transport/src/boxed.rs
@@ -73,15 +73,15 @@ impl Clone for BoxTransport {
 
 /// Helper trait for constructing [`BoxTransport`].
 trait CloneTransport: Transport + std::any::Any {
-    fn clone_box(&self) -> Box<dyn CloneTransport + Send + Sync>;
+    fn clone_box(&self) -> Box<dyn CloneTransport>;
 }
 
 impl<T> CloneTransport for T
 where
-    T: Transport + Clone + Send + Sync,
+    T: Transport + Clone,
 {
     #[inline]
-    fn clone_box(&self) -> Box<dyn CloneTransport + Send + Sync> {
+    fn clone_box(&self) -> Box<dyn CloneTransport> {
         Box::new(self.clone())
     }
 }


### PR DESCRIPTION
Removes redundant `Send + Sync` trait bounds from the internal `CloneTransport` trait and its implementation.