### PR TITLE
feat(signer-local): add conversions between PrivateKeySigner and Secp256k1Signer

### DIFF
--- a/crates/signer-local/src/private_key.rs
+++ b/crates/signer-local/src/private_key.rs
@@ -96,7 +96,8 @@ impl LocalSigner<SigningKey> {
         B512::from_slice(&self.credential.verifying_key().to_encoded_point(false).as_bytes()[1..])
     }
 
-    /// Converts this `PrivateKeySigner` (k256-based) to a [`Secp256k1Signer`](crate::Secp256k1Signer).
+    /// Converts this `PrivateKeySigner` (k256-based) to a
+    /// [`Secp256k1Signer`](crate::Secp256k1Signer).
     ///
     /// This allows switching to the `secp256k1` crate implementation which may offer
     /// better performance in some scenarios.
@@ -112,7 +113,8 @@ impl LocalSigner<SigningKey> {
         signer
     }
 
-    /// Converts this `PrivateKeySigner` (k256-based) into a [`Secp256k1Signer`](crate::Secp256k1Signer).
+    /// Converts this `PrivateKeySigner` (k256-based) into a
+    /// [`Secp256k1Signer`](crate::Secp256k1Signer).
     ///
     /// This is the consuming version of [`to_secp256k1`](Self::to_secp256k1).
     #[cfg(feature = "secp256k1")]

--- a/crates/signer-local/src/secp256k1.rs
+++ b/crates/signer-local/src/secp256k1.rs
@@ -154,7 +154,8 @@ impl LocalSigner<Secp256k1Credential> {
         B512::from_slice(&public.serialize_uncompressed()[1..])
     }
 
-    /// Converts this `Secp256k1Signer` to a [`PrivateKeySigner`](crate::PrivateKeySigner) (k256-based).
+    /// Converts this `Secp256k1Signer` to a [`PrivateKeySigner`](crate::PrivateKeySigner)
+    /// (k256-based).
     ///
     /// The resulting signer will have the same address, private key, and chain ID.
     #[inline]
@@ -165,7 +166,8 @@ impl LocalSigner<Secp256k1Credential> {
         signer
     }
 
-    /// Converts this `Secp256k1Signer` into a [`PrivateKeySigner`](crate::PrivateKeySigner) (k256-based).
+    /// Converts this `Secp256k1Signer` into a [`PrivateKeySigner`](crate::PrivateKeySigner)
+    /// (k256-based).
     ///
     /// This is the consuming version of [`to_k256`](Self::to_k256).
     #[inline]


### PR DESCRIPTION
## Summary

Add methods and `From` implementations for converting between k256-based `PrivateKeySigner` and secp256k1-based `Secp256k1Signer`.

## Motivation

The `secp256k1` crate (libsecp256k1 bindings) can offer better performance than the pure-Rust `k256` implementation in some scenarios. However, `MnemonicBuilder` only produces `PrivateKeySigner`. This PR enables easy conversion so users can leverage the faster implementation:

```rust
let signer: Secp256k1Signer = MnemonicBuilder::from_phrase_nth(phrase, 0).into();
```

## Changes

### `PrivateKeySigner` (gated behind `secp256k1` feature)
- `to_secp256k1(&self) -> Secp256k1Signer`
- `into_secp256k1(self) -> Secp256k1Signer`

### `Secp256k1Signer`
- `to_k256(&self) -> PrivateKeySigner`
- `into_k256(self) -> PrivateKeySigner`

### `From` implementations
- `From<PrivateKeySigner> for Secp256k1Signer`
- `From<&PrivateKeySigner> for Secp256k1Signer`
- `From<Secp256k1Signer> for PrivateKeySigner`
- `From<&Secp256k1Signer> for PrivateKeySigner`

All conversions preserve address, private key bytes, and chain ID.

## Testing

Added comprehensive tests for:
- Bidirectional conversions
- Roundtrip (k256 → secp256k1 → k256)
- Chain ID preservation
- `From` trait implementations