### PR TITLE
avoid closure for default retry backoff

### DIFF
--- a/crates/transport/src/layers/retry.rs
+++ b/crates/transport/src/layers/retry.rs
@@ -271,7 +271,7 @@ where
                     // try to extract the requested backoff from the error or compute the next
                     // backoff based on retry count
                     let backoff_hint = this.policy.backoff_hint(&err);
-                    let next_backoff = backoff_hint.unwrap_or_else(|| this.initial_backoff());
+                    let next_backoff = backoff_hint.unwrap_or(this.initial_backoff());
 
                     let seconds_to_wait_for_compute_budget = compute_unit_offset_in_secs(
                         this.avg_cost,


### PR DESCRIPTION
Context: Retry layer uses a constant default backoff when no hint is provided.
Change: Replaced unwrap_or_else with unwrap_or since the fallback is a cheap const fn.
Why: Removes an unnecessary closure and keeps the path leaner without behavior change.