### PR TITLE
feat(consensus): add decode_sealed for efficient sealed block/header decoding

### DIFF
--- a/crates/consensus/src/block/header.rs
+++ b/crates/consensus/src/block/header.rs
@@ -186,6 +186,17 @@ impl Header {
         keccak256(&out)
     }
 
+    /// Decodes the RLP-encoded header and computes the hash from the raw RLP bytes.
+    ///
+    /// This is more efficient than decoding and then re-encoding to compute the hash,
+    /// as it reuses the original RLP bytes for hashing.
+    pub fn decode_sealed(buf: &mut &[u8]) -> alloy_rlp::Result<Sealed<Self>> {
+        let start = *buf;
+        let header = Self::decode(buf)?;
+        let hash = keccak256(&start[..start.len() - buf.len()]);
+        Ok(header.seal_unchecked(hash))
+    }
+
     /// Check if the ommers hash equals to empty hash list.
     pub fn ommers_hash_is_empty(&self) -> bool {
         self.ommers_hash == EMPTY_OMMER_ROOT_HASH

--- a/crates/consensus/src/block/mod.rs
+++ b/crates/consensus/src/block/mod.rs
@@ -15,7 +15,7 @@ pub(crate) use header::serde_bincode_compat;
 use crate::Transaction;
 use alloc::vec::Vec;
 use alloy_eips::{eip2718::WithEncoded, eip4895::Withdrawals, Encodable2718, Typed2718};
-use alloy_primitives::{Sealable, B256};
+use alloy_primitives::{Sealable, Sealed, B256};
 use alloy_rlp::{Decodable, Encodable, RlpDecodable, RlpEncodable};
 
 /// Ethereum full block.
@@ -373,6 +373,33 @@ mod block_rlp {
             Ok(Self { header, body: BlockBody { transactions, ommers, withdrawals } })
         }
     }
+
+    impl<T: Decodable> Block<T, Header> {
+        /// Decodes the block from RLP, computing the header hash directly from the RLP bytes.
+        ///
+        /// This is more efficient than decoding the block and then sealing it, as the header
+        /// hash is computed from the raw RLP bytes without re-encoding.
+        pub fn decode_sealed(buf: &mut &[u8]) -> alloy_rlp::Result<Sealed<Self>> {
+            // Decode the outer block list header
+            let block_rlp_head = alloy_rlp::Header::decode(buf)?;
+            if !block_rlp_head.list {
+                return Err(alloy_rlp::Error::UnexpectedString);
+            }
+
+            // Decode header with hash computed from raw RLP
+            let sealed_header = Header::decode_sealed(buf)?;
+
+            // Decode remaining body fields
+            let transactions = Vec::<T>::decode(buf)?;
+            let ommers = Vec::<Header>::decode(buf)?;
+            let withdrawals = if buf.is_empty() { None } else { Some(Decodable::decode(buf)?) };
+
+            let (header, hash) = sealed_header.into_parts();
+            let block = Self { header, body: BlockBody { transactions, ommers, withdrawals } };
+
+            Ok(Sealed::new_unchecked(block, hash))
+        }
+    }
 }
 
 #[cfg(any(test, feature = "arbitrary"))]
