### PR TITLE
Use collect_str for FunctionSelector serialization

### DIFF
--- a/crates/rpc-types-mev/src/mevshare.rs
+++ b/crates/rpc-types-mev/src/mevshare.rs
@@ -170,7 +170,7 @@ impl Serialize for FunctionSelector {
     where
         S: Serializer,
     {
-        serializer.serialize_str(self.to_string().as_str())
+        serializer.collect_str(self)
     }
 }
 


### PR DESCRIPTION
Goal: Remove redundant String allocation in FunctionSelector serialization.
Change: Replace serialize_str(self.to_string().as_str()) with serializer.collect_str(self).
Why: FunctionSelector already implements Display; collect_str serializes via Display without the extra String/&str chain.