### PR TITLE
feat: add reth traits to alloy for op-alloy dependency removal

### DIFF
--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -42,9 +42,9 @@ pub mod transaction;
 #[cfg(feature = "kzg")]
 pub use transaction::BlobTransactionValidationError;
 pub use transaction::{
-    EthereumTxEnvelope, EthereumTypedTransaction, SignableTransaction, Transaction,
-    TransactionEnvelope, TxEip1559, TxEip2930, TxEip4844, TxEip4844Variant, TxEip4844WithSidecar,
-    TxEip7702, TxEnvelope, TxLegacy, TxType, TypedTransaction,
+    EthereumTxEnvelope, EthereumTypedTransaction, SignableTransaction, SignedTransaction,
+    Transaction, TransactionEnvelope, TxEip1559, TxEip2930, TxEip4844, TxEip4844Variant,
+    TxEip4844WithSidecar, TxEip7702, TxEnvelope, TxLegacy, TxType, TypedTransaction,
 };
 
 pub use alloy_eips::{
@@ -87,6 +87,14 @@ pub mod serde_bincode_compat {
         transaction::{serde_bincode_compat as transaction, serde_bincode_compat::*},
     };
 }
+
+/// Bincode compatibility traits and Block/BlockBody wrappers.
+///
+/// Contains the [`SerdeBincodeCompat`] trait and its implementations for consensus types.
+#[cfg(all(feature = "serde", feature = "serde-bincode-compat"))]
+pub mod serde_bincode_compat_traits;
+#[cfg(all(feature = "serde", feature = "serde-bincode-compat"))]
+pub use serde_bincode_compat_traits::{BincodeReprFor, RlpBincode, SerdeBincodeCompat};
 
 #[doc(hidden)]
 pub mod private {

--- a/crates/consensus/src/serde_bincode_compat_traits.rs
+++ b/crates/consensus/src/serde_bincode_compat_traits.rs
@@ -1,0 +1,276 @@
+//! Bincode compatibility support traits.
+//!
+//! This module provides traits and implementations to work around bincode's limitations
+//! with optional serde fields. The bincode crate requires all fields to be present during
+//! serialization, which conflicts with types that have `#[serde(skip_serializing_if)]`
+//! attributes for RPC compatibility.
+//!
+//! # Overview
+//!
+//! The main trait is [`SerdeBincodeCompat`], which provides a conversion mechanism between
+//! types and their bincode-compatible representations. There are two main ways to implement
+//! this trait:
+//!
+//! 1. **Using RLP encoding** - Implement [`RlpBincode`] for types that already support RLP
+//! 2. **Custom implementation** - Define a custom representation type
+
+use alloc::vec::Vec;
+use alloy_primitives::Bytes;
+use core::fmt::Debug;
+use serde::{de::DeserializeOwned, Serialize};
+
+/// Trait for types that can be serialized and deserialized using bincode.
+///
+/// This trait provides a workaround for bincode's incompatibility with optional
+/// serde fields. It ensures all fields are serialized, making the type bincode-compatible.
+///
+/// # Implementation
+///
+/// The easiest way to implement this trait is using [`RlpBincode`] for RLP-encodable types:
+///
+/// ```rust,ignore
+/// impl RlpBincode for MyType {}
+/// // SerdeBincodeCompat is automatically implemented
+/// ```
+///
+/// The recommended way to add bincode compatible serialization is via the
+/// [`serde_with`] crate and the `serde_as` macro.
+pub trait SerdeBincodeCompat: Sized + 'static {
+    /// Serde representation of the type for bincode serialization.
+    ///
+    /// This type defines the bincode compatible serde format for the type.
+    type BincodeRepr<'a>: Debug + Serialize + DeserializeOwned;
+
+    /// Convert this type into its bincode representation
+    fn as_repr(&self) -> Self::BincodeRepr<'_>;
+
+    /// Convert from the bincode representation
+    fn from_repr(repr: Self::BincodeRepr<'_>) -> Self;
+}
+
+/// Type alias for the [`SerdeBincodeCompat::BincodeRepr`] associated type.
+pub type BincodeReprFor<'a, T> = <T as SerdeBincodeCompat>::BincodeRepr<'a>;
+
+/// A helper trait for using RLP-encoding for providing bincode-compatible serialization.
+///
+/// By implementing this trait, [`SerdeBincodeCompat`] will be automatically implemented for the
+/// type and RLP encoding will be used for serialization and deserialization for bincode
+/// compatibility.
+pub trait RlpBincode: alloy_rlp::Encodable + alloy_rlp::Decodable {}
+
+impl<T: RlpBincode + 'static> SerdeBincodeCompat for T {
+    type BincodeRepr<'a> = Bytes;
+
+    fn as_repr(&self) -> Self::BincodeRepr<'_> {
+        let mut buf = Vec::new();
+        self.encode(&mut buf);
+        buf.into()
+    }
+
+    fn from_repr(repr: Self::BincodeRepr<'_>) -> Self {
+        Self::decode(&mut repr.as_ref()).expect("Failed to decode bincode rlp representation")
+    }
+}
+
+// --- Implementations for alloy-consensus types ---
+
+impl SerdeBincodeCompat for crate::Header {
+    type BincodeRepr<'a> = crate::serde_bincode_compat::Header<'a>;
+
+    fn as_repr(&self) -> Self::BincodeRepr<'_> {
+        self.into()
+    }
+
+    fn from_repr(repr: Self::BincodeRepr<'_>) -> Self {
+        repr.into()
+    }
+}
+
+impl SerdeBincodeCompat for crate::EthereumTxEnvelope<crate::TxEip4844> {
+    type BincodeRepr<'a> =
+        crate::serde_bincode_compat::transaction::EthereumTxEnvelope<'a>;
+
+    fn as_repr(&self) -> Self::BincodeRepr<'_> {
+        self.into()
+    }
+
+    fn from_repr(repr: Self::BincodeRepr<'_>) -> Self {
+        repr.into()
+    }
+}
+
+// --- Block/BlockBody implementations ---
+
+mod block_bincode {
+    use super::SerdeBincodeCompat;
+    use alloc::{borrow::Cow, vec::Vec};
+    use alloy_eips::eip4895::Withdrawals;
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+    use serde_with::{DeserializeAs, SerializeAs};
+
+    /// Bincode-compatible [`alloy_consensus::Block`] serde implementation.
+    #[derive(Serialize, Deserialize)]
+    pub struct Block<'a, T: SerdeBincodeCompat, H: SerdeBincodeCompat> {
+        header: H::BincodeRepr<'a>,
+        #[serde(bound = "BlockBody<'a, T, H>: Serialize + serde::de::DeserializeOwned")]
+        body: BlockBody<'a, T, H>,
+    }
+
+    impl<T: SerdeBincodeCompat, H: SerdeBincodeCompat> core::fmt::Debug for Block<'_, T, H> {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            f.debug_struct("Block")
+                .field("header", &self.header)
+                .field("body", &self.body)
+                .finish()
+        }
+    }
+
+    impl<'a, T: SerdeBincodeCompat, H: SerdeBincodeCompat>
+        From<&'a crate::Block<T, H>> for Block<'a, T, H>
+    {
+        fn from(value: &'a crate::Block<T, H>) -> Self {
+            Self { header: value.header.as_repr(), body: (&value.body).into() }
+        }
+    }
+
+    impl<'a, T: SerdeBincodeCompat, H: SerdeBincodeCompat> From<Block<'a, T, H>>
+        for crate::Block<T, H>
+    {
+        fn from(value: Block<'a, T, H>) -> Self {
+            Self {
+                header: SerdeBincodeCompat::from_repr(value.header),
+                body: value.body.into(),
+            }
+        }
+    }
+
+    impl<T: SerdeBincodeCompat, H: SerdeBincodeCompat>
+        SerializeAs<crate::Block<T, H>> for Block<'_, T, H>
+    {
+        fn serialize_as<S>(
+            source: &crate::Block<T, H>,
+            serializer: S,
+        ) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            Block::from(source).serialize(serializer)
+        }
+    }
+
+    impl<'de, T: SerdeBincodeCompat, H: SerdeBincodeCompat>
+        DeserializeAs<'de, crate::Block<T, H>> for Block<'de, T, H>
+    {
+        fn deserialize_as<D>(deserializer: D) -> Result<crate::Block<T, H>, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            Block::deserialize(deserializer).map(Into::into)
+        }
+    }
+
+    impl<T: SerdeBincodeCompat, H: SerdeBincodeCompat> SerdeBincodeCompat
+        for crate::Block<T, H>
+    {
+        type BincodeRepr<'a> = Block<'a, T, H>;
+
+        fn as_repr(&self) -> Self::BincodeRepr<'_> {
+            self.into()
+        }
+
+        fn from_repr(repr: Self::BincodeRepr<'_>) -> Self {
+            repr.into()
+        }
+    }
+
+    /// Bincode-compatible [`alloy_consensus::BlockBody`] serde implementation.
+    #[derive(Serialize, Deserialize)]
+    pub struct BlockBody<'a, T: SerdeBincodeCompat, H: SerdeBincodeCompat> {
+        transactions: Vec<T::BincodeRepr<'a>>,
+        ommers: Vec<H::BincodeRepr<'a>>,
+        withdrawals: Cow<'a, Option<Withdrawals>>,
+    }
+
+    impl<T: SerdeBincodeCompat, H: SerdeBincodeCompat> core::fmt::Debug
+        for BlockBody<'_, T, H>
+    {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            f.debug_struct("BlockBody")
+                .field("transactions", &self.transactions)
+                .field("ommers", &self.ommers)
+                .field("withdrawals", &self.withdrawals)
+                .finish()
+        }
+    }
+
+    impl<'a, T: SerdeBincodeCompat, H: SerdeBincodeCompat>
+        From<&'a crate::BlockBody<T, H>> for BlockBody<'a, T, H>
+    {
+        fn from(value: &'a crate::BlockBody<T, H>) -> Self {
+            Self {
+                transactions: value.transactions.iter().map(|tx| tx.as_repr()).collect(),
+                ommers: value.ommers.iter().map(|h| h.as_repr()).collect(),
+                withdrawals: Cow::Borrowed(&value.withdrawals),
+            }
+        }
+    }
+
+    impl<'a, T: SerdeBincodeCompat, H: SerdeBincodeCompat> From<BlockBody<'a, T, H>>
+        for crate::BlockBody<T, H>
+    {
+        fn from(value: BlockBody<'a, T, H>) -> Self {
+            Self {
+                transactions: value
+                    .transactions
+                    .into_iter()
+                    .map(SerdeBincodeCompat::from_repr)
+                    .collect(),
+                ommers: value.ommers.into_iter().map(SerdeBincodeCompat::from_repr).collect(),
+                withdrawals: value.withdrawals.into_owned(),
+            }
+        }
+    }
+
+    impl<T: SerdeBincodeCompat, H: SerdeBincodeCompat>
+        SerializeAs<crate::BlockBody<T, H>> for BlockBody<'_, T, H>
+    {
+        fn serialize_as<S>(
+            source: &crate::BlockBody<T, H>,
+            serializer: S,
+        ) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            BlockBody::from(source).serialize(serializer)
+        }
+    }
+
+    impl<'de, T: SerdeBincodeCompat, H: SerdeBincodeCompat>
+        DeserializeAs<'de, crate::BlockBody<T, H>> for BlockBody<'de, T, H>
+    {
+        fn deserialize_as<D>(
+            deserializer: D,
+        ) -> Result<crate::BlockBody<T, H>, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            BlockBody::deserialize(deserializer).map(Into::into)
+        }
+    }
+
+    impl<T: SerdeBincodeCompat, H: SerdeBincodeCompat> SerdeBincodeCompat
+        for crate::BlockBody<T, H>
+    {
+        type BincodeRepr<'a> = BlockBody<'a, T, H>;
+
+        fn as_repr(&self) -> Self::BincodeRepr<'_> {
+            self.into()
+        }
+
+        fn from_repr(repr: Self::BincodeRepr<'_>) -> Self {
+            repr.into()
+        }
+    }
+}
+
+pub use block_bincode::{Block, BlockBody};

