### PR TITLE
chore: update reth rpc endpoints

### DIFF
--- a/crates/contract/src/multicall.rs
+++ b/crates/contract/src/multicall.rs
@@ -62,7 +62,7 @@ mod tests {
         DummyThatFails::deploy(provider).await.unwrap()
     }
 
-    const FORK_URL: &str = "https://reth-ethereum.ithaca.xyz/rpc";
+    const FORK_URL: &str = "https://ethereum.reth.rs/rpc";
 
     #[tokio::test]
     async fn test_single() {

--- a/crates/contract/src/storage_slot.rs
+++ b/crates/contract/src/storage_slot.rs
@@ -197,7 +197,7 @@ mod tests {
     use alloy_provider::{ext::AnvilApi, Provider, ProviderBuilder};
     use alloy_rpc_types_eth::TransactionRequest;
     use alloy_sol_types::sol;
-    const FORK_URL: &str = "https://reth-ethereum.ithaca.xyz/rpc";
+    const FORK_URL: &str = "https://ethereum.reth.rs/rpc";
     use alloy_sol_types::SolCall;
 
     async fn test_erc20_token_set_balance(token: Address) {

--- a/crates/ens/src/lib.rs
+++ b/crates/ens/src/lib.rs
@@ -406,7 +406,7 @@ mod tests {
     #[tokio::test]
     async fn test_reverse_registrar_fetching_mainnet() {
         let provider = ProviderBuilder::new()
-            .connect_http("https://reth-ethereum.ithaca.xyz/rpc".parse().unwrap());
+            .connect_http("https://ethereum.reth.rs/rpc".parse().unwrap());
 
         let res = provider.get_reverse_registrar().await;
         assert_eq!(*res.unwrap().address(), address!("0xa58E81fe9b61B5c3fE2AFD33CF304c454AbFc7Cb"));
@@ -415,7 +415,7 @@ mod tests {
     #[tokio::test]
     async fn test_pub_resolver_fetching_mainnet() {
         let provider = ProviderBuilder::new()
-            .connect_http("https://reth-ethereum.ithaca.xyz/rpc".parse().unwrap());
+            .connect_http("https://ethereum.reth.rs/rpc".parse().unwrap());
 
         let name = "vitalik.eth";
         let node = namehash(name);
@@ -426,7 +426,7 @@ mod tests {
     #[tokio::test]
     async fn test_resolve_name_via_universal_resolver() {
         let provider = ProviderBuilder::new()
-            .connect_http("https://reth-ethereum.ithaca.xyz/rpc".parse().unwrap());
+            .connect_http("https://ethereum.reth.rs/rpc".parse().unwrap());
 
         let addr = provider.resolve_name("ur.integration-tests.eth").await.unwrap();
         assert_eq!(addr, address!("0x2222222222222222222222222222222222222222"));
@@ -435,7 +435,7 @@ mod tests {
     #[tokio::test]
     async fn test_lookup_address_via_universal_resolver() {
         let provider = ProviderBuilder::new()
-            .connect_http("https://reth-ethereum.ithaca.xyz/rpc".parse().unwrap());
+            .connect_http("https://ethereum.reth.rs/rpc".parse().unwrap());
 
         let name = provider
             .lookup_address(&address!("0xeE9eeaAB0Bb7D9B969D701f6f8212609EDeA252E"))
@@ -447,7 +447,7 @@ mod tests {
     #[tokio::test]
     async fn test_lookup_txt_via_universal_resolver() {
         let provider = ProviderBuilder::new()
-            .connect_http("https://reth-ethereum.ithaca.xyz/rpc".parse().unwrap());
+            .connect_http("https://ethereum.reth.rs/rpc".parse().unwrap());
 
         let avatar = provider.lookup_txt("integration-tests.eth", "avatar").await.unwrap();
         assert_eq!(
@@ -459,7 +459,7 @@ mod tests {
     #[tokio::test]
     async fn test_pub_resolver_text() {
         let provider = ProviderBuilder::new()
-            .connect_http("http://reth-ethereum.ithaca.xyz/rpc".parse().unwrap());
+            .connect_http("http://ethereum.reth.rs/rpc".parse().unwrap());
 
         let name = "vitalik.eth";
         let node = namehash(name);
@@ -471,7 +471,7 @@ mod tests {
     #[tokio::test]
     async fn test_pub_resolver_fetching_txt() {
         let provider = ProviderBuilder::new()
-            .connect_http("http://reth-ethereum.ithaca.xyz/rpc".parse().unwrap());
+            .connect_http("http://ethereum.reth.rs/rpc".parse().unwrap());
 
         let name = "vitalik.eth";
         let res = provider.lookup_txt(name, "avatar").await.unwrap();

--- a/crates/ens/src/lib.rs
+++ b/crates/ens/src/lib.rs
@@ -405,8 +405,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_reverse_registrar_fetching_mainnet() {
-        let provider = ProviderBuilder::new()
-            .connect_http("https://ethereum.reth.rs/rpc".parse().unwrap());
+        let provider =
+            ProviderBuilder::new().connect_http("https://ethereum.reth.rs/rpc".parse().unwrap());
 
         let res = provider.get_reverse_registrar().await;
         assert_eq!(*res.unwrap().address(), address!("0xa58E81fe9b61B5c3fE2AFD33CF304c454AbFc7Cb"));
@@ -414,8 +414,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_pub_resolver_fetching_mainnet() {
-        let provider = ProviderBuilder::new()
-            .connect_http("https://ethereum.reth.rs/rpc".parse().unwrap());
+        let provider =
+            ProviderBuilder::new().connect_http("https://ethereum.reth.rs/rpc".parse().unwrap());
 
         let name = "vitalik.eth";
         let node = namehash(name);
@@ -425,8 +425,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_resolve_name_via_universal_resolver() {
-        let provider = ProviderBuilder::new()
-            .connect_http("https://ethereum.reth.rs/rpc".parse().unwrap());
+        let provider =
+            ProviderBuilder::new().connect_http("https://ethereum.reth.rs/rpc".parse().unwrap());
 
         let addr = provider.resolve_name("ur.integration-tests.eth").await.unwrap();
         assert_eq!(addr, address!("0x2222222222222222222222222222222222222222"));
@@ -434,8 +434,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_lookup_address_via_universal_resolver() {
-        let provider = ProviderBuilder::new()
-            .connect_http("https://ethereum.reth.rs/rpc".parse().unwrap());
+        let provider =
+            ProviderBuilder::new().connect_http("https://ethereum.reth.rs/rpc".parse().unwrap());
 
         let name = provider
             .lookup_address(&address!("0xeE9eeaAB0Bb7D9B969D701f6f8212609EDeA252E"))
@@ -446,8 +446,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_lookup_txt_via_universal_resolver() {
-        let provider = ProviderBuilder::new()
-            .connect_http("https://ethereum.reth.rs/rpc".parse().unwrap());
+        let provider =
+            ProviderBuilder::new().connect_http("https://ethereum.reth.rs/rpc".parse().unwrap());
 
         let avatar = provider.lookup_txt("integration-tests.eth", "avatar").await.unwrap();
         assert_eq!(
@@ -458,8 +458,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_pub_resolver_text() {
-        let provider = ProviderBuilder::new()
-            .connect_http("http://ethereum.reth.rs/rpc".parse().unwrap());
+        let provider =
+            ProviderBuilder::new().connect_http("http://ethereum.reth.rs/rpc".parse().unwrap());
 
         let name = "vitalik.eth";
         let node = namehash(name);
@@ -470,8 +470,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_pub_resolver_fetching_txt() {
-        let provider = ProviderBuilder::new()
-            .connect_http("http://ethereum.reth.rs/rpc".parse().unwrap());
+        let provider =
+            ProviderBuilder::new().connect_http("http://ethereum.reth.rs/rpc".parse().unwrap());
 
         let name = "vitalik.eth";
         let res = provider.lookup_txt(name, "avatar").await.unwrap();

--- a/crates/provider/README.md
+++ b/crates/provider/README.md
@@ -44,7 +44,7 @@ use std::str::FromStr;
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create a basic HTTP provider
-    let provider = RootProvider::<Ethereum>::new_http("https://reth-ethereum.ithaca.xyz/rpc".parse()?);
+    let provider = RootProvider::<Ethereum>::new_http("https://ethereum.reth.rs/rpc".parse()?);
 
     // Get the latest block number
     let block_number = provider.get_block_number().await?;
@@ -56,7 +56,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Balance: {balance}");
 
     // Use the builder pattern to create a provider with recommended fillers
-    let provider = ProviderBuilder::new().connect_http("https://reth-ethereum.ithaca.xyz/rpc".parse()?);
+    let provider = ProviderBuilder::new().connect_http("https://ethereum.reth.rs/rpc".parse()?);
 
     Ok(())
 }

--- a/crates/provider/src/ext/anvil.rs
+++ b/crates/provider/src/ext/anvil.rs
@@ -518,7 +518,7 @@ mod tests {
     use alloy_sol_types::{sol, SolCall};
 
     // use alloy_node_bindings::Anvil; (to be used in `test_anvil_reset`)
-    const FORK_URL: &str = "https://reth-ethereum.ithaca.xyz/rpc";
+    const FORK_URL: &str = "https://ethereum.reth.rs/rpc";
 
     #[tokio::test]
     async fn test_anvil_impersonate_account_stop_impersonating_account() {

--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -2521,7 +2521,7 @@ mod tests {
     #[tokio::test]
     #[cfg(feature = "hyper-tls")]
     async fn hyper_https() {
-        let url = "https://reth-ethereum.ithaca.xyz/rpc";
+        let url = "https://ethereum.reth.rs/rpc";
 
         // With the `hyper` feature enabled .connect builds the provider based on
         // `HyperTransport`.
@@ -2652,7 +2652,7 @@ mod tests {
     #[cfg(feature = "hyper")]
     async fn test_connect_hyper_tls() {
         let p =
-            ProviderBuilder::new().connect("https://reth-ethereum.ithaca.xyz/rpc").await.unwrap();
+            ProviderBuilder::new().connect("https://ethereum.reth.rs/rpc").await.unwrap();
 
         let _num = p.get_block_number().await.unwrap();
 

--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -2651,8 +2651,7 @@ mod tests {
     #[tokio::test]
     #[cfg(feature = "hyper")]
     async fn test_connect_hyper_tls() {
-        let p =
-            ProviderBuilder::new().connect("https://ethereum.reth.rs/rpc").await.unwrap();
+        let p = ProviderBuilder::new().connect("https://ethereum.reth.rs/rpc").await.unwrap();
 
         let _num = p.get_block_number().await.unwrap();
 


### PR DESCRIPTION
## Summary
- replace the old `reth-ethereum.ithaca.xyz` RPC host with `ethereum.reth.rs` in provider examples and tests
- update fork URLs in contract and provider test helpers
- keep the existing `http` vs `https` scheme choices at each call site

## Why
The codebase still referenced the older public Reth RPC host. This updates the examples and test fixtures to the current endpoint so they keep exercising a live public RPC.

## Validation
- `cargo test -p alloy-provider hyper_https --features hyper-tls`
- `cargo test -p alloy-provider test_connect_hyper_tls --features hyper-tls`
- `cargo test -p alloy-contract test_single`
- `cargo test -p alloy-contract test_erc20_dai_set_balance`
- `cargo test -p alloy-ens --features provider test_resolve_name_via_universal_resolver`
- `cargo test -p alloy-ens --features provider test_pub_resolver_text`
