### PR TITLE
fix: remove duplicate log in subscription deserialization error

### DIFF
--- a/crates/pubsub/src/sub.rs
+++ b/crates/pubsub/src/sub.rs
@@ -385,8 +385,7 @@ impl<T: DeserializeOwned> Stream for SubscriptionStream<T> {
                 Some(Ok(value)) => match serde_json::from_str(value.get()) {
                     Ok(item) => return task::Poll::Ready(Some(item)),
                     Err(err) => {
-                        debug!(value = ?value.get(), %err, %self.id, "failed deserializing subscription item");
-                        error!(%err, %self.id, "failed deserializing subscription item");
+                        error!(value = ?value.get(), %err, %self.id, "failed deserializing subscription item");
                         continue;
                     }
                 },


### PR DESCRIPTION
Was logging both debug and error for the same failure - merged into single error log with the value context.