### PR TITLE
refactor(network): remove redundant Clone bound from Network trait

### DIFF
--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -39,7 +39,7 @@ pub use alloy_network_primitives::{
 /// Captures type info for network-specific RPC requests/responses.
 ///
 /// Networks are only containers for types, so it is recommended to use ZSTs for their definition.
-pub trait Network: Debug + Clone + Copy + Sized + Send + Sync + 'static {
+pub trait Network: Debug + Copy + Sized + Send + Sync + 'static {
     // -- Consensus types --
 
     /// The network transaction type enum.


### PR DESCRIPTION
Remove redundant `Clone` trait bound from the `Network` trait definition.