### PR TITLE
fix(rpc-types): off-by-one in TransactionConditional has_exceeded checks

### DIFF
--- a/crates/rpc-types-eth/src/erc4337.rs
+++ b/crates/rpc-types-eth/src/erc4337.rs
@@ -75,17 +75,17 @@ impl TransactionConditional {
         self.has_exceeded_block_number(block.number) || self.has_exceeded_timestamp(block.timestamp)
     }
 
-    /// Returns true if the configured max block number is lower or equal to the given
+    /// Returns true if the configured max block number is strictly lower than the given
     /// `block_number`
     pub const fn has_exceeded_block_number(&self, block_number: BlockNumber) -> bool {
         let Some(max_num) = self.block_number_max else { return false };
-        block_number >= max_num
+        block_number > max_num
     }
 
-    /// Returns true if the configured max timestamp is lower or equal to the given `timestamp`
+    /// Returns true if the configured max timestamp is strictly lower than the given `timestamp`
     pub const fn has_exceeded_timestamp(&self, timestamp: u64) -> bool {
         let Some(max_timestamp) = self.timestamp_max else { return false };
-        timestamp >= max_timestamp
+        timestamp > max_timestamp
     }
 
     /// Returns `true` if the transaction matches the given block attributes.


### PR DESCRIPTION
`has_exceeded_block_number` and `has_exceeded_timestamp` used `>=` while `matches_block_number` and `matches_timestamp` used `>` for the max boundary, so at `block_number == max` a tx would both "match" and be "exceeded". Changed to `>` to keep inclusive range semantics consistent across both sets of helpers.

Before this fix, with `block_number_max = 1000`:
- `matches_block_number(1000)` → true (tx is valid)
- `has_exceeded_block_number(1000)` → true (tx is expired)

Any caller that short-circuits on `has_exceeded` would incorrectly reject a tx at its exact max block.
