### PR TITLE
feat(eips): add SSZ support for blob proof types

### DIFF
--- a/crates/eips/src/eip4844/engine.rs
+++ b/crates/eips/src/eip4844/engine.rs
@@ -13,6 +13,46 @@ pub struct BlobAndProofV1 {
     pub proof: Bytes48,
 }
 
+#[cfg(feature = "ssz")]
+impl ssz::Encode for BlobAndProofV1 {
+    fn is_ssz_fixed_len() -> bool {
+        true
+    }
+
+    fn ssz_fixed_len() -> usize {
+        <Blob as ssz::Encode>::ssz_fixed_len() + <Bytes48 as ssz::Encode>::ssz_fixed_len()
+    }
+
+    fn ssz_bytes_len(&self) -> usize {
+        Self::ssz_fixed_len()
+    }
+
+    fn ssz_append(&self, buf: &mut Vec<u8>) {
+        ssz::Encode::ssz_append(self.blob.as_ref(), buf);
+        ssz::Encode::ssz_append(&self.proof, buf);
+    }
+}
+
+#[cfg(feature = "ssz")]
+impl ssz::Decode for BlobAndProofV1 {
+    fn is_ssz_fixed_len() -> bool {
+        true
+    }
+
+    fn ssz_fixed_len() -> usize {
+        <Blob as ssz::Decode>::ssz_fixed_len() + <Bytes48 as ssz::Decode>::ssz_fixed_len()
+    }
+
+    fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, ssz::DecodeError> {
+        let mut builder = ssz::SszDecoderBuilder::new(bytes);
+        builder.register_type::<Blob>()?;
+        builder.register_type::<Bytes48>()?;
+
+        let mut decoder = builder.build()?;
+        Ok(Self { blob: Box::new(decoder.decode_next()?), proof: decoder.decode_next()? })
+    }
+}
+
 /// Blob type returned in responses to `engine_getBlobsV2`: <https://github.com/ethereum/execution-apis/pull/630>
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -22,4 +62,114 @@ pub struct BlobAndProofV2 {
     pub blob: Box<Blob>,
     /// The cell proofs for the blob.
     pub proofs: Vec<Bytes48>,
+}
+
+#[cfg(feature = "ssz")]
+impl ssz::Encode for BlobAndProofV2 {
+    fn is_ssz_fixed_len() -> bool {
+        false
+    }
+
+    fn ssz_bytes_len(&self) -> usize {
+        <Blob as ssz::Encode>::ssz_fixed_len()
+            + <Vec<Bytes48> as ssz::Encode>::ssz_fixed_len()
+            + ssz::Encode::ssz_bytes_len(&self.proofs)
+    }
+
+    fn ssz_append(&self, buf: &mut Vec<u8>) {
+        let offset =
+            <Blob as ssz::Encode>::ssz_fixed_len() + <Vec<Bytes48> as ssz::Encode>::ssz_fixed_len();
+        let mut encoder = ssz::SszEncoder::container(buf, offset);
+        encoder.append(self.blob.as_ref());
+        encoder.append(&self.proofs);
+        encoder.finalize();
+    }
+}
+
+#[cfg(feature = "ssz")]
+impl ssz::Decode for BlobAndProofV2 {
+    fn is_ssz_fixed_len() -> bool {
+        false
+    }
+
+    fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, ssz::DecodeError> {
+        let mut builder = ssz::SszDecoderBuilder::new(bytes);
+        builder.register_type::<Blob>()?;
+        builder.register_type::<Vec<Bytes48>>()?;
+
+        let mut decoder = builder.build()?;
+        let blob = decoder.decode_next()?;
+        let proofs: Vec<Bytes48> = decoder.decode_next()?;
+        if proofs.len() > crate::eip7594::CELLS_PER_EXT_BLOB {
+            return Err(ssz::DecodeError::BytesInvalid(format!(
+                "Invalid BlobAndProofV2: expected at most {} proofs, got {}",
+                crate::eip7594::CELLS_PER_EXT_BLOB,
+                proofs.len()
+            )));
+        }
+
+        Ok(Self { blob: Box::new(blob), proofs })
+    }
+}
+
+#[cfg(all(test, feature = "ssz"))]
+mod tests {
+    use super::*;
+    use crate::{eip4844::BYTES_PER_BLOB, eip7594::CELLS_PER_EXT_BLOB};
+
+    #[test]
+    fn ssz_blob_and_proof_v1_roundtrip() {
+        let blob_and_proof = BlobAndProofV1 {
+            blob: Box::new(Blob::repeat_byte(0x42)),
+            proof: Bytes48::repeat_byte(0x24),
+        };
+
+        let encoded = ssz::Encode::as_ssz_bytes(&blob_and_proof);
+        assert_eq!(encoded.len(), BYTES_PER_BLOB + 48);
+        assert_eq!(&encoded[..BYTES_PER_BLOB], blob_and_proof.blob.as_slice());
+        assert_eq!(&encoded[BYTES_PER_BLOB..], blob_and_proof.proof.as_slice());
+
+        let decoded = <BlobAndProofV1 as ssz::Decode>::from_ssz_bytes(&encoded).unwrap();
+        assert_eq!(decoded, blob_and_proof);
+    }
+
+    #[test]
+    fn ssz_blob_and_proof_v2_roundtrip() {
+        let proofs =
+            (0..CELLS_PER_EXT_BLOB).map(|i| Bytes48::repeat_byte(i as u8)).collect::<Vec<_>>();
+        let blob_and_proof = BlobAndProofV2 { blob: Box::new(Blob::repeat_byte(0x42)), proofs };
+
+        let encoded = ssz::Encode::as_ssz_bytes(&blob_and_proof);
+        let expected_offset = BYTES_PER_BLOB + ssz::BYTES_PER_LENGTH_OFFSET;
+        assert_eq!(encoded.len(), expected_offset + CELLS_PER_EXT_BLOB * 48);
+        assert_eq!(
+            u32::from_le_bytes(encoded[BYTES_PER_BLOB..expected_offset].try_into().unwrap())
+                as usize,
+            expected_offset
+        );
+        assert_eq!(&encoded[..BYTES_PER_BLOB], blob_and_proof.blob.as_slice());
+
+        let mut proof_chunks = encoded[expected_offset..].chunks_exact(48);
+        for (proof, chunk) in blob_and_proof.proofs.iter().zip(&mut proof_chunks) {
+            assert_eq!(chunk, proof.as_slice());
+        }
+        assert!(proof_chunks.remainder().is_empty());
+
+        let decoded = <BlobAndProofV2 as ssz::Decode>::from_ssz_bytes(&encoded).unwrap();
+        assert_eq!(decoded, blob_and_proof);
+    }
+
+    #[test]
+    fn ssz_blob_and_proof_v2_rejects_too_many_proofs() {
+        let blob_and_proof = BlobAndProofV2 {
+            blob: Box::new(Blob::repeat_byte(0x42)),
+            proofs: vec![Bytes48::ZERO; CELLS_PER_EXT_BLOB + 1],
+        };
+        let encoded = ssz::Encode::as_ssz_bytes(&blob_and_proof);
+
+        let err = <BlobAndProofV2 as ssz::Decode>::from_ssz_bytes(&encoded).unwrap_err();
+        assert!(
+            matches!(err, ssz::DecodeError::BytesInvalid(message) if message.contains("BlobAndProofV2"))
+        );
+    }
 }


### PR DESCRIPTION
Adds SSZ encoding and decoding support for Engine API blob proof response types.

This lets `BlobAndProofV1` and `BlobAndProofV2` be used with binary Engine API transport paths.

Validation:
- `cargo test -p alloy-eips --features ssz eip4844::engine`
- `cargo check -p alloy-rpc-types-engine --features ssz`