### PR TITLE
pubsub: cleanup pending requests on service shutdown

### DIFF
--- a/crates/pubsub/src/managers/req.rs
+++ b/crates/pubsub/src/managers/req.rs
@@ -35,4 +35,9 @@ impl RequestManager {
         }
         None
     }
+
+    /// Drain all in-flight requests for cleanup on shutdown.
+    pub(crate) fn drain(&mut self) -> impl Iterator<Item = (Id, InFlight)> {
+        std::mem::take(&mut self.reqs).into_iter()
+    }
 }


### PR DESCRIPTION
Fixes pending requests hanging forever when reconnect attempts are exhausted. 

Now sends `backend_gone` error to all in-flight requests on final shutdown instead of just logging and dropping everything silently.