### PR TITLE
fix(rpc-types-engine): add missing Amsterdam methods to CAPABILITIES

### DIFF
--- a/crates/rpc-types-engine/src/lib.rs
+++ b/crates/rpc-types-engine/src/lib.rs
@@ -70,4 +70,8 @@ pub const CAPABILITIES: &[&str] = &[
     "engine_getPayloadBodiesByRangeV1",
     "engine_getPayloadBodiesByHashV2",
     "engine_getPayloadBodiesByRangeV2",
+    "engine_getBALsByHashV1",
+    "engine_getBALsByRangeV1",
+    "engine_getBlobsV1",
+    "engine_getBlobsV2",
 ];


### PR DESCRIPTION
part 2 of https://github.com/alloy-rs/alloy/pull/3774