### PR TITLE
fix: support Eip7594 blob format for tx build

### DIFF
--- a/crates/consensus/src/transaction/eip4844.rs
+++ b/crates/consensus/src/transaction/eip4844.rs
@@ -29,7 +29,7 @@ use alloy_eips::eip7594::{BlobTransactionSidecarEip7594, BlobTransactionSidecarV
 #[cfg_attr(feature = "serde", serde(untagged))]
 #[cfg_attr(feature = "borsh", derive(borsh::BorshSerialize, borsh::BorshDeserialize))]
 #[doc(alias = "Eip4844TransactionVariant")]
-pub enum TxEip4844Variant<T = BlobTransactionSidecar> {
+pub enum TxEip4844Variant<T = BlobTransactionSidecarVariant> {
     /// A standalone transaction with blob hashes and max blob fee.
     TxEip4844(TxEip4844),
     /// A transaction with a sidecar, which contains the blob data, commitments, and proofs.
@@ -106,6 +106,16 @@ impl<T> From<TxEip4844> for TxEip4844Variant<T> {
 impl From<(TxEip4844, BlobTransactionSidecar)> for TxEip4844Variant<BlobTransactionSidecar> {
     fn from((tx, sidecar): (TxEip4844, BlobTransactionSidecar)) -> Self {
         TxEip4844WithSidecar::from_tx_and_sidecar(tx, sidecar).into()
+    }
+}
+
+impl From<TxEip4844WithSidecar<BlobTransactionSidecar>>
+    for TxEip4844Variant<BlobTransactionSidecarVariant>
+{
+    fn from(tx: TxEip4844WithSidecar<BlobTransactionSidecar>) -> Self {
+        let (tx, sidecar) = tx.into_parts();
+        let sidecar_variant = BlobTransactionSidecarVariant::Eip4844(sidecar);
+        TxEip4844WithSidecar::from_tx_and_sidecar(tx, sidecar_variant).into()
     }
 }
 
@@ -1039,7 +1049,7 @@ impl<T> From<TxEip4844WithSidecar<T>> for TxEip4844 {
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "borsh", derive(borsh::BorshSerialize, borsh::BorshDeserialize))]
 #[doc(alias = "Eip4844TransactionWithSidecar", alias = "Eip4844TxWithSidecar")]
-pub struct TxEip4844WithSidecar<T = BlobTransactionSidecar> {
+pub struct TxEip4844WithSidecar<T = BlobTransactionSidecarVariant> {
     /// The actual transaction.
     #[cfg_attr(feature = "serde", serde(flatten))]
     #[doc(alias = "transaction")]

--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -1067,6 +1067,7 @@ mod tests {
     use alloy_eips::{
         eip2930::{AccessList, AccessListItem},
         eip4844::BlobTransactionSidecar,
+        eip7594::BlobTransactionSidecarVariant,
         eip7702::Authorization,
     };
     #[allow(unused_imports)]
@@ -1377,7 +1378,7 @@ mod tests {
             blob_versioned_hashes: vec![B256::random()],
             max_fee_per_blob_gas: 0,
         };
-        let tx = TxEip4844Variant::TxEip4844(tx);
+        let tx: TxEip4844Variant = tx.into();
         let signature = Signature::test_signature().with_parity(true);
         test_encode_decode_roundtrip(tx, Some(signature));
     }
@@ -1531,7 +1532,7 @@ mod tests {
     #[test]
     #[cfg(feature = "serde")]
     fn test_serde_roundtrip_eip4844() {
-        let tx = TxEip4844Variant::TxEip4844(TxEip4844 {
+        let tx: TxEip4844Variant = TxEip4844 {
             chain_id: 1,
             nonce: 100,
             max_fee_per_gas: 50_000_000_000,
@@ -1546,7 +1547,8 @@ mod tests {
             }]),
             blob_versioned_hashes: vec![B256::random()],
             max_fee_per_blob_gas: 0,
-        });
+        }
+        .into();
         test_serde_roundtrip(tx);
 
         let tx = TxEip4844Variant::TxEip4844WithSidecar(TxEip4844WithSidecar {
@@ -1566,7 +1568,7 @@ mod tests {
                 blob_versioned_hashes: vec![B256::random()],
                 max_fee_per_blob_gas: 0,
             },
-            sidecar: Default::default(),
+            sidecar: BlobTransactionSidecarVariant::Eip4844(Default::default()),
         });
         test_serde_roundtrip(tx);
     }
@@ -1700,7 +1702,7 @@ mod tests {
             Default::default(),
         );
         let eip4844_variant = Signed::new_unchecked(
-            TxEip4844Variant::TxEip4844(TxEip4844::default()),
+            TxEip4844Variant::<BlobTransactionSidecarVariant>::TxEip4844(TxEip4844::default()),
             Signature::test_signature(),
             Default::default(),
         );

--- a/crates/consensus/src/transaction/pooled.rs
+++ b/crates/consensus/src/transaction/pooled.rs
@@ -196,13 +196,16 @@ mod tests {
                 panic!("Expected EIP-4844 transaction");
             };
             let tx = tx.into_parts().0;
-            assert!(!tx.sidecar.blobs.is_empty());
+            assert!(!tx.sidecar.blobs().is_empty());
             assert!(tx.validate_blob(kzg_settings.get()).is_ok());
 
-            let tx =
-                tx.try_map_sidecar(|sidecar| sidecar.try_into_7594(kzg_settings.get())).unwrap();
+            let tx = tx
+                .try_map_sidecar(|sidecar| {
+                    sidecar.try_convert_into_eip7594_with_settings(kzg_settings.get())
+                })
+                .unwrap();
 
-            assert!(!tx.sidecar.blobs.is_empty());
+            assert!(!tx.sidecar.blobs().is_empty());
             assert!(tx.validate_blob(kzg_settings.get()).is_ok());
         }
     }


### PR DESCRIPTION
## Motivation

Close #3372 

## Solution

- Change TxEip4844Variant and TxEip4844WithSidecar defaults from BlobTransactionSidecar to BlobTransactionSidecarVariant
- Fix build_4844_with_sidecar to build with EIP-4844 and EIP-7594 sidecars
- Update tests to use blob format variant enum

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [x] Breaking changes
