### PR TITLE
Clarify tracing usage in transport-ws wasm backend

### DIFF
--- a/crates/transport-ws/src/wasm.rs
+++ b/crates/transport-ws/src/wasm.rs
@@ -8,6 +8,7 @@ use futures::{
 use serde_json::value::RawValue;
 use std::time::Duration;
 use ws_stream_wasm::{WsErr, WsMessage, WsMeta, WsStream};
+use tracing::error;
 
 /// Simple connection info for the websocket.
 #[derive(Clone, Debug)]


### PR DESCRIPTION
Import tracing’s error macro explicitly in the wasm websocket backend to avoid crate-wide macro injection.
Keep existing logging behavior unchanged while aligning with Edition-2018 import style.