### PR TITLE
feat(ws): auto-extract basic auth from URL in WsConnect

### DIFF
--- a/crates/transport-ws/Cargo.toml
+++ b/crates/transport-ws/Cargo.toml
@@ -28,6 +28,7 @@ alloy-transport.workspace = true
 
 futures.workspace = true
 serde_json.workspace = true
+url.workspace = true
 tokio = { workspace = true, features = ["sync", "rt"] }
 tracing.workspace = true
 


### PR DESCRIPTION
Automatically extract basic auth credentials from WebSocket URLs in `WsConnect::new()`.

Previously, connecting to a URL like `wss://user:pass@provider.xyz` required manually parsing the URL and calling `with_auth()`:

```rust
let mut ws = WsConnect::new(url.clone());
if !url.username().is_empty() {
    let auth = Authorization::basic(url.username(), url.password().unwrap_or_default());
    ws = ws.with_auth(auth);
}
```

Now it just works:

```rust
let ws = WsConnect::new("wss://user:pass@provider.xyz");
// auth is automatically extracted
```

Also simplifies `Authorization::extract_from_url` by removing the `localhost`/`SocketAddr` heuristic guards — the `url` crate only populates userinfo when `@` is present, so the guards were unnecessary and could reject legitimate credentials.