### PR TITLE
feat(provider): add CacheLayer builder methods

### DIFF
--- a/crates/provider/src/builder.rs
+++ b/crates/provider/src/builder.rs
@@ -4,7 +4,7 @@ use crate::{
         GasFiller, JoinFill, NonceFiller, NonceManager, RecommendedFillers, SimpleNonceManager,
         TxFiller, WalletFiller,
     },
-    layers::{CacheLayer, CallBatchLayer, ChainLayer},
+    layers::{CallBatchLayer, ChainLayer},
     provider::SendableTx,
     Provider, RootProvider,
 };
@@ -337,15 +337,22 @@ impl<L, F, N> ProviderBuilder<L, F, N> {
 
     /// Add response caching to the stack being built with the specified maximum cache size.
     ///
-    /// See [`CacheLayer`] for more information.
-    pub fn with_caching(self, max_items: u32) -> ProviderBuilder<Stack<CacheLayer, L>, F, N> {
-        self.layer(CacheLayer::new(max_items))
+    /// See [`CacheLayer`](crate::layers::CacheLayer) for more information.
+    #[cfg(not(target_family = "wasm"))]
+    pub fn with_caching(
+        self,
+        max_items: u32,
+    ) -> ProviderBuilder<Stack<crate::layers::CacheLayer, L>, F, N> {
+        self.layer(crate::layers::CacheLayer::new(max_items))
     }
 
     /// Add response caching to the stack being built with a default cache size of 100 items.
     ///
-    /// See [`CacheLayer`] for more information.
-    pub fn with_default_caching(self) -> ProviderBuilder<Stack<CacheLayer, L>, F, N> {
+    /// See [`CacheLayer`](crate::layers::CacheLayer) for more information.
+    #[cfg(not(target_family = "wasm"))]
+    pub fn with_default_caching(
+        self,
+    ) -> ProviderBuilder<Stack<crate::layers::CacheLayer, L>, F, N> {
         self.with_caching(100)
     }
 


### PR DESCRIPTION
Added `with_caching` and `with_default_caching` to `ProviderBuilder`, facilitating easier `CacheLayer` integration consistent with other layers.