### PR TITLE
perf(json-rpc): preallocate capacity in ResponsePacket deserialization

### DIFF
--- a/crates/json-rpc/src/packet.rs
+++ b/crates/json-rpc/src/packet.rs
@@ -212,7 +212,7 @@ where
             where
                 A: SeqAccess<'de>,
             {
-                let mut responses = Vec::new();
+                let mut responses = Vec::with_capacity(seq.size_hint().unwrap_or(0));
 
                 while let Some(response) = seq.next_element()? {
                     responses.push(response);


### PR DESCRIPTION
Use `Vec::with_capacity(seq.size_hint().unwrap_or(0))` instead of `Vec::new()` when deserializing batch responses. For large batches (100+ responses), this avoids 6-7 reallocation cycles during the while-push loop.
