### PR TITLE
perf: avoid cloning Filter in cache `get_logs`

### DIFF
--- a/crates/provider/src/layers/cache.rs
+++ b/crates/provider/src/layers/cache.rs
@@ -225,7 +225,7 @@ where
             }
         }
 
-        let req = RequestType::new("eth_getLogs", filter.clone());
+        let req = RequestType::new("eth_getLogs", (filter,));
 
         let params_hash = req.params_hash().ok();
 


### PR DESCRIPTION
`CacheProvider::get_logs` was cloning the entire `Filter` just to build a `RequestType` for parameter hashing, even though the inner provider already uses a borrowed `&Filter`. This caused unnecessary allocations and CPU work when hashing log filters.