### PR TITLE
chore: allow unused ignored advisories

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,11 +1,14 @@
 [advisories]
 version = 2
 yanked = "warn"
+unused-ignored-advisory = "allow"
 ignore = [
     # https://rustsec.org/advisories/RUSTSEC-2024-0437, trezor-client dependency, no fix available yet
     "RUSTSEC-2024-0437",
     # https://rustsec.org/advisories/RUSTSEC-2024-0436
     "RUSTSEC-2024-0436",
+    # https://rustsec.org/advisories/RUSTSEC-2025-0137 `reciprocal_mg10` OOB, unused
+    "RUSTSEC-2025-0137",
     # https://rustsec.org/advisories/RUSTSEC-2025-0141 bincode is unmaintained, need to transition all deps to wincode first
     "RUSTSEC-2025-0141",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -6,8 +6,6 @@ ignore = [
     "RUSTSEC-2024-0437",
     # https://rustsec.org/advisories/RUSTSEC-2024-0436
     "RUSTSEC-2024-0436",
-    # https://rustsec.org/advisories/RUSTSEC-2025-0137 `reciprocal_mg10` OOB, unused
-    "RUSTSEC-2025-0137",
     # https://rustsec.org/advisories/RUSTSEC-2025-0141 bincode is unmaintained, need to transition all deps to wincode first
     "RUSTSEC-2025-0141",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -1,6 +1,7 @@
 [advisories]
 version = 2
 yanked = "warn"
+unused-ignored-advisory = "allow"
 ignore = [
     # https://rustsec.org/advisories/RUSTSEC-2024-0437, trezor-client dependency, no fix available yet
     "RUSTSEC-2024-0437",

--- a/deny.toml
+++ b/deny.toml
@@ -7,6 +7,8 @@ ignore = [
     "RUSTSEC-2024-0437",
     # https://rustsec.org/advisories/RUSTSEC-2024-0436
     "RUSTSEC-2024-0436",
+    # https://rustsec.org/advisories/RUSTSEC-2026-0097 rand unsoundness requires a custom logger calling rand::rng()
+    "RUSTSEC-2026-0097",
     # https://rustsec.org/advisories/RUSTSEC-2025-0141 bincode is unmaintained, need to transition all deps to wincode first
     "RUSTSEC-2025-0141",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -1,14 +1,11 @@
 [advisories]
 version = 2
 yanked = "warn"
-unused-ignored-advisory = "allow"
 ignore = [
     # https://rustsec.org/advisories/RUSTSEC-2024-0437, trezor-client dependency, no fix available yet
     "RUSTSEC-2024-0437",
     # https://rustsec.org/advisories/RUSTSEC-2024-0436
     "RUSTSEC-2024-0436",
-    # https://rustsec.org/advisories/RUSTSEC-2025-0137 `reciprocal_mg10` OOB, unused
-    "RUSTSEC-2025-0137",
     # https://rustsec.org/advisories/RUSTSEC-2025-0141 bincode is unmaintained, need to transition all deps to wincode first
     "RUSTSEC-2025-0141",
 ]


### PR DESCRIPTION
## Summary
- allow ignored advisories in `deny.toml` to remain even when they are not currently matched in the dependency graph
- remove the no-longer-needed `RUSTSEC-2025-0137` ignore entry

## Why
The deny workflow is running `cargo-deny 0.19.1`, which emits `advisory-not-detected` for ignored advisories that no longer apply to the current dependency graph. In this repository that currently trips on `RUSTSEC-2024-0437`.

Setting `unused-ignored-advisory = "allow"` makes that currently failing ignored advisory behave like an ignore in CI, while still letting us drop the stale `RUSTSEC-2025-0137` entry that no longer needs to be listed.

## Validation
- confirmed the failing GitHub Actions job is on `cargo-deny 0.19.1`
- confirmed the failing diagnostic is `warning[advisory-not-detected]` for `RUSTSEC-2024-0437`
- local `cargo-deny` in this workspace is `0.18.9`, which is older than CI and does not understand this config key
