### PR TITLE
fix(ci): catch background process failures in install_test_binaries.sh

### DIFF
--- a/.github/scripts/install_test_binaries.sh
+++ b/.github/scripts/install_test_binaries.sh
@@ -19,9 +19,12 @@ main() {
     fi
 
     install_geth &
+    local geth_pid=$!
     install_reth &
+    local reth_pid=$!
 
-    wait
+    wait $geth_pid || { echo "install_geth failed"; exit 1; }
+    wait $reth_pid || { echo "install_reth failed"; exit 1; }
 }
 
 # Installs geth from https://geth.ethereum.org/downloads


### PR DESCRIPTION
Bare `wait` doesn't propagate exit codes from background processes, and `set -e` doesn't apply to them either. If `install_geth` or `install_reth` fails (e.g. bad version string, network issue), the script exits 0 and CI moves on to tests — which then fail with confusing "binary not found" errors that point nowhere near the actual cause.

For example, bumping GETH_BUILD to a non-existent version would result in curl/tar errors inside the background job, but CI would happily proceed and eventually blow up at `geth --dev` in integration tests, making it look like a test issue rather than a setup issue.

Capture each PID and `wait` on them individually so failures are caught early.
