### PR TITLE
chore: ignore test_fill_transaction on Anvil

### DIFF
--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -2659,6 +2659,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "eth_fillTransaction is not supported by Anvil"]
     async fn test_fill_transaction() {
         use alloy_network::TransactionBuilder;
         use alloy_primitives::{address, U256};


### PR DESCRIPTION
Anvil does not implement eth_fillTransaction, so this test fails when run against Anvil. Mark it as ignored to avoid
spurious failures.