### PR TITLE
fix(provider): handle zero confirmations in heartbeat target block calculation

### DIFF
--- a/crates/provider/src/heart.rs
+++ b/crates/provider/src/heart.rs
@@ -619,7 +619,10 @@ impl<N: Network, S: Stream<Item = N::BlockResponse> + Unpin + 'static> Heartbeat
     fn add_to_waiting_list(&mut self, watcher: TxWatcher, block_height: u64) {
         let confirmations = watcher.config.required_confirmations;
         debug!(tx=%watcher.config.tx_hash, %block_height, confirmations, "adding to waiting list");
-        self.waiting_confs.entry(block_height + confirmations.saturating_sub(1)).or_default().push(watcher);
+        self.waiting_confs
+            .entry(block_height + confirmations.saturating_sub(1))
+            .or_default()
+            .push(watcher);
     }
 
     /// Handle a new block by checking if any of the transactions we're


### PR DESCRIPTION
`handle_watch_ix` and `add_to_waiting_list` compute the target block as `block_height + confirmations - 1`, which underflows when `confirmations = 0` — panicking in debug mode and wrapping to u64::MAX in release mode, causing the watcher to never trigger.

`confirmations = 0` is a valid input: `handle_new_block` already handles it correctly with a `confirmations <= 1` early return (heart.rs:664), and `trait.rs:1580` uses the same guard. The underflow only exists in the heartbeat paths that were missed.

Fix:
replace `confirmations - 1` with `confirmations.saturating_sub(1)` in all three call sites so that 0 and 1 both resolve to the transaction's own block.
