### PR TITLE
feat(provider): add EIP-7928 block access list helper methods

### DIFF
--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -468,6 +468,36 @@ pub trait Provider<N: Network = Ethereum>: Send + Sync {
         self.client().request("eth_getBlockReceipts", (block,)).into()
     }
 
+    /// Gets the EIP-7928 block access list by [`BlockId`].
+    ///
+    /// Returns the RLP-encoded block access list, or `None` if the block is not found.
+    async fn get_block_access_list(&self, block: BlockId) -> TransportResult<Option<Bytes>> {
+        match block {
+            BlockId::Hash(hash) => self.get_block_access_list_by_hash(hash.block_hash).await,
+            BlockId::Number(number) => self.get_block_access_list_by_number(number).await,
+        }
+    }
+
+    /// Gets the EIP-7928 block access list by [`BlockHash`].
+    ///
+    /// Returns the RLP-encoded block access list, or `None` if the block is not found.
+    async fn get_block_access_list_by_hash(
+        &self,
+        hash: BlockHash,
+    ) -> TransportResult<Option<Bytes>> {
+        self.client().request("eth_getBlockAccessListByBlockHash", (hash,)).await
+    }
+
+    /// Gets the EIP-7928 block access list by [`BlockNumberOrTag`].
+    ///
+    /// Returns the RLP-encoded block access list, or `None` if the block is not found.
+    async fn get_block_access_list_by_number(
+        &self,
+        number: BlockNumberOrTag,
+    ) -> TransportResult<Option<Bytes>> {
+        self.client().request("eth_getBlockAccessListByBlockNumber", (number,)).await
+    }
+
     /// Gets a block header by its [`BlockId`].
     ///
     /// # Examples


### PR DESCRIPTION
Adds provider helper methods for the EIP-7928 block access list RPC endpoints from [ethereum/execution-apis#726](https://github.com/ethereum/execution-apis/pull/726):

- `get_block_access_list(block: BlockId)` - convenience method that dispatches by block ID
- `get_block_access_list_by_hash(hash: BlockHash)` - calls `eth_getBlockAccessListByBlockHash`
- `get_block_access_list_by_number(number: BlockNumberOrTag)` - calls `eth_getBlockAccessListByBlockNumber`

All methods return `Option<Bytes>` containing the RLP-encoded block access list.

Related: [paradigmxyz/reth#21720](https://github.com/paradigmxyz/reth/pull/21720)