### PR TITLE
test: remove flaky test_erc20_token_polygon test

### DIFF
--- a/crates/contract/src/storage_slot.rs
+++ b/crates/contract/src/storage_slot.rs
@@ -193,7 +193,7 @@ where
 mod tests {
     use crate::StorageSlotFinder;
     use alloy_network::TransactionBuilder;
-    use alloy_primitives::{address, ruint::uint, Address, B256, U256};
+    use alloy_primitives::{address, Address, B256, U256};
     use alloy_provider::{ext::AnvilApi, Provider, ProviderBuilder};
     use alloy_rpc_types_eth::TransactionRequest;
     use alloy_sol_types::sol;


### PR DESCRIPTION
## Summary
Remove `test_erc20_token_polygon` test that relies on `polygon-rpc.com` which has been shut down.

## Changes
- Removed `test_erc20_token_polygon` from `crates/contract/src/storage_slot.rs`

## Context
CI has been failing consistently due to this test: https://github.com/alloy-rs/alloy/actions/runs/22237265444/job/64331885646

Prompted by: mattsse