### PR TITLE
test(provider): re-enable anvil tests

### DIFF
--- a/crates/provider/src/ext/anvil.rs
+++ b/crates/provider/src/ext/anvil.rs
@@ -517,7 +517,6 @@ mod tests {
     use alloy_rpc_types_eth::TransactionRequest;
     use alloy_sol_types::{sol, SolCall};
 
-    // use alloy_node_bindings::Anvil; (to be used in `test_anvil_reset`)
     const FORK_URL: &str = "https://ethereum.reth.rs/rpc";
 
     #[tokio::test]
@@ -733,29 +732,22 @@ mod tests {
         provider.anvil_drop_all_transactions().await.unwrap();
     }
 
-    // TODO: Fix this test, `chain_id` is not being set correctly.
-    // #[tokio::test]
-    // async fn test_anvil_reset() {
-    //     let fork1 = Anvil::default().chain_id(777).spawn();
-    //     let fork2 = Anvil::default().chain_id(888).spawn();
+    #[tokio::test]
+    async fn test_anvil_reset() {
+        let provider = ProviderBuilder::new().connect_anvil();
 
-    //     let provider = ProviderBuilder::new()
-    //         .connect_anvil_with_config(|config| config.fork(fork1.endpoint_url().to_string()));
+        let alice = Address::random();
+        let balance = U256::from(1e18 as u64);
+        provider.anvil_set_balance(alice, balance).await.unwrap();
 
-    //     let chain_id = provider.get_chain_id().await.unwrap();
-    //     assert_eq!(chain_id, 777);
+        let current_balance = provider.get_balance(alice).await.unwrap();
+        assert_eq!(current_balance, balance);
 
-    //     provider
-    //         .anvil_reset(Some(Forking {
-    //             json_rpc_url: Some(fork2.endpoint_url().to_string()),
-    //             block_number: Some(0),
-    //         }))
-    //         .await
-    //         .unwrap();
+        provider.anvil_reset(None).await.unwrap();
 
-    //     let chain_id = provider.get_chain_id().await.unwrap();
-    //     assert_eq!(chain_id, 888);
-    // }
+        let reset_balance = provider.get_balance(alice).await.unwrap();
+        assert_eq!(reset_balance, U256::ZERO);
+    }
 
     #[tokio::test]
     async fn test_anvil_set_chain_id() {
@@ -1091,21 +1083,20 @@ mod tests {
         assert_eq!(num, start_num + 10);
     }
 
-    // TODO: Fix this test, only a single block is being mined regardless of the `blocks` parameter.
-    // #[tokio::test]
-    // async fn test_evm_mine_with_configuration() {
-    //     let provider = ProviderBuilder::new().connect_anvil();
+    #[tokio::test]
+    async fn test_evm_mine_with_configuration() {
+        let provider = ProviderBuilder::new().connect_anvil();
 
-    //     let start_num = provider.get_block_number().await.unwrap();
+        let start_num = provider.get_block_number().await.unwrap();
 
-    //     provider
-    //         .evm_mine(Some(MineOptions::Options { timestamp: Some(100), blocks: Some(10) }))
-    //         .await
-    //         .unwrap();
+        provider
+            .evm_mine(Some(MineOptions::Options { timestamp: None, blocks: Some(10) }))
+            .await
+            .unwrap();
 
-    //     let num = provider.get_block_number().await.unwrap();
-    //     assert_eq!(num, start_num + 10);
-    // }
+        let num = provider.get_block_number().await.unwrap();
+        assert_eq!(num, start_num + 10);
+    }
 
     #[tokio::test]
     async fn test_anvil_mine_detailed_single_block() {
@@ -1123,28 +1114,24 @@ mod tests {
         assert_eq!(num, start_num + 10);
     }
 
-    // TODO: Fix this test, only a single block is being mined regardless of the `blocks` parameter.
-    // #[tokio::test]
-    // async fn test_anvil_mine_detailed_with_configuration() {
-    //     let provider = ProviderBuilder::new().connect_anvil();
+    #[tokio::test]
+    async fn test_anvil_mine_detailed_with_configuration() {
+        let provider = ProviderBuilder::new().connect_anvil();
 
-    //     let start_num = provider.get_block_number().await.unwrap();
+        let start_num = provider.get_block_number().await.unwrap();
 
-    //     let blocks = provider
-    //         .anvil_mine_detailed(Some(MineOptions::Options {
-    //             timestamp: Some(100),
-    //             blocks: Some(10),
-    //         }))
-    //         .await
-    //         .unwrap();
+        let blocks = provider
+            .anvil_mine_detailed(Some(MineOptions::Options { timestamp: None, blocks: Some(10) }))
+            .await
+            .unwrap();
 
-    //     let num = provider.get_block_number().await.unwrap();
-    //     assert_eq!(num, start_num + 10);
+        let num = provider.get_block_number().await.unwrap();
+        assert_eq!(num, start_num + 10);
 
-    //     for (idx, block) in blocks.iter().enumerate() {
-    //         assert_eq!(block.header.number, Some(start_num + idx as u64 + 1));
-    //     }
-    // }
+        for (idx, block) in blocks.iter().enumerate() {
+            assert_eq!(block.header.number, start_num + idx as u64 + 1);
+        }
+    }
 
     #[tokio::test]
     async fn test_anvil_set_rpc_url() {


### PR DESCRIPTION
## Summary

Re-enables the Anvil provider tests that are currently commented out on `main`.

This is split out from #3899 and only carries the test changes:
- re-enable `test_evm_mine_with_configuration`
- re-enable `test_anvil_mine_detailed_with_configuration`
- replace the old disabled reset test with the current `anvil_reset(None)` behavior check

## Validation

Ran on current `main` after pulling:
- `cargo test -p alloy-provider --features anvil-api test_anvil_reset -- --nocapture`
- `cargo test -p alloy-provider --features anvil-api test_evm_mine_with_configuration -- --nocapture`
- `cargo test -p alloy-provider --features anvil-api test_anvil_mine_detailed_with_configuration -- --nocapture`
- `cargo fmt --check --all`
