### PR TITLE
Remove unused assignment allowance in mnemonic builder module

### DIFF
--- a/crates/signer-local/src/mnemonic.rs
+++ b/crates/signer-local/src/mnemonic.rs
@@ -3,8 +3,6 @@
 //!
 //! [BIP-39]: https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki
 
-#![allow(unused_assignments)]
-
 use crate::{LocalSigner, LocalSignerError, PrivateKeySigner};
 use alloy_signer::utils::secret_key_to_address;
 use coins_bip32::path::DerivationPath;


### PR DESCRIPTION
Context: crates/signer-local/src/mnemonic.rs no longer uses unused assignments, so the crate-level #![allow(unused_assignments)] was hiding potential lint issues.
Change: drop the #![allow(unused_assignments)] attribute to enforce linting in the mnemonic builder module.
Impact: no functional change; improves lint coverage and keeps dead code from being masked.