### PR TITLE
chore: bump rand to 0.9 and coins-bip32/bip39 to 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,7 +157,7 @@ lru = "0.16"
 once_cell = { version = "1.21", default-features = false }
 parking_lot = "0.12.3"
 pin-project = "1.1"
-rand = "0.8"
+rand = "0.9"
 reqwest = { version = "0.12", default-features = false }
 semver = "1.0"
 strum = { version = "0.27", default-features = false }

--- a/crates/consensus/src/block/header.rs
+++ b/crates/consensus/src/block/header.rs
@@ -1073,7 +1073,7 @@ pub(crate) mod serde_bincode_compat {
             }
 
             let mut bytes = [0u8; 1024];
-            rand::thread_rng().fill(bytes.as_mut_slice());
+            rand::rng().fill(bytes.as_mut_slice());
             let data = Data {
                 header: Header::arbitrary(&mut arbitrary::Unstructured::new(&bytes)).unwrap(),
             };

--- a/crates/consensus/src/crypto.rs
+++ b/crates/consensus/src/crypto.rs
@@ -436,7 +436,7 @@ mod tests {
         use super::impl_secp256k1::*;
         use alloy_primitives::B256;
 
-        let (secret, public) = secp256k1::generate_keypair(&mut rand::thread_rng());
+        let (secret, public) = secp256k1::generate_keypair(&mut rand::rng());
         let signer = public_key_to_address(public);
 
         let message = b"hello world";
@@ -458,7 +458,7 @@ mod tests {
         use super::impl_k256::*;
         use alloy_primitives::B256;
 
-        let secret = k256::ecdsa::SigningKey::random(&mut rand::thread_rng());
+        let secret = k256::ecdsa::SigningKey::random(&mut rand::rng());
         let public = *secret.verifying_key();
         let signer = public_key_to_address(public);
 
@@ -481,8 +481,7 @@ mod tests {
         use super::{impl_k256, impl_secp256k1};
         use alloy_primitives::B256;
 
-        let (secp256k1_secret, secp256k1_public) =
-            secp256k1::generate_keypair(&mut rand::thread_rng());
+        let (secp256k1_secret, secp256k1_public) = secp256k1::generate_keypair(&mut rand::rng());
         let k256_secret = k256::ecdsa::SigningKey::from_slice(&secp256k1_secret.secret_bytes())
             .expect("k256 secret");
         let k256_public = *k256_secret.verifying_key();

--- a/crates/consensus/src/receipt/envelope.rs
+++ b/crates/consensus/src/receipt/envelope.rs
@@ -443,7 +443,7 @@ pub(crate) mod serde_bincode_compat {
             }
 
             let mut bytes = [0u8; 1024];
-            rand::thread_rng().fill(bytes.as_mut_slice());
+            rand::rng().fill(bytes.as_mut_slice());
             let mut data = Data {
                 transaction: ReceiptEnvelope::arbitrary(&mut arbitrary::Unstructured::new(&bytes))
                     .unwrap(),

--- a/crates/consensus/src/receipt/receipts.rs
+++ b/crates/consensus/src/receipt/receipts.rs
@@ -502,7 +502,7 @@ pub(crate) mod serde_bincode_compat {
             }
 
             let mut bytes = [0u8; 1024];
-            rand::thread_rng().fill(bytes.as_mut_slice());
+            rand::rng().fill(bytes.as_mut_slice());
             let mut data = Data {
                 receipt: Receipt::arbitrary(&mut arbitrary::Unstructured::new(&bytes)).unwrap(),
             };

--- a/crates/consensus/src/transaction/eip1559.rs
+++ b/crates/consensus/src/transaction/eip1559.rs
@@ -395,7 +395,7 @@ pub(super) mod serde_bincode_compat {
             }
 
             let mut bytes = [0u8; 1024];
-            rand::thread_rng().fill(bytes.as_mut_slice());
+            rand::rng().fill(bytes.as_mut_slice());
             let data = Data {
                 transaction: TxEip1559::arbitrary(&mut arbitrary::Unstructured::new(&bytes))
                     .unwrap(),

--- a/crates/consensus/src/transaction/eip2930.rs
+++ b/crates/consensus/src/transaction/eip2930.rs
@@ -416,7 +416,7 @@ pub(super) mod serde_bincode_compat {
             }
 
             let mut bytes = [0u8; 1024];
-            rand::thread_rng().fill(bytes.as_mut_slice());
+            rand::rng().fill(bytes.as_mut_slice());
             let data = Data {
                 transaction: TxEip2930::arbitrary(&mut arbitrary::Unstructured::new(&bytes))
                     .unwrap(),

--- a/crates/consensus/src/transaction/eip7702.rs
+++ b/crates/consensus/src/transaction/eip7702.rs
@@ -385,7 +385,7 @@ pub(super) mod serde_bincode_compat {
             }
 
             let mut bytes = [0u8; 1024];
-            rand::thread_rng().fill(bytes.as_mut_slice());
+            rand::rng().fill(bytes.as_mut_slice());
             let data = Data {
                 transaction: TxEip7702::arbitrary(&mut arbitrary::Unstructured::new(&bytes))
                     .unwrap(),

--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -1039,7 +1039,7 @@ pub mod serde_bincode_compat {
             }
 
             let mut bytes = [0u8; 1024];
-            rand::thread_rng().fill(bytes.as_mut_slice());
+            rand::rng().fill(bytes.as_mut_slice());
             let data = Data {
                 transaction: EthereumTxEnvelope::arbitrary(&mut arbitrary::Unstructured::new(
                     &bytes,

--- a/crates/consensus/src/transaction/legacy.rs
+++ b/crates/consensus/src/transaction/legacy.rs
@@ -715,7 +715,7 @@ pub(super) mod serde_bincode_compat {
             }
 
             let mut bytes = [0u8; 1024];
-            rand::thread_rng().fill(bytes.as_mut_slice());
+            rand::rng().fill(bytes.as_mut_slice());
             let data = Data {
                 transaction: TxLegacy::arbitrary(&mut arbitrary::Unstructured::new(&bytes))
                     .unwrap(),

--- a/crates/consensus/src/transaction/typed.rs
+++ b/crates/consensus/src/transaction/typed.rs
@@ -488,7 +488,7 @@ pub(crate) mod serde_bincode_compat {
             }
 
             let mut bytes = [0u8; 1024];
-            rand::thread_rng().fill(bytes.as_mut_slice());
+            rand::rng().fill(bytes.as_mut_slice());
             let data = Data {
                 transaction: EthereumTypedTransaction::arbitrary(
                     &mut arbitrary::Unstructured::new(&bytes),

--- a/crates/eips/src/eip1559/basefee.rs
+++ b/crates/eips/src/eip1559/basefee.rs
@@ -106,7 +106,7 @@ mod tests {
     #[test]
     fn test_arbitrary_base_fee_params() {
         let mut bytes = [0u8; 1024];
-        rand::thread_rng().fill(bytes.as_mut_slice());
+        rand::rng().fill(bytes.as_mut_slice());
         BaseFeeParams::arbitrary(&mut arbitrary::Unstructured::new(&bytes)).unwrap();
     }
 }

--- a/crates/node-bindings/src/nodes/reth.rs
+++ b/crates/node-bindings/src/nodes/reth.rs
@@ -190,7 +190,7 @@ impl Reth {
             auth_port: DEFAULT_AUTH_PORT,
             p2p_port: DEFAULT_P2P_PORT,
             block_time: None,
-            instance: rand::thread_rng().gen_range(1..200),
+            instance: rand::rng().random_range(1..200),
             discovery_enabled: true,
             program: None,
             ipc_path: None,

--- a/crates/node-bindings/tests/it/geth.rs
+++ b/crates/node-bindings/tests/it/geth.rs
@@ -62,7 +62,7 @@ fn clique_correctly_configured() {
     }
 
     run_with_tempdir_sync("geth-test-", |temp_dir_path| {
-        let private_key = SigningKey::random(&mut rand::thread_rng());
+        let private_key = SigningKey::random(&mut rand::rng());
         let geth = Geth::new()
             .set_clique_private_key(private_key)
             .chain_id(1337u64)

--- a/crates/rpc-types-engine/src/jwt.rs
+++ b/crates/rpc-types-engine/src/jwt.rs
@@ -245,7 +245,7 @@ impl JwtSecret {
 
     /// Generates a random [`JwtSecret`] containing a hex-encoded 256 bit secret key.
     pub fn random() -> Self {
-        Self(rand::thread_rng().gen())
+        Self(rand::rng().random())
     }
 
     /// Encode the header and claims given and sign the payload using the algorithm from the header

--- a/crates/rpc-types-eth/src/block.rs
+++ b/crates/rpc-types-eth/src/block.rs
@@ -826,7 +826,7 @@ mod tests {
     #[test]
     fn arbitrary_header() {
         let mut bytes = [0u8; 1024];
-        rand::thread_rng().fill(bytes.as_mut_slice());
+        rand::rng().fill(bytes.as_mut_slice());
         let _: Header = Header::arbitrary(&mut arbitrary::Unstructured::new(&bytes)).unwrap();
     }
 

--- a/crates/rpc-types-eth/src/index.rs
+++ b/crates/rpc-types-eth/src/index.rs
@@ -83,7 +83,7 @@ impl<'a> serde::Deserialize<'a> for Index {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rand::{thread_rng, Rng};
+    use rand::Rng;
     #[cfg(feature = "serde")]
     use serde_json::json;
     use similar_asserts::assert_eq;
@@ -91,9 +91,9 @@ mod tests {
     #[test]
     #[cfg(feature = "serde")]
     fn test_serde_index_rand() {
-        let mut rng = thread_rng();
+        let mut rng = rand::rng();
         for _ in 0..100 {
-            let index = Index(rng.gen());
+            let index = Index(rng.random());
             let val = serde_json::to_string(&index).unwrap();
             let de: Index = serde_json::from_str(&val).unwrap();
             assert_eq!(index, de);

--- a/crates/rpc-types-eth/src/log.rs
+++ b/crates/rpc-types-eth/src/log.rs
@@ -240,7 +240,7 @@ mod tests {
     #[test]
     fn log_arbitrary() {
         let mut bytes = [0u8; 1024];
-        rand::thread_rng().fill(bytes.as_mut_slice());
+        rand::rng().fill(bytes.as_mut_slice());
 
         let _: Log = Log::arbitrary(&mut arbitrary::Unstructured::new(&bytes)).unwrap();
     }

--- a/crates/rpc-types-eth/src/transaction/receipt.rs
+++ b/crates/rpc-types-eth/src/transaction/receipt.rs
@@ -326,7 +326,7 @@ mod test {
     #[test]
     fn transaction_receipt_arbitrary() {
         let mut bytes = [0u8; 1024];
-        rand::thread_rng().fill(bytes.as_mut_slice());
+        rand::rng().fill(bytes.as_mut_slice());
 
         let _: TransactionReceipt =
             TransactionReceipt::arbitrary(&mut arbitrary::Unstructured::new(&bytes)).unwrap();

--- a/crates/rpc-types-eth/src/transaction/request.rs
+++ b/crates/rpc-types-eth/src/transaction/request.rs
@@ -1552,7 +1552,7 @@ pub(super) mod serde_bincode_compat {
             }
 
             let mut bytes = vec![0u8; 1024];
-            rand::thread_rng().fill(bytes.as_mut_slice());
+            rand::rng().fill(bytes.as_mut_slice());
             let data = Data {
                 transaction: TransactionRequest::arbitrary(&mut arbitrary::Unstructured::new(
                     &bytes,

--- a/crates/serde/src/other/mod.rs
+++ b/crates/serde/src/other/mod.rs
@@ -281,7 +281,7 @@ mod tests {
     #[test]
     fn other_fields_arbitrary() {
         let mut bytes = [0u8; 1024];
-        rand::thread_rng().fill(bytes.as_mut_slice());
+        rand::rng().fill(bytes.as_mut_slice());
 
         let _ = arbitrary::Unstructured::new(&bytes).arbitrary::<OtherFields>().unwrap();
     }

--- a/crates/signer-local/Cargo.toml
+++ b/crates/signer-local/Cargo.toml
@@ -41,8 +41,8 @@ zeroize = { workspace = true, optional = true, features = [
 eth-keystore = { version = "0.5.0", default-features = false, optional = true }
 
 # mnemonic
-coins-bip32 = { version = "0.12", default-features = false, optional = true }
-coins-bip39 = { version = "0.12", default-features = false, features = [
+coins-bip32 = { version = "0.13", default-features = false, optional = true }
+coins-bip39 = { version = "0.13", default-features = false, features = [
     "english",
 ], optional = true }
 

--- a/crates/signer-local/src/mnemonic.rs
+++ b/crates/signer-local/src/mnemonic.rs
@@ -183,7 +183,7 @@ impl<W: Wordlist> MnemonicBuilder<W> {
     /// Builds a `PrivateKeySigner` using the parameters set in the mnemonic builder and
     /// constructing the phrase using the thread RNG.
     pub fn build_random(&self) -> Result<PrivateKeySigner, LocalSignerError> {
-        self.build_random_with(&mut rand::thread_rng())
+        self.build_random_with(&mut rand::rng())
     }
 
     /// Builds a `PrivateKeySigner` using the parameters set in the mnemonic builder and

--- a/crates/signer-local/src/private_key.rs
+++ b/crates/signer-local/src/private_key.rs
@@ -53,10 +53,10 @@ impl LocalSigner<SigningKey> {
         SigningKey::from_slice(bytes).map(Self::from_signing_key)
     }
 
-    /// Creates a new random keypair seeded with [`rand::thread_rng()`].
+    /// Creates a new random keypair seeded with [`rand::rng()`].
     #[inline]
     pub fn random() -> Self {
-        Self::random_with(&mut rand::thread_rng())
+        Self::random_with(&mut rand::rng())
     }
 
     /// Creates a new random keypair seeded with the provided RNG.
@@ -278,7 +278,7 @@ mod tests {
     fn encrypted_json_keystore_new() {
         // create and store an encrypted JSON keystore in this directory
         let dir = tempdir().unwrap();
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let (key, uuid) =
             LocalSigner::<SigningKey>::new_keystore(&dir, &mut rng, "randpsswd", None).unwrap();
 
@@ -290,7 +290,7 @@ mod tests {
     fn encrypted_json_keystore_from_pk() {
         // create and store an encrypted JSON keystore in this directory
         let dir = tempdir().unwrap();
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
 
         let private_key =
             hex::decode("6f142508b4eea641e33cb2a0161221105086a84584c74245ca463a49effea30b")
@@ -317,7 +317,7 @@ mod tests {
 
         use eth_keystore::EthKeystore;
         let dir = tempdir().unwrap();
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let (key, uuid) =
             LocalSigner::<SigningKey>::new_keystore(&dir, &mut rng, "randpsswd", None).unwrap();
 
@@ -334,7 +334,7 @@ mod tests {
     fn signs_msg() {
         let message = "Some data";
         let hash = alloy_primitives::utils::eip191_hash_message(message);
-        let key = LocalSigner::<SigningKey>::random_with(&mut rand::thread_rng());
+        let key = LocalSigner::<SigningKey>::random_with(&mut rand::rng());
         let address = key.address;
 
         // sign a message

--- a/crates/signer-local/src/secp256k1.rs
+++ b/crates/signer-local/src/secp256k1.rs
@@ -125,10 +125,10 @@ impl LocalSigner<Secp256k1Credential> {
         SecretKey::from_slice(bytes).map(Self::from_secp256k1)
     }
 
-    /// Creates a new random keypair seeded with [`rand::thread_rng()`].
+    /// Creates a new random keypair seeded with [`rand::rng()`].
     #[inline]
     pub fn random() -> Self {
-        Self::random_with(&mut rand::thread_rng())
+        Self::random_with(&mut rand::rng())
     }
 
     /// Creates a new random keypair seeded with the provided RNG.
@@ -318,7 +318,7 @@ mod tests {
     fn encrypted_json_keystore_new() {
         // create and store an encrypted JSON keystore in this directory
         let dir = tempdir().unwrap();
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let (key, uuid) = Secp256k1Signer::new_keystore(&dir, &mut rng, "randpsswd", None).unwrap();
 
         test_encrypted_json_keystore(key, &uuid, dir.path());
@@ -329,7 +329,7 @@ mod tests {
     fn encrypted_json_keystore_from_pk() {
         // create and store an encrypted JSON keystore in this directory
         let dir = tempdir().unwrap();
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
 
         let private_key =
             hex::decode("6f142508b4eea641e33cb2a0161221105086a84584c74245ca463a49effea30b")
@@ -346,7 +346,7 @@ mod tests {
     fn signs_msg() {
         let message = "Some data";
         let hash = alloy_primitives::utils::eip191_hash_message(message);
-        let key = Secp256k1Signer::random_with(&mut rand::thread_rng());
+        let key = Secp256k1Signer::random_with(&mut rand::rng());
         let address = key.address;
 
         // sign a message


### PR DESCRIPTION
## Summary

This PR upgrades rand from 0.8 to 0.9 and the coins-bip libraries from 0.12 to 0.13 (which support rand 0.9).

## Changes

### Dependencies
- `rand`: 0.8 → 0.9
- `coins-bip32`: 0.12 → 0.13
- `coins-bip39`: 0.12 → 0.13

### API migrations (rand 0.9)
| Old (0.8) | New (0.9) |
|-----------|-----------|
| `thread_rng()` | `rng()` |
| `.gen()` | `.random()` |
| `.gen_range()` | `.random_range()` |

## Motivation

rand 0.9 has been stable for a while and coins-bip39 0.13.0 now supports it. This unblocks downstream projects that want to consolidate on rand 0.9.