### PR TITLE
feat(provider): add transaction count caching to CacheProvider

### DIFF
--- a/crates/provider/src/layers/cache.rs
+++ b/crates/provider/src/layers/cache.rs
@@ -1,8 +1,12 @@
-use crate::{ParamsWithBlock, Provider, ProviderCall, ProviderLayer, RootProvider, RpcWithBlock};
+use crate::{
+    utils, ParamsWithBlock, Provider, ProviderCall, ProviderLayer, RootProvider, RpcWithBlock,
+};
 use alloy_eips::BlockId;
 use alloy_json_rpc::{RpcError, RpcSend};
 use alloy_network::Network;
-use alloy_primitives::{keccak256, Address, Bytes, StorageKey, StorageValue, TxHash, B256, U256};
+use alloy_primitives::{
+    keccak256, Address, Bytes, StorageKey, StorageValue, TxHash, B256, U256, U64,
+};
 use alloy_rpc_types_eth::{BlockNumberOrTag, EIP1186AccountProofResponse, Filter, Log};
 use alloy_transport::{TransportErrorKind, TransportResult};
 use lru::LruCache;
@@ -345,6 +349,54 @@ where
 
             Ok(result)
         }))
+    }
+
+    fn get_transaction_count(
+        &self,
+        address: Address,
+    ) -> RpcWithBlock<Address, U64, u64, fn(U64) -> u64> {
+        let client = self.inner.weak_client();
+        let cache = self.cache.clone();
+        RpcWithBlock::new_provider(move |block_id| {
+            let req = RequestType::new("eth_getTransactionCount", address).with_block_id(block_id);
+
+            let redirect = req.has_block_tag();
+
+            if !redirect {
+                let params_hash = req.params_hash().ok();
+
+                if let Some(hash) = params_hash {
+                    if let Ok(Some(cached)) = cache.get_deserialized::<U64>(&hash) {
+                        return ProviderCall::BoxedFuture(Box::pin(async move {
+                            Ok(utils::convert_u64(cached))
+                        }));
+                    }
+                }
+            }
+
+            let client = client.clone();
+            let cache = cache.clone();
+
+            ProviderCall::BoxedFuture(Box::pin(async move {
+                let client = client
+                    .upgrade()
+                    .ok_or_else(|| TransportErrorKind::custom_str("RPC client dropped"))?;
+
+                let result: U64 = client
+                    .request(req.method(), req.params())
+                    .map_params(|params| ParamsWithBlock::new(params, block_id))
+                    .await?;
+
+                if !redirect {
+                    let json_str =
+                        serde_json::to_string(&result).map_err(TransportErrorKind::custom)?;
+                    let hash = req.params_hash()?;
+                    let _ = cache.put(hash, json_str);
+                }
+
+                Ok(utils::convert_u64(result))
+            }))
+        })
     }
 }
 
@@ -692,6 +744,70 @@ mod tests {
             assert_eq!(counter2, U256::from(1));
             let counter2_cached = provider.get_storage_at(counter_addr, U256::ZERO).block_id(block_id2).await.unwrap(); // Received from cache.
             assert_eq!(counter2, counter2_cached);
+
+            shared_cache.save_cache(path).unwrap();
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_get_transaction_count() {
+        run_with_tempdir("get-tx-count", |dir| async move {
+            let cache_layer = CacheLayer::new(100);
+            // CacheLayer uses Arc internally, so cloning shares the same cache.
+            let cache_layer2 = cache_layer.clone();
+            let shared_cache = cache_layer.cache();
+            let anvil = Anvil::new().spawn();
+            let provider = ProviderBuilder::new()
+                .disable_recommended_fillers()
+                .layer(cache_layer)
+                .connect_http(anvil.endpoint_url());
+
+            let path = dir.join("rpc-cache-tx-count.txt");
+            shared_cache.load_cache(path.clone()).unwrap();
+
+            let address = anvil.addresses()[0];
+
+            // Send a transaction to increase the nonce
+            let req = TransactionRequest::default()
+                .from(address)
+                .to(Address::repeat_byte(5))
+                .value(U256::ZERO)
+                .input(bytes!("deadbeef").into());
+
+            let receipt = provider
+                .send_transaction(req)
+                .await
+                .expect("failed to send tx")
+                .get_receipt()
+                .await
+                .unwrap();
+            let block_number = receipt.block_number.unwrap();
+
+            // Get transaction count from RPC (populates cache)
+            let count = provider
+                .get_transaction_count(address)
+                .block_id(block_number.into())
+                .await
+                .unwrap();
+            assert_eq!(count, 1);
+
+            // Drop anvil to ensure second call can't hit RPC
+            drop(anvil);
+
+            // Create new provider with same cache but dead endpoint
+            let provider2 = ProviderBuilder::new()
+                .disable_recommended_fillers()
+                .layer(cache_layer2)
+                .connect_http("http://localhost:1".parse().unwrap());
+
+            // This only succeeds if cache is hit
+            let count2 = provider2
+                .get_transaction_count(address)
+                .block_id(block_number.into())
+                .await
+                .unwrap();
+            assert_eq!(count, count2);
 
             shared_cache.save_cache(path).unwrap();
         })


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Add support to cache `eth_getTransactionCount` for specific blocks.


## Solution

Implement `eth_getTransactionCount` cache for `CacheProvider` when no block tag is used.

PS: I tried to use the `rpc_call_with_block` macro, but due to the requirement for `convert_u64` (the output is U64 while the return type requires u64), I opted for a manual implementation instead. I think this will also be the reason why this was missing.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [x] Breaking changes
