### PR TITLE
chore(rpc-types-engine): mark TestingBuildBlockRequestV1 non_exhaustive

### DIFF
--- a/crates/rpc-types-engine/src/testing.rs
+++ b/crates/rpc-types-engine/src/testing.rs
@@ -13,6 +13,7 @@ pub const TESTING_BUILD_BLOCK_V1: &str = "testing_buildBlockV1";
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[non_exhaustive]
 pub struct TestingBuildBlockRequestV1 {
     /// Parent block hash of the block to build.
     pub parent_block_hash: B256,


### PR DESCRIPTION
## Summary

Marks `TestingBuildBlockRequestV1` as `#[non_exhaustive]` so new fields can be added without breaking downstream consumers.