### PR TITLE
refactor(signer-ledger): remove duplicated INS Display match

### DIFF
--- a/crates/signer-ledger/src/types.rs
+++ b/crates/signer-ledger/src/types.rs
@@ -78,14 +78,7 @@ pub(crate) enum INS {
 
 impl fmt::Display for INS {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::GET_PUBLIC_KEY => write!(f, "GET_PUBLIC_KEY"),
-            Self::SIGN => write!(f, "SIGN"),
-            Self::GET_APP_CONFIGURATION => write!(f, "GET_APP_CONFIGURATION"),
-            Self::SIGN_PERSONAL_MESSAGE => write!(f, "SIGN_PERSONAL_MESSAGE"),
-            Self::SIGN_ETH_EIP_712 => write!(f, "SIGN_ETH_EIP_712"),
-            Self::SIGN_EIP7702_AUTHORIZATION => write!(f, "SIGN_EIP7702_AUTHORIZATION"),
-        }
+        fmt::Debug::fmt(self, f)
     }
 }
 


### PR DESCRIPTION
Deduplicate `INS` formatting by delegating `Display` to `Debug` (prints the variant name).
`INS` already derives `Debug`; the previous `Display` impl duplicated variant-name strings and required manual updates when adding new instructions.
