### PR TITLE
perf(contract): Remove redundant allocation in TransportErrorExt

### DIFF
--- a/crates/contract/src/error.rs
+++ b/crates/contract/src/error.rs
@@ -200,15 +200,15 @@ pub trait TransportErrorExt {
 
 impl TransportErrorExt for TransportError {
     fn try_parse_transport_error<I: SolInterface>(self) -> TryParseTransportErrorResult<I> {
-        let revert_data = self.as_error_resp().and_then(|e| e.as_revert_data().map(|d| d.to_vec()));
+        let revert_data = self.as_error_resp().and_then(|e| e.as_revert_data());
         if let Some(decoded) =
-            revert_data.as_ref().and_then(|data| I::abi_decode(data.as_slice()).ok())
+            revert_data.as_ref().and_then(|data| I::abi_decode(data.as_ref()).ok())
         {
             return TryParseTransportErrorResult::Decoded(decoded);
         }
 
         if let Some(decoded) = revert_data {
-            return TryParseTransportErrorResult::UnknownSelector(decoded.into());
+            return TryParseTransportErrorResult::UnknownSelector(decoded);
         }
         TryParseTransportErrorResult::Original(self)
     }


### PR DESCRIPTION
Eliminates an unnecessary Vec allocation in try_parse_transport_error by using Bytes directly without cloning.