### PR TITLE
fix(provider): SendTransaction Failed on BSC due to Legacy TxType)

### DIFF
--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -305,6 +305,7 @@ pub trait Provider<N: Network = Ethereum>: Send + Sync {
                     .header()
                     .as_ref()
                     .base_fee_per_gas()
+                    .filter(|&base_fee| base_fee != 0)
                     .ok_or(RpcError::UnsupportedFeature("eip1559"))?
                     .into()
             }

--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -2543,6 +2543,19 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_estimate_eip1559_fees_when_base_fee_zero() {
+        // Simulate BSC-like behavior where baseFeePerGas is present but zero.
+        let provider = ProviderBuilder::new()
+            .connect_anvil_with_config(|a| a.arg("--base-fee").arg("0"));
+
+        let err = provider.estimate_eip1559_fees().await.unwrap_err();
+        assert!(
+            matches!(err, RpcError::UnsupportedFeature("eip1559")),
+            "Expected UnsupportedFeature(\"eip1559\"), got {err:?}"
+        );
+    }
+
+    #[tokio::test]
     #[cfg(not(windows))]
     async fn eth_sign_transaction() {
         async_ci_only(|| async {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
fix #3775 

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
The fix adds `.filter(|&base_fee| base_fee != 0)`,  so that when BSC (or any chain) returns baseFeePerGas: "0x0" in the block header, it's treated the same as None — resulting in an UnsupportedFeature("eip1559") error instead of silently proceeding with a zero base fee.

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
