### PR TITLE
fix(contract): check receipt status before contract address in deploy

### DIFF
--- a/crates/contract/src/call.rs
+++ b/crates/contract/src/call.rs
@@ -574,7 +574,7 @@ impl<P: Provider<N>, D: CallDecoder, N: Network> CallBuilder<P, D, N> {
         let pending_tx = self.send().await?;
         let receipt = pending_tx.get_receipt().await?;
         if !receipt.status() {
-            return Err(Error::DeploymentReverted);
+            return Err(Error::ContractNotDeployed);
         }
         receipt.contract_address().ok_or(Error::ContractNotDeployed)
     }
@@ -604,7 +604,7 @@ impl<P: Provider<N>, D: CallDecoder, N: Network> CallBuilder<P, D, N> {
         }
         let receipt = self.send_sync().await?;
         if !receipt.status() {
-            return Err(Error::DeploymentReverted);
+            return Err(Error::ContractNotDeployed);
         }
         receipt.contract_address().ok_or(Error::ContractNotDeployed)
     }

--- a/crates/contract/src/error.rs
+++ b/crates/contract/src/error.rs
@@ -21,11 +21,9 @@ pub enum Error {
     /// Called `deploy` with a transaction that is not a deployment transaction.
     #[error("transaction is not a deployment transaction")]
     NotADeploymentTransaction,
-    /// The deployment transaction reverted.
-    #[error("deployment transaction reverted")]
-    DeploymentReverted,
-    /// `contractAddress` was not found in the deployment transaction's receipt.
-    #[error("missing `contractAddress` from deployment transaction receipt")]
+    /// Contract was not deployed: either the deployment transaction reverted or `contractAddress`
+    /// was not found in the receipt.
+    #[error("contract not deployed: deployment transaction failed")]
     ContractNotDeployed,
     /// The contract returned no data.
     #[error("contract call to `{0}` returned no data (\"0x\"); the called address might not be a contract")]


### PR DESCRIPTION
When a contract constructor reverts, `deploy()` and `deploy_sync()` return the misleading error 
"**missing `contractAddress` from deployment transaction receipt**"
because the code only checks `contract_address()` without first checking `receipt.status()`.                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                       
adds a `status()` check before the `contract_address()` check, and introduces a new `Error::DeploymentReverted` variant. Now when the constructor reverts, users see "**deployment transaction reverted**" instead of being pointed toward a missing address problem that doesn't reflect the actual failure.