### PR TITLE
feat(provider): add new_payload_v4_requests accepting RequestsOrHash

### DIFF
--- a/crates/eips/src/eip7685.rs
+++ b/crates/eips/src/eip7685.rs
@@ -22,6 +22,10 @@ pub const EMPTY_REQUESTS_HASH: B256 =
 pub struct Requests(Vec<Bytes>);
 
 impl Requests {
+    /// Create a new [`Requests`] container from an iterator of items convertible to [`Bytes`].
+    pub fn from_requests<T: Into<Bytes>>(requests: impl IntoIterator<Item = T>) -> Self {
+        Self(requests.into_iter().map(Into::into).collect())
+    }
     /// Construct a new [`Requests`] container with the given capacity.
     pub fn with_capacity(capacity: usize) -> Self {
         Self(Vec::with_capacity(capacity))
@@ -180,6 +184,12 @@ impl RequestsOrHash {
 impl Default for RequestsOrHash {
     fn default() -> Self {
         Self::Requests(Requests::default())
+    }
+}
+
+impl From<Vec<Bytes>> for RequestsOrHash {
+    fn from(requests: Vec<Bytes>) -> Self {
+        Self::Requests(requests.into())
     }
 }
 

--- a/crates/provider/src/ext/engine.rs
+++ b/crates/provider/src/ext/engine.rs
@@ -51,6 +51,20 @@ pub trait EngineApi<N>: Send + Sync {
         execution_requests: Vec<Bytes>,
     ) -> TransportResult<PayloadStatus>;
 
+    /// Sends the given payload to the execution layer client, as specified for the Prague fork.
+    ///
+    /// This is a variant of [`Self::new_payload_v4`] that accepts [`RequestsOrHash`] for the
+    /// execution requests, allowing either the full requests or just a precomputed hash.
+    ///
+    /// See also <https://github.com/ethereum/execution-apis/blob/03911ffc053b8b806123f1fc237184b0092a485a/src/engine/prague.md#engine_newpayloadv4>
+    async fn new_payload_v4_requests(
+        &self,
+        payload: ExecutionPayloadV3,
+        versioned_hashes: Vec<B256>,
+        parent_beacon_block_root: B256,
+        execution_requests: RequestsOrHash,
+    ) -> TransportResult<PayloadStatus>;
+
     /// Sends the given payload to the execution layer client, as specified for the Amsterdam fork.
     ///
     /// See also <https://github.com/ethereum/execution-apis/blob/7b4d9f62a3fe62b9b8dcb355f1c5a38b5ff084f6/src/engine/amsterdam.md#engine_newpayloadv5>
@@ -261,6 +275,21 @@ where
         versioned_hashes: Vec<B256>,
         parent_beacon_block_root: B256,
         execution_requests: Vec<Bytes>,
+    ) -> TransportResult<PayloadStatus> {
+        self.client()
+            .request(
+                "engine_newPayloadV4",
+                (payload, versioned_hashes, parent_beacon_block_root, execution_requests),
+            )
+            .await
+    }
+
+    async fn new_payload_v4_requests(
+        &self,
+        payload: ExecutionPayloadV3,
+        versioned_hashes: Vec<B256>,
+        parent_beacon_block_root: B256,
+        execution_requests: RequestsOrHash,
     ) -> TransportResult<PayloadStatus> {
         self.client()
             .request(


### PR DESCRIPTION
## Summary

Adds a new `new_payload_v4_requests` method that accepts `RequestsOrHash` instead of `Vec<Bytes>`, allowing callers to pass either the full requests or just a precomputed hash.

## Changes

- Add `From<Vec<Bytes>>` impl for `Requests` (zero-cost, no allocation)
- Add `Requests::from_requests` for converting from iterators of `Into<Bytes>`
- Add `new_payload_v4_requests` variant that accepts `RequestsOrHash`
- Keep original `new_payload_v4` unchanged for backwards compatibility

This mirrors the approach used for `new_payload_v5` which already accepts `RequestsOrHash`.