### PR TITLE
fix: simplify size functions

### DIFF
--- a/crates/consensus/src/block/header.rs
+++ b/crates/consensus/src/block/header.rs
@@ -15,7 +15,6 @@ use alloy_primitives::{
     keccak256, Address, BlockNumber, Bloom, Bytes, Sealable, Sealed, B256, B64, U256,
 };
 use alloy_rlp::{length_of_length, BufMut, Decodable, Encodable};
-use core::mem;
 
 /// Ethereum Block header
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -240,27 +239,7 @@ impl Header {
     /// Calculate a heuristic for the in-memory size of the [Header].
     #[inline]
     pub fn size(&self) -> usize {
-        mem::size_of::<B256>() + // parent hash
-        mem::size_of::<B256>() + // ommers hash
-        mem::size_of::<Address>() + // beneficiary
-        mem::size_of::<B256>() + // state root
-        mem::size_of::<B256>() + // transactions root
-        mem::size_of::<B256>() + // receipts root
-        mem::size_of::<Option<B256>>() + // withdrawals root
-        mem::size_of::<Bloom>() + // logs bloom
-        mem::size_of::<U256>() + // difficulty
-        mem::size_of::<BlockNumber>() + // number
-        mem::size_of::<u64>() + // gas limit
-        mem::size_of::<u64>() + // gas used
-        mem::size_of::<u64>() + // timestamp
-        mem::size_of::<B256>() + // mix hash
-        mem::size_of::<u64>() + // nonce
-        mem::size_of::<Option<u64>>() + // base fee per gas
-        mem::size_of::<Option<u64>>() + // blob gas used
-        mem::size_of::<Option<u64>>() + // excess blob gas
-        mem::size_of::<Option<B256>>() + // parent beacon block root
-        mem::size_of::<Option<B256>>() + // requests root
-        self.extra_data.len() // extra data
+        size_of::<Self>() + self.extra_data.len()
     }
 
     fn header_payload_length(&self) -> usize {

--- a/crates/consensus/src/transaction/eip1559.rs
+++ b/crates/consensus/src/transaction/eip1559.rs
@@ -1,12 +1,10 @@
+use super::{RlpEcdsaDecodableTx, RlpEcdsaEncodableTx};
 use crate::{SignableTransaction, Transaction, TxType};
 use alloy_eips::{
     eip2718::IsTyped2718, eip2930::AccessList, eip7702::SignedAuthorization, Typed2718,
 };
 use alloy_primitives::{Bytes, ChainId, Signature, TxKind, B256, U256};
 use alloy_rlp::{BufMut, Decodable, Encodable};
-use core::mem;
-
-use super::{RlpEcdsaDecodableTx, RlpEcdsaEncodableTx};
 
 /// A transaction with a priority fee ([EIP-1559](https://eips.ethereum.org/EIPS/eip-1559)).
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
@@ -91,15 +89,7 @@ impl TxEip1559 {
     /// transaction.
     #[inline]
     pub fn size(&self) -> usize {
-        mem::size_of::<ChainId>() + // chain_id
-        mem::size_of::<u64>() + // nonce
-        mem::size_of::<u64>() + // gas_limit
-        mem::size_of::<u128>() + // max_fee_per_gas
-        mem::size_of::<u128>() + // max_priority_fee_per_gas
-        self.to.size() + // to
-        mem::size_of::<U256>() + // value
-        self.access_list.size() + // access_list
-        self.input.len() // input
+        size_of::<Self>() + self.access_list.size() + self.input.len()
     }
 }
 

--- a/crates/consensus/src/transaction/eip2930.rs
+++ b/crates/consensus/src/transaction/eip2930.rs
@@ -1,12 +1,10 @@
+use super::{RlpEcdsaDecodableTx, RlpEcdsaEncodableTx};
 use crate::{SignableTransaction, Transaction, TxType};
 use alloy_eips::{
     eip2718::IsTyped2718, eip2930::AccessList, eip7702::SignedAuthorization, Typed2718,
 };
 use alloy_primitives::{Bytes, ChainId, Signature, TxKind, B256, U256};
 use alloy_rlp::{BufMut, Decodable, Encodable};
-use core::mem;
-
-use super::{RlpEcdsaDecodableTx, RlpEcdsaEncodableTx};
 
 /// Transaction with an [`AccessList`] ([EIP-2930](https://eips.ethereum.org/EIPS/eip-2930)).
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
@@ -76,14 +74,7 @@ impl TxEip2930 {
     /// Calculates a heuristic for the in-memory size of the [TxEip2930] transaction.
     #[inline]
     pub fn size(&self) -> usize {
-        mem::size_of::<ChainId>() + // chain_id
-        mem::size_of::<u64>() + // nonce
-        mem::size_of::<u128>() + // gas_price
-        mem::size_of::<u64>() + // gas_limit
-        self.to.size() + // to
-        mem::size_of::<U256>() + // value
-        self.access_list.size() + // access_list
-        self.input.len() // input
+        size_of::<Self>() + self.access_list.size() + self.input.len()
     }
 }
 

--- a/crates/consensus/src/transaction/eip4844.rs
+++ b/crates/consensus/src/transaction/eip4844.rs
@@ -11,7 +11,7 @@ use alloy_eips::{
 };
 use alloy_primitives::{Address, Bytes, ChainId, Signature, TxKind, B256, U256};
 use alloy_rlp::{BufMut, Decodable, Encodable, Header};
-use core::{fmt, mem};
+use core::fmt;
 
 #[cfg(feature = "kzg")]
 use alloy_eips::eip4844::BlobTransactionValidationError;
@@ -170,7 +170,7 @@ impl<T> TxEip4844Variant<T> {
     pub fn take_sidecar(&mut self) -> Option<T> {
         // Use a placeholder to temporarily replace self
         let placeholder = Self::TxEip4844(TxEip4844::default());
-        match mem::replace(self, placeholder) {
+        match core::mem::replace(self, placeholder) {
             tx @ Self::TxEip4844(_) => {
                 // Put the original transaction back
                 *self = tx;
@@ -839,17 +839,10 @@ impl TxEip4844 {
     /// Calculates a heuristic for the in-memory size of the [TxEip4844Variant] transaction.
     #[inline]
     pub fn size(&self) -> usize {
-        mem::size_of::<ChainId>() + // chain_id
-        mem::size_of::<u64>() + // nonce
-        mem::size_of::<u64>() + // gas_limit
-        mem::size_of::<u128>() + // max_fee_per_gas
-        mem::size_of::<u128>() + // max_priority_fee_per_gas
-        mem::size_of::<Address>() + // to
-        mem::size_of::<U256>() + // value
-        self.access_list.size() + // access_list
-        self.input.len() +  // input
-        self.blob_versioned_hashes.capacity() * mem::size_of::<B256>() + // blob hashes size
-        mem::size_of::<u128>() // max_fee_per_data_gas
+        size_of::<Self>()
+            + self.access_list.size()
+            + self.input.len()
+            + self.blob_versioned_hashes.capacity() * size_of::<B256>()
     }
 }
 

--- a/crates/consensus/src/transaction/eip7702.rs
+++ b/crates/consensus/src/transaction/eip7702.rs
@@ -1,3 +1,4 @@
+use super::{RlpEcdsaDecodableTx, RlpEcdsaEncodableTx};
 use crate::{SignableTransaction, Transaction, TxType};
 use alloc::vec::Vec;
 use alloy_eips::{
@@ -8,9 +9,6 @@ use alloy_eips::{
 };
 use alloy_primitives::{Address, Bytes, ChainId, Signature, TxKind, B256, U256};
 use alloy_rlp::{BufMut, Decodable, Encodable};
-use core::mem;
-
-use super::{RlpEcdsaDecodableTx, RlpEcdsaEncodableTx};
 
 /// A transaction with a priority fee ([EIP-7702](https://eips.ethereum.org/EIPS/eip-7702)).
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
@@ -88,17 +86,10 @@ impl TxEip7702 {
     /// Calculates a heuristic for the in-memory size of the [TxEip7702] transaction.
     #[inline]
     pub fn size(&self) -> usize {
-        mem::size_of::<ChainId>() + // chain_id
-        mem::size_of::<u64>() + // nonce
-        mem::size_of::<u64>() + // gas_limit
-        mem::size_of::<u128>() + // max_fee_per_gas
-        mem::size_of::<u128>() + // max_priority_fee_per_gas
-        mem::size_of::<Address>() + // to
-        mem::size_of::<U256>() + // value
-        self.access_list.size() + // access_list
-        self.input.len() + // input
-        self.authorization_list.capacity() * mem::size_of::<SignedAuthorization>()
-        // authorization_list
+        size_of::<Self>()
+            + self.access_list.size()
+            + self.input.len()
+            + self.authorization_list.capacity() * size_of::<SignedAuthorization>()
     }
 }
 

--- a/crates/consensus/src/transaction/legacy.rs
+++ b/crates/consensus/src/transaction/legacy.rs
@@ -8,7 +8,6 @@ use alloy_eips::{
 };
 use alloy_primitives::{keccak256, Bytes, ChainId, Signature, TxKind, B256, U256};
 use alloy_rlp::{length_of_length, BufMut, Decodable, Encodable, Header, Result};
-use core::mem;
 
 /// Legacy transaction.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
@@ -78,13 +77,7 @@ impl TxLegacy {
     /// Calculates a heuristic for the in-memory size of the [TxLegacy] transaction.
     #[inline]
     pub fn size(&self) -> usize {
-        mem::size_of::<Option<ChainId>>() + // chain_id
-        mem::size_of::<u64>() + // nonce
-        mem::size_of::<u128>() + // gas_price
-        mem::size_of::<u64>() + // gas_limit
-        self.to.size() + // to
-        mem::size_of::<U256>() + // value
-        self.input.len() // input
+        size_of::<Self>() + self.input.len()
     }
 
     /// Outputs the length of EIP-155 fields. Only outputs a non-zero value for EIP-155 legacy

--- a/crates/eips/src/eip4895.rs
+++ b/crates/eips/src/eip4895.rs
@@ -76,7 +76,7 @@ impl Withdrawals {
     /// Calculate a heuristic for the in-memory size of the [Withdrawals].
     #[inline]
     pub const fn size(&self) -> usize {
-        self.0.len() * core::mem::size_of::<Withdrawal>()
+        size_of::<Self>() + self.0.capacity() * size_of::<Withdrawal>()
     }
 
     /// Get an iterator over the Withdrawals.

--- a/crates/eips/src/eip7594/sidecar.rs
+++ b/crates/eips/src/eip7594/sidecar.rs
@@ -545,9 +545,9 @@ impl BlobTransactionSidecarEip7594 {
     /// Calculates a size heuristic for the in-memory size of the [BlobTransactionSidecarEip7594].
     #[inline]
     pub const fn size(&self) -> usize {
-        self.blobs.len() * BYTES_PER_BLOB + // blobs
-               self.commitments.len() * BYTES_PER_COMMITMENT + // commitments
-               self.cell_proofs.len() * BYTES_PER_PROOF // proofs
+        self.blobs.capacity() * BYTES_PER_BLOB
+            + self.commitments.capacity() * BYTES_PER_COMMITMENT
+            + self.cell_proofs.capacity() * BYTES_PER_PROOF
     }
 
     /// Verifies that the versioned hashes are valid for this sidecar's blob data, commitments, and


### PR DESCRIPTION
I don't know why we're summing up individual fields when:
1. it doesn't for padding
2. it's tedious to maintain

Just use `size_of::<Self>()`.