### PR TITLE
chore(rpc-client): remove redundant dead_code lint suppression in tests

### DIFF
--- a/crates/rpc-client/tests/it/main.rs
+++ b/crates/rpc-client/tests/it/main.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)]
 #![allow(missing_docs)]
 
 #[cfg(feature = "reqwest")]


### PR DESCRIPTION
Removes unnecessary `#![allow(dead_code)]` attribute from integration test main file.