### PR TITLE
perf: optimize hex serialization for Index and BlockNumberOrTag

### DIFF
--- a/crates/eips/src/eip1898.rs
+++ b/crates/eips/src/eip1898.rs
@@ -999,7 +999,7 @@ mod tests {
         let pending = BlockNumberOrTag::Pending;
         assert_eq!(serde_json::to_string(&pending).unwrap(), "\"pending\"");
     }
-    
+
     #[test]
     fn block_id_as_u64() {
         assert_eq!(BlockId::number(123).as_u64(), Some(123));

--- a/crates/rpc-types-eth/src/index.rs
+++ b/crates/rpc-types-eth/src/index.rs
@@ -109,7 +109,7 @@ mod tests {
         let index = Index::from(42);
         assert_eq!(serde_json::to_string(&index).unwrap(), "\"0x2a\"");
     }
-    
+
     #[test]
     #[cfg(feature = "serde")]
     fn test_serde_index_deserialization() {


### PR DESCRIPTION
Replace manual `format!` string allocations with `alloy_serde::quantity::serialize` for hex number serialization in `Index` and `BlockNumberOrTag` types.