### PR TITLE
fix(provider): return network blocks from anvil_mine_detailed

### DIFF
--- a/crates/provider/src/ext/anvil.rs
+++ b/crates/provider/src/ext/anvil.rs
@@ -5,7 +5,6 @@ use alloy_consensus::Blob;
 use alloy_network::{Network, TransactionBuilder};
 use alloy_primitives::{Address, Bytes, TxHash, B256, U128, U256, U64};
 use alloy_rpc_types_anvil::{Forking, Metadata, MineOptions, NodeInfo, ReorgOptions};
-use alloy_rpc_types_eth::Block;
 use alloy_transport::{TransportError, TransportResult};
 use futures::try_join;
 
@@ -144,7 +143,10 @@ pub trait AnvilApi<N: Network>: Send + Sync {
 
     /// Mine blocks, instantly and return the mined blocks.
     /// This will mine the blocks regardless of the configured mining mode.
-    async fn anvil_mine_detailed(&self, opts: Option<MineOptions>) -> TransportResult<Vec<Block>>;
+    async fn anvil_mine_detailed(
+        &self,
+        opts: Option<MineOptions>,
+    ) -> TransportResult<Vec<N::BlockResponse>>;
 
     /// Sets the backend rpc url.
     async fn anvil_set_rpc_url(&self, url: String) -> TransportResult<()>;
@@ -359,7 +361,10 @@ where
         self.client().request("evm_mine", (opts,)).await
     }
 
-    async fn anvil_mine_detailed(&self, opts: Option<MineOptions>) -> TransportResult<Vec<Block>> {
+    async fn anvil_mine_detailed(
+        &self,
+        opts: Option<MineOptions>,
+    ) -> TransportResult<Vec<N::BlockResponse>> {
         self.client().request("evm_mine_detailed", (opts,)).await
     }
 
@@ -510,9 +515,10 @@ mod tests {
         fillers::{ChainIdFiller, GasFiller},
         ProviderBuilder,
     };
-    use alloy_consensus::{SidecarBuilder, SimpleCoder};
+    use alloy_consensus::{BlockHeader, SidecarBuilder, SimpleCoder};
     use alloy_eips::BlockNumberOrTag;
-    use alloy_network::{TransactionBuilder, TransactionBuilder4844};
+    use alloy_network::{AnyNetwork, TransactionBuilder, TransactionBuilder4844};
+    use alloy_network_primitives::BlockResponse as _;
     use alloy_primitives::{address, B256};
     use alloy_rpc_types_eth::TransactionRequest;
     use alloy_sol_types::{sol, SolCall};
@@ -1129,7 +1135,24 @@ mod tests {
         assert_eq!(num, start_num + 10);
 
         for (idx, block) in blocks.iter().enumerate() {
-            assert_eq!(block.header.number, start_num + idx as u64 + 1);
+            assert_eq!(block.header().number(), start_num + idx as u64 + 1);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_anvil_mine_detailed_with_any_network() {
+        let provider = ProviderBuilder::new().network::<AnyNetwork>().connect_anvil();
+
+        let start_num = provider.get_block_number().await.unwrap();
+
+        let blocks = provider
+            .anvil_mine_detailed(Some(MineOptions::Options { timestamp: None, blocks: Some(2) }))
+            .await
+            .unwrap();
+
+        assert_eq!(blocks.len(), 2);
+        for (idx, block) in blocks.iter().enumerate() {
+            assert_eq!(block.header().number(), start_num + idx as u64 + 1);
         }
     }
 


### PR DESCRIPTION
## Motivation

`AnvilApi<N>` is generic over the provider network, but `anvil_mine_detailed`
still returns the concrete Ethereum RPC block type. That leaks an Ethereum-only
type through a generic interface and blocks `AnyNetwork` callers from using the
method consistently.

## Solution

Change `anvil_mine_detailed` to return `Vec<N::BlockResponse>` and add an
`AnyNetwork` regression test to confirm the generic return type works end to
end.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes