### PR TITLE
docs(eips): clarify blob_base_cost default values for different hardforks

### DIFF
--- a/crates/eips/src/eip7840.rs
+++ b/crates/eips/src/eip7840.rs
@@ -37,7 +37,8 @@ pub struct BlobParams {
     pub max_blobs_per_tx: u64,
     /// Minimum execution gas required to include a blob in a block.
     ///
-    /// Defaults to `0` unless set otherwise.
+    /// Defaults to `0` for Cancun and Prague hardforks, and [`BLOB_BASE_COST`] for Osaka and
+    /// later.
     pub blob_base_cost: u64,
 }
 


### PR DESCRIPTION
The previous documentation stated that blob_base_cost "Defaults to `0` unless set otherwise", which was misleading. The actual defaults vary by hardfork:
  - Cancun and Prague: 0
  - Osaka, BPO1, and BPO2: BLOB_BASE_COST (8192)

Updated the documentation to accurately reflect these hardfork-specific defaults.
