### PR TITLE
feat(consensus): add `EthereumReceipt::map_logs`

### DIFF
--- a/crates/consensus/src/receipt/receipt2.rs
+++ b/crates/consensus/src/receipt/receipt2.rs
@@ -73,7 +73,12 @@ impl<T, L> EthereumReceipt<T, L> {
     /// Returns the receipt with the new log type.
     pub fn map_logs<U>(self, f: impl FnMut(L) -> U) -> EthereumReceipt<T, U> {
         let Self { tx_type, success, cumulative_gas_used, logs } = self;
-        EthereumReceipt { tx_type, success, cumulative_gas_used, logs: logs.into_iter().map(f).collect() }
+        EthereumReceipt {
+            tx_type,
+            success,
+            cumulative_gas_used,
+            logs: logs.into_iter().map(f).collect(),
+        }
     }
 }
 


### PR DESCRIPTION
Add `pub fn map_logs` on `impl<T, L> EthereumReceipt<T, L>`, following the same pattern as [`Receipt::map_logs`](https://github.com/alloy-rs/alloy/blob/54b1f6645d45a1877cea90a5e0d3850341e31168/crates/consensus/src/receipt/receipts.rs#L38-L41).