### PR TITLE
fix(pubsub): remove duplicate log on subscription deserialization failure

### DIFF
--- a/crates/pubsub/src/sub.rs
+++ b/crates/pubsub/src/sub.rs
@@ -386,7 +386,6 @@ impl<T: DeserializeOwned> Stream for SubscriptionStream<T> {
                     Ok(item) => return task::Poll::Ready(Some(item)),
                     Err(err) => {
                         debug!(value = ?value.get(), %err, %self.id, "failed deserializing subscription item");
-                        error!(%err, %self.id, "failed deserializing subscription item");
                         continue;
                     }
                 },


### PR DESCRIPTION
When deserialization fails in SubscriptionStream::poll_next, both a debug! and an error! are emitted for the same event. The error! line has less info (no value field) and the ERROR level is too noisy for what's often just a type mismatch. Keep only the debug! which already includes the raw value for troubleshooting.