### PR TITLE
fix(node-bindings): align Reth::default with Reth::new

### DIFF
--- a/crates/node-bindings/src/nodes/reth.rs
+++ b/crates/node-bindings/src/nodes/reth.rs
@@ -153,7 +153,7 @@ impl Drop for RethInstance {
 ///
 /// drop(reth); // this will kill the instance
 /// ```
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 #[must_use = "This Builder struct does nothing unless it is `spawn`ed"]
 pub struct Reth {
     dev: bool,
@@ -173,6 +173,12 @@ pub struct Reth {
     genesis: Option<Genesis>,
     args: Vec<OsString>,
     keep_stdout: bool,
+}
+
+impl Default for Reth {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl Reth {
@@ -593,5 +599,28 @@ mod tests {
             assert!(reth.endpoint().starts_with("http://localhost:"));
             assert!(reth.ws_endpoint().starts_with("ws://localhost:"));
         }
+    }
+
+    #[test]
+    fn default_matches_new_semantics() {
+        let reth = Reth::default();
+
+        assert!(!reth.dev);
+        assert_eq!(reth.host, None);
+        assert_eq!(reth.http_port, DEFAULT_HTTP_PORT);
+        assert_eq!(reth.ws_port, DEFAULT_WS_PORT);
+        assert_eq!(reth.auth_port, DEFAULT_AUTH_PORT);
+        assert_eq!(reth.p2p_port, DEFAULT_P2P_PORT);
+        assert_eq!(reth.block_time, None);
+        assert!((1..200).contains(&reth.instance));
+        assert!(reth.discovery_enabled);
+        assert_eq!(reth.program, None);
+        assert_eq!(reth.ipc_path, None);
+        assert!(!reth.ipc_enabled);
+        assert_eq!(reth.data_dir, None);
+        assert_eq!(reth.chain_or_path, None);
+        assert_eq!(reth.genesis, None);
+        assert!(reth.args.is_empty());
+        assert!(!reth.keep_stdout);
     }
 }


### PR DESCRIPTION
## Motivation

`Reth` currently derives `Default`, but `Reth::new()` sets a different set of defaults, including the default ports, discovery, and a randomized instance. That makes `Reth::default()` behave differently from the constructor used throughout the docs and local call sites.

## Solution

Implement `Default` manually for `Reth` by delegating to `Reth::new()`, and add a unit test that locks in the shared defaults.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes