### PR TITLE
feat(rpc-types-eth): derive Default for `SimCallResult`

### DIFF
--- a/crates/rpc-types-eth/src/simulate.rs
+++ b/crates/rpc-types-eth/src/simulate.rs
@@ -87,7 +87,7 @@ pub struct SimulatedBlock<B = Block> {
 
 /// Captures the outcome of a transaction simulation.
 /// It includes the return value, logs produced, gas used, and the status of the transaction.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct SimCallResult {


### PR DESCRIPTION
## Summary
Derives `Default` for `SimCallResult`.

## Motivation
Allows downstream consumers (e.g. reth) to construct `SimCallResult` with `..Default::default()`, so new field additions (like [`max_used_gas`](https://github.com/alloy-rs/alloy/pull/3707)) don't require updating every construction site. This also removes the need for `#[allow(clippy::needless_update)]` annotations in reth.

## Changes
- Added `Default` to the derive macro for `SimCallResult` in `crates/rpc-types-eth/src/simulate.rs`

All fields already have sensible defaults (`Bytes` → empty, `Vec` → empty, `u64` → 0, `bool` → false, `Option` → None).

Prompted by: mattsse