### PR TITLE
fix(transport): eagerly format itertools to prevent double-format panic

### DIFF
--- a/crates/transport-http/src/hyper_transport.rs
+++ b/crates/transport-http/src/hyper_transport.rs
@@ -113,7 +113,7 @@ where
     ResBody::Error: std::error::Error + Send + Sync + 'static,
     ResBody::Data: Send,
 {
-    #[instrument(name = "request", skip_all, fields(method_names = %req.method_names().take(3).format(", ")))]
+    #[instrument(name = "request", skip_all, fields(method_names = %req.method_names().take(3).format(", ").to_string()))]
     async fn do_hyper(self, req: RequestPacket) -> TransportResult<ResponsePacket> {
         debug!(count = req.len(), "sending request packet to server");
 

--- a/crates/transport-http/src/reqwest_transport.rs
+++ b/crates/transport-http/src/reqwest_transport.rs
@@ -35,7 +35,7 @@ impl Http<Client> {
         Self { client: Default::default(), url }
     }
 
-    #[instrument(name = "request", skip_all, fields(method_names = %req.method_names().take(3).format(", ")))]
+    #[instrument(name = "request", skip_all, fields(method_names = %req.method_names().take(3).format(", ").to_string()))]
     async fn do_reqwest(self, req: RequestPacket) -> TransportResult<ResponsePacket> {
         let resp = self
             .client


### PR DESCRIPTION
## Summary
Fixes the panic introduced in f69665c when `#[instrument]` formats the itertools `Format` struct more than once.

## Changes
- Call `.to_string()` on `.format(", ")` in both `hyper_transport.rs` and `reqwest_transport.rs` to eagerly evaluate the formatter

## Context
`itertools::Format` panics with "Format: was already formatted once" if `Display` is called twice. The `#[instrument]` macro can format span fields multiple times, triggering this at runtime.

Closes #3666