### PR TITLE
fix(node-bindings): drain stdout for Anvil and Reth when not kept

### DIFF
--- a/crates/node-bindings/src/nodes/anvil.rs
+++ b/crates/node-bindings/src/nodes/anvil.rs
@@ -513,6 +513,16 @@ impl Anvil {
         if self.keep_stdout {
             // re-attach the stdout handle if requested
             child.stdout = Some(reader.into_inner());
+        } else {
+            // We need to consume the stdout otherwise anvil can become non-responsive
+            // when its pipe buffer fills up.
+            // See: <https://github.com/alloy-rs/alloy/issues/2091#issuecomment-2676134147>
+            std::thread::spawn(move || {
+                let mut buf = String::new();
+                loop {
+                    let _ = reader.read_line(&mut buf);
+                }
+            });
         }
 
         Ok(AnvilInstance {

--- a/crates/node-bindings/src/nodes/anvil.rs
+++ b/crates/node-bindings/src/nodes/anvil.rs
@@ -514,12 +514,11 @@ impl Anvil {
             // re-attach the stdout handle if requested
             child.stdout = Some(reader.into_inner());
         } else {
-            // We need to consume the stdout otherwise anvil can become non-responsive
-            // when its pipe buffer fills up.
-            // See: <https://github.com/alloy-rs/alloy/issues/2091#issuecomment-2676134147>
+            // Drain stdout to prevent the pipe buffer from filling up and blocking the node.
             std::thread::spawn(move || {
                 let mut buf = String::new();
                 loop {
+                    buf.clear();
                     let _ = reader.read_line(&mut buf);
                 }
             });

--- a/crates/node-bindings/src/nodes/geth.rs
+++ b/crates/node-bindings/src/nodes/geth.rs
@@ -678,12 +678,11 @@ impl Geth {
             // re-attach the stderr handle if requested
             child.stderr = Some(reader.into_inner());
         } else {
-            // We need to consume the stderr otherwise geth is non-responsive and RPC server results
-            // in connection refused.
-            // See: <https://github.com/alloy-rs/alloy/issues/2091#issuecomment-2676134147>
+            // Drain stderr to prevent the pipe buffer from filling up and blocking the node.
             std::thread::spawn(move || {
                 let mut buf = String::new();
                 loop {
+                    buf.clear();
                     let _ = reader.read_line(&mut buf);
                 }
             });

--- a/crates/node-bindings/src/nodes/reth.rs
+++ b/crates/node-bindings/src/nodes/reth.rs
@@ -554,6 +554,16 @@ impl Reth {
         if self.keep_stdout {
             // re-attach the stdout handle if requested
             child.stdout = Some(reader.into_inner());
+        } else {
+            // We need to consume the stdout otherwise reth can become non-responsive
+            // when its pipe buffer fills up.
+            // See: <https://github.com/alloy-rs/alloy/issues/2091#issuecomment-2676134147>
+            std::thread::spawn(move || {
+                let mut buf = String::new();
+                loop {
+                    let _ = reader.read_line(&mut buf);
+                }
+            });
         }
 
         Ok(RethInstance {

--- a/crates/node-bindings/src/nodes/reth.rs
+++ b/crates/node-bindings/src/nodes/reth.rs
@@ -555,12 +555,11 @@ impl Reth {
             // re-attach the stdout handle if requested
             child.stdout = Some(reader.into_inner());
         } else {
-            // We need to consume the stdout otherwise reth can become non-responsive
-            // when its pipe buffer fills up.
-            // See: <https://github.com/alloy-rs/alloy/issues/2091#issuecomment-2676134147>
+            // Drain stdout to prevent the pipe buffer from filling up and blocking the node.
             std::thread::spawn(move || {
                 let mut buf = String::new();
                 loop {
+                    buf.clear();
                     let _ = reader.read_line(&mut buf);
                 }
             });


### PR DESCRIPTION
  - Drain stdout for Anvil and Reth when not kept, preventing pipe buffer from blocking the node.
  - Clear drain buffer each iteration to avoid unbounded memory growth (also fixed in Geth). 