### PR TITLE
docs(provider): add cfg_attr doc(cfg) to pubsub/ws/ipc feature-gated items

### DIFF
--- a/crates/provider/src/builder.rs
+++ b/crates/provider/src/builder.rs
@@ -517,6 +517,7 @@ impl<L, F, N> ProviderBuilder<L, F, N> {
     ///
     /// [`PubSubConnect`]: alloy_pubsub::PubSubConnect
     #[cfg(feature = "pubsub")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "pubsub")))]
     pub async fn connect_pubsub_with<C>(self, connect: C) -> Result<F::Provider, TransportError>
     where
         L: ProviderLayer<RootProvider<N>, N>,
@@ -529,6 +530,7 @@ impl<L, F, N> ProviderBuilder<L, F, N> {
 
     /// Build this provider with a websocket connection.
     #[cfg(feature = "ws-base")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ws-base")))]
     pub async fn connect_ws(
         self,
         connect: alloy_transport_ws::WsConnect,
@@ -544,6 +546,7 @@ impl<L, F, N> ProviderBuilder<L, F, N> {
 
     /// Build this provider with an IPC connection.
     #[cfg(feature = "ipc")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ipc")))]
     pub async fn connect_ipc<T>(
         self,
         connect: alloy_transport_ipc::IpcConnect<T>,

--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -1309,6 +1309,7 @@ pub trait Provider<N: Network = Ethereum>: Send + Sync {
     /// # }
     /// ```
     #[cfg(feature = "pubsub")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "pubsub")))]
     fn subscribe_blocks(&self) -> GetSubscription<(SubscriptionKind,), N::HeaderResponse> {
         let rpc_call = self.client().request("eth_subscribe", (SubscriptionKind::NewHeads,));
         GetSubscription::new(self.weak_client(), rpc_call)
@@ -1338,6 +1339,7 @@ pub trait Provider<N: Network = Ethereum>: Send + Sync {
     /// # }
     /// ```
     #[cfg(feature = "pubsub")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "pubsub")))]
     fn subscribe_full_blocks(&self) -> SubFullBlocks<N> {
         SubFullBlocks::new(self.subscribe_blocks(), self.weak_client())
     }
@@ -1368,6 +1370,7 @@ pub trait Provider<N: Network = Ethereum>: Send + Sync {
     /// # }
     /// ```
     #[cfg(feature = "pubsub")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "pubsub")))]
     fn subscribe_pending_transactions(&self) -> GetSubscription<(SubscriptionKind,), B256> {
         let rpc_call =
             self.client().request("eth_subscribe", (SubscriptionKind::NewPendingTransactions,));
@@ -1405,6 +1408,7 @@ pub trait Provider<N: Network = Ethereum>: Send + Sync {
     /// # }
     /// ```
     #[cfg(feature = "pubsub")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "pubsub")))]
     fn subscribe_full_pending_transactions(
         &self,
     ) -> GetSubscription<(SubscriptionKind, Params), N::TransactionResponse> {
@@ -1446,6 +1450,7 @@ pub trait Provider<N: Network = Ethereum>: Send + Sync {
     /// # }
     /// ```
     #[cfg(feature = "pubsub")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "pubsub")))]
     fn subscribe_logs(&self, filter: &Filter) -> GetSubscription<(SubscriptionKind, Params), Log> {
         let rpc_call = self.client().request(
             "eth_subscribe",
@@ -1456,6 +1461,7 @@ pub trait Provider<N: Network = Ethereum>: Send + Sync {
 
     /// Subscribe to an RPC event.
     #[cfg(feature = "pubsub")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "pubsub")))]
     #[auto_impl(keep_default_for(&, &mut, Rc, Arc, Box))]
     fn subscribe<P, R>(&self, params: P) -> GetSubscription<P, R>
     where
@@ -1488,6 +1494,7 @@ pub trait Provider<N: Network = Ethereum>: Send + Sync {
     /// # }
     /// ```
     #[cfg(feature = "pubsub")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "pubsub")))]
     #[auto_impl(keep_default_for(&, &mut, Rc, Arc, Box))]
     fn subscribe_to<R>(&self, method: &'static str) -> GetSubscription<NoParams, R>
     where
@@ -1501,6 +1508,7 @@ pub trait Provider<N: Network = Ethereum>: Send + Sync {
 
     /// Cancels a subscription given the subscription ID.
     #[cfg(feature = "pubsub")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "pubsub")))]
     async fn unsubscribe(&self, id: B256) -> TransportResult<()> {
         self.root().unsubscribe(id)
     }


### PR DESCRIPTION
## Motivation

`alloy-provider` already enables `#![cfg_attr(docsrs, feature(doc_cfg))]` at the crate level. Since #3858, the `anvil-node`-gated methods on `ProviderBuilder` carry `#[cfg_attr(docsrs, doc(cfg(feature = "anvil-node")))]`, so docs.rs renders a clear feature-requirement badge for them.

The `pubsub`, `ws-base`, and `ipc` connect methods on `ProviderBuilder`, and all eight `subscribe_*`/`unsubscribe` methods on the `Provider` trait, were missing the same annotation — leaving users to discover the required feature flags only through a generic "method not found" compiler error.

## Solution

Add the missing `#[cfg_attr(docsrs, doc(cfg(feature = "...")))]` to:

**`crates/provider/src/builder.rs`**
- `ProviderBuilder::connect_pubsub_with` (`pubsub`)
- `ProviderBuilder::connect_ws` (`ws-base`)
- `ProviderBuilder::connect_ipc` (`ipc`)

**`crates/provider/src/provider/trait.rs`**
- `Provider::subscribe_blocks` (`pubsub`)
- `Provider::subscribe_full_blocks` (`pubsub`)
- `Provider::subscribe_pending_transactions` (`pubsub`)
- `Provider::subscribe_full_pending_transactions` (`pubsub`)
- `Provider::subscribe_logs` (`pubsub`)
- `Provider::subscribe` (`pubsub`)
- `Provider::subscribe_to` (`pubsub`)
- `Provider::unsubscribe` (`pubsub`)

doc metadata. Compiles cleanly with `cargo check -p alloy-provider --all-features`.

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [ ] Breaking changes