### PR TITLE
feat(provider): add engine_getPayloadBodiesByHashV2 and engine_getPay…

### DIFF
--- a/crates/provider/src/ext/engine.rs
+++ b/crates/provider/src/ext/engine.rs
@@ -3,11 +3,11 @@ use alloy_eips::eip7685::RequestsOrHash;
 use alloy_network::Network;
 use alloy_primitives::{BlockHash, Bytes, B256, U64};
 use alloy_rpc_types_engine::{
-    ClientVersionV1, ExecutionPayloadBodiesV1, ExecutionPayloadBodiesV2, ExecutionPayloadEnvelopeV2,
-    ExecutionPayloadEnvelopeV3, ExecutionPayloadEnvelopeV4, ExecutionPayloadEnvelopeV5,
-    ExecutionPayloadEnvelopeV6, ExecutionPayloadInputV2, ExecutionPayloadV1, ExecutionPayloadV3,
-    ExecutionPayloadV4, ForkchoiceState, ForkchoiceUpdated, PayloadAttributes, PayloadId,
-    PayloadStatus,
+    ClientVersionV1, ExecutionPayloadBodiesV1, ExecutionPayloadBodiesV2,
+    ExecutionPayloadEnvelopeV2, ExecutionPayloadEnvelopeV3, ExecutionPayloadEnvelopeV4,
+    ExecutionPayloadEnvelopeV5, ExecutionPayloadEnvelopeV6, ExecutionPayloadInputV2,
+    ExecutionPayloadV1, ExecutionPayloadV3, ExecutionPayloadV4, ForkchoiceState, ForkchoiceUpdated,
+    PayloadAttributes, PayloadId, PayloadStatus,
 };
 use alloy_transport::TransportResult;
 


### PR DESCRIPTION
The `CAPABILITIES` constant in `rpc-types-engine` declares support for `engine_getPayloadBodiesByHashV2` and `engine_getPayloadBodiesByRangeV2`, but the `EngineApi` trait only implemented V1 versions. This could cause runtime errors when clients attempt to call V2 methods based on the declared capabilities.

Add `get_payload_bodies_by_hash_v2` and `get_payload_bodies_by_range_v2` methods to `EngineApi` trait