### PR TITLE
feat(rpc-types-engine): add into_payload_and_sidecar to V4 and V5 envelopes

### DIFF
--- a/crates/rpc-types-engine/src/payload.rs
+++ b/crates/rpc-types-engine/src/payload.rs
@@ -275,7 +275,7 @@ impl ExecutionPayloadEnvelopeV4 {
         let versioned_hashes = self.blobs_bundle.versioned_hashes();
 
         let cancun_fields = CancunPayloadFields { parent_beacon_block_root, versioned_hashes };
-        let prague_fields = PraguePayloadFields::from(self.execution_requests);
+        let prague_fields = PraguePayloadFields::new(self.execution_requests);
 
         (
             ExecutionPayload::V3(self.envelope_inner.execution_payload),
@@ -346,7 +346,7 @@ impl ExecutionPayloadEnvelopeV5 {
         let versioned_hashes = self.blobs_bundle.versioned_hashes();
 
         let cancun_fields = CancunPayloadFields { parent_beacon_block_root, versioned_hashes };
-        let prague_fields = PraguePayloadFields::from(self.execution_requests);
+        let prague_fields = PraguePayloadFields::new(self.execution_requests);
 
         (
             ExecutionPayload::V3(self.execution_payload),


### PR DESCRIPTION
## Summary

Adds a new `into_payload_and_sidecar` method to both `ExecutionPayloadEnvelopeV4` and `ExecutionPayloadEnvelopeV5` that converts the envelope into an `(ExecutionPayload, ExecutionPayloadSidecar)` tuple.

## Motivation

This is useful when using `testing_buildBlockV1` or similar APIs that return payload envelopes but need to be converted for use with `newPayload`. Ported from: https://github.com/paradigmxyz/reth/pull/21607

## Changes

- Added `into_payload_and_sidecar(parent_beacon_block_root: B256)` to `ExecutionPayloadEnvelopeV4`
- Added `into_payload_and_sidecar(parent_beacon_block_root: B256)` to `ExecutionPayloadEnvelopeV5`

The `parent_beacon_block_root` must be provided as it is not part of the envelope but is required for the sidecar's `CancunPayloadFields`. The versioned hashes are computed from the blobs bundle commitments.