### PR TITLE
Gate Blob import behind kzg feature to silence unused warning

### DIFF
--- a/crates/eips/src/eip4844/utils.rs
+++ b/crates/eips/src/eip4844/utils.rs
@@ -3,9 +3,10 @@
 //!
 //! [`SidecarCoder`]: crate::eip4844::builder::SidecarCoder
 
+use crate::eip4844::{FIELD_ELEMENT_BYTES_USIZE, USABLE_BITS_PER_FIELD_ELEMENT};
+
 #[cfg(feature = "kzg")]
 use crate::eip4844::Blob;
-use crate::eip4844::{FIELD_ELEMENT_BYTES_USIZE, USABLE_BITS_PER_FIELD_ELEMENT};
 
 /// Determine whether a slice of bytes can be contained in a field element.
 pub const fn fits_in_fe(data: &[u8]) -> bool {


### PR DESCRIPTION
Scope: crates/eips/src/eip4844/utils.rs
Change: move the Blob import under #[cfg(feature = "kzg")], keeping only the constants always imported.
Why: removes the unused import warning when kzg is disabled without altering functionality.