### PR TITLE
docs(rpc-types-eth): fix TransactionInput method documentation inconsistencies

### DIFF
--- a/crates/rpc-types-eth/src/transaction/request.rs
+++ b/crates/rpc-types-eth/src/transaction/request.rs
@@ -287,7 +287,7 @@ impl TransactionRequest {
 
     /// Ensures that if either `input` or `data` is set, the `input` field contains the value.
     ///
-    /// This removes `data` the data field.
+    /// This removes the `data` field.
     pub fn normalize_input(&mut self) {
         self.input.normalize_input()
     }
@@ -300,7 +300,7 @@ impl TransactionRequest {
 
     /// Ensures that if either `data` or `input` is set, the `data` field contains the value.
     ///
-    /// This removes `input` the data field.
+    /// This removes the `input` field.
     pub fn normalize_data(&mut self) {
         self.input.normalize_data();
     }
@@ -311,7 +311,7 @@ impl TransactionRequest {
         self
     }
 
-    /// If only one field is set, this also sets the other field by with that value.
+    /// If only one field is set, this also sets the other field with that value.
     ///
     /// This is a noop if both fields are already set.
     pub fn set_input_and_data(&mut self) {


### PR DESCRIPTION
Fixes documentation inconsistencies in `TransactionInput` methods where comments contradicted actual code behavior.