### PR TITLE
docs(rpc-types-eth): fix incorrect error code in SimulateError

### DIFF
--- a/crates/rpc-types-eth/src/simulate.rs
+++ b/crates/rpc-types-eth/src/simulate.rs
@@ -187,7 +187,7 @@ impl<TxReq> SimulatePayload<TxReq> {
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct SimulateError {
     /// Code error
-    /// -3200: Execution reverted
+    /// 3: Execution reverted
     /// -32015: VM execution error
     pub code: i32,
     /// Message error


### PR DESCRIPTION
The comment on SimulateError::code says `-3200` for execution reverted, but the correct Ethereum JSON-RPC error code is `3` (EthRpcErrorCode::ExecutionError), as defined in this crate's own error.rs.