### PR TITLE
feat(contract): make EthCall own its decoder

### DIFF
--- a/crates/contract/src/call.rs
+++ b/crates/contract/src/call.rs
@@ -553,7 +553,7 @@ impl<P: Provider<N>, D: CallDecoder, N: Network> CallBuilder<P, D, N> {
 
     /// Consuming version of [`call`](Self::call) that returns an owned future.
     ///
-    /// This is useful when you need to use the call in a [`tokio::try_join!`] or similar
+    /// This is useful when you need to use the call in a `tokio::try_join!` or similar
     /// combinator, where the future must not borrow from the [`CallBuilder`].
     ///
     /// # Examples


### PR DESCRIPTION
## Summary

Make the contract `EthCall` wrapper own its decoder instead of borrowing it, removing the lifetime parameter. This allows futures returned by `CallBuilder::call()` to be used in `tokio::try_join!` and similar combinators without the `CallBuilder` needing to outlive the future.

### Before

```rust
// ERROR: call_builder is borrowed by the future and must outlive try_join!
let call_a = contract_a.foo().call();
let call_b = contract_b.bar().call();
let (a, b) = tokio::try_join!(call_a, call_b)?; // ❌ lifetime error
```

### After

```rust
let call_a = contract_a.foo().call();
let call_b = contract_b.bar().call();
let (a, b) = tokio::try_join!(call_a, call_b)?; // ✅ works
```

### Changes

- `EthCall<'coder, D, N>` → `EthCall<D, N>` (removed lifetime parameter)
- Decoder field changed from `&'coder D` to owned `D`
- Added `Clone` supertrait to `CallDecoder` (all impls already implement `Clone`)
- Added `CallBuilder::call_owned(self)` as a consuming alternative to `call(&self)` that avoids cloning the transaction request
- Added `Unpin` bound on `IntoFuture`/`Future` impls (required since decoder is now owned; all impls satisfy this)