### PR TITLE
ci: increase nextest retries for flaky reth test

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,3 +1,7 @@
 [profile.default]
 retries = { backoff = "exponential", count = 2, delay = "2s", jitter = true }
 slow-timeout = { period = "30s", terminate-after = 4 }
+
+[[profile.default.overrides]]
+filter = "test(can_launch_reth_custom_ports)"
+retries = { backoff = "exponential", count = 5, delay = "3s", jitter = true }


### PR DESCRIPTION
Increase retries for `can_launch_reth_custom_ports` from 2 to 5 to reduce CI flakiness.