### PR TITLE
Handle Filler Loop Gracefully

### DIFF
--- a/crates/provider/src/fillers/mod.rs
+++ b/crates/provider/src/fillers/mod.rs
@@ -356,10 +356,10 @@ where
             if count >= 20 {
                 const ERROR: &str = "Tx filler loop detected. This indicates a bug in some filler implementation. Please file an issue containing this message.";
                 error!(
-                    ?tx, ?self.filler,
+                    ?tx, ?self.filler, loop_iterations = count,
                     ERROR
                 );
-                panic!("{}, {:?}, {:?}", ERROR, &tx, &self.filler);
+                return Err(TransportError::local_usage_str(ERROR));
             }
         }
         Ok(tx)


### PR DESCRIPTION
 ## Motivation
                                                                                                                                                                                      
  FillProvider::fill_inner currently panics when filler iterations reach the safety threshold (count >= 20).                                                                          
  That turns a filler implementation bug into a process-level crash, which is too severe for a recoverable local-usage error path.                                                    
                                                                                                                                                                                      
  ## Solution                                                                                                                                                                         
                                                                                                                                                                                      
  Keep the same loop guard and diagnostics, but replace panic! with a structured error return:                                                                                        
                                                                                                                                                                                      
  - return Err(TransportError::local_usage_str(ERROR)) instead of panicking                                                                                                           
  - keep error! logging and add loop_iterations = count for better observability                                                                                                      
                                                                                                                                                                                      
  This preserves the defensive loop protection while avoiding process termination and letting callers handle the failure.                                                             
                                                                                                                                                                                      
  Validation run on this change:                                                                                                                                                      
                                                                                                                                                                                      
  - cargo check -p alloy-provider                                                                                                                                                     
  - cargo test -p alloy-provider --lib --no-run                                                                                                                                       

  ## PR Checklist                                                                                                                                                                     
                                                                                                                                                                                      
  - [ ] Added Tests                                                                                                                                                                   
  - [ ] Added Documentation                                                                                                                                                           
  - [ ] Breaking changes    