### PR TITLE
fix(ci): add alloy-consensus-any to no_std check

### DIFF
--- a/scripts/check_no_std.sh
+++ b/scripts/check_no_std.sh
@@ -7,6 +7,7 @@ crates=(
     alloy-genesis
     alloy-serde
     alloy-consensus
+    alloy-consensus-any
     alloy-network-primitives
     alloy-rpc-types-eth
     alloy-rpc-types-debug


### PR DESCRIPTION
This crate declares `no_std` support but was missing from `check_no_std.sh`, so CI never actually verified it. Add it to the list to catch any future std-only regressions.