### PR TITLE
perf: optimize blob conversion with pre-allocated capacity

### DIFF
--- a/crates/eips/src/eip7594/sidecar.rs
+++ b/crates/eips/src/eip7594/sidecar.rs
@@ -559,9 +559,10 @@ impl BlobTransactionSidecarEip7594 {
         I: IntoIterator<Item = B>,
         B: AsRef<str>,
     {
-        let mut converted = Vec::new();
-        for blob in blobs {
-            converted.push(crate::eip4844::utils::hex_to_blob(blob)?);
+        let blobs_iter = blobs.into_iter();
+        let mut converted = Vec::with_capacity(iter.size_hint().0);
+        for blob in blobs_iter {
+            converted.push(hex_to_blob(blob)?);
         }
         Self::try_from_blobs(converted)
     }


### PR DESCRIPTION


Optimize `try_from_blobs_bytes` to pre-allocate Vec capacity using iterator size hints.

