### PR TITLE
refactor(transport): remove unnecessary Clone bound from FallbackService constructor impl

### DIFF
--- a/crates/transport/src/layers/fallback.rs
+++ b/crates/transport/src/layers/fallback.rs
@@ -37,7 +37,7 @@ pub struct FallbackService<S> {
     sequential_methods: Arc<HashSet<String>>,
 }
 
-impl<S: Clone> FallbackService<S> {
+impl<S> FallbackService<S> {
     /// Create a new fallback service from a list of transports.
     ///
     /// The `active_transport_count` parameter controls how many transports are used for requests


### PR DESCRIPTION
Removed the redundant Clone trait bound from the impl<S> FallbackService<S> block (lines 40-113).