### PR TITLE
Refine transport-ws tracing imports

### DIFF
--- a/crates/transport-ws/src/lib.rs
+++ b/crates/transport-ws/src/lib.rs
@@ -6,9 +6,6 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
-#[macro_use]
-extern crate tracing;
-
 use alloy_pubsub::ConnectionInterface;
 
 #[cfg(not(target_family = "wasm"))]


### PR DESCRIPTION
Switch tracing to explicit imports in transport-ws to avoid crate-wide macro leaks.
Keep logging behavior unchanged across native/wasm backends.