### PR TITLE
transport: deduplicate DualTransport constructor logic

### DIFF
--- a/crates/transport/src/dual.rs
+++ b/crates/transport/src/dual.rs
@@ -49,7 +49,7 @@ impl<L, R, H> DualTransport<L, R, H> {
     where
         F: Fn(RequestPacket, L, R) -> TransportFut<'static> + Send + Sync,
     {
-        DualTransport { left, right, handler: f }
+        DualTransport::new(left, right, f)
     }
 }
 


### PR DESCRIPTION


Deduplicate `DualTransport` constructor logic by making `DualTransport::new_handler` delegate to `DualTransport::new`.

