### PR TITLE
fix(signer-turnkey): use SignatureNotFound for empty signature fields

### DIFF
--- a/crates/signer-turnkey/src/signer.rs
+++ b/crates/signer-turnkey/src/signer.rs
@@ -115,6 +115,17 @@ impl Signer for TurnkeySigner {
             .map_err(|e| alloy_signer::Error::other(TurnkeySignerError::TurnkeyClient(e)))?;
 
         // Parse r, s, v from response
+        // Check for empty signature fields before decoding
+        if response.r.is_empty() {
+            return Err(alloy_signer::Error::other(TurnkeySignerError::SignatureNotFound));
+        }
+        if response.s.is_empty() {
+            return Err(alloy_signer::Error::other(TurnkeySignerError::SignatureNotFound));
+        }
+        if response.v.is_empty() {
+            return Err(alloy_signer::Error::other(TurnkeySignerError::SignatureNotFound));
+        }
+
         let r_bytes = hex::decode(&response.r)
             .map_err(|e| alloy_signer::Error::other(TurnkeySignerError::Hex(e)))?;
         let s_bytes = hex::decode(&response.s)


### PR DESCRIPTION
### Fix
SignatureNotFound was defined but unused. Empty signature fields were handled as hex errors instead of missing signature errors.
### Changes
- Check for empty r, s, v fields before hex decoding
- Return SignatureNotFound when fields are empty
- Improves error semantics by distinguishing missing signatures from invalid hex