### PR TITLE
fix: correct Debug trait name for PendingBlock

### DIFF
--- a/crates/provider/src/provider/get_block.rs
+++ b/crates/provider/src/provider/get_block.rs
@@ -257,7 +257,7 @@ where
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::RpcCall(call) => f.debug_tuple("RpcCall").field(call).finish(),
-            Self::PendingBlock(call) => f.debug_tuple("PendingBlockCall").field(call).finish(),
+            Self::PendingBlock(call) => f.debug_tuple("PendingBlock").field(call).finish(),
             Self::ProviderCall(_) => f.debug_struct("ProviderCall").finish(),
         }
     }


### PR DESCRIPTION
Fixes the mismatch to match the actual variant name, the Debug implementation outputs "PendingBlockCall" instead of "PendingBlock".