### PR TITLE
Remove redundant clone when extracting tuple field

### DIFF
--- a/crates/tx-macros/src/parse.rs
+++ b/crates/tx-macros/src/parse.rs
@@ -187,7 +187,11 @@ impl GroupedVariants {
 
             // Check that variant has exactly one unnamed field
             let ty = match &fields.style {
-                darling::ast::Style::Tuple if fields.len() == 1 => fields.fields[0].clone(),
+                darling::ast::Style::Tuple if fields.len() == 1 => fields
+                    .fields
+                    .into_iter()
+                    .next()
+                    .expect("len checked"),
                 darling::ast::Style::Tuple => {
                     return Err(darling::Error::custom(format!(
                         "expected exactly one field, found {}",


### PR DESCRIPTION
Avoid cloning the only tuple field when processing envelope variants.