### PR TITLE
feat(rpc-types-eth): add optional timestamp field to Transaction

### DIFF
--- a/crates/consensus/src/transaction/meta.rs
+++ b/crates/consensus/src/transaction/meta.rs
@@ -40,6 +40,8 @@ pub struct TransactionInfo {
     pub block_number: Option<u64>,
     /// Base fee of the block.
     pub base_fee: Option<u64>,
+    /// Timestamp of the block.
+    pub block_timestamp: Option<u64>,
 }
 
 impl TransactionInfo {

--- a/crates/rpc-types-eth/src/transaction/mod.rs
+++ b/crates/rpc-types-eth/src/transaction/mod.rs
@@ -65,6 +65,12 @@ pub struct Transaction<T = TxEnvelope> {
 
     /// Deprecated effective gas price value.
     pub effective_gas_price: Option<u128>,
+
+    /// The Unix block_timestamp (in seconds) when the block containing this transaction was mined.
+    ///
+    /// `None` if the transaction is pending.
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
+    pub block_timestamp: Option<u64>,
 }
 
 impl<T> Default for Transaction<T>
@@ -78,6 +84,7 @@ where
             block_number: Default::default(),
             transaction_index: Default::default(),
             effective_gas_price: Default::default(),
+            block_timestamp: Default::default(),
         }
     }
 }
@@ -118,25 +125,41 @@ impl<T> Transaction<T> {
 
     /// Applies the given closure to the inner transaction type.
     pub fn map<Tx>(self, f: impl FnOnce(T) -> Tx) -> Transaction<Tx> {
-        let Self { inner, block_hash, block_number, transaction_index, effective_gas_price } = self;
+        let Self {
+            inner,
+            block_hash,
+            block_number,
+            transaction_index,
+            effective_gas_price,
+            block_timestamp,
+        } = self;
         Transaction {
             inner: inner.map(f),
             block_hash,
             block_number,
             transaction_index,
             effective_gas_price,
+            block_timestamp,
         }
     }
 
     /// Applies the given fallible closure to the inner transactions.
     pub fn try_map<Tx, E>(self, f: impl FnOnce(T) -> Result<Tx, E>) -> Result<Transaction<Tx>, E> {
-        let Self { inner, block_hash, block_number, transaction_index, effective_gas_price } = self;
+        let Self {
+            inner,
+            block_hash,
+            block_number,
+            transaction_index,
+            effective_gas_price,
+            block_timestamp,
+        } = self;
         Ok(Transaction {
             inner: inner.try_map(f)?,
             block_hash,
             block_number,
             transaction_index,
             effective_gas_price,
+            block_timestamp,
         })
     }
 }
@@ -159,7 +182,12 @@ where
     /// Converts a consensus `tx` with an additional context `tx_info` into an RPC [`Transaction`].
     pub fn from_transaction(tx: Recovered<T>, tx_info: TransactionInfo) -> Self {
         let TransactionInfo {
-            block_hash, block_number, index: transaction_index, base_fee, ..
+            block_hash,
+            block_number,
+            index: transaction_index,
+            base_fee,
+            block_timestamp,
+            ..
         } = tx_info;
         let effective_gas_price = base_fee
             .map(|base_fee| {
@@ -173,6 +201,7 @@ where
             block_number,
             transaction_index,
             effective_gas_price: Some(effective_gas_price),
+            block_timestamp,
         }
     }
 }
@@ -193,6 +222,7 @@ where
             // We don't know the base fee of the block when we're constructing this from
             // `Transaction`
             base_fee: None,
+            block_timestamp: self.block_timestamp,
         }
     }
 }
@@ -482,6 +512,12 @@ mod tx_serde {
 
         #[serde(flatten)]
         gas_price: MaybeGasPrice,
+        #[serde(
+            default,
+            with = "alloy_serde::quantity::opt",
+            skip_serializing_if = "Option::is_none"
+        )]
+        block_timestamp: Option<u64>,
     }
 
     impl<T: TransactionTrait> From<Transaction<T>> for TransactionSerdeHelper<T> {
@@ -492,6 +528,7 @@ mod tx_serde {
                 block_number,
                 transaction_index,
                 effective_gas_price,
+                block_timestamp,
             } = value;
 
             let (inner, from) = inner.into_parts();
@@ -510,6 +547,7 @@ mod tx_serde {
                 transaction_index,
                 from,
                 gas_price: MaybeGasPrice { effective_gas_price },
+                block_timestamp,
             }
         }
     }
@@ -525,6 +563,7 @@ mod tx_serde {
                 transaction_index,
                 from,
                 gas_price,
+                block_timestamp,
             } = value;
 
             // Try to get `gasPrice` field from inner envelope or from `MaybeGasPrice` (making
@@ -539,6 +578,7 @@ mod tx_serde {
                 block_number,
                 transaction_index,
                 effective_gas_price,
+                block_timestamp,
             })
         }
     }


### PR DESCRIPTION
Adds an optional `timestamp` field to the RPC `Transaction` struct to include the block timestamp when the transaction was mined.

This field is useful for applications that need to know when a transaction was included in a block without making an additional RPC call to fetch block information.

Related: https://github.com/ethereum/execution-apis/issues/729