### PR TITLE
fix: return cached pubkey in GcpSigner::get_pubkey

### DIFF
--- a/crates/signer-gcp/src/signer.rs
+++ b/crates/signer-gcp/src/signer.rs
@@ -213,7 +213,7 @@ impl GcpSigner {
 
     /// Fetch the pubkey associated with this signer's key.
     pub async fn get_pubkey(&self) -> Result<VerifyingKey, GcpSignerError> {
-        request_get_pubkey(&self.client, &self.key_name).await.and_then(decode_pubkey)
+        Ok(self.pubkey)
     }
 
     /// Sign a digest with this signer's key


### PR DESCRIPTION
GcpSigner is bound to a specific CryptoKeyVersion, so the public key for a given key_name is immutable once fetched. We already retrieve and store the VerifyingKey during construction, but get_pubkey was performing another KMS GetPublicKey call and PEM parse on every invocation. Use the cached pubkey instead to avoid unnecessary network calls and allocations