### PR TITLE
chore(consensus-any): remove redundant Clone bound from TxReceipt impl

### DIFF
--- a/crates/consensus-any/src/receipt/envelope.rs
+++ b/crates/consensus-any/src/receipt/envelope.rs
@@ -121,9 +121,7 @@ where
         Self::logs(self)
     }
 
-    fn into_logs(self) -> Vec<Self::Log>
-
-    {
+    fn into_logs(self) -> Vec<Self::Log> {
         self.inner.receipt.logs
     }
 }


### PR DESCRIPTION
Removes a redundant `where Self::Log: Clone` bound from the `into_logs` method in the `TxReceipt` implementation for `AnyReceiptEnvelope<T>`.