### PR TITLE
refactor(provider): use BoxedFut alias in From impl for ProviderCall

### DIFF
--- a/crates/provider/src/provider/prov_call.rs
+++ b/crates/provider/src/provider/prov_call.rs
@@ -216,14 +216,13 @@ where
     }
 }
 
-impl<Params, Resp, Output, Map> From<Pin<Box<dyn Future<Output = TransportResult<Output>> + Send>>>
-    for ProviderCall<Params, Resp, Output, Map>
+impl<Params, Resp, Output, Map> From<BoxedFut<Output>> for ProviderCall<Params, Resp, Output, Map>
 where
     Params: RpcSend,
     Resp: RpcRecv,
     Map: Fn(Resp) -> Output,
 {
-    fn from(fut: Pin<Box<dyn Future<Output = TransportResult<Output>> + Send>>) -> Self {
+    fn from(fut: BoxedFut<Output>) -> Self {
         Self::BoxedFuture(fut)
     }
 }


### PR DESCRIPTION
Refactor `From` implementation for `ProviderCall` to use the existing `BoxedFut` type alias instead of explicitly specifying `Pin<Box<dyn Future + Send>>`.