### PR TITLE
feat(provider): add get_header methods

### DIFF
--- a/crates/provider/src/fillers/mod.rs
+++ b/crates/provider/src/fillers/mod.rs
@@ -537,6 +537,24 @@ where
         self.inner.get_block_receipts(block)
     }
 
+    async fn get_header(&self, block: BlockId) -> TransportResult<Option<N::HeaderResponse>> {
+        self.inner.get_header(block).await
+    }
+
+    async fn get_header_by_hash(
+        &self,
+        hash: BlockHash,
+    ) -> TransportResult<Option<N::HeaderResponse>> {
+        self.inner.get_header_by_hash(hash).await
+    }
+
+    async fn get_header_by_number(
+        &self,
+        number: BlockNumberOrTag,
+    ) -> TransportResult<Option<N::HeaderResponse>> {
+        self.inner.get_header_by_number(number).await
+    }
+
     fn get_code_at(&self, address: Address) -> RpcWithBlock<Address, Bytes> {
         self.inner.get_code_at(address)
     }

--- a/crates/provider/src/provider/erased.rs
+++ b/crates/provider/src/provider/erased.rs
@@ -184,6 +184,24 @@ impl<N: Network> Provider<N> for DynProvider<N> {
         self.0.get_block_receipts(block)
     }
 
+    async fn get_header(&self, block: BlockId) -> TransportResult<Option<N::HeaderResponse>> {
+        self.0.get_header(block).await
+    }
+
+    async fn get_header_by_hash(
+        &self,
+        hash: BlockHash,
+    ) -> TransportResult<Option<N::HeaderResponse>> {
+        self.0.get_header_by_hash(hash).await
+    }
+
+    async fn get_header_by_number(
+        &self,
+        number: BlockNumberOrTag,
+    ) -> TransportResult<Option<N::HeaderResponse>> {
+        self.0.get_header_by_number(number).await
+    }
+
     fn get_code_at(&self, address: Address) -> RpcWithBlock<Address, Bytes> {
         self.0.get_code_at(address)
     }

--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -468,6 +468,85 @@ pub trait Provider<N: Network = Ethereum>: Send + Sync {
         self.client().request("eth_getBlockReceipts", (block,)).into()
     }
 
+    /// Gets a block header by its [`BlockId`].
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use alloy_provider::{Provider, ProviderBuilder};
+    /// # use alloy_eips::BlockId;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let provider =
+    ///         ProviderBuilder::new().connect_http("https://eth.merkle.io".parse().unwrap());
+    ///
+    ///     // Gets the latest block header.
+    ///     let header = provider.get_header(BlockId::latest()).await.unwrap();
+    ///
+    ///     // Gets the block header by number.
+    ///     let header = provider.get_header(BlockId::number(0)).await.unwrap();
+    /// }
+    /// ```
+    async fn get_header(&self, block: BlockId) -> TransportResult<Option<N::HeaderResponse>> {
+        match block {
+            BlockId::Hash(hash) => self.get_header_by_hash(hash.block_hash).await,
+            BlockId::Number(number) => self.get_header_by_number(number).await,
+        }
+    }
+
+    /// Gets a block header by its [`BlockHash`].
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use alloy_provider::{Provider, ProviderBuilder};
+    /// # use alloy_primitives::b256;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let provider =
+    ///         ProviderBuilder::new().connect_http("https://eth.merkle.io".parse().unwrap());
+    ///     let block_hash = b256!("6032d03ee8e43e8999c2943152a4daebfc4b75b7f7a9647d2677299d215127da");
+    ///
+    ///     // Gets a block header by its hash.
+    ///     let header = provider.get_header_by_hash(block_hash).await.unwrap();
+    /// }
+    /// ```
+    async fn get_header_by_hash(
+        &self,
+        hash: BlockHash,
+    ) -> TransportResult<Option<N::HeaderResponse>> {
+        self.client().request("eth_getHeaderByHash", (hash,)).await
+    }
+
+    /// Gets a block header by its [`BlockNumberOrTag`].
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use alloy_provider::{Provider, ProviderBuilder};
+    /// # use alloy_eips::BlockNumberOrTag;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let provider =
+    ///         ProviderBuilder::new().connect_http("https://eth.merkle.io".parse().unwrap());
+    ///
+    ///     // Gets a block header by its number.
+    ///     let header = provider.get_header_by_number(BlockNumberOrTag::Number(0)).await.unwrap();
+    ///
+    ///     // Gets the latest block header.
+    ///     let header = provider.get_header_by_number(BlockNumberOrTag::Latest).await.unwrap();
+    /// }
+    /// ```
+    async fn get_header_by_number(
+        &self,
+        number: BlockNumberOrTag,
+    ) -> TransportResult<Option<N::HeaderResponse>> {
+        self.client().request("eth_getHeaderByNumber", (number,)).await
+    }
+
     /// Gets the bytecode located at the corresponding [`Address`].
     fn get_code_at(&self, address: Address) -> RpcWithBlock<Address, Bytes> {
         self.client().request("eth_getCode", address).into()


### PR DESCRIPTION
## Summary

Adds `get_header`, `get_header_by_hash`, and `get_header_by_number` methods to the Provider trait.

## Motivation

Currently there's no way to fetch just a block header via the Provider trait. This requires fetching the full block even when only header information is needed.

These methods enable fetching headers via `eth_getHeaderByHash` and `eth_getHeaderByNumber` RPC calls.

## Changes

- Added `get_header(BlockId)` - dispatches to hash or number variant
- Added `get_header_by_hash(BlockHash)` - calls `eth_getHeaderByHash`
- Added `get_header_by_number(BlockNumberOrTag)` - calls `eth_getHeaderByNumber`
- Implemented forwarding in `FillProvider` and erased provider

## Testing

`cargo check` and `cargo clippy` pass. Existing tests pass.

---

Discussion: https://tempoxyz.slack.com/archives/C09FQDW2ZRP/p1769708313406169