### PR TITLE
feat: add EIP-7843 (slot_number), EIP-7928 (block_access_list_hash), ExecutionPayloadV4, and Amsterdam support

### DIFF
--- a/crates/consensus-any/src/block/header.rs
+++ b/crates/consensus-any/src/block/header.rs
@@ -96,6 +96,19 @@ pub struct AnyHeader {
     /// EIP-7685 requests hash.
     #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
     pub requests_hash: Option<B256>,
+    /// EIP-7928 block access list hash.
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
+    pub block_access_list_hash: Option<B256>,
+    /// EIP-7843 slot number.
+    #[cfg_attr(
+        feature = "serde",
+        serde(
+            default,
+            skip_serializing_if = "Option::is_none",
+            with = "alloy_serde::quantity::opt"
+        )
+    )]
+    pub slot_number: Option<u64>,
 }
 
 impl AnyHeader {
@@ -144,6 +157,8 @@ impl AnyHeader {
             excess_blob_gas,
             parent_beacon_block_root,
             requests_hash,
+            block_access_list_hash,
+            slot_number,
         } = self;
 
         Ok(Header {
@@ -168,6 +183,8 @@ impl AnyHeader {
             excess_blob_gas,
             parent_beacon_block_root,
             requests_hash,
+            block_access_list_hash,
+            slot_number,
         })
     }
 
@@ -197,6 +214,8 @@ impl AnyHeader {
             excess_blob_gas,
             parent_beacon_block_root,
             requests_hash,
+            block_access_list_hash,
+            slot_number,
         } = self;
 
         Header {
@@ -221,6 +240,8 @@ impl AnyHeader {
             excess_blob_gas,
             parent_beacon_block_root,
             requests_hash,
+            block_access_list_hash,
+            slot_number,
         }
     }
 }
@@ -306,6 +327,14 @@ impl BlockHeader for AnyHeader {
         self.requests_hash
     }
 
+    fn block_access_list_hash(&self) -> Option<B256> {
+        self.block_access_list_hash
+    }
+
+    fn slot_number(&self) -> Option<u64> {
+        self.slot_number
+    }
+
     fn extra_data(&self) -> &Bytes {
         &self.extra_data
     }
@@ -335,6 +364,8 @@ impl From<Header> for AnyHeader {
             excess_blob_gas,
             parent_beacon_block_root,
             requests_hash,
+            block_access_list_hash,
+            slot_number,
         } = value;
 
         Self {
@@ -359,6 +390,8 @@ impl From<Header> for AnyHeader {
             excess_blob_gas,
             parent_beacon_block_root,
             requests_hash,
+            block_access_list_hash,
+            slot_number,
         }
     }
 }

--- a/crates/consensus/src/block/meta.rs
+++ b/crates/consensus/src/block/meta.rs
@@ -39,6 +39,10 @@ pub struct HeaderInfo {
     ///
     /// [EIP-4399]: https://eips.ethereum.org/EIPS/eip-4399
     pub mix_hash: Option<B256>,
+    /// The slot number corresponding to this block, calculated in the consensus layer.
+    ///
+    /// [EIP-7843]: https://eips.ethereum.org/EIPS/eip-7843
+    pub slot_number: Option<u64>,
 }
 
 /// Roots contained in a block header.

--- a/crates/eips/Cargo.toml
+++ b/crates/eips/Cargo.toml
@@ -27,7 +27,7 @@ workspace = true
 alloy-eip2124.workspace = true
 alloy-eip2930.workspace = true
 alloy-eip7702.workspace = true
-alloy-eip7928.workspace = true
+alloy-eip7928 = { workspace = true, features = ["rlp"] }
 
 alloy-primitives = { workspace = true, features = ["rlp"] }
 alloy-rlp = { workspace = true, features = ["derive"] }

--- a/crates/eips/src/eip7892.rs
+++ b/crates/eips/src/eip7892.rs
@@ -42,9 +42,14 @@ pub struct BlobScheduleBlobParams {
     pub prague: BlobParams,
     /// Configuration for blob-related calculations for the Osaka hardfork.
     pub osaka: BlobParams,
-    /// Time-based scheduled updates to blob parameters.
+    /// All Time-based scheduled updates to blob parameters after Osaka.
     ///
     /// These are ordered by activation timestamps in natural order.
+    ///
+    /// This can include blobparams for hardforks after osaka (e.g. amsterdam) that are interleaved
+    /// with BPOs.
+    ///
+    /// Caution: It is expected that these are only activated at or after osaka.
     pub scheduled: Vec<(u64, BlobParams)>,
 }
 

