### PR TITLE
fix(tx-macros): use private alloy_rlp path for Decodable result

### DIFF
--- a/crates/tx-macros/src/expand.rs
+++ b/crates/tx-macros/src/expand.rs
@@ -594,7 +594,7 @@ impl Expander {
             where
                 #(#variant_types: #alloy_eips::Decodable2718),*
             {
-                fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+                fn decode(buf: &mut &[u8]) -> #alloy_rlp::Result<Self> {
                     Ok(<Self as #alloy_eips::Decodable2718>::network_decode(buf)?)
                 }
             }


### PR DESCRIPTION
The TransactionEnvelope derive generated an RLP Decodable impl that returned alloy_rlp::Result<Self> while using ::alloy_consensus::private::alloy_rlp for the trait itself. This accidentally relied on a direct alloy-rlp dependency in user crates. Switch the return type to #alloy_rlp::Result<Self> so the generated code consistently goes through alloy_consensus::private::alloy_rlp and does not impose an extra public dependency.