### PR TITLE
fix(node-bindings): kill anvil child on timeout

### DIFF
--- a/crates/node-bindings/src/nodes/anvil.rs
+++ b/crates/node-bindings/src/nodes/anvil.rs
@@ -473,6 +473,7 @@ impl Anvil {
         let mut wallet = None;
         loop {
             if start + timeout <= Instant::now() {
+                let _ = child.kill();
                 return Err(NodeError::Timeout);
             }
 


### PR DESCRIPTION
## Motivation

Previously, `Anvil::try_spawn` returned `NodeError::Timeout` without killing the spawned child process. This left stray Anvil instances running in the background whenever startup timed out, unlike the Geth and Reth implementations which explicitly kill their child processes on timeout.
 

## Solution

Add a kill of the Anvil child process when try_spawn times out, aligning its behavior with Geth and Reth and preventing leaked node processes on startup timeout.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
