### PR TITLE
fix(consensus): mark tx_mut as hidden with invalidation warning

### DIFF
--- a/crates/consensus/src/signed.rs
+++ b/crates/consensus/src/signed.rs
@@ -52,6 +52,11 @@ impl<T, Sig> Signed<T, Sig> {
     }
 
     /// Returns a mutable reference to the transaction.
+    ///
+    /// # Warning
+    ///
+    /// Modifying the transaction structurally invalidates the signature and hash.
+    #[doc(hidden)]
     pub const fn tx_mut(&mut self) -> &mut T {
         &mut self.tx
     }


### PR DESCRIPTION
Marks `Signed::tx_mut` as `#[doc(hidden)]` and adds a warning that modifying the transaction structurally invalidates the signature and hash.