### PR TITLE
fix(consensus): delegate is_create() for Extended::Other instead of hardcoding false

### DIFF
--- a/crates/consensus/src/extended.rs
+++ b/crates/consensus/src/extended.rs
@@ -166,10 +166,7 @@ where
     }
 
     fn is_create(&self) -> bool {
-        match self {
-            Self::BuiltIn(tx) => tx.is_create(),
-            Self::Other(_tx) => false,
-        }
+        delegate!(self => tx.is_create())
     }
 
     fn value(&self) -> U256 {


### PR DESCRIPTION
is_create() on Extended::Other was hardcoded to return false instead of delegating to the inner type like every other method does. This means if an Other variant wraps a contract creation tx, kind() correctly returns TxKind::Create but is_create() says false — which is just wrong. Fixed by using the delegate! macro like the rest of the impl.