### PR TITLE
fix: missing populate_blob_hashes in TransactionBuilder7594::set_blob_sidecar_7594

### DIFF
--- a/crates/rpc-types-eth/src/transaction/request.rs
+++ b/crates/rpc-types-eth/src/transaction/request.rs
@@ -2215,4 +2215,32 @@ mod tests {
         assert_eq!(auths.len(), 1);
         assert_eq!(auths[0].y_parity(), 0);
     }
+
+    #[test]
+    fn set_blob_sidecar_7594_populates_versioned_hashes() {
+        use alloy_eips::eip4844::{kzg_to_versioned_hash, Blob, Bytes48};
+
+        // Create a sidecar with a known commitment
+        let commitment = Bytes48::repeat_byte(0x42);
+        let sidecar = BlobTransactionSidecarEip7594::new(
+            vec![Blob::repeat_byte(0xFA)],
+            vec![commitment],
+            vec![Bytes48::repeat_byte(0x11)], // cell proof
+        );
+
+        // Calculate expected versioned hash from the commitment
+        let expected_hash = kzg_to_versioned_hash(commitment.as_slice());
+
+        // Create a transaction request and set the sidecar
+        let mut tx_request = TransactionRequest::default();
+        assert!(tx_request.blob_versioned_hashes.is_none());
+
+        tx_request.set_blob_sidecar_7594(sidecar);
+
+        // Verify that blob_versioned_hashes was populated
+        assert!(tx_request.blob_versioned_hashes.is_some());
+        let hashes = tx_request.blob_versioned_hashes.unwrap();
+        assert_eq!(hashes.len(), 1);
+        assert_eq!(hashes[0], expected_hash);
+    }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

I tried to use `blobhash(uint index) returns (bytes32)` Solidity contract function while calling `provider.estimate_gas`. It works fine for EIP-4844 transaction, but for EIP-7594 I got revert, blob hash was not found. After investigation, I found out that EIP-7594 transaction has no `blob_versioned_hashes` field filled while estimating gas.

## Solution

The solution is to populate blob hashes, similarly to what's done for EIP-4844.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
