### PR TITLE
refactor(signer): remove unnecessary `Sized` bounds from EIP-712 methods

### DIFF
--- a/crates/signer/src/signer.rs
+++ b/crates/signer/src/signer.rs
@@ -44,10 +44,7 @@ pub trait Signer<Sig = Signature> {
         &self,
         payload: &T,
         domain: &Eip712Domain,
-    ) -> Result<Sig>
-    where
-        Self: Sized,
-    {
+    ) -> Result<Sig> {
         self.sign_hash(&payload.eip712_signing_hash(domain)).await
     }
 
@@ -112,8 +109,6 @@ pub trait SignerSync<Sig = Signature> {
     #[inline]
     #[auto_impl(keep_default_for(&, &mut, Box, Rc, Arc))]
     fn sign_typed_data_sync<T: SolStruct>(&self, payload: &T, domain: &Eip712Domain) -> Result<Sig>
-    where
-        Self: Sized,
     {
         self.sign_hash_sync(&payload.eip712_signing_hash(domain))
     }


### PR DESCRIPTION
Removes redundant `Self: Sized` bounds from default trait methods `sign_typed_data` and `sign_typed_data_sync` in the `Signer` and `SignerSync` traits.