### PR TITLE
fix(rpc-types-mev): serialize EthCallBundle timestamp/timeout/gas_limit as plain integers

### DIFF
--- a/crates/rpc-types-mev/src/eth_calls.rs
+++ b/crates/rpc-types-mev/src/eth_calls.rs
@@ -27,13 +27,25 @@ pub struct EthCallBundle {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub coinbase: Option<Address>,
     /// the timestamp to use for this bundle simulation, in seconds since the unix epoch
-    #[serde(default, with = "alloy_serde::quantity::opt", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "alloy_serde::quantity::opt::deserialize",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub timestamp: Option<u64>,
     /// the timeout to apply to execution of this bundle, in milliseconds
-    #[serde(default, with = "alloy_serde::quantity::opt", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "alloy_serde::quantity::opt::deserialize",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub timeout: Option<u64>,
     /// gas limit of the block to use for this simulation
-    #[serde(default, with = "alloy_serde::quantity::opt", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "alloy_serde::quantity::opt::deserialize",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub gas_limit: Option<u64>,
     /// difficulty of the block to use for this simulation
     #[serde(default, skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
EthCallBundle's timestamp, timeout, and gas_limit fields use `with = "alloy_serde::quantity::opt"`, which serializes them as hex strings (e.g. "0x3e8"). However, Flashbots mev-geth defines these as plain Go integer types (*uint64/*int64), and Go's standard JSON unmarshaler rejects hex strings for numeric types.

Fix: switch to `deserialize_with` only (accept hex on input, serialize as plain integers), matching the pattern already used by EthSendBundle's min_timestamp/max_timestamp in the same file.
