### PR TITLE
feat(eips): add eip7928 module re-exporting alloy-eip7928 types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,7 @@ alloy-chains = { version = "0.2", default-features = false }
 alloy-eip2124 = { version = "0.2.0", default-features = false }
 alloy-eip2930 = { version = "0.2.3", default-features = false }
 alloy-eip7702 = { version = "0.6.3", default-features = false }
+alloy-eip7928 = { version = "0.3", default-features = false }
 
 # hardforks
 alloy-hardforks = "0.2.0"

--- a/crates/eips/Cargo.toml
+++ b/crates/eips/Cargo.toml
@@ -27,6 +27,7 @@ workspace = true
 alloy-eip2124.workspace = true
 alloy-eip2930.workspace = true
 alloy-eip7702.workspace = true
+alloy-eip7928.workspace = true
 
 alloy-primitives = { workspace = true, features = ["rlp"] }
 alloy-rlp = { workspace = true, features = ["derive"] }
@@ -85,6 +86,7 @@ std = [
 	"alloy-eip2124/std",
 	"alloy-eip2930/std",
 	"alloy-eip7702/std",
+	"alloy-eip7928/std",
 	"derive_more/std",
 	"sha2?/std",
 	"either/std",
@@ -100,6 +102,7 @@ serde = [
 	"c-kzg?/serde",
 	"alloy-eip2930/serde",
 	"alloy-eip7702/serde",
+	"alloy-eip7928/serde",
 	"alloy-eip2124/serde",
 	"either/serde",
 	"rand/serde",
@@ -120,6 +123,7 @@ arbitrary = [
 	"alloy-eip2930/arbitrary",
 	"alloy-eip7702/arbitrary",
 	"alloy-eip7702/k256",
+	"alloy-eip7928/arbitrary",
 	"c-kzg?/arbitrary"
 ]
 borsh = [

--- a/crates/eips/src/eip7928.rs
+++ b/crates/eips/src/eip7928.rs
@@ -1,0 +1,8 @@
+//! [EIP-7928] Block-Level Access Lists types.
+//!
+//! This module re-exports types from the [`alloy-eip7928`] crate.
+//!
+//! [EIP-7928]: https://eips.ethereum.org/EIPS/eip-7928
+//! [`alloy-eip7928`]: https://crates.io/crates/alloy-eip7928
+
+pub use alloy_eip7928::*;

--- a/crates/eips/src/lib.rs
+++ b/crates/eips/src/lib.rs
@@ -60,3 +60,5 @@ pub mod eip7825;
 pub use eip7892::{BlobScheduleBlobParams, BlobScheduleEntry};
 
 pub mod eip7910;
+
+pub mod eip7928;


### PR DESCRIPTION
Adds `pub mod eip7928` to `alloy-eips` which re-exports all types from [`alloy-eip7928`](https://crates.io/crates/alloy-eip7928) v0.3.

Extracted from #3330.

Co-authored-by: Ishika Choudhury <117741714+Rimeeeeee@users.noreply.github.com>
Co-authored-by: Soubhik Singha Mahapatra <160333583+Soubhik-10@users.noreply.github.com>