### PR TITLE
feat(provider): add balance caching to CacheProvider

### DIFF
--- a/crates/provider/src/layers/cache.rs
+++ b/crates/provider/src/layers/cache.rs
@@ -191,6 +191,15 @@ where
         }))
     }
 
+    fn get_balance(&self, address: Address) -> RpcWithBlock<Address, U256> {
+        let client = self.inner.weak_client();
+        let cache = self.cache.clone();
+        RpcWithBlock::new_provider(move |block_id| {
+            let req = RequestType::new("eth_getBalance", address).with_block_id(block_id);
+            cache_rpc_call_with_block!(cache, client, req)
+        })
+    }
+
     fn get_code_at(&self, address: Address) -> RpcWithBlock<Address, Bytes> {
         let client = self.inner.weak_client();
         let cache = self.cache.clone();
@@ -554,7 +563,7 @@ mod tests {
     use crate::ProviderBuilder;
     use alloy_network::TransactionBuilder;
     use alloy_node_bindings::{utils::run_with_tempdir, Anvil};
-    use alloy_primitives::{bytes, hex, Bytes, FixedBytes};
+    use alloy_primitives::{bytes, hex, utils::Unit, Bytes, FixedBytes};
     use alloy_rpc_types_eth::{BlockId, TransactionRequest};
 
     #[tokio::test]
@@ -672,6 +681,60 @@ mod tests {
             shared_cache.save_cache(path).unwrap();
         })
         .await
+    }
+
+    #[tokio::test]
+    async fn test_get_balance() {
+        run_with_tempdir("get-balance", |dir| async move {
+            let cache_layer = CacheLayer::new(100);
+            let cache_layer2 = cache_layer.clone();
+            let shared_cache = cache_layer.cache();
+            let anvil = Anvil::new().spawn();
+            let provider = ProviderBuilder::new()
+                .disable_recommended_fillers()
+                .layer(cache_layer)
+                .connect_http(anvil.endpoint_url());
+
+            let path = dir.join("rpc-cache-balance.txt");
+            shared_cache.load_cache(path.clone()).unwrap();
+
+            let to = Address::repeat_byte(5);
+
+            // Send a transaction to change balance
+            let req = TransactionRequest::default()
+                .from(anvil.addresses()[0])
+                .to(to)
+                .value(Unit::ETHER.wei());
+
+            let receipt = provider
+                .send_transaction(req)
+                .await
+                .expect("failed to send tx")
+                .get_receipt()
+                .await
+                .unwrap();
+            let block_number = receipt.block_number.unwrap();
+
+            // Get balance from RPC (populates cache)
+            let balance = provider.get_balance(to).block_id(block_number.into()).await.unwrap();
+            assert_eq!(balance, Unit::ETHER.wei());
+
+            // Drop anvil to ensure second call can't hit RPC
+            drop(anvil);
+
+            // Create new provider with same cache but dead endpoint
+            let provider2 = ProviderBuilder::new()
+                .disable_recommended_fillers()
+                .layer(cache_layer2)
+                .connect_http("http://localhost:1".parse().unwrap());
+
+            // This only succeeds if cache is hit
+            let balance2 = provider2.get_balance(to).block_id(block_number.into()).await.unwrap();
+            assert_eq!(balance, balance2);
+
+            shared_cache.save_cache(path).unwrap();
+        })
+        .await;
     }
 
     #[tokio::test]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Cache `eth_getBalance` for request that are not using a block tag.

## Solution

Using `cache_rpc_call_with_block` to cache the request for `eth_getBalance` as it is done for other requests.

PS: I could have just read the anvil balance in the test, but thought a fresh address approach can not have any side effects.

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [x] Breaking changes
