### PR TITLE
perf(rpc-types-eth): use `Vec::with_capacity` in Filter serialization

### DIFF
--- a/crates/rpc-types-eth/src/filter.rs
+++ b/crates/rpc-types-eth/src/filter.rs
@@ -953,7 +953,7 @@ impl serde::Serialize for Filter {
             s.serialize_field("address", &address)?;
         }
 
-        let mut filtered_topics = Vec::new();
+        let mut filtered_topics = Vec::with_capacity(self.topics.len());
         let mut filtered_topics_len = 0;
         for (i, topic) in self.topics.iter().enumerate() {
             if !topic.is_empty() {


### PR DESCRIPTION
Optimizes Filter serialization by pre-allocating vector capacity when constructing the filtered_topics vector, eliminating unnecessary reallocations during the push operations.