### PR TITLE
Clarify tracing usage in transport-ws native backend

### DIFF
--- a/crates/transport-ws/src/native.rs
+++ b/crates/transport-ws/src/native.rs
@@ -5,6 +5,7 @@ use futures::{SinkExt, StreamExt};
 use serde_json::value::RawValue;
 use std::time::Duration;
 use tokio::time::sleep;
+use tracing::error;
 use tokio_tungstenite::{
     tungstenite::{self, client::IntoClientRequest, Message},
     MaybeTlsStream, WebSocketStream,


### PR DESCRIPTION
Import tracing’s error macro explicitly in the native websocket backend to avoid crate-wide macro injection.
Preserve existing logging behavior while aligning with Edition-2018 import style.