### PR TITLE
chore: ignore RUSTSEC-2025-0141 bincode advisory

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -6,6 +6,8 @@ ignore = [
     "RUSTSEC-2024-0437",
     # https://rustsec.org/advisories/RUSTSEC-2024-0436
     "RUSTSEC-2024-0436",
+    # https://rustsec.org/advisories/RUSTSEC-2025-0137 `reciprocal_mg10` OOB, unused
+    "RUSTSEC-2025-0137",
     # https://rustsec.org/advisories/RUSTSEC-2025-0141 bincode is unmaintained, need to transition all deps to wincode first
     "RUSTSEC-2025-0141",
 ]


### PR DESCRIPTION
Ignores the bincode unmaintained advisory until we can transition all dependencies to wincode.

https://rustsec.org/advisories/RUSTSEC-2025-0141