### PR TITLE
Remove dead Clone impl for RootProviderInner

### DIFF
--- a/crates/provider/src/provider/root.rs
+++ b/crates/provider/src/provider/root.rs
@@ -108,12 +108,6 @@ pub(crate) struct RootProviderInner<N: Network = Ethereum> {
     _network: PhantomData<N>,
 }
 
-impl<N: Network> Clone for RootProviderInner<N> {
-    fn clone(&self) -> Self {
-        Self { client: self.client.clone(), heart: self.heart.clone(), _network: PhantomData }
-    }
-}
-
 impl<N: Network> RootProviderInner<N> {
     pub(crate) fn new(client: RpcClient) -> Self {
         Self { client, heart: Default::default(), _network: PhantomData }


### PR DESCRIPTION
 remove the unused `Clone` implementation for `RootProviderInner`
avoid cloning a non-clonable `OnceLock<HeartbeatHandle>`