### PR TITLE
fix(provider): skip batching eth_call with block overrides

### DIFF
--- a/crates/provider/src/layers/batch.rs
+++ b/crates/provider/src/layers/batch.rs
@@ -261,6 +261,9 @@ impl<N: Network> CallBatchProviderInner<N> {
         if params.overrides.as_ref().is_some_and(|overrides| !overrides.is_empty()) {
             return false;
         }
+        if params.block_overrides().is_some_and(|overrides| !overrides.is_empty()) {
+            return false;
+        }
         let tx = params.data();
         if tx.to().is_none() {
             return false;
@@ -531,8 +534,9 @@ impl<N: Network> Caller<N, Bytes> for CallBatchCaller<N> {
 mod tests {
     use super::*;
     use crate::ProviderBuilder;
+    use alloy_network::{Ethereum, TransactionBuilder};
     use alloy_primitives::{address, hex};
-    use alloy_rpc_types_eth::TransactionRequest;
+    use alloy_rpc_types_eth::{BlockOverrides, TransactionRequest};
     use alloy_transport::mock::Asserter;
 
     // https://etherscan.io/address/0xcA11bde05977b3631167028862bE2a173976CA11#code
@@ -596,6 +600,17 @@ mod tests {
         assert!(block_number_err.contains("response count mismatch"), "{block_number_err}");
         assert!(chain_id_err.contains("response count mismatch"), "{chain_id_err}");
         assert!(asserter.read_q().is_empty(), "only 1 request should've been made");
+    }
+
+    #[test]
+    fn should_not_batch_calls_with_block_overrides() {
+        let (tx, _) = tokio::sync::mpsc::unbounded_channel();
+        let inner = CallBatchProviderInner::<Ethereum> { tx };
+        let params =
+            crate::EthCallParams::new(TransactionRequest::default().with_to(COUNTER_ADDRESS))
+                .with_block_overrides(BlockOverrides::default().with_number(U256::from(1)));
+
+        assert!(!inner.should_batch_call(&params));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Motivation

Batched `eth_call` requests currently only screen out block ids and state overrides.
When a caller supplies non-empty `block_overrides`, the batching path drops that
context and silently executes a different call shape than the direct RPC path.

## Solution

Reject batched `eth_call` requests that carry non-empty block overrides so they
fall back to the normal request path, and add a targeted regression test for the
compatibility gate.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes