### PR TITLE
[transport] Remove redundant Send + Sync bounds from CloneTransport

### DIFF
--- a/crates/transport/src/boxed.rs
+++ b/crates/transport/src/boxed.rs
@@ -73,7 +73,7 @@ impl Clone for BoxTransport {
 
 /// Helper trait for constructing [`BoxTransport`].
 trait CloneTransport: Transport + std::any::Any {
-    fn clone_box(&self) -> Box<dyn CloneTransport + Send + Sync>;
+    fn clone_box(&self) -> Box<dyn CloneTransport>;
 }
 
 impl<T> CloneTransport for T
@@ -81,7 +81,7 @@ where
     T: Transport + Clone + Send + Sync,
 {
     #[inline]
-    fn clone_box(&self) -> Box<dyn CloneTransport + Send + Sync> {
+    fn clone_box(&self) -> Box<dyn CloneTransport> {
         Box::new(self.clone())
     }
 }


### PR DESCRIPTION
Removes redundant Send + Sync bounds from the return type of CloneTransport::clone_box().