### PR TITLE
feat(provider): add ProviderBuilder apply helpers

### DIFF
--- a/crates/provider/src/builder.rs
+++ b/crates/provider/src/builder.rs
@@ -184,6 +184,28 @@ impl<L, N: Network> ProviderBuilder<L, Identity, N> {
 }
 
 impl<L, F, N> ProviderBuilder<L, F, N> {
+    /// Apply a function to this builder.
+    ///
+    /// This is useful for extracting reusable builder-style helper functions without manually
+    /// reconstructing the [`ProviderBuilder`].
+    pub fn apply<T>(self, f: impl FnOnce(Self) -> T) -> T {
+        f(self)
+    }
+
+    /// Map the layer stack to a new type.
+    ///
+    /// This is useful for customizing or replacing the accumulated layers in a reusable helper.
+    pub fn map_layer<L2>(self, f: impl FnOnce(L) -> L2) -> ProviderBuilder<L2, F, N> {
+        ProviderBuilder { layer: f(self.layer), filler: self.filler, network: PhantomData }
+    }
+
+    /// Map the filler stack to a new type.
+    ///
+    /// This is useful for customizing or replacing the accumulated fillers in a reusable helper.
+    pub fn map_filler<F2>(self, f: impl FnOnce(F) -> F2) -> ProviderBuilder<L, F2, N> {
+        ProviderBuilder { layer: self.layer, filler: f(self.filler), network: PhantomData }
+    }
+
     /// Add a layer to the stack being built. This is similar to
     /// [`tower::ServiceBuilder::layer`].
     ///
@@ -196,22 +218,14 @@ impl<L, F, N> ProviderBuilder<L, F, N> {
     /// [`tower::ServiceBuilder::layer`]: https://docs.rs/tower/latest/tower/struct.ServiceBuilder.html#method.layer
     /// [`tower::ServiceBuilder`]: https://docs.rs/tower/latest/tower/struct.ServiceBuilder.html
     pub fn layer<Inner>(self, layer: Inner) -> ProviderBuilder<Stack<Inner, L>, F, N> {
-        ProviderBuilder {
-            layer: Stack::new(layer, self.layer),
-            filler: self.filler,
-            network: PhantomData,
-        }
+        self.map_layer(|current| Stack::new(layer, current))
     }
 
     /// Add a transaction filler to the stack being built. Transaction fillers
     /// are used to fill in missing fields on transactions before they are sent,
     /// and are all joined to form the outermost layer of the stack.
     pub fn filler<F2>(self, filler: F2) -> ProviderBuilder<L, JoinFill<F, F2>, N> {
-        ProviderBuilder {
-            layer: self.layer,
-            filler: JoinFill::new(self.filler, filler),
-            network: PhantomData,
-        }
+        self.map_filler(|current| JoinFill::new(current, filler))
     }
 
     /// Change the network.
@@ -830,6 +844,29 @@ mod tests {
             JoinFill<Identity, <AnyNetwork as RecommendedFillers>::RecommendedFillers>,
             AnyNetwork,
         > = builder;
+    }
+
+    #[test]
+    fn apply_transforms_builder() {
+        let builder = ProviderBuilder::new()
+            .apply(|builder| builder.disable_recommended_fillers().with_gas_estimation());
+
+        let _: ProviderBuilder<Identity, JoinFill<Identity, GasFiller>, Ethereum> = builder;
+    }
+
+    #[test]
+    fn map_filler_replaces_fillers() {
+        let builder = ProviderBuilder::new().map_filler(|_| GasFiller::default());
+
+        let _: ProviderBuilder<Identity, GasFiller, Ethereum> = builder;
+    }
+
+    #[test]
+    fn map_layer_replaces_layers() {
+        let builder = ProviderBuilder::<Identity, Identity>::default()
+            .map_layer(|_| ChainLayer::new(NamedChain::Mainnet));
+
+        let _: ProviderBuilder<ChainLayer, Identity, Ethereum> = builder;
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- add `ProviderBuilder::apply`, `map_layer`, and `map_filler` so reusable helper functions can transform the builder or its accumulated stacks without reconstructing internals
- route the existing `layer` and `filler` methods through the new mapping hooks so the composition logic stays centralized
- add focused builder tests covering `apply`, `map_filler`, and `map_layer`

## Testing
- `cargo test -p alloy-provider builder::`