--- a/crates/rpc-types-eth/src/block.rs
+++ b/crates/rpc-types-eth/src/block.rs
@@ -590,6 +590,14 @@ impl<H: BlockHeader> BlockHeader for Header<H> {
         self.inner.requests_hash()
     }
 
+    fn block_access_list_hash(&self) -> Option<B256> {
+        self.inner.block_access_list_hash()
+    }
+
+    fn slot_number(&self) -> Option<u64> {
+        self.inner.slot_number()
+    }
+
     fn extra_data(&self) -> &Bytes {
         self.inner.extra_data()
     }
@@ -881,6 +889,8 @@ mod tests {
                     excess_blob_gas: None,
                     parent_beacon_block_root: None,
                     requests_hash: None,
+                    block_access_list_hash: None,
+                    slot_number: None,
                 },
                 total_difficulty: Some(U256::from(100000)),
                 size: None,
@@ -928,6 +938,8 @@ mod tests {
                     excess_blob_gas: None,
                     parent_beacon_block_root: None,
                     requests_hash: None,
+                    block_access_list_hash: None,
+                    slot_number: None,
                 },
                 size: None,
                 total_difficulty: Some(U256::from(100000)),
@@ -973,6 +985,8 @@ mod tests {
                     excess_blob_gas: None,
                     parent_beacon_block_root: None,
                     requests_hash: None,
+                    block_access_list_hash: None,
+                    slot_number: None,
                 },
                 total_difficulty: Some(U256::from(100000)),
                 size: None,
@@ -1276,6 +1290,8 @@ mod tests {
                 excess_blob_gas: None,
                 parent_beacon_block_root: None,
                 requests_hash: None,
+                block_access_list_hash: None,
+                slot_number: None,
             },
             size: None,
             total_difficulty: None,
@@ -1322,6 +1338,8 @@ mod tests {
                 excess_blob_gas: None,
                 parent_beacon_block_root: None,
                 requests_hash: None,
+                block_access_list_hash: None,
+                slot_number: None,
             },
             total_difficulty: None,
             size: Some(U256::from(505)),
@@ -1380,6 +1398,8 @@ mod tests {
                     excess_blob_gas: None,
                     parent_beacon_block_root: None,
                     requests_hash: None,
+                    block_access_list_hash: None,
+                    slot_number: None,
                 },
                 total_difficulty: Some(U256::from(100000)),
                 size: Some(U256::from(19)),


### PR DESCRIPTION
Squashed net changes from the `bal-devnet2` branch into a single clean commit.

## EIP-7843 (slot_number) and EIP-7928 (block_access_list_hash)
- New fields on `Header`, `AnyHeader`, `HeaderInfo`, and `BlockHeader` trait
- RLP encode/decode, `serde_bincode_compat`, SSZ, and arbitrary support
- `amsterdam_active()` method on `Header`
- `is_empty()` updated to check BAL hash against `EMPTY_BLOCK_ACCESS_LIST_HASH`
- `Header<H>` in rpc-types-eth implements the new `BlockHeader` methods

## ExecutionPayloadV4
- Added `slot_number` field alongside existing `block_access_list`
- Added conversion methods (`from_block_slow`, `from_block_unchecked`, `from_block_unchecked_with_bal`, `try_into_block`, `into_block_raw`, etc.)
- `From<ExecutionPayloadV4>` for `ExecutionPayload` and `TryFrom` for `Block<T>`
- Updated SSZ encode/decode for `slot_number`
- V4 variant added to `ExecutionPayload` enum with `as_v4()`, `as_v4_mut()`, `block_access_list()`, `slot_number()` accessors
- V4 deserialization support in the custom `Deserialize` impl for `ExecutionPayload`

## Beacon types
- `BeaconExecutionPayloadV4` and `BeaconPayloadAttributes` updated with `slot_number`
- V4 variant added to `BeaconExecutionPayload` enum with deserialization

## PayloadAttributes
- Added `slot_number` field with serde quantity hex encoding

## Genesis / ChainConfig
- Added `amsterdam_time` field
- Amsterdam blob schedule handling in `blob_schedule_blob_params()`

## Other
- `alloy-eip7928` dependency enables `rlp` feature
- `eip7892.rs` doc updates on `BlobScheduleBlobParams.scheduled`

## Not included (was added then reverted in the branch)
- EIP-7778 `gas_spent` on `Receipt`, `TransactionReceipt`, and `ReceiptResponse` trait