### PR TITLE
refactor(signer-trezor): deduplicate byte trimming logic in conversion helpers

### DIFF
--- a/crates/signer-trezor/src/signer.rs
+++ b/crates/signer-trezor/src/signer.rs
@@ -253,19 +253,22 @@ impl TrezorSigner {
     }
 }
 
+fn trim_be_bytes(bytes: &[u8]) -> Vec<u8> {
+    trim_be_bytes(&x.to_be_bytes())
+}
+
+
 fn u64_to_trezor(x: u64) -> Vec<u8> {
     let bytes = x.to_be_bytes();
     bytes[x.leading_zeros() as usize / 8..].to_vec()
 }
 
 fn u128_to_trezor(x: u128) -> Vec<u8> {
-    let bytes = x.to_be_bytes();
-    bytes[x.leading_zeros() as usize / 8..].to_vec()
+    trim_be_bytes(&x.to_be_bytes())
 }
 
 fn u256_to_trezor(x: U256) -> Vec<u8> {
-    let bytes = x.to_be_bytes::<32>();
-    bytes[x.leading_zeros() / 8..].to_vec()
+    trim_be_bytes(&x.to_be_bytes::<32>())
 }
 
 fn address_to_trezor(x: &Address) -> String {


### PR DESCRIPTION
Refactored the Trezor signer's numeric conversion helpers by extracting duplicate leading-zero trimming logic into a single reusable function.