### PR TITLE
feat: add trait impls for Cow to support Recovered<Cow<'_, T>>

### DIFF
--- a/crates/consensus/src/transaction/mod.rs
+++ b/crates/consensus/src/transaction/mod.rs
@@ -1,7 +1,7 @@
 //! Transaction types.
 
 use crate::Signed;
-use alloc::vec::Vec;
+use alloc::{borrow::Cow, vec::Vec};
 use alloy_eips::{eip2930::AccessList, eip4844::DATA_GAS_PER_BLOB, eip7702::SignedAuthorization};
 use alloy_primitives::{keccak256, Address, Bytes, ChainId, Selector, TxHash, TxKind, B256, U256};
 use auto_impl::auto_impl;
@@ -574,6 +574,12 @@ impl<T: TxHashRef> TxHashRef for Recovered<T> {
 impl<T: TxHashRef> TxHashRef for alloy_eips::eip2718::WithEncoded<T> {
     fn tx_hash(&self) -> &TxHash {
         self.value().tx_hash()
+    }
+}
+
+impl<T: TxHashRef + Clone> TxHashRef for Cow<'_, T> {
+    fn tx_hash(&self) -> &TxHash {
+        (**self).tx_hash()
     }
 }
 

--- a/crates/consensus/src/transaction/recovered.rs
+++ b/crates/consensus/src/transaction/recovered.rs
@@ -1,5 +1,5 @@
 use crate::crypto::RecoveryError;
-use alloc::vec::Vec;
+use alloc::{borrow::Cow, vec::Vec};
 use alloy_eips::{
     eip2718::{Encodable2718, WithEncoded},
     Typed2718,
@@ -131,6 +131,15 @@ impl<T> Recovered<&T> {
     /// Helper function to explicitly create a new copy of `Recovered<&T>`
     pub const fn copied(&self) -> Self {
         *self
+    }
+}
+
+impl<T: Clone> Recovered<Cow<'_, T>> {
+    /// Converts `Recovered<Cow<'_, T>>` into `Recovered<T>` by cloning the borrowed data if
+    /// necessary.
+    pub fn into_owned(self) -> Recovered<T> {
+        let Self { inner, signer } = self;
+        Recovered::new_unchecked(inner.into_owned(), signer)
     }
 }
 

--- a/crates/eips/src/eip2718.rs
+++ b/crates/eips/src/eip2718.rs
@@ -2,7 +2,7 @@
 //!
 //! [EIP-2718]: https://eips.ethereum.org/EIPS/eip-2718
 
-use crate::alloc::vec::Vec;
+use alloc::{borrow::Cow, vec::Vec};
 use alloy_primitives::{keccak256, Bytes, Sealable, Sealed, B256};
 use alloy_rlp::{Buf, BufMut, Header, EMPTY_STRING_CODE};
 use auto_impl::auto_impl;
@@ -329,6 +329,20 @@ impl<T: Encodable2718> Encodable2718 for Sealed<T> {
     }
 }
 
+impl<T: Encodable2718 + Clone> Encodable2718 for Cow<'_, T> {
+    fn encode_2718_len(&self) -> usize {
+        (**self).encode_2718_len()
+    }
+
+    fn encode_2718(&self, out: &mut dyn BufMut) {
+        (**self).encode_2718(out)
+    }
+
+    fn trie_hash(&self) -> B256 {
+        (**self).trie_hash()
+    }
+}
+
 /// An [EIP-2718] envelope, blanket implemented for types that impl [`Encodable2718`] and
 /// [`Decodable2718`].
 ///
@@ -379,6 +393,12 @@ pub trait Typed2718 {
 impl<T: Typed2718> Typed2718 for Sealed<T> {
     fn ty(&self) -> u8 {
         self.inner().ty()
+    }
+}
+
+impl<T: Typed2718 + Clone> Typed2718 for Cow<'_, T> {
+    fn ty(&self) -> u8 {
+        (**self).ty()
     }
 }
 


### PR DESCRIPTION
Adds `Cow<'_, T>` implementations for key traits so that `Recovered<Cow<'_, T>>` works transparently. This enables pool transaction types to return either borrowed or owned consensus transactions via `Cow`.

## Changes
- `Typed2718 for Cow<'_, T>` in `alloy-eips`
- `Encodable2718 for Cow<'_, T>` in `alloy-eips`
- `TxHashRef for Cow<'_, T>` in `alloy-consensus`
- `Recovered<Cow<'_, T>>::into_owned()` helper in `alloy-consensus`

## Context
reth's `PoolTransaction` trait needs a `consensus_ref` method that returns `Recovered<Cow<'_, Self::Consensus>>`. Types wrapping the consensus tx return `Cow::Borrowed`, while mock/test types that don't store a consensus tx can return `Cow::Owned`. These impls make `Recovered<Cow<'_, T>>` a first-class citizen.

`Transaction` itself can't be impl'd for `Cow<'a, T>` due to the `'static` supertrait bound, but callers access `Transaction` methods through deref coercion.

Prompted by: matthias