### PR TITLE
refactor(network): extract dyn-compatible/network-based methods from `TransactionBuilder`

### DIFF
--- a/crates/contract/src/call.rs
+++ b/crates/contract/src/call.rs
@@ -5,7 +5,7 @@ use alloy_json_abi::Function;
 use alloy_network::{
     eip2718::Encodable2718, Ethereum, IntoWallet, Network, NetworkTransactionBuilder,
     TransactionBuilder, TransactionBuilder4844, TransactionBuilder7594, TransactionBuilder7702,
-    TransactionBuilderError, TxSigner,
+    TransactionBuilderDyn, TransactionBuilderError, TxSigner,
 };
 use alloy_network_primitives::ReceiptResponse;
 use alloy_primitives::{Address, Bytes, ChainId, Signature, TxKind, U256};

--- a/crates/contract/src/call.rs
+++ b/crates/contract/src/call.rs
@@ -3,9 +3,9 @@ use alloy_consensus::SignableTransaction;
 use alloy_dyn_abi::{DynSolValue, JsonAbiExt};
 use alloy_json_abi::Function;
 use alloy_network::{
-    eip2718::Encodable2718, Ethereum, IntoWallet, Network, NetworkTransactionBuilder,
-    TransactionBuilder, TransactionBuilder4844, TransactionBuilder7594, TransactionBuilder7702,
-    DynTransactionBuilder, TransactionBuilderError, TxSigner,
+    eip2718::Encodable2718, DynTransactionBuilder, Ethereum, IntoWallet, Network,
+    NetworkTransactionBuilder, TransactionBuilder, TransactionBuilder4844, TransactionBuilder7594,
+    TransactionBuilder7702, TransactionBuilderError, TxSigner,
 };
 use alloy_network_primitives::ReceiptResponse;
 use alloy_primitives::{Address, Bytes, ChainId, Signature, TxKind, U256};

--- a/crates/contract/src/call.rs
+++ b/crates/contract/src/call.rs
@@ -3,8 +3,8 @@ use alloy_consensus::SignableTransaction;
 use alloy_dyn_abi::{DynSolValue, JsonAbiExt};
 use alloy_json_abi::Function;
 use alloy_network::{
-    eip2718::Encodable2718, Ethereum, IntoWallet, Network, TransactionBuilder,
-    TransactionBuilder4844, TransactionBuilder7594, TransactionBuilder7702,
+    eip2718::Encodable2718, Ethereum, IntoWallet, Network, NetworkTransactionBuilder,
+    TransactionBuilder, TransactionBuilder4844, TransactionBuilder7594, TransactionBuilder7702,
     TransactionBuilderError, TxSigner,
 };
 use alloy_network_primitives::ReceiptResponse;

--- a/crates/contract/src/call.rs
+++ b/crates/contract/src/call.rs
@@ -5,7 +5,7 @@ use alloy_json_abi::Function;
 use alloy_network::{
     eip2718::Encodable2718, Ethereum, IntoWallet, Network, NetworkTransactionBuilder,
     TransactionBuilder, TransactionBuilder4844, TransactionBuilder7594, TransactionBuilder7702,
-    TransactionBuilderDyn, TransactionBuilderError, TxSigner,
+    DynTransactionBuilder, TransactionBuilderError, TxSigner,
 };
 use alloy_network_primitives::ReceiptResponse;
 use alloy_primitives::{Address, Bytes, ChainId, Signature, TxKind, U256};

--- a/crates/contract/src/multicall.rs
+++ b/crates/contract/src/multicall.rs
@@ -4,7 +4,7 @@
 //!
 //! This module is not public API.
 use super::SolCallBuilder;
-use alloy_network::{Network, TransactionBuilder};
+use alloy_network::{Network, TransactionBuilderDyn};
 use alloy_primitives::{Address, Bytes, U256};
 use alloy_provider::{MulticallItem, Provider};
 use alloy_sol_types::SolCall;

--- a/crates/contract/src/multicall.rs
+++ b/crates/contract/src/multicall.rs
@@ -4,7 +4,7 @@
 //!
 //! This module is not public API.
 use super::SolCallBuilder;
-use alloy_network::{Network, DynTransactionBuilder};
+use alloy_network::{DynTransactionBuilder, Network};
 use alloy_primitives::{Address, Bytes, U256};
 use alloy_provider::{MulticallItem, Provider};
 use alloy_sol_types::SolCall;

--- a/crates/contract/src/multicall.rs
+++ b/crates/contract/src/multicall.rs
@@ -4,7 +4,7 @@
 //!
 //! This module is not public API.
 use super::SolCallBuilder;
-use alloy_network::{Network, TransactionBuilderDyn};
+use alloy_network::{Network, DynTransactionBuilder};
 use alloy_primitives::{Address, Bytes, U256};
 use alloy_provider::{MulticallItem, Provider};
 use alloy_sol_types::SolCall;

--- a/crates/network/src/any/builder.rs
+++ b/crates/network/src/any/builder.rs
@@ -1,13 +1,13 @@
 use crate::{
-    any::AnyNetwork, BuildResult, Network, NetworkWallet, TransactionBuilder,
-    TransactionBuilderError,
+    any::AnyNetwork, BuildResult, Network, NetworkTransactionBuilder, NetworkWallet,
+    TransactionBuilder, TransactionBuilderError,
 };
 use alloy_primitives::{Address, Bytes, ChainId, TxKind, U256};
 use alloy_rpc_types_eth::{AccessList, TransactionInputKind, TransactionRequest};
 use alloy_serde::WithOtherFields;
 use std::ops::{Deref, DerefMut};
 
-impl TransactionBuilder<AnyNetwork> for WithOtherFields<TransactionRequest> {
+impl TransactionBuilder for WithOtherFields<TransactionRequest> {
     fn chain_id(&self) -> Option<ChainId> {
         self.deref().chain_id()
     }
@@ -110,16 +110,18 @@ impl TransactionBuilder<AnyNetwork> for WithOtherFields<TransactionRequest> {
         self.deref_mut().set_access_list(access_list)
     }
 
-    fn complete_type(&self, ty: <AnyNetwork as Network>::TxType) -> Result<(), Vec<&'static str>> {
-        self.deref().complete_type(ty.try_into().map_err(|_| vec!["unsupported_transaction_type"])?)
-    }
-
     fn can_submit(&self) -> bool {
         self.deref().can_submit()
     }
 
     fn can_build(&self) -> bool {
         self.deref().can_build()
+    }
+}
+
+impl NetworkTransactionBuilder<AnyNetwork> for WithOtherFields<TransactionRequest> {
+    fn complete_type(&self, ty: <AnyNetwork as Network>::TxType) -> Result<(), Vec<&'static str>> {
+        self.deref().complete_type(ty.try_into().map_err(|_| vec!["unsupported_transaction_type"])?)
     }
 
     #[doc(alias = "output_transaction_type")]

--- a/crates/network/src/any/builder.rs
+++ b/crates/network/src/any/builder.rs
@@ -1,13 +1,13 @@
 use crate::{
     any::AnyNetwork, BuildResult, Network, NetworkTransactionBuilder, NetworkWallet,
-    TransactionBuilderDyn, TransactionBuilderError,
+    DynTransactionBuilder, TransactionBuilderError,
 };
 use alloy_primitives::{Address, Bytes, ChainId, TxKind, U256};
 use alloy_rpc_types_eth::{AccessList, TransactionInputKind, TransactionRequest};
 use alloy_serde::WithOtherFields;
 use std::ops::{Deref, DerefMut};
 
