### PR TITLE
feat: enable auto_impl(&mut) for Transaction trait

### DIFF
--- a/crates/consensus/src/transaction/mod.rs
+++ b/crates/consensus/src/transaction/mod.rs
@@ -83,7 +83,7 @@ use alloy_eips::Typed2718;
 /// We call these transactions "dynamic fee transactions".
 /// We call non dynamic fee transactions(EIP-155, EIP-2930) "legacy fee transactions".
 #[doc(alias = "Tx")]
-#[auto_impl::auto_impl(&, Arc)]
+#[auto_impl::auto_impl(&, &mut, Arc)]
 pub trait Transaction: Typed2718 + fmt::Debug + any::Any + Send + Sync + 'static {
     /// Get `chain_id`.
     fn chain_id(&self) -> Option<ChainId>;
@@ -255,7 +255,7 @@ pub trait SignableTransaction<Signature>: Transaction {
     /// Set `chain_id` if it is not already set. Checks that the provided `chain_id` matches the
     /// existing `chain_id` if it is already set, returning `false` if they do not match.
     fn set_chain_id_checked(&mut self, chain_id: ChainId) -> bool {
-        match self.chain_id() {
+        match Transaction::chain_id(self) {
             Some(tx_chain_id) => {
                 if tx_chain_id != chain_id {
                     return false;

--- a/crates/eips/src/eip2718.rs
+++ b/crates/eips/src/eip2718.rs
@@ -354,7 +354,7 @@ pub trait Eip2718Envelope: Decodable2718 + Encodable2718 {}
 impl<T> Eip2718Envelope for T where T: Decodable2718 + Encodable2718 {}
 
 /// A trait that helps to determine the type of the transaction.
-#[auto_impl::auto_impl(&)]
+#[auto_impl::auto_impl(&, &mut)]
 pub trait Typed2718 {
     /// Returns the EIP-2718 type flag.
     fn ty(&self) -> u8;


### PR DESCRIPTION
This PR extends the `Transaction` trait by adding support for `auto_impl(&mut)`:

```diff
- #[auto_impl::auto_impl(&, Arc)]
+ #[auto_impl::auto_impl(&, &mut, Arc)]
pub trait Transaction: Typed2718 + fmt::Debug + any::Any + Send + Sync + 'static {
```

## Motivation

While implementing the following:

```rust
#[async_trait::async_trait]
impl TxSigner<Signature> for MySigner {
    async fn sign_transaction(
        &self,
        tx: &mut dyn SignableTransaction<Signature>,
    ) -> alloy_signer::Result<Signature> {
        ...
        let tx_req = TransactionRequest::from_transaction_with_sender(tx, MY_ADDRESS);
        ...
    }
}
```

I ran into a compilation issue. The Transaction trait
- ✅ is implemented for `&dyn SignableTransaction<Signature>`,
- ❌ but **not** for `&mut dyn SignableTransaction<Signature>`.

I explored several workarounds, but none were satisfactory. Adding `&mut` support via `auto_impl` appears to be the most straightforward and robust solution, so this change proposes upstreaming that fix.

## Solution

Just a one-line change: update `#[auto_impl::auto_impl(&, Arc)]` to `#[auto_impl::auto_impl(&, &mut, Arc)]`