### PR TITLE
fix(pubsub): drop poisoned in-flight requests after repeated reconnects

### DIFF
--- a/crates/pubsub/src/managers/in_flight.rs
+++ b/crates/pubsub/src/managers/in_flight.rs
@@ -16,6 +16,9 @@ pub struct InFlight {
 
     /// The channel to send the response on.
     pub tx: oneshot::Sender<TransportResult<Response>>,
+
+    /// Number of times this request has been re-issued across reconnects.
+    pub(crate) reconnect_count: u32,
 }
 
 impl fmt::Debug for InFlight {
@@ -24,6 +27,7 @@ impl fmt::Debug for InFlight {
             .field("request", &self.request)
             .field("channel_size", &self.channel_size)
             .field("tx_is_closed", &self.tx.is_closed())
+            .field("reconnect_count", &self.reconnect_count)
             .finish()
     }
 }
@@ -36,7 +40,7 @@ impl InFlight {
     ) -> (Self, oneshot::Receiver<TransportResult<Response>>) {
         let (tx, rx) = oneshot::channel();
 
-        (Self { request, channel_size, tx }, rx)
+        (Self { request, channel_size, tx, reconnect_count: 0 }, rx)
     }
 
     /// Check if the request is a subscription.

--- a/crates/pubsub/src/managers/req.rs
+++ b/crates/pubsub/src/managers/req.rs
@@ -1,6 +1,12 @@
 use crate::managers::InFlight;
 use alloy_json_rpc::{Id, Response, SubId};
 use alloy_primitives::map::HashMap;
+use alloy_transport::TransportErrorKind;
+use serde_json::value::RawValue;
+
+/// Maximum number of times a single in-flight request may be re-issued across
+/// reconnects before being dropped with a `backend_gone` error.
+const MAX_REQUEST_REISSUES: u32 = 3;
 
 /// Manages in-flight requests.
 #[derive(Debug, Default)]
@@ -9,16 +15,6 @@ pub(crate) struct RequestManager {
 }
 
 impl RequestManager {
-    /// Get the number of in-flight requests.
-    pub(crate) fn len(&self) -> usize {
-        self.reqs.len()
-    }
-
-    /// Get an iterator over the in-flight requests.
-    pub(crate) fn iter(&self) -> impl Iterator<Item = (&Id, &InFlight)> {
-        self.reqs.iter()
-    }
-
     /// Insert a new in-flight request.
     pub(crate) fn insert(&mut self, in_flight: InFlight) {
         self.reqs.insert(in_flight.request.id().clone(), in_flight);
@@ -34,5 +30,31 @@ impl RequestManager {
             return in_flight.fulfill(resp);
         }
         None
+    }
+
+    /// Bump each request's reconnect count. Requests that have been re-issued
+    /// [`MAX_REQUEST_REISSUES`] times are drained with a `backend_gone` error.
+    /// Returns the serialized messages for the surviving requests so the caller
+    /// can dispatch them to the new backend.
+    pub(crate) fn reissue_or_drain(&mut self) -> Vec<Box<RawValue>> {
+        let reqs = std::mem::take(&mut self.reqs);
+        let mut to_reissue = Vec::new();
+
+        for (id, mut in_flight) in reqs {
+            if in_flight.reconnect_count >= MAX_REQUEST_REISSUES {
+                warn!(
+                    id = %id,
+                    reconnect_count = in_flight.reconnect_count,
+                    "Dropping in-flight request after too many reconnects"
+                );
+                let _ = in_flight.tx.send(Err(TransportErrorKind::backend_gone()));
+            } else {
+                in_flight.reconnect_count += 1;
+                to_reissue.push(in_flight.request.serialized().to_owned());
+                self.reqs.insert(id, in_flight);
+            }
+        }
+
+        to_reissue
     }
 }

--- a/crates/pubsub/src/service.rs
+++ b/crates/pubsub/src/service.rs
@@ -79,10 +79,10 @@ impl<T: PubSubConnect> PubSubService<T> {
 
         old_handle.shutdown();
 
-        // Re-issue pending requests.
-        debug!(count = self.in_flights.len(), "Reissuing pending requests");
-        for (_, in_flight) in self.in_flights.iter() {
-            let msg = in_flight.request.serialized().to_owned();
+        // Re-issue pending requests, dropping any that exceeded their reissue limit.
+        let msgs = self.in_flights.reissue_or_drain();
+        debug!(count = msgs.len(), "Reissuing pending requests");
+        for msg in msgs {
             self.dispatch_request(msg)?;
         }
 
@@ -343,5 +343,57 @@ mod tests {
                 .expect("request should be dispatched after reconnect")
                 .expect("new backend should receive the request");
         assert_eq!(dispatched.get(), expected);
+    }
+
+    /// Mock connector: reconnect always succeeds but the backend immediately closes.
+    #[derive(Clone, Debug, Default)]
+    struct AlwaysReconnectThenDie;
+
+    impl PubSubConnect for AlwaysReconnectThenDie {
+        fn is_local(&self) -> bool {
+            true
+        }
+
+        async fn connect(&self) -> TransportResult<ConnectionHandle> {
+            Err(TransportErrorKind::custom_str("connect is not used in this test"))
+        }
+
+        async fn try_reconnect(&self) -> TransportResult<ConnectionHandle> {
+            let (handle, _interface) = ConnectionHandle::new();
+            Ok(handle)
+        }
+    }
+
+    #[tokio::test]
+    async fn poisoned_request_is_drained_after_repeated_reconnects() {
+        let req = Request::new("eth_getLogs", Id::Number(1), ()).serialize().unwrap();
+        let (in_flight, rx) = InFlight::new(req, 16);
+
+        let mut in_flights = RequestManager::default();
+        in_flights.insert(in_flight);
+
+        let (dead_handle, dead_interface) = ConnectionHandle::new();
+        let dead_handle = dead_handle.with_retry_interval(Duration::from_millis(1));
+        drop(dead_interface);
+
+        let connector = AlwaysReconnectThenDie;
+        let (tx, reqs) = mpsc::unbounded_channel();
+        let service = PubSubService {
+            handle: dead_handle,
+            connector,
+            reqs,
+            subs: SubscriptionManager::default(),
+            in_flights,
+        };
+        service.spawn();
+
+        let _tx = tx; // keep channel open
+
+        let result = timeout(Duration::from_secs(2), rx)
+            .await
+            .expect("request should resolve within timeout")
+            .expect("oneshot should receive a value, not be dropped");
+
+        assert!(result.is_err(), "drained request should receive a backend_gone error");
     }
 }


### PR DESCRIPTION
- Track per-request reissue count across reconnects
- Drop in-flight requests that exceed 3 reissues with a `backend_gone` error
- Prevents infinite reconnect loop when a request's response kills the backend (e.g. oversized `eth_getLogs` exceeding `max_frame_size`)