### PR TITLE
refactor(consensus): simplify signer access in Recovered::as_recovered_ref

### DIFF
--- a/crates/consensus/src/transaction/recovered.rs
+++ b/crates/consensus/src/transaction/recovered.rs
@@ -64,7 +64,7 @@ impl<T> Recovered<T> {
 
     /// Converts from `&Recovered<T>` to `Recovered<&T>`.
     pub const fn as_recovered_ref(&self) -> Recovered<&T> {
-        Recovered { inner: &self.inner, signer: self.signer() }
+        Recovered { inner: &self.inner, signer: self.signer }
     }
 
     /// Create [`Recovered`] from the given transaction and [`Address`] of the signer.


### PR DESCRIPTION
Summary
- Replace `self.signer()` with direct field access `self.signer` in `Recovered::as_recovered_ref`.
- Keep behavior unchanged while removing an unnecessary method indirection in a hot utility path.
Why
- `as_recovered_ref` is implemented within `Recovered<T>`, so direct access to the private field is available.
- The getter currently returns the same `Address` value; using the field directly is simpler and clearer.