### PR TITLE
fix(provider): update `test_anvil_set_time` for corrected `evm_setTime`

### DIFF
--- a/crates/provider/src/ext/anvil.rs
+++ b/crates/provider/src/ext/anvil.rs
@@ -1015,7 +1015,7 @@ mod tests {
 
         let seconds = provider.anvil_set_time(1001).await.unwrap();
 
-        assert_eq!(seconds, 1);
+        assert_eq!(seconds, 1001);
     }
 
     #[tokio::test]


### PR DESCRIPTION
Anvil's `evm_setTime` was fixed in foundry-rs/foundry#14292 to return the offset in seconds directly instead of wrapping it through `Duration::from_millis().as_secs()` (which divided by 1000).
