### PR TITLE
feat: impl From<Recovered<T>> for TransactionRequest

### DIFF
--- a/crates/rpc-types-eth/src/transaction/request.rs
+++ b/crates/rpc-types-eth/src/transaction/request.rs
@@ -1335,6 +1335,12 @@ impl From<TypedTransaction> for TransactionRequest {
     }
 }
 
+impl<T: TransactionTrait> From<Recovered<T>> for TransactionRequest {
+    fn from(tx: Recovered<T>) -> Self {
+        Self::from_recovered_transaction(tx)
+    }
+}
+
 impl From<TxEnvelope> for TransactionRequest {
     fn from(envelope: TxEnvelope) -> Self {
         match envelope {


### PR DESCRIPTION
Implements `From<Recovered<T>>` for `TransactionRequest` where `T: Transaction`, delegating to the existing `from_recovered_transaction` method.

ref #3723

cc @mablr