--- a/crates/consensus/src/serde_bincode_compat_traits.rs
+++ b/crates/consensus/src/serde_bincode_compat_traits.rs
@@ -87,8 +87,7 @@ impl SerdeBincodeCompat for crate::Header {
 }
 
 impl SerdeBincodeCompat for crate::EthereumTxEnvelope<crate::TxEip4844> {
-    type BincodeRepr<'a> =
-        crate::serde_bincode_compat::transaction::EthereumTxEnvelope<'a>;
+    type BincodeRepr<'a> = crate::serde_bincode_compat::transaction::EthereumTxEnvelope<'a>;
 
     fn as_repr(&self) -> Self::BincodeRepr<'_> {
         self.into()
@@ -118,15 +117,12 @@ mod block_bincode {
 
     impl<T: SerdeBincodeCompat, H: SerdeBincodeCompat> core::fmt::Debug for Block<'_, T, H> {
         fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-            f.debug_struct("Block")
-                .field("header", &self.header)
-                .field("body", &self.body)
-                .finish()
+            f.debug_struct("Block").field("header", &self.header).field("body", &self.body).finish()
         }
     }
 
-    impl<'a, T: SerdeBincodeCompat, H: SerdeBincodeCompat>
-        From<&'a crate::Block<T, H>> for Block<'a, T, H>
+    impl<'a, T: SerdeBincodeCompat, H: SerdeBincodeCompat> From<&'a crate::Block<T, H>>
+        for Block<'a, T, H>
     {
         fn from(value: &'a crate::Block<T, H>) -> Self {
             Self { header: value.header.as_repr(), body: (&value.body).into() }
@@ -137,20 +133,14 @@ mod block_bincode {
         for crate::Block<T, H>
     {
         fn from(value: Block<'a, T, H>) -> Self {
-            Self {
-                header: SerdeBincodeCompat::from_repr(value.header),
-                body: value.body.into(),
-            }
+            Self { header: SerdeBincodeCompat::from_repr(value.header), body: value.body.into() }
         }
     }
 
-    impl<T: SerdeBincodeCompat, H: SerdeBincodeCompat>
-        SerializeAs<crate::Block<T, H>> for Block<'_, T, H>
+    impl<T: SerdeBincodeCompat, H: SerdeBincodeCompat> SerializeAs<crate::Block<T, H>>
+        for Block<'_, T, H>
     {
-        fn serialize_as<S>(
-            source: &crate::Block<T, H>,
-            serializer: S,
-        ) -> Result<S::Ok, S::Error>
+        fn serialize_as<S>(source: &crate::Block<T, H>, serializer: S) -> Result<S::Ok, S::Error>
         where
             S: Serializer,
         {
@@ -158,8 +148,8 @@ mod block_bincode {
         }
     }
 
-    impl<'de, T: SerdeBincodeCompat, H: SerdeBincodeCompat>
-        DeserializeAs<'de, crate::Block<T, H>> for Block<'de, T, H>
+    impl<'de, T: SerdeBincodeCompat, H: SerdeBincodeCompat> DeserializeAs<'de, crate::Block<T, H>>
+        for Block<'de, T, H>
     {
         fn deserialize_as<D>(deserializer: D) -> Result<crate::Block<T, H>, D::Error>
         where
@@ -169,9 +159,7 @@ mod block_bincode {
         }
     }
 
-    impl<T: SerdeBincodeCompat, H: SerdeBincodeCompat> SerdeBincodeCompat
-        for crate::Block<T, H>
-    {
+    impl<T: SerdeBincodeCompat, H: SerdeBincodeCompat> SerdeBincodeCompat for crate::Block<T, H> {
         type BincodeRepr<'a> = Block<'a, T, H>;
 
         fn as_repr(&self) -> Self::BincodeRepr<'_> {
@@ -191,9 +179,7 @@ mod block_bincode {
         withdrawals: Cow<'a, Option<Withdrawals>>,
     }
 
-    impl<T: SerdeBincodeCompat, H: SerdeBincodeCompat> core::fmt::Debug
-        for BlockBody<'_, T, H>
-    {
+    impl<T: SerdeBincodeCompat, H: SerdeBincodeCompat> core::fmt::Debug for BlockBody<'_, T, H> {
         fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
             f.debug_struct("BlockBody")
                 .field("transactions", &self.transactions)
@@ -203,8 +189,8 @@ mod block_bincode {
         }
     }
 
-    impl<'a, T: SerdeBincodeCompat, H: SerdeBincodeCompat>
-        From<&'a crate::BlockBody<T, H>> for BlockBody<'a, T, H>
+    impl<'a, T: SerdeBincodeCompat, H: SerdeBincodeCompat> From<&'a crate::BlockBody<T, H>>
+        for BlockBody<'a, T, H>
     {
         fn from(value: &'a crate::BlockBody<T, H>) -> Self {
             Self {
@@ -231,8 +217,8 @@ mod block_bincode {
         }
     }
 
-    impl<T: SerdeBincodeCompat, H: SerdeBincodeCompat>
-        SerializeAs<crate::BlockBody<T, H>> for BlockBody<'_, T, H>
+    impl<T: SerdeBincodeCompat, H: SerdeBincodeCompat> SerializeAs<crate::BlockBody<T, H>>
+        for BlockBody<'_, T, H>
     {
         fn serialize_as<S>(
             source: &crate::BlockBody<T, H>,
@@ -248,9 +234,7 @@ mod block_bincode {
     impl<'de, T: SerdeBincodeCompat, H: SerdeBincodeCompat>
         DeserializeAs<'de, crate::BlockBody<T, H>> for BlockBody<'de, T, H>
     {
-        fn deserialize_as<D>(
-            deserializer: D,
-        ) -> Result<crate::BlockBody<T, H>, D::Error>
+        fn deserialize_as<D>(deserializer: D) -> Result<crate::BlockBody<T, H>, D::Error>
         where
             D: Deserializer<'de>,
         {
@@ -258,9 +242,7 @@ mod block_bincode {
         }
     }
 
-    impl<T: SerdeBincodeCompat, H: SerdeBincodeCompat> SerdeBincodeCompat
-        for crate::BlockBody<T, H>
-    {
+    impl<T: SerdeBincodeCompat, H: SerdeBincodeCompat> SerdeBincodeCompat for crate::BlockBody<T, H> {
         type BincodeRepr<'a> = BlockBody<'a, T, H>;
 
         fn as_repr(&self) -> Self::BincodeRepr<'_> {

--- a/crates/consensus/src/transaction/mod.rs
+++ b/crates/consensus/src/transaction/mod.rs
@@ -63,6 +63,9 @@ pub use recovered::{Recovered, SignerRecoverable};
 mod hashable;
 pub use hashable::TxHashable;
 
+mod signed_tx;
+pub use signed_tx::SignedTransaction;
+
 #[cfg(feature = "serde")]
 pub use legacy::{signed_legacy_serde, untagged_legacy_serde};
 

--- a/crates/consensus/src/transaction/signed_tx.rs
+++ b/crates/consensus/src/transaction/signed_tx.rs
@@ -1,0 +1,148 @@
+//! API of a signed transaction.
+
+use crate::{
+    size::InMemorySize,
+    transaction::{
+        recovered::{Recovered, SignerRecoverable},
+        RlpEcdsaEncodableTx, TxHashRef,
+    },
+    SignableTransaction,
+};
+use alloc::fmt;
+use alloy_eips::eip2718::{Decodable2718, Encodable2718, IsTyped2718};
+use alloy_primitives::{keccak256, Address, Signature, B256};
+use alloy_rlp::{Decodable, Encodable};
+use core::hash::Hash;
+
+pub use crate::crypto::RecoveryError;
+
+/// A signed transaction.
+///
+/// # Recovery Methods
+///
+/// This trait provides two types of recovery methods:
+/// - Standard methods (e.g., `try_recover`) - enforce EIP-2 low-s signature requirement
+/// - Unchecked methods (e.g., `try_recover_unchecked`) - skip EIP-2 validation for pre-EIP-2
+///   transactions
+///
+/// Use unchecked methods only when dealing with historical pre-EIP-2 transactions.
+#[auto_impl::auto_impl(&, Arc)]
+pub trait SignedTransaction:
+    Send
+    + Sync
+    + Unpin
+    + Clone
+    + fmt::Debug
+    + PartialEq
+    + Eq
+    + Hash
+    + Encodable
+    + Decodable
+    + Encodable2718
+    + Decodable2718
+    + crate::Transaction
+    + InMemorySize
+    + SignerRecoverable
+    + TxHashRef
+    + IsTyped2718
+{
+    /// Returns whether this is a system transaction.
+    ///
+    /// System transactions are created at the protocol level rather than by users. They are
+    /// typically used by L2s for special purposes (e.g., Optimism deposit transactions with type
+    /// 126) and may have different validation rules or fee handling compared to standard
+    /// user-initiated transactions.
+    fn is_system_tx(&self) -> bool {
+        false
+    }
+
+    /// Returns whether this transaction type can be __broadcasted__ as full transaction over the
+    /// network.
+    ///
+    /// Some transactions are not broadcastable as objects and only allowed to be broadcasted as
+    /// hashes, e.g. because they missing context (e.g. blob sidecar).
+    fn is_broadcastable_in_full(&self) -> bool {
+        // EIP-4844 transactions are not broadcastable in full, only hashes are allowed.
+        !self.is_eip4844()
+    }
+
+    /// Recover signer from signature and hash.
+    ///
+    /// Returns an error if the transaction's signature is invalid.
+    fn try_recover(&self) -> Result<Address, RecoveryError> {
+        self.recover_signer()
+    }
+
+    /// Recover signer from signature and hash _without ensuring that the signature has a low `s`
+    /// value_.
+    ///
+    /// Returns an error if the transaction's signature is invalid.
+    fn try_recover_unchecked(&self) -> Result<Address, RecoveryError> {
+        self.recover_signer_unchecked()
+    }
+
+    /// Calculate transaction hash, eip2728 transaction does not contain rlp header and start with
+    /// tx type.
+    fn recalculate_hash(&self) -> B256 {
+        keccak256(self.encoded_2718())
+    }
+
+    /// Tries to recover signer and return [`Recovered`] by cloning the type.
+    #[auto_impl(keep_default_for(&, Arc))]
+    fn try_clone_into_recovered(&self) -> Result<Recovered<Self>, RecoveryError> {
+        self.recover_signer().map(|signer| Recovered::new_unchecked(self.clone(), signer))
+    }
+
+    /// Tries to recover signer and return [`Recovered`] by cloning the type.
+    #[auto_impl(keep_default_for(&, Arc))]
+    fn try_clone_into_recovered_unchecked(&self) -> Result<Recovered<Self>, RecoveryError> {
+        self.recover_signer_unchecked()
+            .map(|signer| Recovered::new_unchecked(self.clone(), signer))
+    }
+
+    /// Tries to recover signer and return [`Recovered`].
+    ///
+    /// Returns `Err(Self)` if the transaction's signature is invalid, see also
+    /// [`SignerRecoverable::recover_signer`].
+    #[auto_impl(keep_default_for(&, Arc))]
+    fn try_into_recovered(self) -> Result<Recovered<Self>, Self> {
+        match self.recover_signer() {
+            Ok(signer) => Ok(Recovered::new_unchecked(self, signer)),
+            Err(_) => Err(self),
+        }
+    }
+
+    /// Consumes the type, recover signer and return [`Recovered`] _without
+    /// ensuring that the signature has a low `s` value_ (EIP-2).
+    ///
+    /// Returns `RecoveryError` if the transaction's signature is invalid.
+    #[deprecated(note = "Use try_into_recovered_unchecked instead")]
+    #[auto_impl(keep_default_for(&, Arc))]
+    fn into_recovered_unchecked(self) -> Result<Recovered<Self>, RecoveryError> {
+        self.recover_signer_unchecked().map(|signer| Recovered::new_unchecked(self, signer))
+    }
+
+    /// Returns the [`Recovered`] transaction with the given sender.
+    ///
+    /// Note: assumes the given signer is the signer of this transaction.
+    #[auto_impl(keep_default_for(&, Arc))]
+    fn with_signer(self, signer: Address) -> Recovered<Self> {
+        Recovered::new_unchecked(self, signer)
+    }
+
+    /// Returns the [`Recovered`] transaction with the given signer, using a reference to self.
+    ///
+    /// Note: assumes the given signer is the signer of this transaction.
+    #[auto_impl(keep_default_for(&, Arc))]
+    fn with_signer_ref(&self, signer: Address) -> Recovered<&Self> {
+        Recovered::new_unchecked(self, signer)
+    }
+}
+
+#[cfg(any(feature = "secp256k1", feature = "k256"))]
+impl<T> SignedTransaction for crate::EthereumTxEnvelope<T>
+where
+    T: RlpEcdsaEncodableTx + SignableTransaction<Signature> + Unpin,
+    Self: Clone + PartialEq + Eq + Decodable + Decodable2718 + InMemorySize,
+{
+}

--- a/crates/network/src/convert.rs
+++ b/crates/network/src/convert.rs
@@ -1,0 +1,178 @@
+//! Conversion traits between consensus and RPC types.
+//!
+//! This module provides traits for converting between consensus-layer types and
+//! RPC-layer types, enabling generic implementations that work across different
+//! network types.
+
+use crate::{Network, TxSigner};
+use alloy_consensus::{
+    error::ValueError, transaction::Recovered, EthereumTxEnvelope, SignableTransaction, TxEip4844,
+    Transaction,
+};
+use alloy_primitives::{Address, Signature};
+use alloy_rpc_types_eth::{TransactionInfo, TransactionRequest};
+use core::{error, fmt::Debug, future::Future};
+use std::convert::Infallible;
+
+/// Converts `T` into `self`. It is reciprocal of [`IntoRpcTx`].
+///
+/// Should create an RPC transaction response object based on a consensus transaction, its signer
+/// [`Address`] and an additional context [`FromConsensusTx::TxInfo`].
+///
+/// Prefer implementing [`FromConsensusTx`] over [`IntoRpcTx`] because it automatically provides an
+/// implementation of [`IntoRpcTx`] thanks to the blanket implementation in this crate.
+///
+/// Prefer using [`IntoRpcTx`] over using [`FromConsensusTx`] when specifying trait bounds on a
+/// generic function. This way, types that directly implement [`IntoRpcTx`] can be used as arguments
+/// as well.
+pub trait FromConsensusTx<T>: Sized {
+    /// An additional context, usually [`TransactionInfo`] in a wrapper that carries some
+    /// implementation specific extra information.
+    type TxInfo;
+    /// An associated RPC conversion error.
+    type Err: error::Error;
+
+    /// Performs the conversion consuming `tx` with `signer` and `tx_info`. See [`FromConsensusTx`]
+    /// for details.
+    fn from_consensus_tx(tx: T, signer: Address, tx_info: Self::TxInfo) -> Result<Self, Self::Err>;
+}
+
+impl<TxIn: Transaction, T: Transaction + From<TxIn>> FromConsensusTx<TxIn>
+    for alloy_rpc_types_eth::Transaction<T>
+{
+    type TxInfo = TransactionInfo;
+    type Err = Infallible;
+
+    fn from_consensus_tx(
+        tx: TxIn,
+        signer: Address,
+        tx_info: Self::TxInfo,
+    ) -> Result<Self, Self::Err> {
+        Ok(Self::from_transaction(Recovered::new_unchecked(tx.into(), signer), tx_info))
+    }
+}
+
+/// Converts `self` into `T`. The opposite of [`FromConsensusTx`].
+///
+/// Should create an RPC transaction response object based on a consensus transaction, its signer
+/// [`Address`] and an additional context [`IntoRpcTx::TxInfo`].
+///
+/// Avoid implementing [`IntoRpcTx`] and use [`FromConsensusTx`] instead. Implementing it
+/// automatically provides an implementation of [`IntoRpcTx`] thanks to the blanket implementation
+/// in this crate.
+///
+/// Prefer using [`IntoRpcTx`] over [`FromConsensusTx`] when specifying trait bounds on a generic
+/// function to ensure that types that only implement [`IntoRpcTx`] can be used as well.
+pub trait IntoRpcTx<T> {
+    /// An additional context, usually [`TransactionInfo`] in a wrapper that carries some
+    /// implementation specific extra information.
+    type TxInfo;
+    /// An associated RPC conversion error.
+    type Err: error::Error;
+
+    /// Performs the conversion consuming `self` with `signer` and `tx_info`. See [`IntoRpcTx`]
+    /// for details.
+    fn into_rpc_tx(self, signer: Address, tx_info: Self::TxInfo) -> Result<T, Self::Err>;
+}
+
+impl<ConsensusTx, RpcTx> IntoRpcTx<RpcTx> for ConsensusTx
+where
+    ConsensusTx: Transaction,
+    RpcTx: FromConsensusTx<Self>,
+    <RpcTx as FromConsensusTx<ConsensusTx>>::Err: Debug,
+{
+    type TxInfo = RpcTx::TxInfo;
+    type Err = <RpcTx as FromConsensusTx<ConsensusTx>>::Err;
+
+    fn into_rpc_tx(self, signer: Address, tx_info: Self::TxInfo) -> Result<RpcTx, Self::Err> {
+        RpcTx::from_consensus_tx(self, signer, tx_info)
+    }
+}
+
+/// Trait for converting network transaction responses to primitive transaction types.
+pub trait TryFromTransactionResponse<N: Network> {
+    /// The error type returned if the conversion fails.
+    type Error: core::error::Error + Send + Sync + Unpin;
+
+    /// Converts a network transaction response to a primitive transaction type.
+    ///
+    /// # Returns
+    ///
+    /// Returns `Ok(Self)` on successful conversion, or `Err(Self::Error)` if the conversion fails.
+    fn from_transaction_response(
+        transaction_response: N::TransactionResponse,
+    ) -> Result<Self, Self::Error>
+    where
+        Self: Sized;
+}
+
+/// Trait for converting network receipt responses to primitive receipt types.
+pub trait TryFromReceiptResponse<N: Network> {
+    /// The error type returned if the conversion fails.
+    type Error: core::error::Error + Send + Sync + Unpin;
+
+    /// Converts a network receipt response to a primitive receipt type.
+    ///
+    /// # Returns
+    ///
+    /// Returns `Ok(Self)` on successful conversion, or `Err(Self::Error)` if the conversion fails.
+    fn from_receipt_response(receipt_response: N::ReceiptResponse) -> Result<Self, Self::Error>
+    where
+        Self: Sized;
+}
+
+/// Converts `self` into `T`.
+///
+/// Should create a fake transaction for simulation using [`TransactionRequest`].
+pub trait TryIntoSimTx<T>
+where
+    Self: Sized,
+{
+    /// Performs the conversion.
+    ///
+    /// Should return a signed typed transaction envelope for the [`eth_simulateV1`] endpoint with a
+    /// dummy signature or an error if [required fields] are missing.
+    ///
+    /// [`eth_simulateV1`]: <https://github.com/ethereum/execution-apis/pull/484>
+    /// [required fields]: TransactionRequest::buildable_type
+    fn try_into_sim_tx(self) -> Result<T, ValueError<Self>>;
+}
+
+impl TryIntoSimTx<EthereumTxEnvelope<TxEip4844>> for TransactionRequest {
+    fn try_into_sim_tx(self) -> Result<EthereumTxEnvelope<TxEip4844>, ValueError<Self>> {
+        Self::build_typed_simulate_transaction(self)
+    }
+}
+
+/// Error for [`SignableTxRequest`] trait.
+#[derive(Debug, thiserror::Error)]
+pub enum SignTxRequestError {
+    /// The transaction request is invalid.
+    #[error("invalid transaction request")]
+    InvalidTransactionRequest,
+
+    /// The signer is not supported.
+    #[error(transparent)]
+    SignerNotSupported(#[from] alloy_signer::Error),
+}
+
+/// An abstraction over transaction requests that can be signed.
+pub trait SignableTxRequest<T>: Send + Sync + 'static {
+    /// Attempts to build a transaction request and sign it with the given signer.
+    fn try_build_and_sign(
+        self,
+        signer: impl TxSigner<Signature> + Send,
+    ) -> impl Future<Output = Result<T, SignTxRequestError>> + Send;
+}
+
+impl SignableTxRequest<EthereumTxEnvelope<TxEip4844>> for TransactionRequest {
+    async fn try_build_and_sign(
+        self,
+        signer: impl TxSigner<Signature> + Send,
+    ) -> Result<EthereumTxEnvelope<TxEip4844>, SignTxRequestError> {
+        let mut tx =
+            self.build_typed_tx().map_err(|_| SignTxRequestError::InvalidTransactionRequest)?;
+        let signature = signer.sign_transaction(&mut tx).await?;
+        Ok(tx.into_signed(signature).into())
+    }
+}

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -42,50 +42,23 @@ pub use alloy_network_primitives::{
     self as primitives, BlockResponse, ReceiptResponse, TransactionResponse,
 };
 
-/// RPC types used by the `eth_` RPC API.
-///
-/// This is a subset of [`Network`] trait with only RPC response types kept.
-pub trait RpcTypes: Send + Sync + Clone + Unpin + Debug + 'static {
-    /// Header response type.
-    type Header: RpcObject + HeaderResponse;
-    /// Receipt response type.
-    type Receipt: RpcObject + ReceiptResponse;
-    /// Transaction response type.
-    type TransactionResponse: RpcObject + TransactionResponse;
-    /// Transaction request type.
-    type TransactionRequest: RpcObject
-        + AsRef<alloy_rpc_types_eth::TransactionRequest>
-        + AsMut<alloy_rpc_types_eth::TransactionRequest>;
-}
-
-impl<T> RpcTypes for T
-where
-    T: Network<
-            TransactionRequest: AsRef<alloy_rpc_types_eth::TransactionRequest>
-                                    + AsMut<alloy_rpc_types_eth::TransactionRequest>,
-        > + Unpin,
-{
-    type Header = T::HeaderResponse;
-    type Receipt = T::ReceiptResponse;
-    type TransactionResponse = T::TransactionResponse;
-    type TransactionRequest = T::TransactionRequest;
-}
-
 /// Adapter for network specific transaction response.
-pub type RpcTransaction<T> = <T as RpcTypes>::TransactionResponse;
+pub type RpcTransaction<T> = <T as Network>::TransactionResponse;
 
 /// Adapter for network specific receipt response.
-pub type RpcReceipt<T> = <T as RpcTypes>::Receipt;
+pub type RpcReceiptEnvelope<T> = <T as Network>::ReceiptEnvelope;
+
+/// Adapter for network specific receipt response.
+pub type RpcReceiptResponse<T> = <T as Network>::ReceiptResponse;
 
 /// Adapter for network specific header response.
-pub type RpcHeader<T> = <T as RpcTypes>::Header;
+pub type RpcHeader<T> = <T as Network>::Header;
 
 /// Adapter for network specific block type.
-pub type RpcBlock<T> =
-    alloy_rpc_types_eth::Block<RpcTransaction<T>, RpcHeader<T>>;
+pub type RpcBlock<T> = alloy_rpc_types_eth::Block<RpcTransaction<T>, RpcHeader<T>>;
 
 /// Adapter for network specific transaction request.
-pub type RpcTxReq<T> = <T as RpcTypes>::TransactionRequest;
+pub type RpcTxReq<T> = <T as Network>::TransactionRequest;
 
 /// Captures type info for network-specific RPC requests/responses.
 ///

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -19,6 +19,12 @@ pub use transaction::{
     TransactionBuilderError, TxSigner, TxSignerSync, UnbuiltTransactionError,
 };
 
+pub mod convert;
+pub use convert::{
+    FromConsensusTx, IntoRpcTx, SignTxRequestError, SignableTxRequest, TryFromReceiptResponse,
+    TryFromTransactionResponse, TryIntoSimTx,
+};
+
 mod ethereum;
 pub use ethereum::{Ethereum, EthereumWallet, IntoWallet};
 
@@ -35,6 +41,51 @@ use alloy_eips::Typed2718;
 pub use alloy_network_primitives::{
     self as primitives, BlockResponse, ReceiptResponse, TransactionResponse,
 };
+
+/// RPC types used by the `eth_` RPC API.
+///
+/// This is a subset of [`Network`] trait with only RPC response types kept.
+pub trait RpcTypes: Send + Sync + Clone + Unpin + Debug + 'static {
+    /// Header response type.
+    type Header: RpcObject + HeaderResponse;
+    /// Receipt response type.
+    type Receipt: RpcObject + ReceiptResponse;
+    /// Transaction response type.
+    type TransactionResponse: RpcObject + TransactionResponse;
+    /// Transaction request type.
+    type TransactionRequest: RpcObject
+        + AsRef<alloy_rpc_types_eth::TransactionRequest>
+        + AsMut<alloy_rpc_types_eth::TransactionRequest>;
+}
+
+impl<T> RpcTypes for T
+where
+    T: Network<
+            TransactionRequest: AsRef<alloy_rpc_types_eth::TransactionRequest>
+                                    + AsMut<alloy_rpc_types_eth::TransactionRequest>,
+        > + Unpin,
+{
+    type Header = T::HeaderResponse;
+    type Receipt = T::ReceiptResponse;
+    type TransactionResponse = T::TransactionResponse;
+    type TransactionRequest = T::TransactionRequest;
+}
+
+/// Adapter for network specific transaction response.
+pub type RpcTransaction<T> = <T as RpcTypes>::TransactionResponse;
+
+/// Adapter for network specific receipt response.
+pub type RpcReceipt<T> = <T as RpcTypes>::Receipt;
+
+/// Adapter for network specific header response.
+pub type RpcHeader<T> = <T as RpcTypes>::Header;
+
+/// Adapter for network specific block type.
+pub type RpcBlock<T> =
+    alloy_rpc_types_eth::Block<RpcTransaction<T>, RpcHeader<T>>;
+
+/// Adapter for network specific transaction request.
+pub type RpcTxReq<T> = <T as RpcTypes>::TransactionRequest;
 
 /// Captures type info for network-specific RPC requests/responses.
 ///

--- a/crates/rpc-types-engine/src/lib.rs
+++ b/crates/rpc-types-engine/src/lib.rs
@@ -34,6 +34,16 @@ pub use jwt::*;
 pub mod payload;
 pub use payload::*;
 
+#[cfg(feature = "serde")]
+pub mod traits;
+#[cfg(feature = "serde")]
+pub use traits::{
+    ExecutionPayload as ExecutionPayloadTrait, PayloadAttributes as PayloadAttributesTrait,
+};
+
+// Re-export trait names without the `Trait` suffix inside the traits module for direct use.
+// Users can also import from `alloy_rpc_types_engine::traits::{PayloadAttributes, ExecutionPayload}`.
+
 mod error;
 pub use error::*;
 

--- a/crates/rpc-types-engine/src/lib.rs
+++ b/crates/rpc-types-engine/src/lib.rs
@@ -41,9 +41,6 @@ pub use traits::{
     ExecutionPayload as ExecutionPayloadTrait, PayloadAttributes as PayloadAttributesTrait,
 };
 
-// Re-export trait names without the `Trait` suffix inside the traits module for direct use.
-// Users can also import from `alloy_rpc_types_engine::traits::{PayloadAttributes, ExecutionPayload}`.
-
 mod error;
 pub use error::*;
 

--- a/crates/rpc-types-engine/src/traits.rs
+++ b/crates/rpc-types-engine/src/traits.rs
@@ -1,0 +1,130 @@
+//! Traits for execution payload and payload attributes abstractions.
+
+use alloc::vec::Vec;
+use alloy_eips::{eip1898::BlockWithParent, eip4895::Withdrawal, BlockNumHash};
+use alloy_primitives::{Bytes, B256};
+use core::fmt::Debug;
+
+/// Basic attributes required to initiate payload construction.
+///
+/// Defines minimal parameters needed to build a new execution payload.
+pub trait PayloadAttributes:
+    serde::de::DeserializeOwned + serde::Serialize + Debug + Clone + Send + Sync + 'static
+{
+    /// Returns the timestamp for the new payload.
+    fn timestamp(&self) -> u64;
+
+    /// Returns the withdrawals to be included in the payload.
+    ///
+    /// `Some` for post-Shanghai blocks, `None` for earlier blocks.
+    fn withdrawals(&self) -> Option<&Vec<Withdrawal>>;
+
+    /// Returns the parent beacon block root.
+    ///
+    /// `Some` for post-merge blocks, `None` for pre-merge blocks.
+    fn parent_beacon_block_root(&self) -> Option<B256>;
+}
+
+impl PayloadAttributes for crate::PayloadAttributes {
+    fn timestamp(&self) -> u64 {
+        self.timestamp
+    }
+
+    fn withdrawals(&self) -> Option<&Vec<Withdrawal>> {
+        self.withdrawals.as_ref()
+    }
+
+    fn parent_beacon_block_root(&self) -> Option<B256> {
+        self.parent_beacon_block_root
+    }
+}
+
+/// Represents the core data structure of an execution payload.
+///
+/// Contains all necessary information to execute and validate a block, including
+/// headers, transactions, and consensus fields. Provides a unified interface
+/// regardless of protocol version.
+pub trait ExecutionPayload:
+    serde::Serialize + serde::de::DeserializeOwned + Debug + Clone + Send + Sync + 'static
+{
+    /// Returns the hash of this block's parent.
+    fn parent_hash(&self) -> B256;
+
+    /// Returns this block's hash.
+    fn block_hash(&self) -> B256;
+
+    /// Returns this block's number (height).
+    fn block_number(&self) -> u64;
+
+    /// Returns this block's number hash.
+    fn num_hash(&self) -> BlockNumHash {
+        BlockNumHash::new(self.block_number(), self.block_hash())
+    }
+
+    /// Returns a [`BlockWithParent`] for this block.
+    fn block_with_parent(&self) -> BlockWithParent {
+        BlockWithParent::new(self.parent_hash(), self.num_hash())
+    }
+
+    /// Returns the withdrawals included in this payload.
+    ///
+    /// Returns `None` for pre-Shanghai blocks.
+    fn withdrawals(&self) -> Option<&Vec<Withdrawal>>;
+
+    /// Returns the access list included in this payload.
+    ///
+    /// Returns `None` for pre-Amsterdam blocks.
+    fn block_access_list(&self) -> Option<&Bytes>;
+
+    /// Returns the beacon block root associated with this payload.
+    ///
+    /// Returns `None` for pre-merge payloads.
+    fn parent_beacon_block_root(&self) -> Option<B256>;
+
+    /// Returns this block's timestamp (seconds since Unix epoch).
+    fn timestamp(&self) -> u64;
+
+    /// Returns the total gas consumed by all transactions in this block.
+    fn gas_used(&self) -> u64;
+
+    /// Returns the number of transactions in the payload.
+    fn transaction_count(&self) -> usize;
+}
+
+impl ExecutionPayload for crate::ExecutionData {
+    fn parent_hash(&self) -> B256 {
+        self.payload.parent_hash()
+    }
+
+    fn block_hash(&self) -> B256 {
+        self.payload.block_hash()
+    }
+
+    fn block_number(&self) -> u64 {
+        self.payload.block_number()
+    }
+
+    fn withdrawals(&self) -> Option<&Vec<Withdrawal>> {
+        self.payload.withdrawals()
+    }
+
+    fn block_access_list(&self) -> Option<&Bytes> {
+        None
+    }
+
+    fn parent_beacon_block_root(&self) -> Option<B256> {
+        self.sidecar.parent_beacon_block_root()
+    }
+
+    fn timestamp(&self) -> u64 {
+        self.payload.timestamp()
+    }
+
+    fn gas_used(&self) -> u64 {
+        self.payload.as_v1().gas_used
+    }
+
+    fn transaction_count(&self) -> usize {
+        self.payload.as_v1().transactions.len()
+    }
+}


### PR DESCRIPTION
## Summary

- Add 10 trait definitions from reth core crates into alloy so that op-alloy can implement them natively without depending on reth
- `alloy-consensus`: `InMemorySize`, `SerdeBincodeCompat`, `SignedTransaction` traits + impls for Ethereum types
- `alloy-rpc-types-engine`: `PayloadAttributes`, `ExecutionPayload` traits + impls for alloy's own structs
- `alloy-network`: `FromConsensusTx`, `TryFromTransactionResponse`, `TryFromReceiptResponse`, `SignableTxRequest`, `TryIntoSimTx`, `RpcTypes` traits + Ethereum impls

## Motivation

This is part of a multi-repo effort to remove `op-alloy-*` dependencies from core (non-optimism) reth crates. By moving trait definitions into alloy, op-alloy can implement them natively for OP types without needing to depend on reth, and reth core crates can drop their op-alloy dependencies entirely.

## Test plan

- [ ] `cargo check --workspace --all-features`
- [ ] `cargo nextest run --workspace`
- [ ] Verify traits are correctly re-exported from each crate's `lib.rs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)