### PR TITLE
feat(provider): add filler getters to FillProvider

### DIFF
--- a/crates/provider/src/fillers/mod.rs
+++ b/crates/provider/src/fillers/mod.rs
@@ -317,6 +317,16 @@ where
         Self { inner, filler, _pd: PhantomData }
     }
 
+    /// Returns a reference to the filler.
+    pub const fn filler(&self) -> &F {
+        &self.filler
+    }
+
+    /// Returns a mutable reference to the filler.
+    pub const fn filler_mut(&mut self) -> &mut F {
+        &mut self.filler
+    }
+
     /// Joins a filler to this provider
     pub fn join_with<Other: TxFiller<N>>(
         self,


### PR DESCRIPTION
Adds `filler()` and `filler_mut()` getters to `FillProvider` for accessing the underlying filler.

Adds `left_mut()`, `map_left()`, and `map_right()` helpers to `JoinFill` for modifying and mapping fillers.