### PR TITLE
fix: correct Debug trait name for `JwtSecret`

### DIFF
--- a/crates/rpc-types-engine/src/jwt.rs
+++ b/crates/rpc-types-engine/src/jwt.rs
@@ -266,7 +266,7 @@ impl JwtSecret {
 
 impl core::fmt::Debug for JwtSecret {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("JwtSecretHash").field(&"{{}}").finish()
+        f.debug_tuple("JwtSecret").field(&"{{}}").finish()
     }
 }
 


### PR DESCRIPTION
The Debug implementation for JwtSecret incorrectly used "JwtSecretHash" as the tuple name instead of the actual type name "JwtSecret".
Fixed the debug output to show the correct type name.