### PR TITLE
Fix: propagate eip712 feature to signer-local

### DIFF
--- a/crates/alloy/Cargo.toml
+++ b/crates/alloy/Cargo.toml
@@ -343,6 +343,7 @@ eip712 = [
     "alloy-signer-aws?/eip712",
     "alloy-signer-gcp?/eip712",
     "alloy-signer-ledger?/eip712",
+    "alloy-signer-local?/eip712",
     "alloy-signer-turnkey?/eip712",
     # TODO: https://github.com/alloy-rs/alloy/issues/201
     # "alloy-signer-trezor?/eip712",


### PR DESCRIPTION
signer-local was missing from the eip712 feature list. All other signers have it but this one got skipped somehow.

Verified by running the typed_data tests in signer-local - they're gated behind the eip712 feature and weren't running when enabling eip712 from the main crate.