### PR TITLE
chore: fix incorrect topic in `FinalizedCheckpointEvent` docs

### DIFF
--- a/crates/rpc-types-beacon/src/events/mod.rs
+++ b/crates/rpc-types-beacon/src/events/mod.rs
@@ -184,7 +184,7 @@ pub struct BlsToExecutionChangeMessage {
     pub to_execution_address: Address,
 }
 
-/// Event for the `Deposit` topic of the beacon API node event stream.
+/// Event for the `FinalizedCheckpoint` topic of the beacon API node event stream.
 ///
 /// Finalized checkpoint has been updated
 #[serde_as]


### PR DESCRIPTION
## 
Fixes a copy-paste error where `FinalizedCheckpointEvent` was incorrectly documented as belonging to the `Deposit` topic.

Updated the doc comment to correctly reference the `FinalizedCheckpoint` topic.
