### PR TITLE
refactor(rpc-types-mev): remove duplicate formatting logic in FunctionSelector

### DIFF
--- a/crates/rpc-types-mev/src/mevshare.rs
+++ b/crates/rpc-types-mev/src/mevshare.rs
@@ -213,7 +213,7 @@ impl std::fmt::Display for FunctionSelector {
 
 impl LowerHex for FunctionSelector {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "0x{}", self.hex_encode())
+        std::fmt::Display::fmt(self, f)
     }
 }
 


### PR DESCRIPTION


Delegate `LowerHex::fmt` to `Display::fmt` to eliminate duplication while maintaining identical behavior. This follows the same pattern used elsewhere in the codebase (e.g., `BlockNumberOrTag`).

**Before:**
```rust
impl LowerHex for FunctionSelector {
    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
        write!(f, "0x{}", self.hex_encode())
    }
}
```

**After:**
```rust
impl LowerHex for FunctionSelector {
    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
        std::fmt::Display::fmt(self, f)
    }
}
