### PR TITLE
feat: add `gas_spent` field to receipts

### DIFF
--- a/crates/network-primitives/src/traits.rs
+++ b/crates/network-primitives/src/traits.rs
@@ -79,6 +79,11 @@ pub trait ReceiptResponse {
     /// Returns the cumulative gas used at this receipt.
     fn cumulative_gas_used(&self) -> u64;
 
+    /// EIP-7778: Per-transaction gas after refunds.
+    fn gas_spent(&self) -> Option<u64> {
+        None
+    }
+
     /// The post-transaction state root (pre Byzantium)
     ///
     /// EIP98 makes this field optional.
@@ -261,6 +266,10 @@ impl<T: ReceiptResponse> ReceiptResponse for WithOtherFields<T> {
 
     fn cumulative_gas_used(&self) -> u64 {
         self.inner.cumulative_gas_used()
+    }
+
+    fn gas_spent(&self) -> Option<u64> {
+        self.inner.gas_spent()
     }
 
     fn state_root(&self) -> Option<B256> {

--- a/crates/rpc-types-eth/src/transaction/receipt.rs
+++ b/crates/rpc-types-eth/src/transaction/receipt.rs
@@ -66,6 +66,16 @@ pub struct TransactionReceipt<T = ReceiptEnvelope<Log>> {
     pub to: Option<Address>,
     /// Contract address created, or None if not a deployment.
     pub contract_address: Option<Address>,
+    /// EIP-7778: Per-transaction gas after refunds.
+    #[cfg_attr(
+        feature = "serde",
+        serde(
+            skip_serializing_if = "Option::is_none",
+            with = "alloy_serde::quantity::opt",
+            default
+        )
+    )]
+    pub gas_spent: Option<u64>,
 }
 
 #[cfg(feature = "serde")]
@@ -112,6 +122,12 @@ where
             from: Address,
             to: Option<Address>,
             contract_address: Option<Address>,
+            #[serde(
+                default,
+                skip_serializing_if = "Option::is_none",
+                with = "alloy_serde::quantity::opt"
+            )]
+            gas_spent: Option<u64>,
         }
 
         let helper = ReceiptDeserHelper::deserialize(deserializer)?;
@@ -128,6 +144,7 @@ where
             from: helper.from,
             to: helper.to,
             contract_address: helper.contract_address,
+            gas_spent: helper.gas_spent,
         })
     }
 }
@@ -176,6 +193,7 @@ impl<T> TransactionReceipt<T> {
             from: self.from,
             to: self.to,
             contract_address: self.contract_address,
+            gas_spent: self.gas_spent,
         }
     }
 
@@ -304,6 +322,10 @@ impl<T: TxReceipt<Log = Log>> ReceiptResponse for TransactionReceipt<T> {
 
     fn state_root(&self) -> Option<B256> {
         self.inner.status_or_post_state().as_post_state()
+    }
+
+    fn gas_spent(&self) -> Option<u64> {
+        self.gas_spent
     }
 }
 


### PR DESCRIPTION
EIP-7778 introduces a new gas_spent field in receipts to track per-transaction gas after refunds (what users actually pay). This separates it from cumulative_gas_used, which now represents gas before refunds for block limit enforcement. This PR adds the gas_spent field to TransactionReceipt and the ReceiptResponse trait, following the same pattern as blob_gas_used with optional serde handling for backward compatibility.