### PR TITLE
feat(alloy-provider): add methods for creating custom gas estimator for `GasFiller`

### DIFF
--- a/crates/provider/src/builder.rs
+++ b/crates/provider/src/builder.rs
@@ -6,6 +6,7 @@ use crate::{
     },
     layers::{BlockIdLayer, CallBatchLayer, ChainLayer},
     provider::SendableTx,
+    utils::Eip1559Estimator,
     Provider, RootProvider,
 };
 use alloy_chains::NamedChain;
@@ -256,7 +257,17 @@ impl<L, F, N> ProviderBuilder<L, F, N> {
     ///
     /// See [`GasFiller`] for more information.
     pub fn with_gas_estimation(self) -> ProviderBuilder<L, JoinFill<F, GasFiller>, N> {
-        self.filler(GasFiller)
+        self.filler(GasFiller::default())
+    }
+
+    /// Add EIP-1559 gas estimation to the stack being built, using the provided estimator.
+    ///
+    /// See [`GasFiller`] and [`Eip1559Estimator`] for more information.
+    pub fn with_eip1559_estimator(
+        self,
+        estimator: Eip1559Estimator,
+    ) -> ProviderBuilder<L, JoinFill<F, GasFiller>, N> {
+        self.filler(GasFiller { estimator })
     }
 
     /// Add nonce management to the stack being built.

--- a/crates/provider/src/ext/anvil.rs
+++ b/crates/provider/src/ext/anvil.rs
@@ -525,7 +525,7 @@ mod tests {
         let provider = ProviderBuilder::new()
             .disable_recommended_fillers()
             .with_simple_nonce_management()
-            .filler(GasFiller)
+            .filler(GasFiller::default())
             .filler(ChainIdFiller::default())
             .connect_anvil();
 
@@ -566,7 +566,7 @@ mod tests {
         let provider = ProviderBuilder::new()
             .disable_recommended_fillers()
             .with_simple_nonce_management()
-            .filler(GasFiller)
+            .filler(GasFiller::default())
             .filler(ChainIdFiller::default())
             .connect_anvil();
 
@@ -595,7 +595,7 @@ mod tests {
         let provider = ProviderBuilder::new()
             .disable_recommended_fillers()
             .with_simple_nonce_management()
-            .filler(GasFiller)
+            .filler(GasFiller::default())
             .filler(ChainIdFiller::default())
             .connect_anvil();
 

--- a/crates/provider/src/fillers/gas.rs
+++ b/crates/provider/src/fillers/gas.rs
@@ -7,7 +7,7 @@ use std::{
 use crate::{
     fillers::{FillerControlFlow, TxFiller},
     provider::SendableTx,
-    utils::Eip1559Estimation,
+    utils::{Eip1559Estimation, Eip1559Estimator},
     Provider,
 };
 use alloy_eips::eip4844::BLOB_TX_MIN_BLOB_GASPRICE;
@@ -70,8 +70,11 @@ pub enum GasFillable {
 /// # Ok(())
 /// # }
 /// ```
-#[derive(Clone, Copy, Debug, Default)]
-pub struct GasFiller;
+#[derive(Clone, Debug, Default)]
+pub struct GasFiller {
+    /// The eip1559 gas estimator to use.
+    pub estimator: Eip1559Estimator,
+}
 
 impl GasFiller {
     async fn prepare_legacy<P, N>(
@@ -118,7 +121,7 @@ impl GasFiller {
             async move { Ok(Eip1559Estimation { max_fee_per_gas, max_priority_fee_per_gas }) }
                 .left_future()
         } else {
-            provider.estimate_eip1559_fees().right_future()
+            provider.estimate_eip1559_fees_with(self.estimator.clone()).right_future()
         };
 
         let (gas_limit, estimate) = futures::try_join!(gas_limit_fut, eip1559_fees_fut)?;

--- a/crates/provider/src/fillers/gas.rs
+++ b/crates/provider/src/fillers/gas.rs
@@ -70,6 +70,7 @@ pub enum GasFillable {
 /// # Ok(())
 /// # }
 /// ```
+#[non_exhaustive]
 #[derive(Clone, Debug, Default)]
 pub struct GasFiller {
     /// The eip1559 gas estimator to use.

--- a/crates/provider/src/utils.rs
+++ b/crates/provider/src/utils.rs
@@ -9,7 +9,10 @@ use alloy_network::BlockResponse;
 use alloy_primitives::{B256, U128, U64};
 use alloy_rpc_client::WeakClient;
 use alloy_transport::{TransportError, TransportResult};
-use std::{fmt, fmt::Formatter};
+use std::{
+    fmt::{self, Formatter},
+    sync::Arc,
+};
 
 pub use alloy_eips::eip1559::Eip1559Estimation;
 
@@ -26,33 +29,33 @@ pub const EIP1559_MIN_PRIORITY_FEE: u128 = 1;
 pub type EstimatorFunction = fn(u128, &[Vec<u128>]) -> Eip1559Estimation;
 
 /// A trait responsible for estimating EIP-1559 values
-pub trait Eip1559EstimatorFn: Send + Unpin {
+pub trait Eip1559EstimatorFn: Send + Sync + Unpin {
     /// Estimates the EIP-1559 values given the latest basefee and the recent rewards.
     fn estimate(&self, base_fee: u128, rewards: &[Vec<u128>]) -> Eip1559Estimation;
 }
 
 /// EIP-1559 estimator variants
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub enum Eip1559Estimator {
     /// Uses the builtin estimator
     #[default]
     Default,
     /// Uses a custom estimator
-    Custom(Box<dyn Eip1559EstimatorFn>),
+    Custom(Arc<dyn Eip1559EstimatorFn>),
 }
 
 impl Eip1559Estimator {
     /// Creates a new estimator from a closure
     pub fn new<F>(f: F) -> Self
     where
-        F: Fn(u128, &[Vec<u128>]) -> Eip1559Estimation + Send + Unpin + 'static,
+        F: Fn(u128, &[Vec<u128>]) -> Eip1559Estimation + Send + Sync + Unpin + 'static,
     {
         Self::new_estimator(f)
     }
 
     /// Creates a new estimate fn
     pub fn new_estimator<F: Eip1559EstimatorFn + 'static>(f: F) -> Self {
-        Self::Custom(Box::new(f))
+        Self::Custom(Arc::new(f))
     }
 
     /// Estimates the EIP-1559 values given the latest basefee and the recent rewards.
@@ -66,7 +69,7 @@ impl Eip1559Estimator {
 
 impl<F> Eip1559EstimatorFn for F
 where
-    F: Fn(u128, &[Vec<u128>]) -> Eip1559Estimation + Send + Unpin,
+    F: Fn(u128, &[Vec<u128>]) -> Eip1559Estimation + Send + Sync + Unpin,
 {
     fn estimate(&self, base_fee: u128, rewards: &[Vec<u128>]) -> Eip1559Estimation {
         (self)(base_fee, rewards)


### PR DESCRIPTION
## Motivation

Our case is that we want to send transactions in next 3 blocks from head block.

```rust
ProviderBuilder::default()
    .with_eip1559_estimator(Eip1559Estimator::new(move |base_fee_per_gas, rewards| {
        utils::eip1559_default_estimator(base_fee_per_gas, rewards)
            .scaled_by_pct(eip1559_fee_increase_percentage)
    }))
    // ...
```

@mattsse

## Solution

Same approach as in #3447 and #3489. I haven't implemented same for `prepare_legacy` yet, but I think current implementation is sufficient if you, for example, want to use more aggressive approach to gas calculation.

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [x] Breaking changes
  ```diff
  -.filler(GasFiller)
  +.filler(GasFiller::default())
  ```