### PR TITLE
feat(provider): add `watch_headers` to `Provider` trait

### DIFF
--- a/crates/provider/src/provider/get_block.rs
+++ b/crates/provider/src/provider/get_block.rs
@@ -4,7 +4,7 @@ use crate::{utils, ProviderCall};
 use alloy_eips::{BlockId, BlockNumberOrTag};
 use alloy_json_rpc::RpcRecv;
 use alloy_network::BlockResponse;
-use alloy_network_primitives::BlockTransactionsKind;
+use alloy_network_primitives::{BlockTransactionsKind, HeaderResponse};
 use alloy_primitives::{Address, BlockHash, B256, B64};
 use alloy_rpc_client::{ClientRef, RpcCall};
 #[cfg(feature = "pubsub")]
@@ -341,6 +341,60 @@ where
                     Ok(blocks) => {
                         // Ignore `None` responses.
                         Either::Left(blocks.into_iter().filter_map(|block| block.map(Ok)))
+                    }
+                    Err(err) => Either::Right(std::iter::once(Err(err))),
+                })
+            });
+        Box::pin(stream)
+    }
+}
+
+/// A builder type for polling new block headers using the [`FilterPollerBuilder`].
+///
+/// The polling stream must be consumed by calling [`WatchHeaders::into_stream`].
+#[derive(Debug)]
+#[must_use = "this builder does nothing unless you call `.into_stream`"]
+pub struct WatchHeaders<HeaderResp> {
+    poller: FilterPollerBuilder<B256>,
+    _pd: std::marker::PhantomData<HeaderResp>,
+}
+
+impl<HeaderResp> WatchHeaders<HeaderResp>
+where
+    HeaderResp: HeaderResponse + RpcRecv,
+{
+    /// Create a new [`WatchHeaders`] instance.
+    pub(crate) const fn new(poller: FilterPollerBuilder<B256>) -> Self {
+        Self { poller, _pd: PhantomData }
+    }
+
+    /// Sets the channel size for the poller task.
+    pub const fn set_channel_size(&mut self, channel_size: usize) {
+        self.poller.set_channel_size(channel_size);
+    }
+
+    /// Sets a limit on the number of successful polls.
+    pub fn set_limit(&mut self, limit: Option<usize>) {
+        self.poller.set_limit(limit);
+    }
+
+    /// Sets the duration between polls.
+    pub const fn set_poll_interval(&mut self, poll_interval: Duration) {
+        self.poller.set_poll_interval(poll_interval);
+    }
+
+    /// Consumes the stream of block hashes from the inner [`FilterPollerBuilder`] and maps it to a
+    /// stream of [`HeaderResponse`].
+    pub fn into_stream(self) -> impl Stream<Item = TransportResult<HeaderResp>> + Unpin {
+        let client = self.poller.client();
+        let stream = self
+            .poller
+            .into_stream()
+            .then(move |hashes| utils::hashes_to_headers(hashes, client.clone()))
+            .flat_map(|res| {
+                futures::stream::iter(match res {
+                    Ok(headers) => {
+                        Either::Left(headers.into_iter().filter_map(|header| header.map(Ok)))
                     }
                     Err(err) => Either::Right(std::iter::once(Err(err))),
                 })

--- a/crates/provider/src/provider/mod.rs
+++ b/crates/provider/src/provider/mod.rs
@@ -4,7 +4,7 @@ pub use eth_call::{Caller, EthCall, EthCallMany, EthCallManyParams, EthCallParam
 mod get_block;
 #[cfg(feature = "pubsub")]
 pub use get_block::SubFullBlocks;
-pub use get_block::{EthGetBlock, EthGetBlockParams, WatchBlocks};
+pub use get_block::{EthGetBlock, EthGetBlockParams, WatchBlocks, WatchHeaders};
 
 mod prov_call;
 pub use prov_call::{BoxedFut, ProviderCall};

--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -4,7 +4,7 @@
 
 #[cfg(feature = "pubsub")]
 use super::get_block::SubFullBlocks;
-use super::{DynProvider, Empty, EthCallMany, MulticallBuilder, WatchBlocks};
+use super::{DynProvider, Empty, EthCallMany, MulticallBuilder, WatchBlocks, WatchHeaders};
 #[cfg(feature = "pubsub")]
 use crate::GetSubscription;
 use crate::{
@@ -643,6 +643,39 @@ pub trait Provider<N: Network = Ethereum>: Send + Sync {
         let poller = PollerBuilder::new(self.weak_client(), "eth_getFilterChanges", (id,));
 
         Ok(WatchBlocks::new(poller))
+    }
+
+    /// Watch for new blocks by polling the provider with
+    /// [`eth_getFilterChanges`](Self::get_filter_changes) and fetching the header for each
+    /// returned block hash.
+    ///
+    /// Returns the [`WatchHeaders`] type which consumes the stream of block hashes from
+    /// [`PollerBuilder`] and returns a stream of [`alloy_network_primitives::HeaderResponse`]s.
+    ///
+    /// Note that the backing RPC methods (`eth_getHeaderByHash` / `eth_getHeaderByNumber`) are
+    /// not supported by all clients.
+    ///
+    /// # Examples
+    ///
+    /// Get the next 5 headers:
+    ///
+    /// ```no_run
+    /// # async fn example(provider: impl alloy_provider::Provider) -> Result<(), Box<dyn std::error::Error>> {
+    /// use futures::StreamExt;
+    ///
+    /// let poller = provider.watch_headers().await?;
+    /// let mut stream = poller.into_stream().take(5);
+    /// while let Some(header) = stream.next().await {
+    ///   println!("new header: {header:#?}");
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    async fn watch_headers(&self) -> TransportResult<WatchHeaders<N::HeaderResponse>> {
+        let id = self.new_block_filter().await?;
+        let poller = PollerBuilder::new(self.weak_client(), "eth_getFilterChanges", (id,));
+
+        Ok(WatchHeaders::new(poller))
     }
 
     /// Watch for new pending transaction by polling the provider with

--- a/crates/provider/src/utils.rs
+++ b/crates/provider/src/utils.rs
@@ -158,6 +158,23 @@ pub(crate) async fn hashes_to_blocks<BlockResp: BlockResponse + RpcRecv>(
     Ok(blocks)
 }
 
+/// Fetches headers for a list of block hashes.
+pub(crate) async fn hashes_to_headers<
+    HeaderResp: alloy_network_primitives::HeaderResponse + RpcRecv,
+>(
+    hashes: Vec<B256>,
+    client: WeakClient,
+) -> TransportResult<Vec<Option<HeaderResp>>> {
+    let client = client.upgrade().ok_or(TransportError::local_usage_str("client dropped"))?;
+    let headers = futures::future::try_join_all(
+        hashes
+            .into_iter()
+            .map(|hash| client.request::<_, Option<HeaderResp>>("eth_getHeaderByHash", (hash,))),
+    )
+    .await?;
+    Ok(headers)
+}
+
 /// Helper type representing the joined recommended fillers i.e [`GasFiller`],
 /// [`BlobGasFiller`], [`NonceFiller`], and [`ChainIdFiller`].
 pub type JoinedRecommendedFillers = JoinFill<


### PR DESCRIPTION
The `Provider` trait has `watch_blocks()` (stream of block hashes) and `watch_full_blocks()` (stream of full blocks) but no way to watch for new headers specifically. Headers are lighter-weight than full blocks, making `watch_headers` useful when callers only need header data without transaction bodies.

Adds `watch_headers()` following the same pattern as `watch_full_blocks()` — polls `eth_getFilterChanges` for new block hashes, then fetches each header via `eth_getHeaderByHash`. Includes a `WatchHeaders` builder with the same poller configuration methods (`set_channel_size`, `set_limit`, `set_poll_interval`) and `into_stream()` conversion.

Note: the doc comment carries the same caveat as `get_header` — not all clients support `eth_getHeaderByHash`.