### PR TITLE
Avoid extra clone when serializing txpool content test

### DIFF
--- a/crates/rpc-types-txpool/src/txpool.rs
+++ b/crates/rpc-types-txpool/src/txpool.rs
@@ -422,7 +422,7 @@ mod tests {
         let serialized: String = serde_json::to_string_pretty(&deserialized).unwrap();
 
         let origin: serde_json::Value = serde_json::from_str(txpool_content_json).unwrap();
-        let serialized_value = serde_json::to_value(deserialized.clone()).unwrap();
+        let serialized_value = serde_json::to_value(&deserialized).unwrap();        
         assert_eq!(origin, serialized_value);
         assert_eq!(deserialized, serde_json::from_str::<TxpoolContent>(&serialized).unwrap());
     }


### PR DESCRIPTION
Ensure txpool content roundtrip test serializes directly from the borrowed value to drop an unnecessary clone.
No behavior changes; keeps test coverage identical while avoiding redundant allocation.
No lints or clippy issues introduced (crates/rpc-types-txpool/src/txpool.rs).