### PR TITLE
fix: Optimism network incompatible with ProviderBuilder::new constructor

### DIFF
--- a/crates/provider/src/builder.rs
+++ b/crates/provider/src/builder.rs
@@ -782,7 +782,7 @@ mod tests {
     #[test]
     fn network_replaces_fillers() {
         // Add an extra filler before swapping, it should be dropped.
-        let builder = ProviderBuilder::new().filler(GasFiller::default()).network::<AnyNetwork>();
+        let builder = ProviderBuilder::new().filler(GasFiller).network::<AnyNetwork>();
 
         let _: ProviderBuilder<
             Identity,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
#2478 
`ProviderBuilder::new().network::<Optimism>()` fails to compile because `.network()` only swaps the type parameter while keeping Ethereum's fillers (including `BlobGasFiller`). Custom networks like Optimism don't implement `TransactionBuilder4844`, so the leftover `BlobGasFiller` causes a trait bound error.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
`.network()` now replaces the filler stack with the target network's recommended fillers instead of carrying over the old ones. This is consistent with how `new_with_network` already works.

The alternative would have been to leave `.network()` alone and add a new method like `.with_network()` that replaces fillers, additive, non-breaking. But then there would be 2 methods that do almost the same thing.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [x] Breaking changes
