### PR TITLE
perf(rpc-types-trace): optimize input truncation in Otterscan serialization

### DIFF
--- a/crates/rpc-types-trace/src/otterscan.rs
+++ b/crates/rpc-types-trace/src/otterscan.rs
@@ -212,8 +212,8 @@ where
                     if let Value::Object(map) = tx {
                         if let Some(Value::String(input)) = map.get_mut("input") {
                             // Truncate the input to the first 4 bytes (8 hex characters) plus 0x
-                            // prefix
-                            *input = input.chars().take(2 + 4 + 4).collect::<String>();
+                            // prefix, in place to avoid extra allocation.
+                            input.truncate(2 + 8);
                         }
                     }
                 }


### PR DESCRIPTION
Replace `chars().take().collect()` with in-place `truncate()` when serializing Otterscan transaction inputs to eliminate unnecessary allocations.