### PR TITLE
chore(serde): remove redundant clone

### DIFF
--- a/crates/serde/src/other/mod.rs
+++ b/crates/serde/src/other/mod.rs
@@ -50,7 +50,9 @@ impl OtherFields {
 
     /// Deserialized this type into another container type.
     pub fn deserialize_as<T: DeserializeOwned>(&self) -> serde_json::Result<T> {
-        serde_json::from_value(Value::Object(self.inner.clone().into_iter().collect()))
+        serde_json::from_value(Value::Object(
+            self.inner.iter().map(|(k, v)| (k.clone(), v.clone())).collect(),
+        ))
     }
 
     /// Deserialized this type into another container type.


### PR DESCRIPTION
Remove redundant clone in `deserialize_as`, avoiding unnecessary intermedia allocation.