### PR TITLE
feat(engine): add ExecutionPayloadV4 and ExecutionPayloadEnvelopeV6 types

### DIFF
--- a/typos.toml
+++ b/typos.toml
@@ -18,3 +18,4 @@ extend-exclude = [
 ser = "ser"
 typ = "typ"
 bimap = "bimap"
+BA = "BA"


### PR DESCRIPTION
Add type definitions and engine API methods for Amsterdam fork:

## Types (rpc-types-engine)
- `ExecutionPayloadV4`: Extends V3 with `block_access_list` field ([EIP-7928](https://eips.ethereum.org/EIPS/eip-7928))
- `ExecutionPayloadEnvelopeV6`: Return type for `engine_getPayloadV6`
- SSZ encode/decode for `ExecutionPayloadV4`

## Engine API (provider)
- `new_payload_v5`: Send `ExecutionPayloadV4` to EL
- `get_payload_v6`: Returns `ExecutionPayloadEnvelopeV6`
- `get_bals_by_hash_v1`: Retrieve BALs by block hashes ([EIP-7928](https://eips.ethereum.org/EIPS/eip-7928))
- `get_bals_by_range_v1`: Retrieve BALs by block range ([EIP-7928](https://eips.ethereum.org/EIPS/eip-7928))

Extracted from #3330.

Co-authored-by: Ishika Choudhury <117741714+Rimeeeeee@users.noreply.github.com>
Co-authored-by: Soubhik Singha Mahapatra <160333583+Soubhik-10@users.noreply.github.com>