### PR TITLE
chore: remove redundant clone in reth

### DIFF
--- a/crates/node-bindings/src/nodes/reth.rs
+++ b/crates/node-bindings/src/nodes/reth.rs
@@ -96,7 +96,7 @@ impl RethInstance {
 
     /// Returns the IPC endpoint of this instance.
     pub fn ipc_endpoint(&self) -> String {
-        self.ipc.clone().map_or_else(|| "reth.ipc".to_string(), |ipc| ipc.display().to_string())
+        self.ipc.as_ref().map_or_else(|| "reth.ipc".to_string(), |ipc| ipc.display().to_string())
     }
 
     /// Returns the HTTP endpoint url of this instance.


### PR DESCRIPTION
Remove redundant clone call in `ipc_endpoint` method, use `as_ref` instead for better performance.