### PR TITLE
fix(provider): remove inverted condition in convert_to_hashes

### DIFF
--- a/crates/provider/src/utils.rs
+++ b/crates/provider/src/utils.rs
@@ -134,10 +134,7 @@ pub(crate) fn convert_to_hashes<BlockResp: alloy_network::BlockResponse>(
     r: Option<BlockResp>,
 ) -> Option<BlockResp> {
     r.map(|mut block| {
-        if block.transactions().is_empty() {
-            block.transactions_mut().convert_to_hashes();
-        }
-
+        block.transactions_mut().convert_to_hashes();
         block
     })
 }


### PR DESCRIPTION
The condition `if block.transactions().is_empty()` was inverted - it only converted to hashes when there were NO transactions, which is pointless. When the block actually had transactions, they were never converted.

Removed the unnecessary check since `BlockTransactions::convert_to_hashes()` already handles this internally by checking `if !self.is_hashes()`.