### PR TITLE
Remove redundant Send + Sync bounds from CloneTransport impl

### DIFF
--- a/crates/transport/src/boxed.rs
+++ b/crates/transport/src/boxed.rs
@@ -78,7 +78,7 @@ trait CloneTransport: Transport + std::any::Any {
 
 impl<T> CloneTransport for T
 where
-    T: Transport + Clone + Send + Sync,
+    T: Transport + Clone,
 {
     #[inline]
     fn clone_box(&self) -> Box<dyn CloneTransport + Send + Sync> {


### PR DESCRIPTION
Removes redundant Send + Sync trait bounds from the CloneTransport blanket implementation in alloy-transport.