### PR TITLE
fix: clear stderr buffer and break on EOF in geth reader thread

### DIFF
--- a/crates/node-bindings/src/nodes/geth.rs
+++ b/crates/node-bindings/src/nodes/geth.rs
@@ -684,7 +684,11 @@ impl Geth {
             std::thread::spawn(move || {
                 let mut buf = String::new();
                 loop {
-                    let _ = reader.read_line(&mut buf);
+                    buf.clear();
+                    match reader.read_line(&mut buf) {
+                        Ok(0) | Err(_) => break,
+                        Ok(_) => {}
+                    }
                 }
             });
         }


### PR DESCRIPTION
The background thread that drains geth's stderr was calling `read_line` without clearing the buffer between reads. Because `BufRead::read_line` appends, the buffer grew unbounded for the lifetime of the process, holding every stderr line in memory. The loop also never terminated on EOF, so it would spin on a closed pipe once the child exited.

Clear the buffer each iteration and break on `Ok(0)` / `Err(_)`.