### PR TITLE
perf(transport-ws): remove unnecessary clone in WsConnect::connect

### DIFF
--- a/crates/transport-ws/src/native.rs
+++ b/crates/transport-ws/src/native.rs
@@ -109,13 +109,27 @@ impl IntoClientRequest for WsConnect {
     }
 }
 
+impl IntoClientRequest for &WsConnect {
+    fn into_client_request(self) -> tungstenite::Result<tungstenite::handshake::client::Request> {
+        let mut request: http::Request<()> = self.url.as_str().into_client_request()?;
+        if let Some(auth) = self.auth.as_ref() {
+            let mut auth_value = http::HeaderValue::from_str(&auth.to_string())?;
+            auth_value.set_sensitive(true);
+
+            request.headers_mut().insert(http::header::AUTHORIZATION, auth_value);
+        }
+
+        request.into_client_request()
+    }
+}
+
 impl PubSubConnect for WsConnect {
     fn is_local(&self) -> bool {
         alloy_transport::utils::guess_local_url(&self.url)
     }
 
     async fn connect(&self) -> TransportResult<alloy_pubsub::ConnectionHandle> {
-        let request = self.clone().into_client_request();
+        let request = self.into_client_request();
         let req = request.map_err(TransportErrorKind::custom)?;
         let (socket, _) = tokio_tungstenite::connect_async_with_config(req, self.config, false)
             .await


### PR DESCRIPTION
Remove unnecessary heap allocation in WebSocket connection establishment