### PR TITLE
fix: resolve infinite recursion in Sealable::hash_slow for Header

### DIFF
--- a/crates/consensus/src/block/header.rs
+++ b/crates/consensus/src/block/header.rs
@@ -167,7 +167,7 @@ impl Default for Header {
 
 impl Sealable for Header {
     fn hash_slow(&self) -> B256 {
-        self.hash_slow()
+        Self::hash_slow(self)
     }
 }
 


### PR DESCRIPTION
Changed Sealable::hash_slow implementation to explicitly call the inherent method instead of self.hash_slow() to prevent infinite recursion when invoked through the trait.