### PR TITLE
feat(rpc-types-eth): add `max_used_gas` to `SimCallResult`

### DIFF
--- a/crates/rpc-types-eth/src/simulate.rs
+++ b/crates/rpc-types-eth/src/simulate.rs
@@ -99,6 +99,16 @@ pub struct SimCallResult {
     /// The amount of gas used by the transaction.
     #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
     pub gas_used: u64,
+    /// Maximum gas consumed during execution, before refunds.
+    #[cfg_attr(
+        feature = "serde",
+        serde(
+            default,
+            skip_serializing_if = "Option::is_none",
+            with = "alloy_serde::quantity::opt"
+        )
+    )]
+    pub max_used_gas: Option<u64>,
     /// The final status of the transaction, typically indicating success or failure.
     #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
     pub status: bool,


### PR DESCRIPTION
## Summary
Adds optional `maxUsedGas` field to `SimCallResult` for `eth_simulateV1` responses.

## Motivation
Mirrors [ethereum/execution-apis#746](https://github.com/ethereum/execution-apis/pull/746) and [ethereum/go-ethereum#32789](https://github.com/ethereum/go-ethereum/pull/32789).

The `maxUsedGas` field represents the maximum gas consumed during transaction execution before refunds are applied. This is valuable for DeFi applications that need accurate gas limit estimation for complex transaction sequences (e.g. approve + swap flows), where `gasUsed` (post-refund) can underestimate the required gas limit.

## Changes
- Added `max_used_gas: Option<u64>` to `SimCallResult` in `crates/rpc-types-eth/src/simulate.rs`
- Serialized as `"maxUsedGas"` (camelCase), quantity-encoded, optional (skipped if `None`)

Prompted by: mattsse