### PR TITLE
feat(rpc-types-eth): add TransactionRequest::create() builder method

### DIFF
--- a/crates/rpc-types-eth/src/transaction/request.rs
+++ b/crates/rpc-types-eth/src/transaction/request.rs
@@ -252,6 +252,13 @@ impl TransactionRequest {
         self
     }
 
+    /// Marks this transaction as a contract creation (deploy) with no recipient.
+    #[inline]
+    pub const fn create(mut self) -> Self {
+        self.to = Some(TxKind::Create);
+        self
+    }
+
     /// Sets the value (amount) for the transaction.
     pub const fn value(mut self, value: U256) -> Self {
         self.value = Some(value);


### PR DESCRIPTION
Adds a builder method to mark a `TransactionRequest` as a contract creation (deploy) transaction. This sets `to = Some(TxKind::Create)`, which is required by the wallet filler middleware to distinguish deployments from incomplete transactions (where `to` is `None`).

Previously, users had to break the builder chain:
```rust
let mut tx = TransactionRequest::default().input(bytecode.into());
tx.to = Some(TxKind::Create);
```

Now:
```rust
TransactionRequest::default().create().input(bytecode.into())
```