### PR TITLE
fix: avoid cloning withdrawals in payload body

### DIFF
--- a/crates/rpc-types-engine/src/payload.rs
+++ b/crates/rpc-types-engine/src/payload.rs
@@ -2086,7 +2086,8 @@ impl ExecutionPayloadBodyV1 {
 
     /// Converts a [`alloy_consensus::Block`] into an execution payload body.
     pub fn from_block<T: Encodable2718, H>(block: Block<T, H>) -> Self {
-        Self::new(block.body.withdrawals.clone(), block.body.transactions())
+        let BlockBody { withdrawals, transactions, .. } = block.into_body();
+        Self::new(withdrawals, transactions.iter())
     }
 }
 


### PR DESCRIPTION
Remove an unnecessary clone when building ExecutionPayloadBodyV1 from an owned Block, reducing allocations in a hot conversion path.
Move withdrawals out of the block body before encoding transactions, avoiding a redundant allocation while preserving behavior.