### PR TITLE
fix(rpc-types-eth): add serde alias for MovePrecompileToAddress

### DIFF
--- a/crates/rpc-types-eth/src/state.rs
+++ b/crates/rpc-types-eth/src/state.rs
@@ -169,7 +169,8 @@ pub struct AccountOverride {
         serde(
             default,
             skip_serializing_if = "Option::is_none",
-            rename = "movePrecompileToAddress"
+            rename = "movePrecompileToAddress",
+            alias = "MovePrecompileToAddress"
         )
     )]
     pub move_precompile_to: Option<Address>,


### PR DESCRIPTION
## Summary

Accept both camelCase (`movePrecompileToAddress`) and PascalCase (`MovePrecompileToAddress`) for the `move_precompile_to` field in `AccountOverride`.

## Context

The hive test fixtures at `ethereum/execution-apis` use PascalCase `MovePrecompileToAddress` for this field, but the OpenRPC spec and geth use camelCase `movePrecompileToAddress`. 

Adding a serde alias allows accepting both variants for backwards compatibility, fixing the parsing error:

```
unknown field `MovePrecompileToAddress`, expected one of `balance`, `nonce`, `code`, `state`, `stateDiff`, `movePrecompileToAddress`
```

## Test

Fixes hive tests:
- `eth_simulateV1/ethSimulate-move-ecrecover-and-call-old-and-new`
- `eth_simulateV1/ethSimulate-move-ecrecover-and-call`
- Other move-precompile tests