### PR TITLE
feat(rpc-types-engine): add `into_block_raw_with_transactions_root` to execution payloads

### DIFF
--- a/crates/rpc-types-engine/src/payload.rs
+++ b/crates/rpc-types-engine/src/payload.rs
@@ -509,13 +509,36 @@ impl ExecutionPayloadV1 {
     /// This is similar to [`Self::try_into_block_with`] but returns the transactions as raw bytes
     /// without any conversion.
     pub fn into_block_raw(self) -> Result<Block<Bytes>, PayloadError> {
+        self.into_block_raw_with_transactions_root_opt(None)
+    }
+
+    /// Converts [`ExecutionPayloadV1`] to [`Block`] with raw [`Bytes`] transactions using the
+    /// given `transactions_root`.
+    ///
+    /// This is the same as [`Self::into_block_raw`] but allows the caller to provide a
+    /// pre-computed transactions root instead of computing it from the transactions.
+    pub fn into_block_raw_with_transactions_root(
+        self,
+        transactions_root: B256,
+    ) -> Result<Block<Bytes>, PayloadError> {
+        self.into_block_raw_with_transactions_root_opt(Some(transactions_root))
+    }
+
+    /// Converts [`ExecutionPayloadV1`] to [`Block`] with raw [`Bytes`] transactions, optionally
+    /// using the given `transactions_root`.
+    ///
+    /// If `transactions_root` is `None`, it will be computed from the transactions.
+    pub fn into_block_raw_with_transactions_root_opt(
+        self,
+        transactions_root: Option<B256>,
+    ) -> Result<Block<Bytes>, PayloadError> {
         if self.extra_data.len() > MAXIMUM_EXTRA_DATA_SIZE {
             return Err(PayloadError::ExtraData(self.extra_data));
         }
 
-        // Calculate the transactions root using encoded bytes
-        let transactions_root =
-            alloy_consensus::proofs::ordered_trie_root_encoded(&self.transactions);
+        let transactions_root = transactions_root.unwrap_or_else(|| {
+            alloy_consensus::proofs::ordered_trie_root_encoded(&self.transactions)
+        });
 
         let header = Header {
             parent_hash: self.parent_hash,
@@ -717,7 +740,30 @@ impl ExecutionPayloadV2 {
     /// This is similar to [`Self::try_into_block_with`] but returns the transactions as raw bytes
     /// without any conversion.
     pub fn into_block_raw(self) -> Result<Block<Bytes>, PayloadError> {
-        let mut base_sealed_block = self.payload_inner.into_block_raw()?;
+        self.into_block_raw_with_transactions_root_opt(None)
+    }
+
+    /// Converts [`ExecutionPayloadV2`] to [`Block`] with raw [`Bytes`] transactions using the
+    /// given `transactions_root`.
+    ///
+    /// See also [`ExecutionPayloadV1::into_block_raw_with_transactions_root`].
+    pub fn into_block_raw_with_transactions_root(
+        self,
+        transactions_root: B256,
+    ) -> Result<Block<Bytes>, PayloadError> {
+        self.into_block_raw_with_transactions_root_opt(Some(transactions_root))
+    }
+
+    /// Converts [`ExecutionPayloadV2`] to [`Block`] with raw [`Bytes`] transactions, optionally
+    /// using the given `transactions_root`.
+    ///
+    /// If `transactions_root` is `None`, it will be computed from the transactions.
+    pub fn into_block_raw_with_transactions_root_opt(
+        self,
+        transactions_root: Option<B256>,
+    ) -> Result<Block<Bytes>, PayloadError> {
+        let mut base_sealed_block =
+            self.payload_inner.into_block_raw_with_transactions_root_opt(transactions_root)?;
         let withdrawals_root =
             alloy_consensus::proofs::calculate_withdrawals_root(&self.withdrawals);
         base_sealed_block.body.withdrawals = Some(self.withdrawals.into());
@@ -916,7 +962,30 @@ impl ExecutionPayloadV3 {
     /// This is similar to [`Self::try_into_block_with`] but returns the transactions as raw bytes
     /// without any conversion.
     pub fn into_block_raw(self) -> Result<Block<Bytes>, PayloadError> {
-        let mut base_block = self.payload_inner.into_block_raw()?;
+        self.into_block_raw_with_transactions_root_opt(None)
+    }
+
+    /// Converts [`ExecutionPayloadV3`] to [`Block`] with raw [`Bytes`] transactions using the
+    /// given `transactions_root`.
+    ///
+    /// See also [`ExecutionPayloadV1::into_block_raw_with_transactions_root`].
+    pub fn into_block_raw_with_transactions_root(
+        self,
+        transactions_root: B256,
+    ) -> Result<Block<Bytes>, PayloadError> {
+        self.into_block_raw_with_transactions_root_opt(Some(transactions_root))
+    }
+
+    /// Converts [`ExecutionPayloadV3`] to [`Block`] with raw [`Bytes`] transactions, optionally
+    /// using the given `transactions_root`.
+    ///
+    /// If `transactions_root` is `None`, it will be computed from the transactions.
+    pub fn into_block_raw_with_transactions_root_opt(
+        self,
+        transactions_root: Option<B256>,
+    ) -> Result<Block<Bytes>, PayloadError> {
+        let mut base_block =
+            self.payload_inner.into_block_raw_with_transactions_root_opt(transactions_root)?;
 
         base_block.header.blob_gas_used = Some(self.blob_gas_used);
         base_block.header.excess_blob_gas = Some(self.excess_blob_gas);
@@ -1753,11 +1822,54 @@ impl ExecutionPayload {
     /// This is similar to [`Self::try_into_block_with`] but returns the transactions as raw bytes
     /// without any conversion.
     pub fn into_block_raw(self) -> Result<Block<Bytes>, PayloadError> {
+        self.into_block_raw_with_transactions_root_opt(None)
+    }
+
+    /// Converts [`ExecutionPayload`] to [`Block`] with raw [`Bytes`] transactions using the
+    /// given `transactions_root`.
+    ///
+    /// See also [`ExecutionPayloadV1::into_block_raw_with_transactions_root`].
+    pub fn into_block_raw_with_transactions_root(
+        self,
+        transactions_root: B256,
+    ) -> Result<Block<Bytes>, PayloadError> {
+        self.into_block_raw_with_transactions_root_opt(Some(transactions_root))
+    }
+
+    /// Converts [`ExecutionPayload`] to [`Block`] with raw [`Bytes`] transactions, optionally
+    /// using the given `transactions_root`.
+    ///
+    /// If `transactions_root` is `None`, it will be computed from the transactions.
+    pub fn into_block_raw_with_transactions_root_opt(
+        self,
+        transactions_root: Option<B256>,
+    ) -> Result<Block<Bytes>, PayloadError> {
         match self {
-            Self::V1(payload) => payload.into_block_raw(),
-            Self::V2(payload) => payload.into_block_raw(),
-            Self::V3(payload) => payload.into_block_raw(),
+            Self::V1(payload) => {
+                payload.into_block_raw_with_transactions_root_opt(transactions_root)
+            }
+            Self::V2(payload) => {
+                payload.into_block_raw_with_transactions_root_opt(transactions_root)
+            }
+            Self::V3(payload) => {
+                payload.into_block_raw_with_transactions_root_opt(transactions_root)
+            }
         }
+    }
+
+    /// Converts [`ExecutionPayload`] to [`Block`] with raw [`Bytes`] transactions and sidecar
+    /// using the given `transactions_root`.
+    ///
+    /// See also [`Self::into_block_with_sidecar_raw`].
+    pub fn into_block_with_sidecar_raw_with_transactions_root(
+        self,
+        sidecar: &ExecutionPayloadSidecar,
+        transactions_root: B256,
+    ) -> Result<Block<Bytes>, PayloadError> {
+        let mut base_block = self.into_block_raw_with_transactions_root(transactions_root)?;
+        base_block.header.parent_beacon_block_root = sidecar.parent_beacon_block_root();
+        base_block.header.requests_hash = sidecar.requests_hash();
+        Ok(base_block)
     }
 
     /// Returns a reference to the V1 payload.
@@ -3429,6 +3541,144 @@ mod tests {
                 path, expected_hash, actual_hash
             );
         }
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn test_into_block_raw_with_transactions_root() {
+        use std::path::PathBuf;
+
+        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("testdata/payload");
+        let dir = std::fs::read_dir(path).expect("Unable to read payload folder");
+
+        for entry in dir {
+            let entry = entry.expect("Unable to read entry");
+            let path = entry.path();
+
+            if path.extension().and_then(|s| s.to_str()) != Some("json") {
+                continue;
+            }
+
+            let contents = std::fs::read_to_string(&path).expect("Unable to read file");
+            let value: serde_json::Value = serde_json::from_str(&contents)
+                .unwrap_or_else(|e| panic!("Failed to parse JSON from {path:?}: {e}"));
+
+            let new_payload = &value["newPayload"];
+            let payload_value = &new_payload["payload"];
+            let sidecar_value = &new_payload["sidecar"];
+
+            let payload: ExecutionPayload = serde_json::from_value(payload_value.clone())
+                .unwrap_or_else(|e| panic!("Failed to deserialize payload from {path:?}: {e}"));
+
+            let sidecar: ExecutionPayloadSidecar = serde_json::from_value(sidecar_value.clone())
+                .unwrap_or_else(|e| panic!("Failed to deserialize sidecar from {path:?}: {e}"));
+
+            let expected_hash = payload_value["blockHash"]
+                .as_str()
+                .unwrap()
+                .parse::<B256>()
+                .unwrap_or_else(|e| panic!("Failed to parse block hash from {path:?}: {e}"));
+
+            // Build the block normally to get the computed transactions root
+            let block_normal =
+                payload.clone().into_block_with_sidecar_raw(&sidecar).unwrap_or_else(|e| {
+                    panic!("Failed to convert payload to block from {path:?}: {e}")
+                });
+            let tx_root = block_normal.header.transactions_root;
+
+            // Build using pre-computed transactions root
+            let block_with_root =
+                payload.clone().into_block_raw_with_transactions_root(tx_root).unwrap();
+            assert_eq!(
+                block_with_root.header.transactions_root, tx_root,
+                "transactions_root mismatch in {path:?}"
+            );
+
+            // Build using the opt variant with Some
+            let block_opt_some =
+                payload.clone().into_block_raw_with_transactions_root_opt(Some(tx_root)).unwrap();
+            assert_eq!(
+                block_opt_some.header.transactions_root, tx_root,
+                "opt(Some) transactions_root mismatch in {path:?}"
+            );
+
+            // Build using the opt variant with None (should compute same root)
+            let block_opt_none =
+                payload.clone().into_block_raw_with_transactions_root_opt(None).unwrap();
+            assert_eq!(
+                block_opt_none.header.transactions_root, tx_root,
+                "opt(None) transactions_root mismatch in {path:?}"
+            );
+
+            // Build with sidecar + pre-computed root and verify block hash
+            let block_sidecar_root = payload
+                .into_block_with_sidecar_raw_with_transactions_root(&sidecar, tx_root)
+                .unwrap();
+            let actual_hash = block_sidecar_root.header.hash_slow();
+            assert_eq!(
+                actual_hash, expected_hash,
+                "Block hash mismatch with pre-computed tx root in {path:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_v1_with_transactions_root_override() {
+        let transaction = Bytes::from_static(&hex!("f86d0a8458b20efd825208946177843db3138ae69679a54b95cf345ed759450d8806f3e8d87878800080820a95a0f8bddb1dcc4558b532ff747760a6f547dd275afdbe7bdecc90680e71de105757a014f34ba38c180913c0543b0ac2eccfb77cc3f801a535008dc50e533fbe435f53"));
+
+        let payload = ExecutionPayloadV1 {
+            parent_hash: B256::default(),
+            fee_recipient: Address::default(),
+            state_root: B256::default(),
+            receipts_root: B256::default(),
+            logs_bloom: Bloom::default(),
+            prev_randao: B256::default(),
+            block_number: 0,
+            gas_limit: 0,
+            gas_used: 0,
+            timestamp: 0,
+            extra_data: Bytes::default(),
+            base_fee_per_gas: U256::from(1),
+            block_hash: B256::default(),
+            transactions: vec![transaction],
+        };
+
+        let computed_root = payload.clone().into_block_raw().unwrap().header.transactions_root;
+
+        let fake_root = b256!("1111111111111111111111111111111111111111111111111111111111111111");
+        assert_ne!(computed_root, fake_root);
+
+        let block = payload.clone().into_block_raw_with_transactions_root(fake_root).unwrap();
+        assert_eq!(block.header.transactions_root, fake_root);
+
+        let block_opt = payload.into_block_raw_with_transactions_root_opt(Some(fake_root)).unwrap();
+        assert_eq!(block_opt.header.transactions_root, fake_root);
+    }
+
+    #[test]
+    fn test_with_transactions_root_extra_data_validation() {
+        let payload = ExecutionPayloadV1 {
+            parent_hash: B256::default(),
+            fee_recipient: Address::default(),
+            state_root: B256::default(),
+            receipts_root: B256::default(),
+            logs_bloom: Bloom::default(),
+            prev_randao: B256::default(),
+            block_number: 0,
+            gas_limit: 0,
+            gas_used: 0,
+            timestamp: 0,
+            extra_data: Bytes::from(vec![0u8; MAXIMUM_EXTRA_DATA_SIZE + 1]),
+            base_fee_per_gas: U256::from(1),
+            block_hash: B256::default(),
+            transactions: vec![],
+        };
+
+        let fake_root = b256!("1111111111111111111111111111111111111111111111111111111111111111");
+
+        assert!(payload.clone().into_block_raw().is_err());
+        assert!(payload.clone().into_block_raw_with_transactions_root(fake_root).is_err());
+        assert!(payload.into_block_raw_with_transactions_root_opt(Some(fake_root)).is_err());
     }
 
     #[test]


### PR DESCRIPTION
Adds `into_block_raw_with_transactions_root(B256)` to `ExecutionPayloadV1`, `ExecutionPayloadV2`, `ExecutionPayloadV3`, and the `ExecutionPayload` enum.

This allows callers who already have a pre-computed transactions root to skip the trie computation when converting an execution payload to a block.

Also adds `into_block_with_sidecar_and_transactions_root_raw` on `ExecutionPayload` for the sidecar conversion path.

Closes #3444