### PR TITLE
feat(rpc-types-eth): add SimulateError::invalid_params constructor

### DIFF
--- a/crates/rpc-types-eth/src/simulate.rs
+++ b/crates/rpc-types-eth/src/simulate.rs
@@ -1,6 +1,8 @@
 //! 'eth_simulateV1' Request / Response types: <https://github.com/ethereum/execution-apis/pull/484>
 
-use crate::{state::StateOverride, Block, BlockOverrides, Log, TransactionRequest};
+use crate::{
+    alloc::string::ToString, state::StateOverride, Block, BlockOverrides, Log, TransactionRequest,
+};
 use alloc::{string::String, vec::Vec};
 use alloy_primitives::{Bytes, U256};
 


### PR DESCRIPTION
Adds a convenience constructor `SimulateError::invalid_params()` that creates a standard JSON-RPC invalid params error (code -32602).

This aligns with the pattern used in `alloy-json-rpc`'s `ErrorPayload::invalid_params()`.