### PR TITLE
perf(serde): avoid heap allocation in JsonStorageKey Display

### DIFF
--- a/crates/serde/src/storage.rs
+++ b/crates/serde/src/storage.rs
@@ -88,7 +88,7 @@ impl fmt::Display for JsonStorageKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Hash(hash) => hash.fmt(f),
-            Self::Number(num) => alloc::format!("{num:#x}").fmt(f),
+            Self::Number(num) => write!(f, "{num:#x}"),
         }
     }
 }


### PR DESCRIPTION
Replace `alloc::format!("{num:#x}").fmt(f)` with `write!(f, "{num:#x}")` in `JsonStorageKey::fmt`. The old code created a temporary `String` on every call, wasting allocations on hot paths like `eth_getStorageAt`. Same pattern fixed in cdcc69c4 for `BlockNumberOrTag` and `Index`.