### PR TITLE
fix: resolve infinite recursion in Sealable::hash_slow for Header

### DIFF
--- a/crates/consensus/src/block/header.rs
+++ b/crates/consensus/src/block/header.rs
@@ -167,7 +167,7 @@ impl Default for Header {
 
 impl Sealable for Header {
     fn hash_slow(&self) -> B256 {
-        Header::hash_slow(self)
+        Self::hash_slow(self)
     }
 }
 


### PR DESCRIPTION
The impl Sealable for Header was calling `self.hash_slow()` which caused infinite recursion because Rust's method resolution finds the trait method first, creating a self-referential loop. Fixed by using fully qualified syntax `Header::hash_slow(self)` to explicitly call the inherent method.