### PR TITLE
Clean up Trezor signer: drop redundant clone and reuse trim helper

### DIFF
--- a/crates/signer-trezor/src/signer.rs
+++ b/crates/signer-trezor/src/signer.rs
@@ -93,13 +93,13 @@ impl TrezorSigner {
         chain_id: Option<ChainId>,
     ) -> Result<Self, TrezorError> {
         let mut signer = Self {
-            derivation: derivation.clone(),
+            derivation,
             chain_id,
             address: Address::ZERO,
             session_id: vec![],
         };
         signer.initiate_session()?;
-        signer.address = signer.get_address_with_path(&derivation).await?;
+        signer.address = signer.get_address_with_path(&signer.derivation).await?;
         Ok(signer)
     }
 
@@ -253,19 +253,23 @@ impl TrezorSigner {
     }
 }
 
+fn trim_leading_zero_bytes(bytes: &[u8], leading_zero_bits: u32) -> Vec<u8> {
+    bytes[(leading_zero_bits as usize) / 8..].to_vec()
+}
+
 fn u64_to_trezor(x: u64) -> Vec<u8> {
     let bytes = x.to_be_bytes();
-    bytes[x.leading_zeros() as usize / 8..].to_vec()
+    trim_leading_zero_bytes(&bytes, x.leading_zeros())
 }
 
 fn u128_to_trezor(x: u128) -> Vec<u8> {
     let bytes = x.to_be_bytes();
-    bytes[x.leading_zeros() as usize / 8..].to_vec()
+    trim_leading_zero_bytes(&bytes, x.leading_zeros())
 }
 
 fn u256_to_trezor(x: U256) -> Vec<u8> {
     let bytes = x.to_be_bytes::<32>();
-    bytes[x.leading_zeros() / 8..].to_vec()
+    trim_leading_zero_bytes(&bytes, x.leading_zeros())
 }
 
 fn address_to_trezor(x: &Address) -> String {


### PR DESCRIPTION
Remove an unnecessary DerivationType clone in TrezorSigner::new and reuse the stored value. Factor leading-zero byte trimming into a helper and call it from the trezor conversion helpers to avoid duplicated slicing code.