### PR TITLE
refactor(node-bindings): remove redundant TempDir::close calls

### DIFF
--- a/crates/node-bindings/src/utils.rs
+++ b/crates/node-bindings/src/utils.rs
@@ -101,10 +101,6 @@ pub fn run_with_tempdir_sync(prefix: &str, f: impl FnOnce(PathBuf)) {
     let temp_dir = TempDir::with_prefix(prefix).unwrap();
     let temp_dir_path = temp_dir.path().to_path_buf();
     f(temp_dir_path);
-    #[cfg(not(windows))]
-    {
-        let _ = temp_dir.close();
-    }
 }
 
 /// Runs the given async closure with a temporary directory.
@@ -116,10 +112,6 @@ where
     let temp_dir = TempDir::with_prefix(prefix).unwrap();
     let temp_dir_path = temp_dir.path().to_path_buf();
     f(temp_dir_path).await;
-    #[cfg(not(windows))]
-    {
-        let _ = temp_dir.close();
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION


Remove redundant `TempDir::close` calls in `run_with_tempdir_sync` and `run_with_tempdir` helpers in the `node-bindings` crate.

