### PR TITLE
fix(jwt): strip 0x prefix when reporting InvalidLength

### DIFF
--- a/crates/rpc-types-engine/src/jwt.rs
+++ b/crates/rpc-types-engine/src/jwt.rs
@@ -176,7 +176,10 @@ impl JwtSecret {
         match hex::decode_to_array(hex) {
             Ok(b) => Ok(Self(b)),
             Err(hex::FromHexError::InvalidStringLength | hex::FromHexError::OddLength) => {
-                Err(JwtError::InvalidLength(JWT_SECRET_LEN, hex.len()))
+                Err(JwtError::InvalidLength(
+                    JWT_SECRET_LEN,
+                    hex.strip_prefix("0x").or_else(|| hex.strip_prefix("0X")).unwrap_or(hex).len(),
+                ))
             }
             Err(e) => Err(JwtError::JwtSecretHexDecodeError(e)),
         }


### PR DESCRIPTION
## Summary
- Fix misleading `InvalidLength` error message in `JwtSecret::from_hex` when input has `0x` prefix
- `from_hex` supports `0x`-prefixed input (via `hex::decode_to_array` which strips it internally), but when reporting `InvalidLength`, it used `hex.len()` which still includes the `0x` prefix. Since `JWT_SECRET_LEN = 64` counts only hex digits (not prefix), this produced contradictory errors like "expected 64 digits, got 64 digits" for inputs such as `0x` + 62 hex chars (31 bytes, one byte short)
- Fix: strip `0x`/`0X` prefix before computing the reported length, so the error message accurately reflects the number of hex digits provided