### PR TITLE
[eips] Make Blob import conditional

### DIFF
--- a/crates/eips/src/eip4844/utils.rs
+++ b/crates/eips/src/eip4844/utils.rs
@@ -3,9 +3,9 @@
 //!
 //! [`SidecarCoder`]: crate::eip4844::builder::SidecarCoder
 
-use crate::eip4844::{FIELD_ELEMENT_BYTES_USIZE, USABLE_BITS_PER_FIELD_ELEMENT};
 #[cfg(feature = "kzg")]
 use crate::eip4844::Blob;
+use crate::eip4844::{FIELD_ELEMENT_BYTES_USIZE, USABLE_BITS_PER_FIELD_ELEMENT};
 
 /// Determine whether a slice of bytes can be contained in a field element.
 pub const fn fits_in_fe(data: &[u8]) -> bool {


### PR DESCRIPTION


Fixes unused import warning by making the `Blob` import conditional on the `kzg` feature flag, matching where it's actually used.
The `Blob` type is only used within functions guarded by `#[cfg(feature = "kzg")]`, but was imported unconditionally at the module level, causing compiler warnings when building without the `kzg` feature enabled.

