### PR TITLE
fix(rpc-types-trace): add 0x prefix to storage keys and values in `StructLog`

### DIFF
--- a/crates/rpc-types-trace/src/geth/mod.rs
+++ b/crates/rpc-types-trace/src/geth/mod.rs
@@ -781,7 +781,7 @@ impl From<GethDebugTracingOptions> for GethDebugTracingCallOptions {
     }
 }
 
-/// Serializes a storage map as a list of key-value pairs _without_ 0x-prefix
+/// Serializes a storage map as a list of key-value pairs with 0x-prefix
 fn serialize_string_storage_map_opt<S: Serializer>(
     storage: &Option<BTreeMap<B256, B256>>,
     s: S,
@@ -793,8 +793,7 @@ fn serialize_string_storage_map_opt<S: Serializer>(
             for (key, val) in storage {
                 let key = format!("{key:?}");
                 let val = format!("{val:?}");
-                // skip the 0x prefix
-                m.serialize_entry(&key.as_str()[2..], &val.as_str()[2..])?;
+                m.serialize_entry(key.as_str(), val.as_str())?;
             }
             m.end()
         }
@@ -872,7 +871,7 @@ mod tests {
 
     #[test]
     fn test_serialize_storage_map() {
-        let s = r#"{"pc":3349,"op":"SLOAD","gas":23959,"gasCost":2100,"depth":1,"stack":[],"memory":[],"storage":{"6693dabf5ec7ab1a0d1c5bc58451f85d5e44d504c9ffeb75799bfdb61aa2997a":"0000000000000000000000000000000000000000000000000000000000000000"}}"#;
+        let s = r#"{"pc":3349,"op":"SLOAD","gas":23959,"gasCost":2100,"depth":1,"stack":[],"memory":[],"storage":{"0x6693dabf5ec7ab1a0d1c5bc58451f85d5e44d504c9ffeb75799bfdb61aa2997a":"0x0000000000000000000000000000000000000000000000000000000000000000"}}"#;
         let log: StructLog = serde_json::from_str(s).unwrap();
         let val = serde_json::to_value(&log).unwrap();
         let input = serde_json::from_str::<serde_json::Value>(s).unwrap();


### PR DESCRIPTION
The [opcode tracer spec](https://github.com/ethereum/execution-apis/pull/762) requires storage keys and values to be `0x`-prefixed `bytes32`.

`serialize_string_storage_map_opt` was explicitly stripping the `0x` prefix with `&key.as_str()[2..]`. This produces bare hex like `ef7498a2...` instead of the spec-required `0xef7498a2...`.

Verified on a live reth archive node — storage now serializes as `"0xef7498a2...": "0x00000000..."`.