### PR TITLE
rpc-types: expose fallible JSON parsing for RpcModules

### DIFF
--- a/crates/rpc-types/Cargo.toml
+++ b/crates/rpc-types/Cargo.toml
@@ -25,6 +25,7 @@ workspace = true
 [dependencies]
 alloy-primitives = { workspace = true, features = ["map"] }
 alloy-serde.workspace = true
+serde_json = { workspace = true }
 alloy-rpc-types-admin = { workspace = true, optional = true }
 alloy-rpc-types-anvil = { workspace = true, optional = true }
 alloy-rpc-types-any = { workspace = true, optional = true }

--- a/crates/rpc-types/src/rpc.rs
+++ b/crates/rpc-types/src/rpc.rs
@@ -21,6 +21,11 @@ impl RpcModules {
     pub fn into_modules(self) -> HashMap<String, String> {
         self.module_map
     }
+
+    /// Parse `RpcModules` from a JSON string.
+    pub fn from_json(s: &str) -> Result<Self, serde_json::Error> {
+    serde_json::from_str(s)
+    }
 }
 
 #[cfg(test)]
@@ -38,7 +43,7 @@ mod tests {
             ("net".to_owned(), "1.0".to_owned()),
         ]);
         let m = RpcModules::new(module_map);
-        let de_serialized: RpcModules = serde_json::from_str(s).unwrap();
+        let de_serialized = RpcModules::from_json(s).unwrap();
         assert_eq!(de_serialized, m);
     }
 }


### PR DESCRIPTION
Expose a fallible JSON parsing API for RpcModules to avoid implicit panics.

