### PR TITLE
fix(node-bindings): remove duplicate clique_address() call and dead code

### DIFF
--- a/crates/node-bindings/src/nodes/geth.rs
+++ b/crates/node-bindings/src/nodes/geth.rs
@@ -4,7 +4,7 @@ use crate::{
     utils::{extract_endpoint, extract_value, unused_port, GracefulShutdown},
     NodeError, NODE_DIAL_LOOP_TIMEOUT, NODE_STARTUP_TIMEOUT,
 };
-use alloy_genesis::{CliqueConfig, Genesis};
+use alloy_genesis::Genesis;
 use alloy_primitives::Address;
 use k256::ecdsa::SigningKey;
 use std::{
@@ -493,28 +493,9 @@ impl Geth {
 
         // use geth init to initialize the datadir if the genesis exists
         if is_clique {
-            let clique_addr = self.clique_address();
-            if let Some(genesis) = &mut self.genesis {
-                // set up a clique config with an instant sealing period and short (8 block) epoch
-                let clique_config = CliqueConfig { period: Some(0), epoch: Some(8) };
-                genesis.config.clique = Some(clique_config);
-
-                let clique_addr = clique_addr.ok_or_else(|| {
-                    NodeError::CliqueAddressError(
-                        "could not calculates the address of the Clique consensus address."
-                            .to_string(),
-                    )
-                })?;
-
-                // set the extraData field
-                let extra_data_bytes =
-                    [&[0u8; 32][..], clique_addr.as_ref(), &[0u8; 65][..]].concat();
-                genesis.extra_data = extra_data_bytes.into();
-            }
-
             let clique_addr = self.clique_address().ok_or_else(|| {
                 NodeError::CliqueAddressError(
-                    "could not calculates the address of the Clique consensus address.".to_string(),
+                    "could not calculate the address of the Clique consensus address.".to_string(),
                 )
             })?;
 


### PR DESCRIPTION
When `is_clique` was true, `clique_address()` was called twice and there was a block of dead code that modified a user-provided genesis file which was then immediately overwritten by `Genesis::clique_genesis()`.
Removed duplicate method call and dead code block, fixed typo, cleaned up unused import.