### PR TITLE
refactor(serde): reuse remove_with in OtherFields::remove_deserialized

### DIFF
--- a/crates/serde/src/other/mod.rs
+++ b/crates/serde/src/other/mod.rs
@@ -94,7 +94,7 @@ impl OtherFields {
         &mut self,
         key: impl AsRef<str>,
     ) -> Option<serde_json::Result<V>> {
-        self.inner.remove(key.as_ref()).map(serde_json::from_value)
+        self.remove_with(key, serde_json::from_value)
     }
 
     /// Removes the deserialized value of the field, if it exists.


### PR DESCRIPTION

This refactor removes a small piece of duplicated logic by delegating `OtherFields::remove_deserialized` to `OtherFields::remove_with`.

