### PR TITLE
chore: bump ethereum_ssz to 0.10 and tree_hash to 0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,10 +94,10 @@ alloy-eip7928 = { version = "0.3", default-features = false }
 alloy-hardforks = "0.2.0"
 
 # ethereum
-ethereum_ssz_derive = "0.9"
-ethereum_ssz = "0.9"
-tree_hash = "0.10.0"
-tree_hash_derive = "0.10.0"
+ethereum_ssz_derive = "0.10"
+ethereum_ssz = "0.10"
+tree_hash = "0.12"
+tree_hash_derive = "0.12"
 
 # crypto
 c-kzg = { version = "2.1.1", default-features = false }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Alloy has a dependency conflict when used with latest `ethereum_ssz.`

## Solution

Bump to next breaking versions: `ethereum_ssz/ethereum_ssz_derive` 0.10 and `tree_hash/tree_hash_derive` 0.12. Latest releases are 0.10.1 and 0.12.1 respectively.

https://github.com/sigp/ethereum_ssz/releases
https://github.com/sigp/tree_hash/releases

## PR Checklist

- [-] Added Tests
- [-] Added Documentation
- [-] Breaking changes
