### PR TITLE
fix(rpc-types-trace): skip serializing None fields in TraceFilter

### DIFF
--- a/crates/rpc-types-trace/src/filter.rs
+++ b/crates/rpc-types-trace/src/filter.rs
@@ -13,10 +13,10 @@ use serde::{Deserialize, Serialize};
 #[serde(rename_all = "camelCase")]
 pub struct TraceFilter {
     /// From block
-    #[serde(with = "alloy_serde::quantity::opt")]
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
     pub from_block: Option<u64>,
     /// To block
-    #[serde(with = "alloy_serde::quantity::opt")]
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
     pub to_block: Option<u64>,
     /// From address
     #[serde(default)]
@@ -28,8 +28,10 @@ pub struct TraceFilter {
     #[serde(default)]
     pub mode: TraceFilterMode,
     /// Output offset
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub after: Option<u64>,
     /// Output amount
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub count: Option<u64>,
 }
 


### PR DESCRIPTION
`from_block`, `to_block`, `after`, and `count` fields in `TraceFilter` are missing `skip_serializing_if` attributes, causing `None` values to be serialized as null.

Before:
{"fromBlock": null, "toBlock": null, "fromAddress": [], "toAddress": [], "mode": "union", "after": null, "count": null}

After:
{"fromAddress": [], "toAddress": [], "mode": "union"}

Strict JSON-RPC validators may reject trace_filter requests containing unexpected null fields. All other Option fields in the codebase correctly use skip_serializing_if = "Option::is_none" — this was an oversight.
