### PR TITLE
fix(transport-ws): use native-roots to avoid UnknownIssuer

### DIFF
--- a/crates/transport-ws/Cargo.toml
+++ b/crates/transport-ws/Cargo.toml
@@ -37,7 +37,7 @@ tracing.workspace = true
 http = "1.1"
 tokio = { workspace = true, features = ["sync", "rt", "time"] }
 rustls = { version = "0.23", default-features = false, features = ["aws_lc_rs"] }
-tokio-tungstenite = { workspace = true, features = ["rustls-tls-webpki-roots"] }
+tokio-tungstenite = { workspace = true, features = ["rustls-tls-native-roots"] }
 
 # WASM only
 [target.'cfg(target_family = "wasm")'.dependencies]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
Fixes https://github.com/alloy-rs/alloy/issues/3790
## Solution

Switch `tokio-tungstenite` TLS configuration from `rustls-tls-webpki-roots` to `rustls-tls-native-roots`.

This allows rustls to use the system trust store and aligns WebSocket behavior with the HTTP transport.

Output:
```
Connecting to wss://localhost:8443 ...
TLS + WebSocket connection OK (native-roots or fixed build)
```


<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
