### PR TITLE
refactor(transport): remove redundant trait bounds in BoxTransport

### DIFF
--- a/crates/transport/src/boxed.rs
+++ b/crates/transport/src/boxed.rs
@@ -73,15 +73,15 @@ impl Clone for BoxTransport {
 
 /// Helper trait for constructing [`BoxTransport`].
 trait CloneTransport: Transport + std::any::Any {
-    fn clone_box(&self) -> Box<dyn CloneTransport + Send + Sync>;
+    fn clone_box(&self) -> Box<dyn CloneTransport>;
 }
 
 impl<T> CloneTransport for T
 where
-    T: Transport + Clone + Send + Sync,
+    T: Transport + Clone,
 {
     #[inline]
-    fn clone_box(&self) -> Box<dyn CloneTransport + Send + Sync> {
+    fn clone_box(&self) -> Box<dyn CloneTransport> {
         Box::new(self.clone())
     }
 }
@@ -132,9 +132,8 @@ mod test {
     const fn _compile_check() {
         const fn inner<T>()
         where
-            T: Transport + CloneTransport + Send + Sync + Clone + IntoBoxTransport + 'static,
-        {
-        }
+            T: CloneTransport + IntoBoxTransport,
+        {}
         inner::<BoxTransport>();
     }
 


### PR DESCRIPTION
Removes redundant trait bounds from `CloneTransport` trait and its implementations, relying on supertrait bounds to provide the necessary constraints.