### PR TITLE
fix(rpc-types-engine): add missing Amsterdam Engine API methods to CAPABILITIES

### DIFF
--- a/crates/rpc-types-engine/src/lib.rs
+++ b/crates/rpc-types-engine/src/lib.rs
@@ -50,7 +50,7 @@ pub use alloy_eips::eip4844::BlobAndProofV2;
 
 /// The list of all supported Engine capabilities available over the engine endpoint.
 ///
-/// Latest spec: Prague
+/// Latest spec: Amsterdam
 pub const CAPABILITIES: &[&str] = &[
     "engine_forkchoiceUpdatedV1",
     "engine_forkchoiceUpdatedV2",
@@ -62,10 +62,12 @@ pub const CAPABILITIES: &[&str] = &[
     "engine_getPayloadV3",
     "engine_getPayloadV4",
     "engine_getPayloadV5",
+    "engine_getPayloadV6",
     "engine_newPayloadV1",
     "engine_newPayloadV2",
     "engine_newPayloadV3",
     "engine_newPayloadV4",
+    "engine_newPayloadV5",
     "engine_getPayloadBodiesByHashV1",
     "engine_getPayloadBodiesByRangeV1",
     "engine_getPayloadBodiesByHashV2",


### PR DESCRIPTION
`engine_newPayloadV5` and `engine_getPayloadV6` were implemented in the provider but never added to the `CAPABILITIES` list, so nodes would incorrectly advertise they don't support these methods. Also bumped the spec comment from Prague to Amsterdam.