### PR TITLE
fix(pubsub): use unused id for eth_unsubscribe instead of hardcoded

### DIFF
--- a/crates/pubsub/src/managers/req.rs
+++ b/crates/pubsub/src/managers/req.rs
@@ -6,6 +6,8 @@ use alloy_primitives::map::HashMap;
 #[derive(Debug, Default)]
 pub(crate) struct RequestManager {
     reqs: HashMap<Id, InFlight>,
+    /// Counter for generating IDs that don't collide with in-flight requests.
+    next_id: u64,
 }
 
 impl RequestManager {
@@ -22,6 +24,17 @@ impl RequestManager {
     /// Insert a new in-flight request.
     pub(crate) fn insert(&mut self, in_flight: InFlight) {
         self.reqs.insert(in_flight.request.id().clone(), in_flight);
+    }
+
+    /// Returns an [`Id`] that is not currently used by any in-flight request.
+    pub(crate) fn unused_id(&mut self) -> Id {
+        loop {
+            let id = Id::Number(self.next_id);
+            self.next_id = self.next_id.wrapping_add(1);
+            if !self.reqs.contains_key(&id) {
+                return id;
+            }
+        }
     }
 
     /// Handle a response by sending the payload to the waiter.

--- a/crates/pubsub/src/service.rs
+++ b/crates/pubsub/src/service.rs
@@ -4,7 +4,7 @@ use crate::{
     managers::{InFlight, RequestManager, SubscriptionManager},
     PubSubConnect, PubSubFrontend, RawSubscription,
 };
-use alloy_json_rpc::{Id, PubSubItem, Request, Response, ResponsePayload, SubId};
+use alloy_json_rpc::{PubSubItem, Request, Response, ResponsePayload, SubId};
 use alloy_primitives::B256;
 use alloy_transport::{
     utils::{to_json_raw_value, Spawnable},
@@ -132,8 +132,7 @@ impl<T: PubSubConnect> PubSubService<T> {
     /// Service an unsubscribe instruction.
     fn service_unsubscribe(&mut self, local_id: B256) -> TransportResult<()> {
         if let Some(server_id) = self.subs.server_id_for(&local_id) {
-            // TODO: ideally we can send this with an unused id
-            let req = Request::new("eth_unsubscribe", Id::Number(1), [server_id]);
+            let req = Request::new("eth_unsubscribe", self.in_flights.unused_id(), [server_id]);
             let brv = req.serialize().expect("no ser error").take_request();
 
             self.dispatch_request(brv)?;


### PR DESCRIPTION
The hardcoded `Id::Number(1)` in `service_unsubscribe` can collide with an actual in-flight request, causing its response to be fulfilled with the unsubscribe result (a bool). This is a known issue (there was a TODO for it).

Fix: add `RequestManager::unused_id()` that hands out an id not present in the current in-flights map.
