### PR TITLE
chore: add deprecated type alias back

### DIFF
--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -16,6 +16,10 @@ use once_cell as _;
 
 pub use alloy_trie::TrieAccount;
 
+/// Represents an TrieAccount in the account trie
+#[deprecated(since = "0.7.3", note = "use TrieAccount instead")]
+pub type Account = TrieAccount;
+
 mod block;
 pub use block::{Block, BlockBody, BlockHeader, EthBlock, Header, HeaderInfo};
 


### PR DESCRIPTION
removed in #3341 because deprecate isnt picked up on pub use as, we need to introduce an alias, this way people can migrate properly because this caused some friction:


https://github.com/a16z/helios/pull/752