### PR TITLE
refactor(transport): remove redundant nested function in guess_local_url

### DIFF
--- a/crates/transport/src/utils.rs
+++ b/crates/transport/src/utils.rs
@@ -18,13 +18,10 @@ where
 /// Best-effort heuristic: returns `true` if the connection has no hostname, or
 /// the host is `localhost`, `127.0.0.1`, or the IPv6 loopback `::1`.
 pub fn guess_local_url(s: impl AsRef<str>) -> bool {
-    fn _guess_local_url(url: &str) -> bool {
-        url.parse::<Url>().is_ok_and(|url| {
-            url.host_str()
-                .is_none_or(|host| host == "localhost" || host == "127.0.0.1" || host == "::1")
-        })
-    }
-    _guess_local_url(s.as_ref())
+    s.as_ref().parse::<Url>().is_ok_and(|url| {
+        url.host_str()
+            .is_none_or(|host| host == "localhost" || host == "127.0.0.1" || host == "::1")
+    })
 }
 
 #[doc(hidden)]


### PR DESCRIPTION


The `guess_local_url` function contains an unnecessary nested helper function `_guess_local_url` that is only called once and adds no value. This extra indirection makes the code harder to read without providing any benefit.

