### PR TITLE
chore: prep 2.0.0-rc.1 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "1.8.3"
+version = "2.0.0-rc.1"
 edition = "2021"
 rust-version = "1.91"
 authors = ["Alloy Contributors"]
@@ -32,46 +32,46 @@ large-enum-variant = "allow"
 result-large-err = "allow"
 
 [workspace.dependencies]
-alloy-consensus = { version = "1.8.3", path = "crates/consensus", default-features = false }
-alloy-consensus-any = { version = "1.8.3", path = "crates/consensus-any", default-features = false }
-alloy-contract = { version = "1.8.3", path = "crates/contract", default-features = false }
-alloy-eips = { version = "1.8.3", path = "crates/eips", default-features = false }
-alloy-ens = { version = "1.8.3", path = "crates/ens", default-features = false }
-alloy-eip7547 = { version = "1.8.3", path = "crates/eip7547", default-features = false }
-alloy-genesis = { version = "1.8.3", path = "crates/genesis", default-features = false }
-alloy-json-rpc = { version = "1.8.3", path = "crates/json-rpc", default-features = false }
-alloy-network = { version = "1.8.3", path = "crates/network", default-features = false }
-alloy-network-primitives = { version = "1.8.3", path = "crates/network-primitives", default-features = false }
-alloy-node-bindings = { version = "1.8.3", path = "crates/node-bindings", default-features = false }
-alloy-provider = { version = "1.8.3", path = "crates/provider", default-features = false }
-alloy-pubsub = { version = "1.8.3", path = "crates/pubsub", default-features = false }
-alloy-rpc-client = { version = "1.8.3", path = "crates/rpc-client", default-features = false }
-alloy-rpc-types-admin = { version = "1.8.3", path = "crates/rpc-types-admin", default-features = false }
-alloy-rpc-types-anvil = { version = "1.8.3", path = "crates/rpc-types-anvil", default-features = false }
-alloy-rpc-types-any = { version = "1.8.3", path = "crates/rpc-types-any", default-features = false }
-alloy-rpc-types-beacon = { version = "1.8.3", path = "crates/rpc-types-beacon", default-features = false }
-alloy-rpc-types-debug = { version = "1.8.3", path = "crates/rpc-types-debug", default-features = false }
-alloy-rpc-types-engine = { version = "1.8.3", path = "crates/rpc-types-engine", default-features = false }
-alloy-rpc-types-eth = { version = "1.8.3", path = "crates/rpc-types-eth", default-features = false }
-alloy-rpc-types-mev = { version = "1.8.3", path = "crates/rpc-types-mev", default-features = false }
-alloy-rpc-types-tenderly = { version = "1.8.3", path = "crates/rpc-types-tenderly", default-features = false }
-alloy-rpc-types-trace = { version = "1.8.3", path = "crates/rpc-types-trace", default-features = false }
-alloy-rpc-types-txpool = { version = "1.8.3", path = "crates/rpc-types-txpool", default-features = false }
-alloy-rpc-types = { version = "1.8.3", path = "crates/rpc-types", default-features = false }
-alloy-serde = { version = "1.8.3", path = "crates/serde", default-features = false }
-alloy-signer = { version = "1.8.3", path = "crates/signer", default-features = false }
-alloy-signer-aws = { version = "1.8.3", path = "crates/signer-aws", default-features = false }
-alloy-signer-gcp = { version = "1.8.3", path = "crates/signer-gcp", default-features = false }
-alloy-signer-ledger = { version = "1.8.3", path = "crates/signer-ledger", default-features = false }
-alloy-signer-local = { version = "1.8.3", path = "crates/signer-local", default-features = false }
-alloy-signer-trezor = { version = "1.8.3", path = "crates/signer-trezor", default-features = false }
-alloy-signer-turnkey = { version = "1.8.3", path = "crates/signer-turnkey", default-features = false }
-alloy-transport = { version = "1.8.3", path = "crates/transport", default-features = false }
-alloy-transport-http = { version = "1.8.3", path = "crates/transport-http", default-features = false }
-alloy-transport-ipc = { version = "1.8.3", path = "crates/transport-ipc", default-features = false }
-alloy-transport-ws = { version = "1.8.3", path = "crates/transport-ws", default-features = false }
-alloy-eip5792 = { version = "1.8.3", path = "crates/eip5792", default-features = false }
-alloy-tx-macros = { version = "1.8.3", path = "crates/tx-macros", default-features = false }
+alloy-consensus = { version = "2.0.0-rc.1", path = "crates/consensus", default-features = false }
+alloy-consensus-any = { version = "2.0.0-rc.1", path = "crates/consensus-any", default-features = false }
+alloy-contract = { version = "2.0.0-rc.1", path = "crates/contract", default-features = false }
+alloy-eips = { version = "2.0.0-rc.1", path = "crates/eips", default-features = false }
+alloy-ens = { version = "2.0.0-rc.1", path = "crates/ens", default-features = false }
+alloy-eip7547 = { version = "2.0.0-rc.1", path = "crates/eip7547", default-features = false }
+alloy-genesis = { version = "2.0.0-rc.1", path = "crates/genesis", default-features = false }
+alloy-json-rpc = { version = "2.0.0-rc.1", path = "crates/json-rpc", default-features = false }
+alloy-network = { version = "2.0.0-rc.1", path = "crates/network", default-features = false }
+alloy-network-primitives = { version = "2.0.0-rc.1", path = "crates/network-primitives", default-features = false }
+alloy-node-bindings = { version = "2.0.0-rc.1", path = "crates/node-bindings", default-features = false }
+alloy-provider = { version = "2.0.0-rc.1", path = "crates/provider", default-features = false }
+alloy-pubsub = { version = "2.0.0-rc.1", path = "crates/pubsub", default-features = false }
+alloy-rpc-client = { version = "2.0.0-rc.1", path = "crates/rpc-client", default-features = false }
+alloy-rpc-types-admin = { version = "2.0.0-rc.1", path = "crates/rpc-types-admin", default-features = false }
+alloy-rpc-types-anvil = { version = "2.0.0-rc.1", path = "crates/rpc-types-anvil", default-features = false }
+alloy-rpc-types-any = { version = "2.0.0-rc.1", path = "crates/rpc-types-any", default-features = false }
+alloy-rpc-types-beacon = { version = "2.0.0-rc.1", path = "crates/rpc-types-beacon", default-features = false }
+alloy-rpc-types-debug = { version = "2.0.0-rc.1", path = "crates/rpc-types-debug", default-features = false }
+alloy-rpc-types-engine = { version = "2.0.0-rc.1", path = "crates/rpc-types-engine", default-features = false }
+alloy-rpc-types-eth = { version = "2.0.0-rc.1", path = "crates/rpc-types-eth", default-features = false }
+alloy-rpc-types-mev = { version = "2.0.0-rc.1", path = "crates/rpc-types-mev", default-features = false }
+alloy-rpc-types-tenderly = { version = "2.0.0-rc.1", path = "crates/rpc-types-tenderly", default-features = false }
+alloy-rpc-types-trace = { version = "2.0.0-rc.1", path = "crates/rpc-types-trace", default-features = false }
+alloy-rpc-types-txpool = { version = "2.0.0-rc.1", path = "crates/rpc-types-txpool", default-features = false }
+alloy-rpc-types = { version = "2.0.0-rc.1", path = "crates/rpc-types", default-features = false }
+alloy-serde = { version = "2.0.0-rc.1", path = "crates/serde", default-features = false }
+alloy-signer = { version = "2.0.0-rc.1", path = "crates/signer", default-features = false }
+alloy-signer-aws = { version = "2.0.0-rc.1", path = "crates/signer-aws", default-features = false }
+alloy-signer-gcp = { version = "2.0.0-rc.1", path = "crates/signer-gcp", default-features = false }
+alloy-signer-ledger = { version = "2.0.0-rc.1", path = "crates/signer-ledger", default-features = false }
+alloy-signer-local = { version = "2.0.0-rc.1", path = "crates/signer-local", default-features = false }
+alloy-signer-trezor = { version = "2.0.0-rc.1", path = "crates/signer-trezor", default-features = false }
+alloy-signer-turnkey = { version = "2.0.0-rc.1", path = "crates/signer-turnkey", default-features = false }
+alloy-transport = { version = "2.0.0-rc.1", path = "crates/transport", default-features = false }
+alloy-transport-http = { version = "2.0.0-rc.1", path = "crates/transport-http", default-features = false }
+alloy-transport-ipc = { version = "2.0.0-rc.1", path = "crates/transport-ipc", default-features = false }
+alloy-transport-ws = { version = "2.0.0-rc.1", path = "crates/transport-ws", default-features = false }
+alloy-eip5792 = { version = "2.0.0-rc.1", path = "crates/eip5792", default-features = false }
+alloy-tx-macros = { version = "2.0.0-rc.1", path = "crates/tx-macros", default-features = false }
 
 alloy-core = { version = "1.4.1", default-features = false }
 alloy-dyn-abi = { version = "1.4.1", default-features = false }


### PR DESCRIPTION
Bump workspace version from `1.8.3` to `2.0.0-rc.1` across all 41 crate entries in `Cargo.toml`.