### PR TITLE
feat(eips): add sidecar shrink_to_fit helpers

### DIFF
--- a/crates/eips/src/eip4844/sidecar.rs
+++ b/crates/eips/src/eip4844/sidecar.rs
@@ -239,6 +239,14 @@ impl BlobTransactionSidecar {
         Self { blobs, commitments, proofs }
     }
 
+    /// Shrinks the sidecar vectors to fit their current contents.
+    #[inline]
+    pub fn shrink_to_fit(&mut self) {
+        self.blobs.shrink_to_fit();
+        self.commitments.shrink_to_fit();
+        self.proofs.shrink_to_fit();
+    }
+
     /// Creates a new instance from the given KZG types.
     #[cfg(feature = "kzg")]
     pub fn from_kzg(

--- a/crates/eips/src/eip7594/sidecar.rs
+++ b/crates/eips/src/eip7594/sidecar.rs
@@ -556,6 +556,14 @@ impl BlobTransactionSidecarEip7594 {
             + self.cell_proofs.capacity() * BYTES_PER_PROOF
     }
 
+    /// Shrinks the sidecar vectors to fit their current contents.
+    #[inline]
+    pub fn shrink_to_fit(&mut self) {
+        self.blobs.shrink_to_fit();
+        self.commitments.shrink_to_fit();
+        self.cell_proofs.shrink_to_fit();
+    }
+
     /// Tries to create a new [`BlobTransactionSidecarEip7594`] from the hex encoded blob str.
     ///
     /// See also [`Blob::from_hex`](c_kzg::Blob::from_hex)


### PR DESCRIPTION
## Summary
- add `shrink_to_fit` to `BlobTransactionSidecar`
- add `shrink_to_fit` to `BlobTransactionSidecarEip7594`
- keep the change API-only without adding targeted tests

## Why
These sidecar containers can hold large blob vectors after decode or other growth-heavy paths, so exposing an explicit capacity-trimming helper lets callers release excess allocation when they know the sidecar will be retained.

## Validation
- not run (per request)