### PR TITLE
fix(rpc-types-engine): correct doc comment for PrePragueBlockWithEip7702Transactions

### DIFF
--- a/crates/rpc-types-engine/src/error.rs
+++ b/crates/rpc-types-engine/src/error.rs
@@ -50,7 +50,7 @@ pub enum PayloadError {
     /// cancun fields missing in post-cancun payload.
     #[display("cancun fields missing in post-cancun payload")]
     PostCancunWithoutCancunFields,
-    /// blob transactions present in pre-prague payload.
+    /// EIP-7702 transactions present in pre-prague payload.
     #[display("eip 7702 transactions present in pre-prague payload")]
     PrePragueBlockWithEip7702Transactions,
     /// requests present in pre-prague payload.


### PR DESCRIPTION
Fix documentation inconsistency where the doc comment incorrectly referred to "blob transactions" when it should reference "EIP-7702 transactions" to match the display message and enum variant name.
The variant `PrePragueBlockWithEip7702Transactions` is for EIP-7702 transactions (Set EOA account code), not blob transactions (EIP-4844). This aligns the documentation with the actual error being described.