### PR TITLE
refactor(serde): reuse deserialize_into in OtherFields::deserialize_as

### DIFF
--- a/crates/serde/src/other/mod.rs
+++ b/crates/serde/src/other/mod.rs
@@ -50,7 +50,7 @@ impl OtherFields {
 
     /// Deserialized this type into another container type.
     pub fn deserialize_as<T: DeserializeOwned>(&self) -> serde_json::Result<T> {
-        serde_json::from_value(Value::Object(self.inner.clone().into_iter().collect()))
+        self.clone().deserialize_into()
     }
 
     /// Deserialized this type into another container type.


### PR DESCRIPTION
`OtherFields::deserialize_as` duplicated the conversion logic already implemented in `deserialize_into`, which increases the chance of the two methods drifting over time.

Make `deserialize_as` delegate to `deserialize_into` (`self.clone().deserialize_into()`), keeping the API and behavior unchanged while maintaining a single source of truth.

