### PR TITLE
feat(alloy): support no_std for the meta crate

### DIFF
--- a/crates/alloy/src/lib.rs
+++ b/crates/alloy/src/lib.rs
@@ -5,6 +5,7 @@
 )]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 /* --------------------------------------- Core re-exports -------------------------------------- */
 


### PR DESCRIPTION
The `std` feature and its propagation to sub-crates was already wired up in `Cargo.toml`, but the `#![cfg_attr(not(feature = "std"), no_std)]` attribute was missing from `lib.rs`. This makes it possible to use the `alloy` meta crate (e.g. for `alloy::primitives`) in `no_std` environments.