### PR TITLE
fix: actually retry failed block fetches instead of skipping them

### DIFF
--- a/crates/provider/src/blocks.rs
+++ b/crates/provider/src/blocks.rs
@@ -193,29 +193,32 @@ impl<N: Network> NewBlocks<N> {
 
             // Then try to fill as many blocks as possible.
             // TODO: Maybe use `join_all`
-            let mut retries = MAX_RETRIES;
             for number in self.next_yield..=block_number {
                 debug!(number, "fetching block");
-                let block = match client.request("eth_getBlockByNumber", (U64::from(number), false)).await {
-                    Ok(Some(block)) => block,
-                    Err(RpcError::Transport(err)) if retries > 0 && err.recoverable() => {
-                        debug!(number, %err, "failed to fetch block, retrying");
-                        retries -= 1;
-                        continue;
+                let mut retries = MAX_RETRIES;
+                let block = loop {
+                    match client.request("eth_getBlockByNumber", (U64::from(number), false)).await {
+                        Ok(Some(block)) => break Some(block),
+                        Err(RpcError::Transport(err)) if retries > 0 && err.recoverable() => {
+                            debug!(number, %err, "failed to fetch block, retrying");
+                            retries -= 1;
+                        }
+                        Ok(None) if retries > 0 => {
+                            debug!(number, "failed to fetch block (doesn't exist), retrying");
+                            retries -= 1;
+                        }
+                        Err(err) => {
+                            error!(number, %err, "failed to fetch block");
+                            break None;
+                        }
+                        Ok(None) => {
+                            error!(number, "failed to fetch block (doesn't exist)");
+                            break None;
+                        }
                     }
-                    Ok(None) if retries > 0 => {
-                        debug!(number, "failed to fetch block (doesn't exist), retrying");
-                        retries -= 1;
-                        continue;
-                    }
-                    Err(err) => {
-                        error!(number, %err, "failed to fetch block");
-                        break;
-                    }
-                    Ok(None) => {
-                        error!(number, "failed to fetch block (doesn't exist)");
-                        break;
-                    }
+                };
+                let Some(block) = block else {
+                    break;
                 };
                 self.known_blocks.put(number, block);
                 if self.known_blocks.len() == BLOCK_CACHE_SIZE.get() {


### PR DESCRIPTION
The retry logic in `NewBlocks::into_block_stream` was broken: `continue` in a `for` loop advances the iterator, so failed blocks were skipped rather than retried. The shared `retries` counter also meant retry budget was spread across the whole batch instead of per-block.

Moved retries into an inner loop so each block gets its own retry attempts.