### PR TITLE
fix(provider): use pending nonce in CachedNonceManager init

### DIFF
--- a/crates/provider/src/fillers/nonce.rs
+++ b/crates/provider/src/fillers/nonce.rs
@@ -79,7 +79,7 @@ impl NonceManager for CachedNonceManager {
         let new_nonce = if *nonce == NONE {
             // Initialize the nonce if we haven't seen this account before.
             trace!(%address, "fetching nonce");
-            provider.get_transaction_count(address).await?
+            provider.get_transaction_count(address).pending().await?
         } else {
             trace!(%address, current_nonce = *nonce, "incrementing nonce");
             *nonce + 1


### PR DESCRIPTION
`CachedNonceManager` was fetching `get_transaction_count` without `.pending()`, defaulting to latest block. This means if there are already pending txs in the mempool, the cached nonce starts too low and causes nonce collisions. SimpleNonceManager already uses `.pending()` correctly — this just aligns the cached variant.