### PR TITLE
refactor: extract shared signer recovery logic

### DIFF
--- a/crates/rpc-types-eth/src/transaction/request.rs
+++ b/crates/rpc-types-eth/src/transaction/request.rs
@@ -7,7 +7,7 @@ use alloc::{
     vec::Vec,
 };
 use alloy_consensus::{
-    error::ValueError, transaction::Recovered, BlobTransactionSidecar, Signed, SignableTransaction,
+    error::ValueError, transaction::Recovered, BlobTransactionSidecar, SignableTransaction, Signed,
     TxEip1559, TxEip2930, TxEip4844, TxEip4844Variant, TxEip4844WithSidecar, TxEip7702, TxEnvelope,
     TxLegacy, TxType, Typed2718, TypedTransaction,
 };


### PR DESCRIPTION
The `From<TxEnvelope> for TransactionRequest` impl had the same 15-line signer recovery + strip signature block copy-pasted across all 5 match arms. Pulled it into a generic `signed_to_request` helper to keep things DRY.