### PR TITLE
feat(eips): add `ref-cast` workspace dep and derive `RefCast` on `Withdrawals`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,6 +163,7 @@ semver = "1.0"
 strum = { version = "0.27", default-features = false }
 thiserror = { version = "2.0", default-features = false }
 url = "2.5"
+ref-cast = "1.0"
 
 # misc-testing
 arbitrary = "1.3"

--- a/crates/eips/Cargo.toml
+++ b/crates/eips/Cargo.toml
@@ -64,6 +64,7 @@ borsh = { workspace = true, optional = true, features = ["derive"] }
 
 # misc
 auto_impl.workspace = true
+ref-cast.workspace = true
 
 [dev-dependencies]
 alloy-primitives = { workspace = true, features = [

--- a/crates/eips/src/eip4895.rs
+++ b/crates/eips/src/eip4895.rs
@@ -6,6 +6,7 @@ use alloc::vec::Vec;
 use alloy_primitives::{Address, U256};
 use alloy_rlp::{RlpDecodable, RlpDecodableWrapper, RlpEncodable, RlpEncodableWrapper};
 use derive_more::derive::{AsRef, Deref, DerefMut, From, IntoIterator};
+use ref_cast::RefCast;
 
 /// Multiplier for converting gwei to wei.
 pub const GWEI_TO_WEI: u64 = 1_000_000_000;
@@ -55,7 +56,9 @@ impl Withdrawal {
     IntoIterator,
     RlpEncodableWrapper,
     RlpDecodableWrapper,
+    RefCast,
 )]
+#[repr(transparent)]
 #[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "borsh", derive(borsh::BorshSerialize, borsh::BorshDeserialize))]


### PR DESCRIPTION
## Motivation

`Withdrawals` is a `#[repr(transparent)]` newtype wrapper around `Vec<Withdrawal>`. However, there was no way to perform a zero-cost cast from `&[Withdrawal]` (or `&Vec<Withdrawal>`) to `&Withdrawals` without an allocation or unsafe code.

## Changes

- Add `ref-cast = "1.0"` to `[workspace.dependencies]` in the root `Cargo.toml`.
- Add `ref-cast.workspace = true` to `alloy-eips` dependencies.
- Derive `ref_cast::RefCast` on `Withdrawals` and ensure `#[repr(transparent)]` is present.

## Why `ref-cast`

The [`ref-cast`](https://crates.io/crates/ref-cast) crate provides a safe, well-audited macro for deriving zero-cost reference casts on `#[repr(transparent)]` types. It generates a safe `RefCast::ref_cast(src: &Vec<Withdrawal>) -> &Withdrawals` impl, avoiding any need for `unsafe` transmute at call sites.

## Usage example

```rust
use ref_cast::RefCast;
use alloy_eips::eip4895::{Withdrawal, Withdrawals};

let vec: Vec<Withdrawal> = vec![/* ... */];
let withdrawals: &Withdrawals = Withdrawals::ref_cast(&vec);
```