### PR TITLE
perf(genesis): avoid redundant clone in ChainConfig conversion

### DIFF
--- a/crates/genesis/src/lib.rs
+++ b/crates/genesis/src/lib.rs
@@ -589,9 +589,9 @@ pub mod serde_bincode_compat {
                 blob_schedule: Cow::Borrowed(&value.blob_schedule),
                 extra_fields: {
                     let mut extra_fields = BTreeMap::new();
-                    for (k, v) in value.extra_fields.clone().into_iter() {
+                    for (k, v) in &value.extra_fields {
                         // Convert all serde_json::Value types to string for bincode compatibility
-                        extra_fields.insert(k, v.to_string());
+                        extra_fields.insert(k.clone(), v.to_string());
                     }
                     extra_fields
                 },


### PR DESCRIPTION
Removes unnecessary allocation in `serde_bincode_compat::ChainConfig::from()` by iterating over `extra_fields` by reference instead of cloning the entire map.