### PR TITLE
feat(rpc-types-trace): add depth-first iterator for CallFrame

### DIFF
--- a/crates/rpc-types-trace/src/geth/call.rs
+++ b/crates/rpc-types-trace/src/geth/call.rs
@@ -454,20 +454,19 @@ mod tests {
 
     /// Helper to build a call frame tree for testing.
     fn make_frame(label: &str, children: Vec<CallFrame>) -> CallFrame {
-        CallFrame {
-            typ: label.to_string(),
-            calls: children,
-            ..Default::default()
-        }
+        CallFrame { typ: label.to_string(), calls: children, ..Default::default() }
     }
 
     #[test]
     fn test_callframe_iter_all() {
         // Build tree:  A -> [B -> [D, E], C]
-        let root = make_frame("A", vec![
-            make_frame("B", vec![make_frame("D", vec![]), make_frame("E", vec![])]),
-            make_frame("C", vec![]),
-        ]);
+        let root = make_frame(
+            "A",
+            vec![
+                make_frame("B", vec![make_frame("D", vec![]), make_frame("E", vec![])]),
+                make_frame("C", vec![]),
+            ],
+        );
 
         let labels: Vec<&str> = root.iter().map(|f| f.typ.as_str()).collect();
         assert_eq!(labels, vec!["A", "B", "D", "E", "C"]);
@@ -476,10 +475,13 @@ mod tests {
     #[test]
     fn test_callframe_iter_skip_children() {
         // Build tree:  A -> [B -> [D, E], C]
-        let root = make_frame("A", vec![
-            make_frame("B", vec![make_frame("D", vec![]), make_frame("E", vec![])]),
-            make_frame("C", vec![]),
-        ]);
+        let root = make_frame(
+            "A",
+            vec![
+                make_frame("B", vec![make_frame("D", vec![]), make_frame("E", vec![])]),
+                make_frame("C", vec![]),
+            ],
+        );
 
         let mut labels = Vec::new();
         let mut iter = root.iter();
@@ -501,10 +503,7 @@ mod tests {
 
     #[test]
     fn test_callframe_iter_skip_root_children() {
-        let root = make_frame("A", vec![
-            make_frame("B", vec![]),
-            make_frame("C", vec![]),
-        ]);
+        let root = make_frame("A", vec![make_frame("B", vec![]), make_frame("C", vec![])]);
 
         let mut iter = root.iter();
         let first = iter.next().unwrap();


### PR DESCRIPTION
## Motivation

`CallFrame` is a recursive structure where each frame can contain nested child calls. Traversing this tree currently requires manual recursion. This PR adds an ergonomic iterator with subtree-skipping support.

## Solution

Added `CallFrame::iter()` which returns a `CallFrameIter` that traverses the call tree in depth-first pre-order using an internal stack.

### API

```rust
// Iterate over all frames
for call in frame.iter() {
    println!("{} -> {:?}", call.from, call.to);
}

// Skip child calls selectively
let mut iter = frame.iter();
while let Some(call) = iter.next() {
    if call.is_static_call() {
        iter.skip_children(); // don't descend into static calls
    }
}
```

### `skip_children()`

Removes the children of the most recently yielded frame from the internal stack, so iteration continues with the next sibling or ancestor. This is useful for filtering out subtrees (e.g. skipping delegate calls, or only inspecting top-level calls in a trace).

Closes #2775