### PR TITLE
fix(features): enable `alloy-transport-ipc` in `transport-ipc-mock` feature

### DIFF
--- a/crates/alloy/Cargo.toml
+++ b/crates/alloy/Cargo.toml
@@ -292,7 +292,7 @@ secp256k1 = [
 transports = ["dep:alloy-transport"]
 transport-http = ["transports", "dep:alloy-transport-http"]
 transport-ipc = ["transports", "pubsub", "dep:alloy-transport-ipc"]
-transport-ipc-mock = ["alloy-transport-ipc?/mock"]
+transport-ipc-mock = ["dep:alloy-transport-ipc", "alloy-transport-ipc?/mock"]
 transport-ws = ["transports", "pubsub", "dep:alloy-transport-ws"]
 transport-throttle = ["transports", "alloy-transport?/throttle"]
 


### PR DESCRIPTION
Fixes the transport-ipc-mock feature flag to properly enable the alloy-transport-ipc optional dependency.