### PR TITLE
feat(provider): add engine_getBlobsV1/V2 to EngineApi trait

### DIFF
--- a/crates/provider/src/ext/engine.rs
+++ b/crates/provider/src/ext/engine.rs
@@ -3,11 +3,11 @@ use alloy_eips::eip7685::RequestsOrHash;
 use alloy_network::Network;
 use alloy_primitives::{BlockHash, Bytes, B256, U64};
 use alloy_rpc_types_engine::{
-    ClientVersionV1, ExecutionPayloadBodiesV1, ExecutionPayloadBodiesV2,
-    ExecutionPayloadEnvelopeV2, ExecutionPayloadEnvelopeV3, ExecutionPayloadEnvelopeV4,
-    ExecutionPayloadEnvelopeV5, ExecutionPayloadEnvelopeV6, ExecutionPayloadInputV2,
-    ExecutionPayloadV1, ExecutionPayloadV3, ExecutionPayloadV4, ForkchoiceState, ForkchoiceUpdated,
-    PayloadAttributes, PayloadId, PayloadStatus,
+    BlobAndProofV1, BlobAndProofV2, ClientVersionV1, ExecutionPayloadBodiesV1,
+    ExecutionPayloadBodiesV2, ExecutionPayloadEnvelopeV2, ExecutionPayloadEnvelopeV3,
+    ExecutionPayloadEnvelopeV4, ExecutionPayloadEnvelopeV5, ExecutionPayloadEnvelopeV6,
+    ExecutionPayloadInputV2, ExecutionPayloadV1, ExecutionPayloadV3, ExecutionPayloadV4,
+    ForkchoiceState, ForkchoiceUpdated, PayloadAttributes, PayloadId, PayloadStatus,
 };
 use alloy_transport::TransportResult;
 
@@ -250,6 +250,27 @@ pub trait EngineApi<N>: Send + Sync {
     /// See also <https://eips.ethereum.org/EIPS/eip-7928>
     async fn get_bals_by_range_v1(&self, start: u64, count: u64) -> TransportResult<Vec<Bytes>>;
 
+    /// Returns the requested blobs and their associated proofs for the given versioned hashes.
+    ///
+    /// Returns `None` for any blob that is not available.
+    ///
+    /// See also <https://github.com/ethereum/execution-apis/pull/559>
+    async fn get_blobs_v1(
+        &self,
+        versioned_hashes: Vec<B256>,
+    ) -> TransportResult<Vec<Option<BlobAndProofV1>>>;
+
+    /// Returns the requested blobs and their associated cell proofs for the given versioned
+    /// hashes.
+    ///
+    /// Returns `None` for any blob that is not available.
+    ///
+    /// See also <https://github.com/ethereum/execution-apis/pull/630>
+    async fn get_blobs_v2(
+        &self,
+        versioned_hashes: Vec<B256>,
+    ) -> TransportResult<Vec<Option<BlobAndProofV2>>>;
+
     /// Returns the execution client version information.
     ///
     /// Note:
@@ -456,6 +477,20 @@ where
 
     async fn get_bals_by_range_v1(&self, start: u64, count: u64) -> TransportResult<Vec<Bytes>> {
         self.client().request("engine_getBALsByRangeV1", (U64::from(start), U64::from(count))).await
+    }
+
+    async fn get_blobs_v1(
+        &self,
+        versioned_hashes: Vec<B256>,
+    ) -> TransportResult<Vec<Option<BlobAndProofV1>>> {
+        self.client().request("engine_getBlobsV1", (versioned_hashes,)).await
+    }
+
+    async fn get_blobs_v2(
+        &self,
+        versioned_hashes: Vec<B256>,
+    ) -> TransportResult<Vec<Option<BlobAndProofV2>>> {
+        self.client().request("engine_getBlobsV2", (versioned_hashes,)).await
     }
 
     async fn get_client_version_v1(

--- a/crates/rpc-types-engine/src/lib.rs
+++ b/crates/rpc-types-engine/src/lib.rs
@@ -45,6 +45,8 @@ pub use testing::*;
 
 #[doc(inline)]
 pub use alloy_eips::eip4844::BlobAndProofV1;
+#[doc(inline)]
+pub use alloy_eips::eip4844::BlobAndProofV2;
 
 /// The list of all supported Engine capabilities available over the engine endpoint.
 ///


### PR DESCRIPTION
`engine_getBlobsV2` are missing from the provider layer. All the other Engine API methods have proper trait methods — newPayload, getPayload, getPayloadBodies, getBALs, etc — but getBlobs somehow got left out.

The types (`BlobAndProofV1`, `BlobAndProofV2`) and helpers already exist in the codebase, so this just adds the thin provider wrapper to complete the set. Also re-exports `BlobAndProofV2` from `alloy-rpc-types-engine` since only V1 was being re-exported.

Without this, users have to manually call `client().request("engine_getBlobsV1", ...)` which is not great.

FIxed by @claude 