-impl TransactionBuilderDyn for WithOtherFields<TransactionRequest> {
+impl DynTransactionBuilder for WithOtherFields<TransactionRequest> {
     fn chain_id(&self) -> Option<ChainId> {
         self.deref().chain_id()
     }

--- a/crates/network/src/any/builder.rs
+++ b/crates/network/src/any/builder.rs
@@ -1,13 +1,13 @@
 use crate::{
     any::AnyNetwork, BuildResult, Network, NetworkTransactionBuilder, NetworkWallet,
-    TransactionBuilder, TransactionBuilderError,
+    TransactionBuilderDyn, TransactionBuilderError,
 };
 use alloy_primitives::{Address, Bytes, ChainId, TxKind, U256};
 use alloy_rpc_types_eth::{AccessList, TransactionInputKind, TransactionRequest};
 use alloy_serde::WithOtherFields;
 use std::ops::{Deref, DerefMut};
 
-impl TransactionBuilder for WithOtherFields<TransactionRequest> {
+impl TransactionBuilderDyn for WithOtherFields<TransactionRequest> {
     fn chain_id(&self) -> Option<ChainId> {
         self.deref().chain_id()
     }
@@ -32,11 +32,11 @@ impl TransactionBuilder for WithOtherFields<TransactionRequest> {
         self.deref().input()
     }
 
-    fn set_input<T: Into<Bytes>>(&mut self, input: T) {
+    fn set_input(&mut self, input: Bytes) {
         self.deref_mut().set_input(input);
     }
 
-    fn set_input_kind<T: Into<Bytes>>(&mut self, input: T, kind: TransactionInputKind) {
+    fn set_input_kind(&mut self, input: Bytes, kind: TransactionInputKind) {
         self.deref_mut().set_input_kind(input, kind)
     }
 
@@ -118,6 +118,8 @@ impl TransactionBuilder for WithOtherFields<TransactionRequest> {
         self.deref().can_build()
     }
 }
+
+impl crate::TransactionBuilder for WithOtherFields<TransactionRequest> {}
 
 impl NetworkTransactionBuilder<AnyNetwork> for WithOtherFields<TransactionRequest> {
     fn complete_type(&self, ty: <AnyNetwork as Network>::TxType) -> Result<(), Vec<&'static str>> {

--- a/crates/network/src/any/builder.rs
+++ b/crates/network/src/any/builder.rs
@@ -1,6 +1,6 @@
 use crate::{
-    any::AnyNetwork, BuildResult, Network, NetworkTransactionBuilder, NetworkWallet,
-    DynTransactionBuilder, TransactionBuilderError,
+    any::AnyNetwork, BuildResult, DynTransactionBuilder, Network, NetworkTransactionBuilder,
+    NetworkWallet, TransactionBuilderError,
 };
 use alloy_primitives::{Address, Bytes, ChainId, TxKind, U256};
 use alloy_rpc_types_eth::{AccessList, TransactionInputKind, TransactionRequest};

--- a/crates/network/src/ethereum/builder.rs
+++ b/crates/network/src/ethereum/builder.rs
@@ -1,12 +1,12 @@
 use crate::{
-    BuildResult, Ethereum, Network, NetworkWallet, TransactionBuilder, TransactionBuilder7702,
-    TransactionBuilderError,
+    BuildResult, Ethereum, Network, NetworkTransactionBuilder, NetworkWallet, TransactionBuilder,
+    TransactionBuilder7702, TransactionBuilderError,
 };
 use alloy_consensus::{TxType, TypedTransaction};
 use alloy_primitives::{Address, Bytes, ChainId, TxKind, U256};
 use alloy_rpc_types_eth::{request::TransactionRequest, AccessList, TransactionInputKind};
 
-impl TransactionBuilder<Ethereum> for TransactionRequest {
+impl TransactionBuilder for TransactionRequest {
     fn chain_id(&self) -> Option<ChainId> {
         self.chain_id
     }
@@ -115,16 +115,6 @@ impl TransactionBuilder<Ethereum> for TransactionRequest {
         self.access_list = Some(access_list);
     }
 
-    fn complete_type(&self, ty: TxType) -> Result<(), Vec<&'static str>> {
-        match ty {
-            TxType::Legacy => self.complete_legacy(),
-            TxType::Eip2930 => self.complete_2930(),
-            TxType::Eip1559 => self.complete_1559(),
-            TxType::Eip4844 => self.complete_4844(),
-            TxType::Eip7702 => self.complete_7702(),
-        }
-    }
-
     fn can_submit(&self) -> bool {
         // value and data may be None. If they are, they will be set to default.
         // gas fields and nonce may be None, if they are, they will be populated
@@ -148,6 +138,17 @@ impl TransactionBuilder<Ethereum> for TransactionRequest {
 
         let eip7702 = eip1559 && self.authorization_list().is_some();
         common && (legacy || eip2930 || eip1559 || eip4844 || eip7702)
+    }
+}
+impl NetworkTransactionBuilder<Ethereum> for TransactionRequest {
+    fn complete_type(&self, ty: TxType) -> Result<(), Vec<&'static str>> {
+        match ty {
+            TxType::Legacy => self.complete_legacy(),
+            TxType::Eip2930 => self.complete_2930(),
+            TxType::Eip1559 => self.complete_1559(),
+            TxType::Eip4844 => self.complete_4844(),
+            TxType::Eip7702 => self.complete_7702(),
+        }
     }
 
     #[doc(alias = "output_transaction_type")]
@@ -185,7 +186,8 @@ impl TransactionBuilder<Ethereum> for TransactionRequest {
 #[cfg(test)]
 mod tests {
     use crate::{
-        TransactionBuilder, TransactionBuilder4844, TransactionBuilder7702, TransactionBuilderError,
+        NetworkTransactionBuilder, TransactionBuilder, TransactionBuilder4844,
+        TransactionBuilder7702, TransactionBuilderError,
     };
     use alloy_consensus::{BlobTransactionSidecar, TxEip1559, TxType, TypedTransaction};
     use alloy_eips::eip7702::Authorization;

--- a/crates/network/src/ethereum/builder.rs
+++ b/crates/network/src/ethereum/builder.rs
@@ -1,6 +1,6 @@
 use crate::{
-    BuildResult, Ethereum, Network, NetworkTransactionBuilder, NetworkWallet, TransactionBuilder,
-    TransactionBuilder7702, DynTransactionBuilder, TransactionBuilderError,
+    BuildResult, DynTransactionBuilder, Ethereum, Network, NetworkTransactionBuilder,
+    NetworkWallet, TransactionBuilder, TransactionBuilder7702, TransactionBuilderError,
 };
 use alloy_consensus::{TxType, TypedTransaction};
 use alloy_primitives::{Address, Bytes, ChainId, TxKind, U256};

--- a/crates/network/src/ethereum/builder.rs
+++ b/crates/network/src/ethereum/builder.rs
@@ -1,12 +1,12 @@
 use crate::{
     BuildResult, Ethereum, Network, NetworkTransactionBuilder, NetworkWallet, TransactionBuilder,
-    TransactionBuilder7702, TransactionBuilderError,
+    TransactionBuilder7702, TransactionBuilderDyn, TransactionBuilderError,
 };
 use alloy_consensus::{TxType, TypedTransaction};
 use alloy_primitives::{Address, Bytes, ChainId, TxKind, U256};
 use alloy_rpc_types_eth::{request::TransactionRequest, AccessList, TransactionInputKind};
 
-impl TransactionBuilder for TransactionRequest {
+impl TransactionBuilderDyn for TransactionRequest {
     fn chain_id(&self) -> Option<ChainId> {
         self.chain_id
     }
@@ -31,18 +31,17 @@ impl TransactionBuilder for TransactionRequest {
         self.input.input()
     }
 
-    fn set_input<T: Into<Bytes>>(&mut self, input: T) {
-        self.input.input = Some(input.into());
+    fn set_input(&mut self, input: Bytes) {
+        self.input.input = Some(input);
     }
 
-    fn set_input_kind<T: Into<Bytes>>(&mut self, input: T, kind: TransactionInputKind) {
+    fn set_input_kind(&mut self, input: Bytes, kind: TransactionInputKind) {
         match kind {
-            TransactionInputKind::Input => self.input.input = Some(input.into()),
-            TransactionInputKind::Data => self.input.data = Some(input.into()),
+            TransactionInputKind::Input => self.input.input = Some(input),
+            TransactionInputKind::Data => self.input.data = Some(input),
             TransactionInputKind::Both => {
-                let bytes = input.into();
-                self.input.input = Some(bytes.clone());
-                self.input.data = Some(bytes);
+                self.input.input = Some(input.clone());
+                self.input.data = Some(input);
             }
         }
     }
@@ -140,6 +139,9 @@ impl TransactionBuilder for TransactionRequest {
         common && (legacy || eip2930 || eip1559 || eip4844 || eip7702)
     }
 }
+
+impl TransactionBuilder for TransactionRequest {}
+
 impl NetworkTransactionBuilder<Ethereum> for TransactionRequest {
     fn complete_type(&self, ty: TxType) -> Result<(), Vec<&'static str>> {
         match ty {

--- a/crates/network/src/ethereum/builder.rs
+++ b/crates/network/src/ethereum/builder.rs
@@ -1,12 +1,12 @@
 use crate::{
     BuildResult, Ethereum, Network, NetworkTransactionBuilder, NetworkWallet, TransactionBuilder,
-    TransactionBuilder7702, TransactionBuilderDyn, TransactionBuilderError,
+    TransactionBuilder7702, DynTransactionBuilder, TransactionBuilderError,
 };
 use alloy_consensus::{TxType, TypedTransaction};
 use alloy_primitives::{Address, Bytes, ChainId, TxKind, U256};
 use alloy_rpc_types_eth::{request::TransactionRequest, AccessList, TransactionInputKind};
 
-impl TransactionBuilderDyn for TransactionRequest {
+impl DynTransactionBuilder for TransactionRequest {
     fn chain_id(&self) -> Option<ChainId> {
         self.chain_id
     }

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -16,7 +16,8 @@ mod transaction;
 pub use transaction::{
     BuildResult, FullSigner, FullSignerSync, NetworkTransactionBuilder, NetworkWallet,
     TransactionBuilder, TransactionBuilder4844, TransactionBuilder7594, TransactionBuilder7702,
-    TransactionBuilderError, TxSigner, TxSignerSync, UnbuiltTransactionError,
+    TransactionBuilderDyn, TransactionBuilderError, TxSigner, TxSignerSync,
+    UnbuiltTransactionError,
 };
 
 mod ethereum;

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -14,8 +14,8 @@ use core::fmt::{Debug, Display};
 
 mod transaction;
 pub use transaction::{
-    BuildResult, FullSigner, FullSignerSync, NetworkWallet, TransactionBuilder,
-    TransactionBuilder4844, TransactionBuilder7594, TransactionBuilder7702,
+    BuildResult, FullSigner, FullSignerSync, NetworkTransactionBuilder, NetworkWallet,
+    TransactionBuilder, TransactionBuilder4844, TransactionBuilder7594, TransactionBuilder7702,
     TransactionBuilderError, TxSigner, TxSignerSync, UnbuiltTransactionError,
 };
 
@@ -80,7 +80,7 @@ pub trait Network: Debug + Clone + Copy + Sized + Send + Sync + 'static {
     /// The JSON body of a transaction request.
     #[doc(alias = "TxRequest")]
     type TransactionRequest: RpcObject
-        + TransactionBuilder<Self>
+        + NetworkTransactionBuilder<Self>
         + Debug
         + From<Self::TxEnvelope>
         + From<Self::UnsignedTx>;

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -16,7 +16,7 @@ mod transaction;
 pub use transaction::{
     BuildResult, FullSigner, FullSignerSync, NetworkTransactionBuilder, NetworkWallet,
     TransactionBuilder, TransactionBuilder4844, TransactionBuilder7594, TransactionBuilder7702,
-    TransactionBuilderDyn, TransactionBuilderError, TxSigner, TxSignerSync,
+    DynTransactionBuilder, TransactionBuilderError, TxSigner, TxSignerSync,
     UnbuiltTransactionError,
 };
 

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -14,9 +14,9 @@ use core::fmt::{Debug, Display};
 
 mod transaction;
 pub use transaction::{
-    BuildResult, FullSigner, FullSignerSync, NetworkTransactionBuilder, NetworkWallet,
-    TransactionBuilder, TransactionBuilder4844, TransactionBuilder7594, TransactionBuilder7702,
-    DynTransactionBuilder, TransactionBuilderError, TxSigner, TxSignerSync,
+    BuildResult, DynTransactionBuilder, FullSigner, FullSignerSync, NetworkTransactionBuilder,
+    NetworkWallet, TransactionBuilder, TransactionBuilder4844, TransactionBuilder7594,
+    TransactionBuilder7702, TransactionBuilderError, TxSigner, TxSignerSync,
     UnbuiltTransactionError,
 };
 

--- a/crates/network/src/transaction/builder.rs
+++ b/crates/network/src/transaction/builder.rs
@@ -69,7 +69,7 @@ impl<N: Network> TransactionBuilderError<N> {
 /// object-safe. For generic wrapper setters (e.g., `set_input<T: Into<Bytes>>`), use
 /// [`TransactionBuilder`].
 #[doc(alias = "TxBuilderDyn")]
-pub trait DynTransactionBuilder: Send + Sync {
+pub trait DynTransactionBuilder: Send + Sync + 'static {
     /// Get the chain ID for the transaction.
     fn chain_id(&self) -> Option<ChainId>;
 
@@ -202,9 +202,7 @@ pub trait DynTransactionBuilder: Send + Sync {
 /// The `Sized` bound enables consuming methods and builder patterns while maintaining default
 /// implementations inherited from [`DynTransactionBuilder`].
 #[doc(alias = "TxBuilder")]
-pub trait TransactionBuilder:
-    DynTransactionBuilder + Default + Sized + Send + Sync + 'static
-{
+pub trait TransactionBuilder: DynTransactionBuilder + Default {
     /// Builder-pattern method for setting the chain ID.
     fn with_chain_id(mut self, chain_id: ChainId) -> Self {
         self.set_chain_id(chain_id);

--- a/crates/network/src/transaction/builder.rs
+++ b/crates/network/src/transaction/builder.rs
@@ -57,16 +57,13 @@ impl<N: Network> TransactionBuilderError<N> {
     }
 }
 
-/// A Transaction builder for a network.
+/// Base Transaction builder.
 ///
 /// Transaction builders are primarily used to construct typed transactions that can be signed with
 /// [`TransactionBuilder::build`], or unsigned typed transactions with
 /// [`TransactionBuilder::build_unsigned`].
-///
-/// Transaction builders should be able to construct all available transaction types on a given
-/// network.
 #[doc(alias = "TxBuilder")]
-pub trait TransactionBuilder<N: Network>: Default + Sized + Send + Sync + 'static {
+pub trait TransactionBuilder: Default + Sized + Send + Sync + 'static {
     /// Get the chain ID for the transaction.
     fn chain_id(&self) -> Option<ChainId>;
 
@@ -294,6 +291,36 @@ pub trait TransactionBuilder<N: Network>: Default + Sized + Send + Sync + 'stati
         self
     }
 
+    /// Apply a function to the builder, returning the modified builder.
+    fn apply<F>(self, f: F) -> Self
+    where
+        F: FnOnce(Self) -> Self,
+    {
+        f(self)
+    }
+
+    /// Apply a fallible function to the builder, returning the modified builder or an error.
+    fn try_apply<F, E>(self, f: F) -> Result<Self, E>
+    where
+        F: FnOnce(Self) -> Result<Self, E>,
+    {
+        f(self)
+    }
+
+    /// True if the builder contains all necessary information to be submitted
+    /// to the `eth_sendTransaction` endpoint.
+    fn can_submit(&self) -> bool;
+
+    /// True if the builder contains all necessary information to be built into
+    /// a valid transaction.
+    fn can_build(&self) -> bool;
+}
+
+/// Network-specific transaction builder operations.
+///
+/// Network Transaction builders should be able to construct all available transaction types on a
+/// given network.
+pub trait NetworkTransactionBuilder<N: Network>: TransactionBuilder {
     /// Check if all necessary keys are present to build the specified type,
     /// returning a list of missing keys.
     fn complete_type(&self, ty: N::TxType) -> Result<(), Vec<&'static str>>;
@@ -320,30 +347,6 @@ pub trait TransactionBuilder<N: Network>: Default + Sized + Send + Sync + 'stati
         self.assert_preferred(ty);
         self
     }
-
-    /// Apply a function to the builder, returning the modified builder.
-    fn apply<F>(self, f: F) -> Self
-    where
-        F: FnOnce(Self) -> Self,
-    {
-        f(self)
-    }
-
-    /// Apply a fallible function to the builder, returning the modified builder or an error.
-    fn try_apply<F, E>(self, f: F) -> Result<Self, E>
-    where
-        F: FnOnce(Self) -> Result<Self, E>,
-    {
-        f(self)
-    }
-
-    /// True if the builder contains all necessary information to be submitted
-    /// to the `eth_sendTransaction` endpoint.
-    fn can_submit(&self) -> bool;
-
-    /// True if the builder contains all necessary information to be built into
-    /// a valid transaction.
-    fn can_build(&self) -> bool;
 
     /// Returns the transaction type that this builder will attempt to build.
     /// This does not imply that the builder is ready to build.

--- a/crates/network/src/transaction/builder.rs
+++ b/crates/network/src/transaction/builder.rs
@@ -57,24 +57,24 @@ impl<N: Network> TransactionBuilderError<N> {
     }
 }
 
-/// Base Transaction builder.
+/// Object-safe transaction builder trait.
 ///
-/// Transaction builders are primarily used to construct typed transactions that can be signed with
-/// [`TransactionBuilder::build`], or unsigned typed transactions with
-/// [`TransactionBuilder::build_unsigned`].
-#[doc(alias = "TxBuilder")]
-pub trait TransactionBuilder: Default + Sized + Send + Sync + 'static {
+/// This is the core trait for building transactions with support for dynamic dispatch (`dyn
+/// TransactionBuilderDyn`). It provides:
+///
+/// - **Getters** for all transaction fields (`chain_id()`, `nonce()`, `input()`, etc.)
+/// - **Setters** with concretized `Bytes` parameters (no generic type parameters)
+///
+/// All setter methods take concrete types rather than generics, enabling the trait to be
+/// object-safe. For generic wrapper setters (e.g., `set_input<T: Into<Bytes>>`), use
+/// [`TransactionBuilder`].
+#[doc(alias = "TxBuilderDyn")]
+pub trait TransactionBuilderDyn: Send + Sync {
     /// Get the chain ID for the transaction.
     fn chain_id(&self) -> Option<ChainId>;
 
     /// Set the chain ID for the transaction.
     fn set_chain_id(&mut self, chain_id: ChainId);
-
-    /// Builder-pattern method for setting the chain ID.
-    fn with_chain_id(mut self, chain_id: ChainId) -> Self {
-        self.set_chain_id(chain_id);
-        self
-    }
 
     /// Get the nonce for the transaction.
     fn nonce(&self) -> Option<u64>;
@@ -85,40 +85,17 @@ pub trait TransactionBuilder: Default + Sized + Send + Sync + 'static {
     /// Takes the nonce out of the transaction, clearing it.
     fn take_nonce(&mut self) -> Option<u64>;
 
-    /// Builder-pattern method for setting the nonce.
-    fn with_nonce(mut self, nonce: u64) -> Self {
-        self.set_nonce(nonce);
-        self
-    }
-
-    /// Takes the nonce out of the transaction, clearing it.
-    fn without_nonce(mut self) -> Self {
-        self.take_nonce();
-        self
-    }
-
     /// Get the input data for the transaction.
     fn input(&self) -> Option<&Bytes>;
 
-    /// Set the input data for the transaction.
-    fn set_input<T: Into<Bytes>>(&mut self, input: T);
+    /// Set the input data for the transaction (concretized from generic).
+    fn set_input(&mut self, input: Bytes);
 
-    /// Builder-pattern method for setting the input data.
-    fn with_input<T: Into<Bytes>>(mut self, input: T) -> Self {
-        self.set_input(input);
-        self
-    }
-
-    /// Set the input data for the transaction, respecting the input kind
-    fn set_input_kind<T: Into<Bytes>>(&mut self, input: T, _: TransactionInputKind) {
+    /// Set the input data for the transaction, respecting the input kind (concretized from
+    /// generic).
+    fn set_input_kind(&mut self, input: Bytes, _kind: TransactionInputKind) {
         // forward all to input by default
         self.set_input(input);
-    }
-
-    /// Builder-pattern method for setting the input data, respecting the input kind
-    fn with_input_kind<T: Into<Bytes>>(mut self, input: T, kind: TransactionInputKind) -> Self {
-        self.set_input_kind(input, kind);
-        self
     }
 
     /// Get the sender for the transaction.
@@ -126,12 +103,6 @@ pub trait TransactionBuilder: Default + Sized + Send + Sync + 'static {
 
     /// Set the sender for the transaction.
     fn set_from(&mut self, from: Address);
-
-    /// Builder-pattern method for setting the sender.
-    fn with_from(mut self, from: Address) -> Self {
-        self.set_from(from);
-        self
-    }
 
     /// Get the kind of transaction.
     fn kind(&self) -> Option<TxKind>;
@@ -141,12 +112,6 @@ pub trait TransactionBuilder: Default + Sized + Send + Sync + 'static {
 
     /// Set the kind of transaction.
     fn set_kind(&mut self, kind: TxKind);
-
-    /// Builder-pattern method for setting the kind of transaction.
-    fn with_kind(mut self, kind: TxKind) -> Self {
-        self.set_kind(kind);
-        self
-    }
 
     /// Get the recipient for the transaction.
     fn to(&self) -> Option<Address> {
@@ -161,50 +126,9 @@ pub trait TransactionBuilder: Default + Sized + Send + Sync + 'static {
         self.set_kind(to.into());
     }
 
-    /// Builder-pattern method for setting the recipient.
-    fn with_to(mut self, to: Address) -> Self {
-        self.set_to(to);
-        self
-    }
-
     /// Set the `to` field to a create call.
     fn set_create(&mut self) {
         self.set_kind(TxKind::Create);
-    }
-
-    /// Set the `to` field to a create call.
-    fn into_create(mut self) -> Self {
-        self.set_create();
-        self
-    }
-
-    /// Deploy the code by making a create call with data. This will set the
-    /// `to` field to [`TxKind::Create`].
-    fn set_deploy_code<T: Into<Bytes>>(&mut self, code: T) {
-        self.set_input(code.into());
-        self.set_create()
-    }
-
-    /// Deploy the code by making a create call with data. This will set the
-    /// `to` field to [`TxKind::Create`].
-    fn with_deploy_code<T: Into<Bytes>>(mut self, code: T) -> Self {
-        self.set_deploy_code(code);
-        self
-    }
-
-    /// Set the data field to a contract call. This will clear the `to` field
-    /// if it is set to [`TxKind::Create`].
-    fn set_call<T: SolCall>(&mut self, t: &T) {
-        self.set_input(t.abi_encode());
-        if matches!(self.kind(), Some(TxKind::Create)) {
-            self.clear_kind();
-        }
-    }
-
-    /// Make a contract call with data.
-    fn with_call<T: SolCall>(mut self, t: &T) -> Self {
-        self.set_call(t);
-        self
     }
 
     /// Calculates the address that will be created by the transaction, if any.
@@ -226,35 +150,17 @@ pub trait TransactionBuilder: Default + Sized + Send + Sync + 'static {
     /// Set the value for the transaction.
     fn set_value(&mut self, value: U256);
 
-    /// Builder-pattern method for setting the value.
-    fn with_value(mut self, value: U256) -> Self {
-        self.set_value(value);
-        self
-    }
-
     /// Get the legacy gas price for the transaction.
     fn gas_price(&self) -> Option<u128>;
 
     /// Set the legacy gas price for the transaction.
     fn set_gas_price(&mut self, gas_price: u128);
 
-    /// Builder-pattern method for setting the legacy gas price.
-    fn with_gas_price(mut self, gas_price: u128) -> Self {
-        self.set_gas_price(gas_price);
-        self
-    }
-
     /// Get the max fee per gas for the transaction.
     fn max_fee_per_gas(&self) -> Option<u128>;
 
-    /// Set the max fee per gas  for the transaction.
+    /// Set the max fee per gas for the transaction.
     fn set_max_fee_per_gas(&mut self, max_fee_per_gas: u128);
-
-    /// Builder-pattern method for setting max fee per gas .
-    fn with_max_fee_per_gas(mut self, max_fee_per_gas: u128) -> Self {
-        self.set_max_fee_per_gas(max_fee_per_gas);
-        self
-    }
 
     /// Get the max priority fee per gas for the transaction.
     fn max_priority_fee_per_gas(&self) -> Option<u128>;
@@ -262,28 +168,174 @@ pub trait TransactionBuilder: Default + Sized + Send + Sync + 'static {
     /// Set the max priority fee per gas for the transaction.
     fn set_max_priority_fee_per_gas(&mut self, max_priority_fee_per_gas: u128);
 
-    /// Builder-pattern method for setting max priority fee per gas.
-    fn with_max_priority_fee_per_gas(mut self, max_priority_fee_per_gas: u128) -> Self {
-        self.set_max_priority_fee_per_gas(max_priority_fee_per_gas);
-        self
-    }
     /// Get the gas limit for the transaction.
     fn gas_limit(&self) -> Option<u64>;
 
     /// Set the gas limit for the transaction.
     fn set_gas_limit(&mut self, gas_limit: u64);
 
-    /// Builder-pattern method for setting the gas limit.
-    fn with_gas_limit(mut self, gas_limit: u64) -> Self {
-        self.set_gas_limit(gas_limit);
-        self
-    }
-
     /// Get the EIP-2930 access list for the transaction.
     fn access_list(&self) -> Option<&AccessList>;
 
     /// Sets the EIP-2930 access list.
     fn set_access_list(&mut self, access_list: AccessList);
+
+    /// True if the builder contains all necessary information to be submitted
+    /// to the `eth_sendTransaction` endpoint.
+    fn can_submit(&self) -> bool;
+
+    /// True if the builder contains all necessary information to be built into
+    /// a valid transaction.
+    fn can_build(&self) -> bool;
+}
+
+/// Sized transaction builder with builder-pattern and generic wrappers.
+///
+/// This trait extends [`TransactionBuilderDyn`] with:
+///
+/// - **Generic setter wrappers**: `set_input<T: Into<Bytes>>()` accept any type convertible to
+///   `Bytes`
+/// - **Builder-pattern methods**: `with_*()` methods return `self` for method chaining
+/// - **Functional methods**: `apply()` and `try_apply()` for composable transformations
+/// - **Specialized builders**: `with_deploy_code()`, `with_call()` for contract interactions
+///
+/// The `Sized` bound enables consuming methods and builder patterns while maintaining default
+/// implementations inherited from [`TransactionBuilderDyn`].
+#[doc(alias = "TxBuilder")]
+pub trait TransactionBuilder:
+    TransactionBuilderDyn + Default + Sized + Send + Sync + 'static
+{
+    /// Builder-pattern method for setting the chain ID.
+    fn with_chain_id(mut self, chain_id: ChainId) -> Self {
+        self.set_chain_id(chain_id);
+        self
+    }
+
+    /// Builder-pattern method for setting the nonce.
+    fn with_nonce(mut self, nonce: u64) -> Self {
+        self.set_nonce(nonce);
+        self
+    }
+
+    /// Takes the nonce out of the transaction, clearing it.
+    fn without_nonce(mut self) -> Self {
+        self.take_nonce();
+        self
+    }
+
+    /// Set the input data for the transaction (generic wrapper).
+    /// Delegates to [`TransactionBuilderDyn::set_input`] to combine ergonomic generics with
+    /// object-safety.
+    fn set_input<T: Into<Bytes>>(&mut self, input: T) {
+        TransactionBuilderDyn::set_input(self, input.into());
+    }
+
+    /// Builder-pattern method for setting the input data.
+    fn with_input<T: Into<Bytes>>(mut self, input: T) -> Self {
+        TransactionBuilder::set_input(&mut self, input);
+        self
+    }
+
+    /// Set the input data for the transaction, respecting the input kind (generic wrapper).
+    /// Delegates to [`TransactionBuilderDyn::set_input_kind`] to combine ergonomic generics with
+    /// object-safety.
+    fn set_input_kind<T: Into<Bytes>>(&mut self, input: T, kind: TransactionInputKind) {
+        TransactionBuilderDyn::set_input_kind(self, input.into(), kind);
+    }
+
+    /// Builder-pattern method for setting the input data, respecting the input kind
+    fn with_input_kind<T: Into<Bytes>>(mut self, input: T, kind: TransactionInputKind) -> Self {
+        TransactionBuilder::set_input_kind(&mut self, input, kind);
+        self
+    }
+
+    /// Builder-pattern method for setting the sender.
+    fn with_from(mut self, from: Address) -> Self {
+        self.set_from(from);
+        self
+    }
+
+    /// Builder-pattern method for setting the kind of transaction.
+    fn with_kind(mut self, kind: TxKind) -> Self {
+        self.set_kind(kind);
+        self
+    }
+
+    /// Builder-pattern method for setting the recipient.
+    fn with_to(mut self, to: Address) -> Self {
+        self.set_to(to);
+        self
+    }
+
+    /// Set the `to` field to a create call.
+    fn into_create(mut self) -> Self {
+        self.set_create();
+        self
+    }
+
+    /// Deploy the code by making a create call with data. This will set the
+    /// `to` field to [`TxKind::Create`].
+    ///
+    /// This delegates to [`TransactionBuilderDyn::set_input`] to handle the generic input
+    /// conversion.
+    fn set_deploy_code<T: Into<Bytes>>(&mut self, code: T) {
+        TransactionBuilderDyn::set_input(self, code.into());
+        self.set_create()
+    }
+
+    /// Deploy the code by making a create call with data. This will set the
+    /// `to` field to [`TxKind::Create`].
+    fn with_deploy_code<T: Into<Bytes>>(mut self, code: T) -> Self {
+        self.set_deploy_code(code);
+        self
+    }
+
+    /// Set the data field to a contract call. This will clear the `to` field
+    /// if it is set to [`TxKind::Create`].
+    ///
+    /// This delegates to [`TransactionBuilderDyn::set_input`] to store the ABI-encoded call data.
+    fn set_call<T: SolCall>(&mut self, t: &T) {
+        TransactionBuilderDyn::set_input(self, t.abi_encode().into());
+        if matches!(self.kind(), Some(TxKind::Create)) {
+            self.clear_kind();
+        }
+    }
+
+    /// Make a contract call with data.
+    fn with_call<T: SolCall>(mut self, t: &T) -> Self {
+        self.set_call(t);
+        self
+    }
+
+    /// Builder-pattern method for setting the value.
+    fn with_value(mut self, value: U256) -> Self {
+        self.set_value(value);
+        self
+    }
+
+    /// Builder-pattern method for setting the legacy gas price.
+    fn with_gas_price(mut self, gas_price: u128) -> Self {
+        self.set_gas_price(gas_price);
+        self
+    }
+
+    /// Builder-pattern method for setting max fee per gas .
+    fn with_max_fee_per_gas(mut self, max_fee_per_gas: u128) -> Self {
+        self.set_max_fee_per_gas(max_fee_per_gas);
+        self
+    }
+
+    /// Builder-pattern method for setting max priority fee per gas.
+    fn with_max_priority_fee_per_gas(mut self, max_priority_fee_per_gas: u128) -> Self {
+        self.set_max_priority_fee_per_gas(max_priority_fee_per_gas);
+        self
+    }
+
+    /// Builder-pattern method for setting the gas limit.
+    fn with_gas_limit(mut self, gas_limit: u64) -> Self {
+        self.set_gas_limit(gas_limit);
+        self
+    }
 
     /// Builder-pattern method for setting the access list.
     fn with_access_list(mut self, access_list: AccessList) -> Self {
@@ -306,20 +358,16 @@ pub trait TransactionBuilder: Default + Sized + Send + Sync + 'static {
     {
         f(self)
     }
-
-    /// True if the builder contains all necessary information to be submitted
-    /// to the `eth_sendTransaction` endpoint.
-    fn can_submit(&self) -> bool;
-
-    /// True if the builder contains all necessary information to be built into
-    /// a valid transaction.
-    fn can_build(&self) -> bool;
 }
 
 /// Network-specific transaction builder operations.
 ///
-/// Network Transaction builders should be able to construct all available transaction types on a
-/// given network.
+/// This trait extends [`TransactionBuilder`] with network-dependent functionality. It enables:
+///
+/// - **Transaction request validation**: Check completeness for each transaction type
+/// - **Transaction Type detection**: Automatically determine the best transaction type based on
+///   fields
+/// - **Transaction building**: Construct signed envelope or typed transaction.
 pub trait NetworkTransactionBuilder<N: Network>: TransactionBuilder {
     /// Check if all necessary keys are present to build the specified type,
     /// returning a list of missing keys.

--- a/crates/network/src/transaction/builder.rs
+++ b/crates/network/src/transaction/builder.rs
@@ -193,14 +193,10 @@ pub trait DynTransactionBuilder: Send + Sync + 'static {
 ///
 /// This trait extends [`DynTransactionBuilder`] with:
 ///
-/// - **Generic setter wrappers**: `set_input<T: Into<Bytes>>()` accept any type convertible to
-///   `Bytes`
 /// - **Builder-pattern methods**: `with_*()` methods return `self` for method chaining
 /// - **Functional methods**: `apply()` and `try_apply()` for composable transformations
-/// - **Specialized builders**: `with_deploy_code()`, `with_call()` for contract interactions
-///
-/// The `Sized` bound enables consuming methods and builder patterns while maintaining default
-/// implementations inherited from [`DynTransactionBuilder`].
+/// - **Generic setter wrappers**: `set_input<T: Into<Bytes>>()` accept any type convertible to
+///   `Bytes`
 #[doc(alias = "TxBuilder")]
 pub trait TransactionBuilder: DynTransactionBuilder + Default {
     /// Builder-pattern method for setting the chain ID.

--- a/crates/network/src/transaction/builder.rs
+++ b/crates/network/src/transaction/builder.rs
@@ -60,7 +60,7 @@ impl<N: Network> TransactionBuilderError<N> {
 /// Object-safe transaction builder trait.
 ///
 /// This is the core trait for building transactions with support for dynamic dispatch (`dyn
-/// TransactionBuilderDyn`). It provides:
+/// DynTransactionBuilder`). It provides:
 ///
 /// - **Getters** for all transaction fields (`chain_id()`, `nonce()`, `input()`, etc.)
 /// - **Setters** with concretized `Bytes` parameters (no generic type parameters)
@@ -69,7 +69,7 @@ impl<N: Network> TransactionBuilderError<N> {
 /// object-safe. For generic wrapper setters (e.g., `set_input<T: Into<Bytes>>`), use
 /// [`TransactionBuilder`].
 #[doc(alias = "TxBuilderDyn")]
-pub trait TransactionBuilderDyn: Send + Sync {
+pub trait DynTransactionBuilder: Send + Sync {
     /// Get the chain ID for the transaction.
     fn chain_id(&self) -> Option<ChainId>;
 
@@ -191,7 +191,7 @@ pub trait TransactionBuilderDyn: Send + Sync {
 
 /// Sized transaction builder with builder-pattern and generic wrappers.
 ///
-/// This trait extends [`TransactionBuilderDyn`] with:
+/// This trait extends [`DynTransactionBuilder`] with:
 ///
 /// - **Generic setter wrappers**: `set_input<T: Into<Bytes>>()` accept any type convertible to
 ///   `Bytes`
@@ -200,10 +200,10 @@ pub trait TransactionBuilderDyn: Send + Sync {
 /// - **Specialized builders**: `with_deploy_code()`, `with_call()` for contract interactions
 ///
 /// The `Sized` bound enables consuming methods and builder patterns while maintaining default
-/// implementations inherited from [`TransactionBuilderDyn`].
+/// implementations inherited from [`DynTransactionBuilder`].
 #[doc(alias = "TxBuilder")]
 pub trait TransactionBuilder:
-    TransactionBuilderDyn + Default + Sized + Send + Sync + 'static
+    DynTransactionBuilder + Default + Sized + Send + Sync + 'static
 {
     /// Builder-pattern method for setting the chain ID.
     fn with_chain_id(mut self, chain_id: ChainId) -> Self {
@@ -224,10 +224,10 @@ pub trait TransactionBuilder:
     }
 
     /// Set the input data for the transaction (generic wrapper).
-    /// Delegates to [`TransactionBuilderDyn::set_input`] to combine ergonomic generics with
+    /// Delegates to [`DynTransactionBuilder::set_input`] to combine ergonomic generics with
     /// object-safety.
     fn set_input<T: Into<Bytes>>(&mut self, input: T) {
-        TransactionBuilderDyn::set_input(self, input.into());
+        DynTransactionBuilder::set_input(self, input.into());
     }
 
     /// Builder-pattern method for setting the input data.
@@ -237,10 +237,10 @@ pub trait TransactionBuilder:
     }
 
     /// Set the input data for the transaction, respecting the input kind (generic wrapper).
-    /// Delegates to [`TransactionBuilderDyn::set_input_kind`] to combine ergonomic generics with
+    /// Delegates to [`DynTransactionBuilder::set_input_kind`] to combine ergonomic generics with
     /// object-safety.
     fn set_input_kind<T: Into<Bytes>>(&mut self, input: T, kind: TransactionInputKind) {
-        TransactionBuilderDyn::set_input_kind(self, input.into(), kind);
+        DynTransactionBuilder::set_input_kind(self, input.into(), kind);
     }
 
     /// Builder-pattern method for setting the input data, respecting the input kind
@@ -276,10 +276,10 @@ pub trait TransactionBuilder:
     /// Deploy the code by making a create call with data. This will set the
     /// `to` field to [`TxKind::Create`].
     ///
-    /// This delegates to [`TransactionBuilderDyn::set_input`] to handle the generic input
+    /// This delegates to [`DynTransactionBuilder::set_input`] to handle the generic input
     /// conversion.
     fn set_deploy_code<T: Into<Bytes>>(&mut self, code: T) {
-        TransactionBuilderDyn::set_input(self, code.into());
+        DynTransactionBuilder::set_input(self, code.into());
         self.set_create()
     }
 
@@ -293,9 +293,9 @@ pub trait TransactionBuilder:
     /// Set the data field to a contract call. This will clear the `to` field
     /// if it is set to [`TxKind::Create`].
     ///
-    /// This delegates to [`TransactionBuilderDyn::set_input`] to store the ABI-encoded call data.
+    /// This delegates to [`DynTransactionBuilder::set_input`] to store the ABI-encoded call data.
     fn set_call<T: SolCall>(&mut self, t: &T) {
-        TransactionBuilderDyn::set_input(self, t.abi_encode().into());
+        DynTransactionBuilder::set_input(self, t.abi_encode().into());
         if matches!(self.kind(), Some(TxKind::Create)) {
             self.clear_kind();
         }

--- a/crates/network/src/transaction/mod.rs
+++ b/crates/network/src/transaction/mod.rs
@@ -1,7 +1,8 @@
 mod builder;
 pub use builder::{
-    BuildResult, TransactionBuilder, TransactionBuilder4844, TransactionBuilder7594,
-    TransactionBuilder7702, TransactionBuilderError, UnbuiltTransactionError,
+    BuildResult, NetworkTransactionBuilder, TransactionBuilder, TransactionBuilder4844,
+    TransactionBuilder7594, TransactionBuilder7702, TransactionBuilderError,
+    UnbuiltTransactionError,
 };
 
 mod signer;

--- a/crates/network/src/transaction/mod.rs
+++ b/crates/network/src/transaction/mod.rs
@@ -1,7 +1,7 @@
 mod builder;
 pub use builder::{
     BuildResult, NetworkTransactionBuilder, TransactionBuilder, TransactionBuilder4844,
-    TransactionBuilder7594, TransactionBuilder7702, TransactionBuilderDyn, TransactionBuilderError,
+    TransactionBuilder7594, TransactionBuilder7702, DynTransactionBuilder, TransactionBuilderError,
     UnbuiltTransactionError,
 };
 

--- a/crates/network/src/transaction/mod.rs
+++ b/crates/network/src/transaction/mod.rs
@@ -1,7 +1,7 @@
 mod builder;
 pub use builder::{
     BuildResult, NetworkTransactionBuilder, TransactionBuilder, TransactionBuilder4844,
-    TransactionBuilder7594, TransactionBuilder7702, TransactionBuilderError,
+    TransactionBuilder7594, TransactionBuilder7702, TransactionBuilderDyn, TransactionBuilderError,
     UnbuiltTransactionError,
 };
 

--- a/crates/network/src/transaction/mod.rs
+++ b/crates/network/src/transaction/mod.rs
@@ -1,8 +1,8 @@
 mod builder;
 pub use builder::{
-    BuildResult, NetworkTransactionBuilder, TransactionBuilder, TransactionBuilder4844,
-    TransactionBuilder7594, TransactionBuilder7702, DynTransactionBuilder, TransactionBuilderError,
-    UnbuiltTransactionError,
+    BuildResult, DynTransactionBuilder, NetworkTransactionBuilder, TransactionBuilder,
+    TransactionBuilder4844, TransactionBuilder7594, TransactionBuilder7702,
+    TransactionBuilderError, UnbuiltTransactionError,
 };
 
 mod signer;

--- a/crates/network/src/transaction/signer.rs
+++ b/crates/network/src/transaction/signer.rs
@@ -1,4 +1,4 @@
-use crate::{Network, TransactionBuilder};
+use crate::{Network, NetworkTransactionBuilder, TransactionBuilder};
 use alloy_consensus::SignableTransaction;
 use alloy_primitives::Address;
 use alloy_signer::{Signer, SignerSync};

--- a/crates/network/src/transaction/signer.rs
+++ b/crates/network/src/transaction/signer.rs
@@ -1,4 +1,4 @@
-use crate::{Network, NetworkTransactionBuilder, TransactionBuilder};
+use crate::{Network, NetworkTransactionBuilder, TransactionBuilderDyn};
 use alloy_consensus::SignableTransaction;
 use alloy_primitives::Address;
 use alloy_signer::{Signer, SignerSync};

--- a/crates/network/src/transaction/signer.rs
+++ b/crates/network/src/transaction/signer.rs
@@ -1,4 +1,4 @@
-use crate::{Network, NetworkTransactionBuilder, DynTransactionBuilder};
+use crate::{DynTransactionBuilder, Network, NetworkTransactionBuilder};
 use alloy_consensus::SignableTransaction;
 use alloy_primitives::Address;
 use alloy_signer::{Signer, SignerSync};

--- a/crates/network/src/transaction/signer.rs
+++ b/crates/network/src/transaction/signer.rs
@@ -1,4 +1,4 @@
-use crate::{Network, NetworkTransactionBuilder, TransactionBuilderDyn};
+use crate::{Network, NetworkTransactionBuilder, DynTransactionBuilder};
 use alloy_consensus::SignableTransaction;
 use alloy_primitives::Address;
 use alloy_signer::{Signer, SignerSync};

--- a/crates/provider/src/ext/anvil.rs
+++ b/crates/provider/src/ext/anvil.rs
@@ -2,7 +2,7 @@
 
 use crate::{PendingTransactionBuilder, Provider};
 use alloy_consensus::Blob;
-use alloy_network::{Network, TransactionBuilder};
+use alloy_network::{Network, TransactionBuilderDyn};
 use alloy_primitives::{Address, Bytes, TxHash, B256, U128, U256, U64};
 use alloy_rpc_types_anvil::{Forking, Metadata, MineOptions, NodeInfo, ReorgOptions};
 use alloy_rpc_types_eth::Block;

--- a/crates/provider/src/ext/anvil.rs
+++ b/crates/provider/src/ext/anvil.rs
@@ -2,7 +2,7 @@
 
 use crate::{PendingTransactionBuilder, Provider};
 use alloy_consensus::Blob;
-use alloy_network::{Network, DynTransactionBuilder};
+use alloy_network::{DynTransactionBuilder, Network};
 use alloy_primitives::{Address, Bytes, TxHash, B256, U128, U256, U64};
 use alloy_rpc_types_anvil::{Forking, Metadata, MineOptions, NodeInfo, ReorgOptions};
 use alloy_rpc_types_eth::Block;

--- a/crates/provider/src/ext/anvil.rs
+++ b/crates/provider/src/ext/anvil.rs
@@ -2,7 +2,7 @@
 
 use crate::{PendingTransactionBuilder, Provider};
 use alloy_consensus::Blob;
-use alloy_network::{Network, TransactionBuilderDyn};
+use alloy_network::{Network, DynTransactionBuilder};
 use alloy_primitives::{Address, Bytes, TxHash, B256, U128, U256, U64};
 use alloy_rpc_types_anvil::{Forking, Metadata, MineOptions, NodeInfo, ReorgOptions};
 use alloy_rpc_types_eth::Block;

--- a/crates/provider/src/ext/trace/mod.rs
+++ b/crates/provider/src/ext/trace/mod.rs
@@ -167,7 +167,7 @@ mod test {
     use super::*;
     use crate::{ext::test::async_ci_only, ProviderBuilder};
     use alloy_eips::{BlockNumberOrTag, Encodable2718};
-    use alloy_network::{EthereumWallet, TransactionBuilder};
+    use alloy_network::{EthereumWallet, NetworkTransactionBuilder, TransactionBuilder};
     use alloy_node_bindings::{utils::run_with_tempdir, Reth};
     use alloy_primitives::{address, U256};
     use alloy_rpc_types_eth::TransactionRequest;

--- a/crates/provider/src/fillers/chain_id.rs
+++ b/crates/provider/src/fillers/chain_id.rs
@@ -1,6 +1,6 @@
 use std::sync::{Arc, OnceLock};
 
-use alloy_network::{Network, TransactionBuilderDyn};
+use alloy_network::{Network, DynTransactionBuilder};
 use alloy_primitives::ChainId;
 use alloy_transport::TransportResult;
 

--- a/crates/provider/src/fillers/chain_id.rs
+++ b/crates/provider/src/fillers/chain_id.rs
@@ -1,6 +1,6 @@
 use std::sync::{Arc, OnceLock};
 
-use alloy_network::{Network, TransactionBuilder};
+use alloy_network::{Network, TransactionBuilderDyn};
 use alloy_primitives::ChainId;
 use alloy_transport::TransportResult;
 

--- a/crates/provider/src/fillers/chain_id.rs
+++ b/crates/provider/src/fillers/chain_id.rs
@@ -1,6 +1,6 @@
 use std::sync::{Arc, OnceLock};
 
-use alloy_network::{Network, DynTransactionBuilder};
+use alloy_network::{DynTransactionBuilder, Network};
 use alloy_primitives::ChainId;
 use alloy_transport::TransportResult;
 

--- a/crates/provider/src/fillers/gas.rs
+++ b/crates/provider/src/fillers/gas.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 use alloy_eips::eip4844::BLOB_TX_MIN_BLOB_GASPRICE;
 use alloy_json_rpc::RpcError;
-use alloy_network::{Network, TransactionBuilder, TransactionBuilder4844};
+use alloy_network::{Network, TransactionBuilder4844, TransactionBuilderDyn};
 use alloy_rpc_types_eth::BlockNumberOrTag;
 use alloy_transport::TransportResult;
 use futures::FutureExt;

--- a/crates/provider/src/fillers/gas.rs
+++ b/crates/provider/src/fillers/gas.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 use alloy_eips::eip4844::BLOB_TX_MIN_BLOB_GASPRICE;
 use alloy_json_rpc::RpcError;
-use alloy_network::{Network, TransactionBuilder4844, DynTransactionBuilder};
+use alloy_network::{DynTransactionBuilder, Network, TransactionBuilder4844};
 use alloy_rpc_types_eth::BlockNumberOrTag;
 use alloy_transport::TransportResult;
 use futures::FutureExt;

--- a/crates/provider/src/fillers/gas.rs
+++ b/crates/provider/src/fillers/gas.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 use alloy_eips::eip4844::BLOB_TX_MIN_BLOB_GASPRICE;
 use alloy_json_rpc::RpcError;
-use alloy_network::{Network, TransactionBuilder4844, TransactionBuilderDyn};
+use alloy_network::{Network, TransactionBuilder4844, DynTransactionBuilder};
 use alloy_rpc_types_eth::BlockNumberOrTag;
 use alloy_transport::TransportResult;
 use futures::FutureExt;

--- a/crates/provider/src/fillers/mod.rs
+++ b/crates/provider/src/fillers/mod.rs
@@ -374,7 +374,7 @@ where
     /// # use alloy_primitives::{address, U256};
     /// # use alloy_provider::ProviderBuilder;
     /// # use alloy_rpc_types_eth::TransactionRequest;
-    /// # use alloy_network::TransactionBuilder;
+    /// # use alloy_network::{NetworkTransactionBuilder, TransactionBuilder};
     ///
     /// async fn example() -> Result<(), Box<dyn std::error::Error>> {
     ///     // Create transaction request

--- a/crates/provider/src/fillers/nonce.rs
+++ b/crates/provider/src/fillers/nonce.rs
@@ -3,7 +3,7 @@ use crate::{
     provider::SendableTx,
     Provider,
 };
-use alloy_network::{Network, DynTransactionBuilder};
+use alloy_network::{DynTransactionBuilder, Network};
 use alloy_primitives::Address;
 use alloy_transport::TransportResult;
 use async_trait::async_trait;

--- a/crates/provider/src/fillers/nonce.rs
+++ b/crates/provider/src/fillers/nonce.rs
@@ -3,7 +3,7 @@ use crate::{
     provider::SendableTx,
     Provider,
 };
-use alloy_network::{Network, TransactionBuilderDyn};
+use alloy_network::{Network, DynTransactionBuilder};
 use alloy_primitives::Address;
 use alloy_transport::TransportResult;
 use async_trait::async_trait;

--- a/crates/provider/src/fillers/nonce.rs
+++ b/crates/provider/src/fillers/nonce.rs
@@ -3,7 +3,7 @@ use crate::{
     provider::SendableTx,
     Provider,
 };
-use alloy_network::{Network, TransactionBuilder};
+use alloy_network::{Network, TransactionBuilderDyn};
 use alloy_primitives::Address;
 use alloy_transport::TransportResult;
 use async_trait::async_trait;

--- a/crates/provider/src/fillers/wallet.rs
+++ b/crates/provider/src/fillers/wallet.rs
@@ -2,7 +2,7 @@ use std::fmt::Debug;
 
 use crate::{provider::SendableTx, Provider};
 use alloy_json_rpc::RpcError;
-use alloy_network::{Network, NetworkWallet, TransactionBuilder};
+use alloy_network::{Network, NetworkTransactionBuilder, NetworkWallet, TransactionBuilder};
 use alloy_transport::TransportResult;
 
 use super::{FillerControlFlow, TxFiller};

--- a/crates/provider/src/fillers/wallet.rs
+++ b/crates/provider/src/fillers/wallet.rs
@@ -2,7 +2,7 @@ use std::fmt::Debug;
 
 use crate::{provider::SendableTx, Provider};
 use alloy_json_rpc::RpcError;
-use alloy_network::{Network, NetworkTransactionBuilder, NetworkWallet, DynTransactionBuilder};
+use alloy_network::{DynTransactionBuilder, Network, NetworkTransactionBuilder, NetworkWallet};
 use alloy_transport::TransportResult;
 
 use super::{FillerControlFlow, TxFiller};

--- a/crates/provider/src/fillers/wallet.rs
+++ b/crates/provider/src/fillers/wallet.rs
@@ -2,7 +2,7 @@ use std::fmt::Debug;
 
 use crate::{provider::SendableTx, Provider};
 use alloy_json_rpc::RpcError;
-use alloy_network::{Network, NetworkTransactionBuilder, NetworkWallet, TransactionBuilder};
+use alloy_network::{Network, NetworkTransactionBuilder, NetworkWallet, TransactionBuilderDyn};
 use alloy_transport::TransportResult;
 
 use super::{FillerControlFlow, TxFiller};

--- a/crates/provider/src/fillers/wallet.rs
+++ b/crates/provider/src/fillers/wallet.rs
@@ -2,7 +2,7 @@ use std::fmt::Debug;
 
 use crate::{provider::SendableTx, Provider};
 use alloy_json_rpc::RpcError;
-use alloy_network::{Network, NetworkTransactionBuilder, NetworkWallet, TransactionBuilderDyn};
+use alloy_network::{Network, NetworkTransactionBuilder, NetworkWallet, DynTransactionBuilder};
 use alloy_transport::TransportResult;
 
 use super::{FillerControlFlow, TxFiller};

--- a/crates/provider/src/layers/batch.rs
+++ b/crates/provider/src/layers/batch.rs
@@ -4,7 +4,7 @@ use crate::{
     MULTICALL3_ADDRESS,
 };
 use alloy_eips::BlockId;
-use alloy_network::{Ethereum, Network, TransactionBuilder, TransactionBuilderDyn};
+use alloy_network::{Ethereum, Network, TransactionBuilder, DynTransactionBuilder};
 use alloy_primitives::{Address, Bytes, U256};
 use alloy_rpc_client::WeakClient;
 use alloy_sol_types::{SolCall, SolType, SolValue};

--- a/crates/provider/src/layers/batch.rs
+++ b/crates/provider/src/layers/batch.rs
@@ -4,7 +4,7 @@ use crate::{
     MULTICALL3_ADDRESS,
 };
 use alloy_eips::BlockId;
-use alloy_network::{Ethereum, Network, TransactionBuilder};
+use alloy_network::{Ethereum, Network, TransactionBuilder, TransactionBuilderDyn};
 use alloy_primitives::{Address, Bytes, U256};
 use alloy_rpc_client::WeakClient;
 use alloy_sol_types::{SolCall, SolType, SolValue};

--- a/crates/provider/src/layers/batch.rs
+++ b/crates/provider/src/layers/batch.rs
@@ -4,7 +4,7 @@ use crate::{
     MULTICALL3_ADDRESS,
 };
 use alloy_eips::BlockId;
-use alloy_network::{Ethereum, Network, TransactionBuilder, DynTransactionBuilder};
+use alloy_network::{DynTransactionBuilder, Ethereum, Network, TransactionBuilder};
 use alloy_primitives::{Address, Bytes, U256};
 use alloy_rpc_client::WeakClient;
 use alloy_sol_types::{SolCall, SolType, SolValue};

--- a/crates/provider/src/provider/multicall/mod.rs
+++ b/crates/provider/src/provider/multicall/mod.rs
@@ -1,7 +1,7 @@
 //! A Multicall Builder
 
 use crate::{PendingTransactionBuilder, Provider};
-use alloy_network::{Network, TransactionBuilder, TransactionBuilderDyn};
+use alloy_network::{Network, TransactionBuilder, DynTransactionBuilder};
 use alloy_primitives::{address, Address, BlockNumber, Bytes, B256, U256};
 use alloy_rpc_types_eth::{state::StateOverride, BlockId, TransactionInputKind};
 use alloy_sol_types::SolCall;

--- a/crates/provider/src/provider/multicall/mod.rs
+++ b/crates/provider/src/provider/multicall/mod.rs
@@ -1,7 +1,7 @@
 //! A Multicall Builder
 
 use crate::{PendingTransactionBuilder, Provider};
-use alloy_network::{Network, TransactionBuilder};
+use alloy_network::{Network, TransactionBuilder, TransactionBuilderDyn};
 use alloy_primitives::{address, Address, BlockNumber, Bytes, B256, U256};
 use alloy_rpc_types_eth::{state::StateOverride, BlockId, TransactionInputKind};
 use alloy_sol_types::SolCall;

--- a/crates/provider/src/provider/multicall/mod.rs
+++ b/crates/provider/src/provider/multicall/mod.rs
@@ -1,7 +1,7 @@
 //! A Multicall Builder
 
 use crate::{PendingTransactionBuilder, Provider};
-use alloy_network::{Network, TransactionBuilder, DynTransactionBuilder};
+use alloy_network::{DynTransactionBuilder, Network, TransactionBuilder};
 use alloy_primitives::{address, Address, BlockNumber, Bytes, B256, U256};
 use alloy_rpc_types_eth::{state::StateOverride, BlockId, TransactionInputKind};
 use alloy_sol_types::SolCall;

--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -1123,7 +1123,7 @@ pub trait Provider<N: Network = Ethereum>: Send + Sync {
 
         match tx {
             SendableTx::Builder(mut tx) => {
-                alloy_network::TransactionBuilder::prep_for_submission(&mut tx);
+                alloy_network::NetworkTransactionBuilder::prep_for_submission(&mut tx);
                 let tx_hash = self.client().request("eth_sendTransaction", (tx,)).await?;
                 Ok(PendingTransactionBuilder::new(self.root().clone(), tx_hash))
             }
@@ -1200,7 +1200,7 @@ pub trait Provider<N: Network = Ethereum>: Send + Sync {
 
         match tx {
             SendableTx::Builder(mut tx) => {
-                alloy_network::TransactionBuilder::prep_for_submission(&mut tx);
+                alloy_network::NetworkTransactionBuilder::prep_for_submission(&mut tx);
                 let receipt = self.client().request("eth_sendTransactionSync", (tx,)).await?;
                 Ok(receipt)
             }
@@ -1599,7 +1599,9 @@ mod tests {
     use super::*;
     use crate::{builder, ext::test::async_ci_only, ProviderBuilder, WalletProvider};
     use alloy_consensus::{Transaction, TxEnvelope};
-    use alloy_network::{AnyNetwork, EthereumWallet, TransactionBuilder};
+    use alloy_network::{
+        AnyNetwork, EthereumWallet, NetworkTransactionBuilder, TransactionBuilder,
+    };
     use alloy_node_bindings::{utils::run_with_tempdir, Anvil, Reth};
     use alloy_primitives::{address, b256, bytes, keccak256};
     use alloy_rlp::Decodable;

--- a/crates/provider/src/provider/web3_signer.rs
+++ b/crates/provider/src/provider/web3_signer.rs
@@ -1,5 +1,5 @@
 use alloy_eips::Decodable2718;
-use alloy_network::{Ethereum, Network, TransactionBuilder};
+use alloy_network::{Ethereum, Network, TransactionBuilderDyn};
 use alloy_primitives::{Address, Bytes};
 
 use super::Provider;

--- a/crates/provider/src/provider/web3_signer.rs
+++ b/crates/provider/src/provider/web3_signer.rs
@@ -1,5 +1,5 @@
 use alloy_eips::Decodable2718;
-use alloy_network::{Ethereum, Network, TransactionBuilderDyn};
+use alloy_network::{Ethereum, Network, DynTransactionBuilder};
 use alloy_primitives::{Address, Bytes};
 
 use super::Provider;

--- a/crates/provider/src/provider/web3_signer.rs
+++ b/crates/provider/src/provider/web3_signer.rs
@@ -1,5 +1,5 @@
 use alloy_eips::Decodable2718;
-use alloy_network::{Ethereum, Network, DynTransactionBuilder};
+use alloy_network::{DynTransactionBuilder, Ethereum, Network};
 use alloy_primitives::{Address, Bytes};
 
 use super::Provider;

--- a/crates/signer-trezor/src/signer.rs
+++ b/crates/signer-trezor/src/signer.rs
@@ -283,7 +283,7 @@ fn signature_from_trezor(x: trezor_client::client::Signature) -> Result<Signatur
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_network::{EthereumWallet, TransactionBuilder};
+    use alloy_network::{EthereumWallet, NetworkTransactionBuilder, TransactionBuilder};
     use alloy_primitives::{address, b256};
     use alloy_rpc_types_eth::{AccessList, AccessListItem, TransactionRequest};
 


### PR DESCRIPTION
## Motivation

Provide dyn-compatible transaction builder.

## Solution

- Rebased https://github.com/alloy-rs/alloy/pull/3344
- Introduced `DynTransactionBuilder` trait
- Smol trick: using concrete types in `TransactionBuilderDyn`, extend in Sized `TransactionBuilder`, e.g `TransactionBuilderDyn::set_input(&mut self, input: Bytes)` / `TransactionBuilder::set_input<T: Into<Bytes>>(&mut self, input: T)`

## PR Checklist

- [ ] Added Tests (no new functionality, all existing pass)
- [x] Added Documentation
- [x] Breaking changes
