### PR TITLE
fix(filter): matches_block should not bypass block hash check

### DIFF
--- a/crates/rpc-types-eth/src/filter.rs
+++ b/crates/rpc-types-eth/src/filter.rs
@@ -711,10 +711,13 @@ impl Filter {
         }
     }
 
-    /// Returns `true` if the filter matches the given block. Checks both the
-    /// block number and hash.
+    /// Returns `true` if the filter matches the given block. Checks the block
+    /// hash when filtering by block hash, otherwise checks the block number range.
     pub fn matches_block(&self, block: &BlockNumHash) -> bool {
-        self.matches_block_range(block.number) || self.matches_block_hash(block.hash)
+        match self.block_option {
+            FilterBlockOption::AtBlockHash(hash) => hash == block.hash,
+            FilterBlockOption::Range { .. } => self.matches_block_range(block.number),
+        }
     }
 
     /// Returns `true` if either of the following is true:


### PR DESCRIPTION
When FilterBlockOption is AtBlockHash, matches_block_range() implicitly returns true (no range bounds to check), which short-circuits the OR in matches_block() and makes the block hash constraint a no-op.

e.g. filter set to at_block_hash(0xaaa...), calling matches_block({ number: 99, hash: 0xbbb... }):
- matches_block_range(99) → true (AtBlockHash has no from/to, so both checks are skipped)
- true || matches_block_hash(0xbbb...) → true (short-circuit, hash never checked)

Switch to matching on the block option variant directly so AtBlockHash only checks the hash and Range only checks the number range.
