### PR TITLE
feat(rpc-types-eth): add blob_base_fee to BlockOverrides

### DIFF
--- a/crates/rpc-types-eth/src/block.rs
+++ b/crates/rpc-types-eth/src/block.rs
@@ -641,7 +641,7 @@ impl From<Header> for alloy_serde::WithOtherFields<Header> {
 /// BlockOverrides is a set of header fields to override.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(default, rename_all = "camelCase", deny_unknown_fields))]
+#[cfg_attr(feature = "serde", serde(default, rename_all = "camelCase"))]
 pub struct BlockOverrides {
     /// Overrides the block number.
     ///
@@ -696,6 +696,9 @@ pub struct BlockOverrides {
         serde(default, skip_serializing_if = "Option::is_none", alias = "baseFeePerGas")
     )]
     pub base_fee: Option<U256>,
+    /// Overrides the blob base fee of the block.
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
+    pub blob_base_fee: Option<U256>,
     /// A dictionary that maps blockNumber to a user-defined hash. It can be queried from the
     /// EVM opcode BLOCKHASH.
     #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
@@ -712,6 +715,7 @@ impl BlockOverrides {
             && self.coinbase.is_none()
             && self.random.is_none()
             && self.base_fee.is_none()
+            && self.blob_base_fee.is_none()
             && self.block_hash.is_none()
     }
 
@@ -754,6 +758,12 @@ impl BlockOverrides {
     /// Sets the base fee override
     pub const fn with_base_fee(mut self, base_fee: U256) -> Self {
         self.base_fee = Some(base_fee);
+        self
+    }
+
+    /// Sets the blob base fee override
+    pub const fn with_blob_base_fee(mut self, blob_base_fee: U256) -> Self {
+        self.blob_base_fee = Some(blob_base_fee);
         self
     }
 


### PR DESCRIPTION
## Summary

This PR adds support for the `blobBaseFee` field in `BlockOverrides` and removes `deny_unknown_fields` for better forward compatibility.

### Changes

- **Remove `deny_unknown_fields`**: Allows clients to accept new fields without breaking, improving forward compatibility
- **Add `blob_base_fee` field**: Supports overriding the blob base fee in `eth_simulateV1` calls
- **Add `with_blob_base_fee` builder method**: Convenience method for setting blob base fee
- **Update `is_empty` check**: Include `blob_base_fee` in the emptiness check

### Motivation

The `eth_simulateV1` RPC method supports overriding block parameters including `blobBaseFee`. This field is used in the [execution-apis test suite](https://github.com/ethereum/execution-apis/tree/main/tests/eth_simulateV1) and clients like geth support it.

Removing `deny_unknown_fields` also prevents deserialization failures when new fields are added to the spec, making the type more resilient to upstream changes.

### Testing

- `cargo check -p alloy-rpc-types-eth --all-features` passes
- `cargo test -p alloy-rpc-types-eth --all-features` passes