### PR TITLE
feat: add versioned_hashes helper to BlobsBundle and try_into_sealed to AnyRpcBlock

### DIFF
--- a/crates/rpc-types-engine/src/payload.rs
+++ b/crates/rpc-types-engine/src/payload.rs
@@ -1021,6 +1021,14 @@ impl BlobsBundleV1 {
         Self::default()
     }
 
+    /// Computes the versioned hashes from the KZG commitments.
+    pub fn versioned_hashes(&self) -> Vec<B256> {
+        self.commitments
+            .iter()
+            .map(|c| alloy_eips::eip4844::kzg_to_versioned_hash(c.as_slice()))
+            .collect()
+    }
+
     /// Take `len` blob data from the bundle.
     ///
     /// # Panics
@@ -1245,6 +1253,14 @@ impl BlobsBundleV2 {
     /// payload for API compatibility reasons.
     pub fn empty() -> Self {
         Self::default()
+    }
+
+    /// Computes the versioned hashes from the KZG commitments.
+    pub fn versioned_hashes(&self) -> Vec<B256> {
+        self.commitments
+            .iter()
+            .map(|c| alloy_eips::eip4844::kzg_to_versioned_hash(c.as_slice()))
+            .collect()
     }
 
     /// Take `len` blob data from the bundle.


### PR DESCRIPTION
### Changes

**BlobsBundleV1/V2:**
- Added `versioned_hashes()` helper that computes versioned hashes from KZG commitments using `kzg_to_versioned_hash`

**AnyRpcBlock:**
- Added `try_into_sealed()` helper that converts the RPC block into a sealed consensus block using the block hash from the RPC header