### PR TITLE
fix(provider): use debug_struct instead of debug_tuple for named fields

### DIFF
--- a/crates/provider/src/provider/eth_call/call_many.rs
+++ b/crates/provider/src/provider/eth_call/call_many.rs
@@ -246,9 +246,9 @@ where
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             CallManyInnerFut::Preparing { params, .. } => {
-                f.debug_tuple("Preparing").field(&params).finish()
+                f.debug_struct("Preparing").field("params", &params).finish()
             }
-            CallManyInnerFut::Running { .. } => f.debug_tuple("Running").finish(),
+            CallManyInnerFut::Running { .. } => f.debug_struct("Running").finish(),
             CallManyInnerFut::Polling => f.debug_tuple("Polling").finish(),
         }
     }

--- a/crates/provider/src/provider/eth_call/mod.rs
+++ b/crates/provider/src/provider/eth_call/mod.rs
@@ -67,7 +67,7 @@ where
             Self::Preparing { caller: _, params, method, map: _ } => {
                 f.debug_struct("Preparing").field("params", params).field("method", method).finish()
             }
-            Self::Running { .. } => f.debug_tuple("Running").finish(),
+            Self::Running { .. } => f.debug_struct("Running").finish(),
             Self::Polling => f.debug_tuple("Polling").finish(),
         }
     }


### PR DESCRIPTION
Use `debug_struct` for struct variants in `EthCallFutInner` and `CallManyInnerFut`, ensuring the formatted output correctly reflects the named fields.
