### PR TITLE
fix(eips): use post-EIP-2028 non-zero byte calldata cost (16)

### DIFF
--- a/crates/eips/src/eip7623.rs
+++ b/crates/eips/src/eip7623.rs
@@ -5,8 +5,8 @@
 /// The standard cost of calldata token.
 pub const STANDARD_TOKEN_COST: u64 = 4;
 
-/// The cost of a non-zero byte in calldata.
-pub const NON_ZERO_BYTE_DATA_COST: u64 = 68;
+/// The cost of a non-zero byte in calldata post-[EIP-2028](https://eips.ethereum.org/EIPS/eip-2028).
+pub const NON_ZERO_BYTE_DATA_COST: u64 = 16;
 
 /// The multiplier for a non zero byte in calldata.
 pub const NON_ZERO_BYTE_MULTIPLIER: u64 = NON_ZERO_BYTE_DATA_COST / STANDARD_TOKEN_COST;


### PR DESCRIPTION
## Summary

Updates `NON_ZERO_BYTE_DATA_COST` from 68 to 16 in `eip7623.rs`.

## Motivation

The value 68 is the pre-Istanbul cost. [EIP-2028](https://eips.ethereum.org/EIPS/eip-2028) reduced non-zero byte calldata cost to 16, which has been active since Istanbul. This matches [go-ethereum's `TxDataNonZeroGasEIP2028`](https://github.com/ethereum/go-ethereum/blob/cee751a1edc34a3f04be13e794e504f59ac11fc0/params/protocol_params.go#L96).

## Changes

- `crates/eips/src/eip7623.rs`: `NON_ZERO_BYTE_DATA_COST` 68 → 16, added EIP-2028 reference in doc comment

Prompted by: mattsse