@@ -400,10 +427,151 @@ where
 mod tests {
     use super::*;
     use crate::{Signed, TxEnvelope, TxLegacy};
+    use alloy_rlp::Encodable;
 
     #[test]
     fn can_convert_block() {
         let block: Block<Signed<TxLegacy>> = Block::default();
         let _: Block<TxEnvelope> = block.convert_transactions();
+    }
+
+    #[test]
+    fn decode_sealed_produces_correct_hash() {
+        let block: Block<TxEnvelope> = Block::default();
+        let expected_hash = block.header.hash_slow();
+
+        let mut encoded = Vec::new();
+        block.encode(&mut encoded);
+
+        let mut buf = encoded.as_slice();
+        let sealed = Block::<TxEnvelope>::decode_sealed(&mut buf).unwrap();
+
+        assert_eq!(sealed.hash(), expected_hash);
+        assert_eq!(*sealed.inner(), block);
+    }
+
+    #[test]
+    fn header_decode_sealed_produces_correct_hash() {
+        let header = Header::default();
+        let expected_hash = header.hash_slow();
+
+        let mut encoded = Vec::new();
+        header.encode(&mut encoded);
+
+        let mut buf = encoded.as_slice();
+        let sealed = Header::decode_sealed(&mut buf).unwrap();
+
+        assert_eq!(sealed.hash(), expected_hash);
+        assert_eq!(*sealed.inner(), header);
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn decode_sealed_roundtrip_with_transactions() {
+        use crate::{SignableTransaction, TxLegacy};
+        use alloy_primitives::{Address, Signature, TxKind, U256};
+
+        let tx = TxLegacy {
+            nonce: 1,
+            gas_price: 100,
+            gas_limit: 21000,
+            to: TxKind::Call(Address::ZERO),
+            value: U256::from(1000),
+            input: Default::default(),
+            chain_id: Some(1),
+        };
+        let sig = Signature::new(U256::from(1), U256::from(2), false);
+        let signed = tx.into_signed(sig);
+        let envelope: TxEnvelope = signed.into();
+
+        let block = Block {
+            header: Header { number: 42, gas_limit: 30_000_000, ..Default::default() },
+            body: BlockBody { transactions: vec![envelope], ommers: vec![], withdrawals: None },
+        };
+
+        let expected_hash = block.header.hash_slow();
+
+        let mut encoded = Vec::new();
+        block.encode(&mut encoded);
+
+        let mut buf = encoded.as_slice();
+        let sealed = Block::<TxEnvelope>::decode_sealed(&mut buf).unwrap();
+
+        assert_eq!(sealed.hash(), expected_hash);
+        assert_eq!(sealed.header.number, 42);
+        assert_eq!(sealed.body.transactions.len(), 1);
+        assert!(buf.is_empty());
+    }
+}
+
+#[cfg(all(test, feature = "arbitrary"))]
+mod fuzz_tests {
+    use super::*;
+    use alloy_primitives::Bytes;
+    use alloy_rlp::{Decodable, Encodable};
+    use arbitrary::{Arbitrary, Unstructured};
+
+    #[test]
+    fn fuzz_decode_sealed_block_roundtrip() {
+        let mut data = [0u8; 8192];
+        for (i, byte) in data.iter_mut().enumerate() {
+            *byte = (i.wrapping_mul(31).wrapping_add(17)) as u8;
+        }
+
+        let mut success_count = 0;
+        for offset in 0..200 {
+            let slice = &data[offset..];
+            let mut u = Unstructured::new(slice);
+
+            if let Ok(block) = Block::<Bytes, Header>::arbitrary(&mut u) {
+                let expected_hash = block.header.hash_slow();
+
+                let mut encoded = Vec::new();
+                block.encode(&mut encoded);
+
+                let mut buf = encoded.as_slice();
+                if Block::<Bytes>::decode(&mut buf).is_ok() {
+                    let mut buf = encoded.as_slice();
+                    let sealed = Block::<Bytes>::decode_sealed(&mut buf).unwrap();
+
+                    assert_eq!(sealed.hash(), expected_hash);
+                    assert_eq!(*sealed.inner(), block);
+                    success_count += 1;
+                }
+            }
+        }
+        assert!(success_count > 0, "No blocks were successfully tested");
+    }
+
+    #[test]
+    fn fuzz_header_decode_sealed_roundtrip() {
+        let mut data = [0u8; 4096];
+        for (i, byte) in data.iter_mut().enumerate() {
+            *byte = (i.wrapping_mul(37).wrapping_add(23)) as u8;
+        }
+
+        let mut success_count = 0;
+        for offset in 0..200 {
+            let slice = &data[offset..];
+            let mut u = Unstructured::new(slice);
+
+            if let Ok(header) = Header::arbitrary(&mut u) {
+                let expected_hash = header.hash_slow();
+
+                let mut encoded = Vec::new();
+                header.encode(&mut encoded);
+
+                let mut buf = encoded.as_slice();
+                if Header::decode(&mut buf).is_ok() {
+                    let mut buf = encoded.as_slice();
+                    let sealed = Header::decode_sealed(&mut buf).unwrap();
+
+                    assert_eq!(sealed.hash(), expected_hash);
+                    assert_eq!(*sealed.inner(), header);
+                    success_count += 1;
+                }
+            }
+        }
+        assert!(success_count > 0, "No headers were successfully tested");
     }
 }


### PR DESCRIPTION
## Summary

Add `Header::decode_sealed` and `Block::decode_sealed` methods that decode RLP and compute the header hash directly from the raw RLP bytes, avoiding the need to re-encode after decoding.

## Motivation

When decoding blocks/headers from RLP that need to be sealed (e.g., from p2p messages), the current approach requires:
1. Decode from RLP
2. Re-encode to compute hash
3. Seal with hash

This PR adds efficient methods that compute the hash from the original RLP bytes during decoding, eliminating the re-encode step.

## Changes

- Add `Header::decode_sealed(buf) -> Result<Sealed<Header>>` - decodes header and computes hash from raw RLP bytes
- Add `Block::decode_sealed(buf) -> Result<Sealed<Block>>` - uses `Header::decode_sealed` internally, then decodes body fields
- Add comprehensive tests including fuzz tests with arbitrary blocks/headers