### PR TITLE
fix(consensus): use unchecked recovery in recover_unchecked_with_buf default impl

### DIFF
--- a/crates/consensus/src/transaction/recovered.rs
+++ b/crates/consensus/src/transaction/recovered.rs
@@ -232,7 +232,7 @@ pub trait SignerRecoverable {
         buf: &mut alloc::vec::Vec<u8>,
     ) -> Result<Address, RecoveryError> {
         let _ = buf;
-        self.recover_signer()
+        self.recover_signer_unchecked()
     }
 
     /// Recover the signer via [`SignerRecoverable::recover_signer`] and returns a


### PR DESCRIPTION
The default implementation of `recover_unchecked_with_buf` falls back to `recover_signer()` instead of `recover_signer_unchecked()`. This means the "unchecked" variant still applies EIP-2 low-S validation, which silently rejects valid pre-EIP-2 historical signatures for any type relying on the default impl.

One-line fix: call `recover_signer_unchecked()` to match the documented behavior and the pattern used by all other unchecked methods in the trait.
