### PR TITLE
fix: normalize secp256k1 recovery id and serialize backend tests

### DIFF
--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -73,6 +73,8 @@ rand.workspace = true
 serde_json.workspace = true
 assert_matches.workspace = true
 
+serial_test = { workspace = true }
+
 [features]
 default = ["std"]
 std = [


### PR DESCRIPTION
Normalizes secp256k1 recovery id and avoids flaky backend tests