### PR TITLE
fix(serde): validate JsonStorageKey length during deserialization

### DIFF
--- a/crates/serde/src/storage.rs
+++ b/crates/serde/src/storage.rs
@@ -4,7 +4,7 @@ use alloy_primitives::{
     Bytes, B256, U256,
 };
 use core::{fmt, str::FromStr};
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{de, Deserialize, Deserializer, Serialize};
 
 /// A storage key type that can be serialized to and from a hex string up to 32 bytes. Used for
 /// `eth_getStorageAt` and `eth_getProof` RPCs.
@@ -26,13 +26,23 @@ use serde::{Deserialize, Deserializer, Serialize};
 ///
 /// The contained [B256] and From implementation for String are used to preserve the input and
 /// implement this behavior from geth.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
 #[serde(untagged)]
 pub enum JsonStorageKey {
     /// A full 32-byte key (tried first during deserialization)
     Hash(B256),
     /// A number (fallback if B256 deserialization fails)
     Number(U256),
+}
+
+impl<'de> Deserialize<'de> for JsonStorageKey {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = alloc::string::String::deserialize(deserializer)?;
+        s.parse().map_err(de::Error::custom)
+    }
 }
 
 impl JsonStorageKey {
@@ -254,6 +264,14 @@ mod tests {
         let result = JsonStorageKey::from_str(&long_hex_str);
 
         assert!(matches!(result, Err(ParseError::BaseConvertError(BaseConvertError::Overflow))));
+    }
+
+    #[test]
+    fn test_deserialize_too_long_storage_key() {
+        // 65 hex zeros after 0x — should be rejected even though the numeric value is 0
+        let key = "0x00000000000000000000000000000000000000000000000000000000000000000";
+        let result: Result<JsonStorageKey, _> = serde_json::from_str(&json!(key).to_string());
+        assert!(result.is_err(), "storage key with 65 hex chars should fail deserialization");
     }
 
     #[test]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

From https://github.com/ethereum/execution-apis/blob/main/src/eth/state.yaml#L33-L38 it said the storage key should be at most 32bytes, so for the keys like `0x00..00`(65 hex chars) should be failed, but currently `JsonStorageKey` used a derived `#[serde(untagged)]` `Deserialize` that tried `B256` first, then fell back to `U256`, this key will return as zero.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
