### PR TITLE
feat(signer-tempo): add Tempo wallet keystore reader

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,7 @@ jobs:
             --exclude alloy-signer-gcp \
             --exclude alloy-signer-ledger \
             --exclude alloy-signer-local \
+            --exclude alloy-signer-tempo \
             --exclude alloy-signer-trezor \
             --exclude alloy-signer-turnkey \
             --exclude alloy-transport-ipc

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ alloy-signer-aws = { version = "2.0.1", path = "crates/signer-aws", default-feat
 alloy-signer-gcp = { version = "2.0.1", path = "crates/signer-gcp", default-features = false }
 alloy-signer-ledger = { version = "2.0.1", path = "crates/signer-ledger", default-features = false }
 alloy-signer-local = { version = "2.0.1", path = "crates/signer-local", default-features = false }
+alloy-signer-tempo = { version = "2.0.1", path = "crates/signer-tempo", default-features = false }
 alloy-signer-trezor = { version = "2.0.1", path = "crates/signer-trezor", default-features = false }
 alloy-signer-turnkey = { version = "2.0.1", path = "crates/signer-turnkey", default-features = false }
 alloy-transport = { version = "2.0.1", path = "crates/transport", default-features = false }

--- a/crates/signer-tempo/Cargo.toml
+++ b/crates/signer-tempo/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "alloy-signer-tempo"
+description = "Read-only Tempo wallet keystore reader for alloy"
+publish = false
+
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+exclude.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = [
+    "-Zunstable-options",
+    "--generate-link-to-definition",
+    "--show-type-layout",
+]
+
+[lints]
+workspace = true
+
+[dependencies]
+alloy-primitives = { workspace = true, features = ["serde"] }
+alloy-signer-local.workspace = true
+serde.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
+toml = { version = "0.8", default-features = false, features = ["parse"] }
+
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+dirs = "5"
+
+[dev-dependencies]
+serial_test.workspace = true
+tempfile.workspace = true

--- a/crates/signer-tempo/Cargo.toml
+++ b/crates/signer-tempo/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "alloy-signer-tempo"
 description = "Read-only Tempo wallet keystore reader for alloy"
-publish = false
 
 version.workspace = true
 edition.workspace = true

--- a/crates/signer-tempo/README.md
+++ b/crates/signer-tempo/README.md
@@ -1,0 +1,40 @@
+# alloy-signer-tempo
+
+Read-only [Tempo wallet](https://github.com/tempoxyz/wallet) keystore reader
+for alloy. Parses the file that `tempo wallet login` writes and exposes the
+materialized signer plus optional Keychain-mode metadata. No network I/O.
+
+## On-disk path
+
+`$TEMPO_HOME/wallet/keys.toml`, falling back to `~/.tempo/wallet/keys.toml`
+(Unix mode `0600`). Matches the Tempo CLI exactly.
+
+## Example
+
+```rust,no_run
+use alloy_primitives::address;
+use alloy_signer_tempo::{TempoKeystore, TempoLookup};
+
+let store = TempoKeystore::load()?;
+match store.find_by_from(address!("0x70997970c51812dc3a010c7d01b50e0d17dc79c8"))? {
+    TempoLookup::Direct(signer) => {
+        // EOA: the on-disk key IS the wallet account.
+        let _ = signer;
+    }
+    TempoLookup::Keychain(signer, access_key) => {
+        // Smart wallet: ephemeral access key signs on behalf of the root wallet.
+        let _ = (signer, access_key);
+    }
+    _ => unreachable!("TempoLookup is `#[non_exhaustive]`"),
+}
+# Ok::<_, alloy_signer_tempo::TempoSignerError>(())
+```
+
+## Scope
+
+In: read `keys.toml`, materialize `PrivateKeySigner`, expose Keychain
+metadata, foundry-compatible env vars (`TEMPO_PRIVATE_KEY`,
+`TEMPO_ACCESS_KEY`, `TEMPO_ROOT_ACCOUNT`).
+
+Out: writing/rotating keys, decoding `key_authorization` to a typed value
+(the RLP bytes are exposed opaquely), any network I/O.

--- a/crates/signer-tempo/src/entry.rs
+++ b/crates/signer-tempo/src/entry.rs
@@ -1,0 +1,82 @@
+use alloy_primitives::Address;
+use serde::Deserialize;
+
+/// On-chain wallet type recorded for an entry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+#[non_exhaustive]
+pub enum WalletType {
+    /// EOA: the on-disk key is the wallet account.
+    Local,
+    /// Smart wallet: the on-disk key is an access key authorized by a passkey.
+    Passkey,
+    /// Unrecognized variant.
+    #[serde(other)]
+    Unknown,
+}
+
+/// Cryptographic key type recorded for an entry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+#[non_exhaustive]
+pub enum KeyType {
+    /// secp256k1 ECDSA. The only type this crate can materialize.
+    Secp256k1,
+    /// p256 (NIST P-256) ECDSA.
+    P256,
+    /// WebAuthn passkey signature.
+    #[serde(rename = "webauthn")]
+    WebAuthn,
+    /// Unrecognized variant.
+    #[serde(other)]
+    Unknown,
+}
+
+/// Per-token spending limit attached to an access key.
+#[derive(Debug, Clone, Deserialize)]
+pub struct TokenLimit {
+    /// ERC-20 token contract address.
+    pub currency: Address,
+    /// Spending limit as a decimal-string integer (kept as `String` to avoid precision loss).
+    pub limit: String,
+}
+
+/// Internal TOML schema. Not part of the public API.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct RawKeyEntry {
+    pub(crate) wallet_type: WalletType,
+    pub(crate) wallet_address: Address,
+    pub(crate) chain_id: u64,
+    pub(crate) key_type: KeyType,
+    pub(crate) key_address: Option<Address>,
+    /// 0x-hex secp256k1 private key.
+    pub(crate) key: Option<String>,
+    /// 0x-hex RLP-encoded `SignedKeyAuthorization`.
+    pub(crate) key_authorization: Option<String>,
+    pub(crate) expiry: Option<u64>,
+    #[serde(default)]
+    pub(crate) limits: Vec<TokenLimit>,
+}
+
+/// Redacted summary of a single keystore entry. Contains no secret material.
+#[derive(Debug, Clone)]
+pub struct EntrySummary<'a> {
+    /// Wallet type.
+    pub wallet_type: WalletType,
+    /// Key type.
+    pub key_type: KeyType,
+    /// Smart-wallet/EOA address (the `from` for transactions).
+    pub wallet_address: Address,
+    /// Address derived from the on-disk key, if recorded.
+    pub key_address: Option<Address>,
+    /// Chain ID this entry is bound to.
+    pub chain_id: u64,
+    /// Expiry as a unix timestamp, if any.
+    pub expiry: Option<u64>,
+    /// Per-token spending limits.
+    pub limits: &'a [TokenLimit],
+    /// Whether the entry has a usable private key.
+    pub has_key: bool,
+    /// Whether the entry has a `key_authorization` field.
+    pub has_key_authorization: bool,
+}

--- a/crates/signer-tempo/src/env.rs
+++ b/crates/signer-tempo/src/env.rs
@@ -1,0 +1,59 @@
+use crate::{
+    error::TempoSignerError,
+    keystore::parse_signer,
+    lookup::{TempoAccessKey, TempoLookup},
+};
+use alloy_primitives::Address;
+use std::str::FromStr;
+
+/// Hex-encoded private key for Direct-mode signing.
+pub const ENV_PRIVATE_KEY: &str = "TEMPO_PRIVATE_KEY";
+/// Hex-encoded access key for Keychain-mode signing.
+pub const ENV_ACCESS_KEY: &str = "TEMPO_ACCESS_KEY";
+/// Smart-wallet/root address authorizing `TEMPO_ACCESS_KEY`. When absent (or
+/// equal to the access-key address), the access key is treated as Direct.
+pub const ENV_ROOT_ACCOUNT: &str = "TEMPO_ROOT_ACCOUNT";
+
+/// Resolve a Tempo signer from environment variables.
+///
+/// `TEMPO_ACCESS_KEY` (with optional `TEMPO_ROOT_ACCOUNT`) takes precedence
+/// over `TEMPO_PRIVATE_KEY`. Returns `Ok(None)` when no relevant env var is set.
+pub fn tempo_signer_from_env() -> Result<Option<TempoLookup>, TempoSignerError> {
+    if let Ok(val) = std::env::var(ENV_ACCESS_KEY) {
+        let signer = parse_signer(val.trim()).map_err(|e| match e {
+            TempoSignerError::BadHex { .. } => TempoSignerError::BadEnvHex { var: ENV_ACCESS_KEY },
+            other => other,
+        })?;
+        let signer_addr = signer.address();
+
+        let wallet_address = match std::env::var(ENV_ROOT_ACCOUNT) {
+            Ok(s) => Address::from_str(s.trim())
+                .map_err(|_| TempoSignerError::BadEnvAddress { var: ENV_ROOT_ACCOUNT })?,
+            Err(_) => signer_addr,
+        };
+
+        if wallet_address == signer_addr {
+            return Ok(Some(TempoLookup::Direct(signer)));
+        }
+        return Ok(Some(TempoLookup::Keychain(
+            signer,
+            TempoAccessKey {
+                wallet_address,
+                key_address: signer_addr,
+                key_authorization: None,
+                chain_id: 0,
+                expiry: None,
+            },
+        )));
+    }
+
+    if let Ok(val) = std::env::var(ENV_PRIVATE_KEY) {
+        let signer = parse_signer(val.trim()).map_err(|e| match e {
+            TempoSignerError::BadHex { .. } => TempoSignerError::BadEnvHex { var: ENV_PRIVATE_KEY },
+            other => other,
+        })?;
+        return Ok(Some(TempoLookup::Direct(signer)));
+    }
+
+    Ok(None)
+}

--- a/crates/signer-tempo/src/error.rs
+++ b/crates/signer-tempo/src/error.rs
@@ -1,0 +1,86 @@
+use crate::entry::KeyType;
+use alloy_primitives::Address;
+use std::path::PathBuf;
+
+/// Errors that can occur while reading or interpreting a Tempo keystore.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum TempoSignerError {
+    /// The keystore file does not exist.
+    #[error("Tempo keystore not found at {}", path.display())]
+    NotFound {
+        /// The path that was attempted.
+        path: PathBuf,
+    },
+
+    /// The keystore file could not be parsed as TOML.
+    #[error("invalid TOML in {}: {source}", path.display())]
+    BadToml {
+        /// The keystore path.
+        path: PathBuf,
+        /// Underlying TOML deserialization error.
+        #[source]
+        source: toml::de::Error,
+    },
+
+    /// No usable Tempo key was found for the requested address.
+    #[error("no usable Tempo key for {from}")]
+    NoMatch {
+        /// The address that was looked up.
+        from: Address,
+    },
+
+    /// More than one usable Tempo key matched the requested address.
+    #[error("multiple usable Tempo keys match {from}; cannot disambiguate")]
+    Ambiguous {
+        /// The address that was looked up.
+        from: Address,
+    },
+
+    /// The matching Tempo key has expired.
+    #[error("Tempo key expired (expiry={expiry})")]
+    Expired {
+        /// The expiry that was recorded for the key.
+        expiry: u64,
+    },
+
+    /// The matching Tempo entry uses an unsupported `key_type` (e.g. passkey).
+    #[error("unsupported Tempo key_type {kind:?} (only secp256k1 is supported)")]
+    UnsupportedKeyType {
+        /// The unsupported key type.
+        kind: KeyType,
+    },
+
+    /// A hex-encoded field in the keystore could not be decoded.
+    #[error("invalid hex in keystore field `{field}`")]
+    BadHex {
+        /// Name of the offending field (e.g. `"key"`, `"key_authorization"`).
+        field: &'static str,
+    },
+
+    /// The decoded private key bytes are not a valid secp256k1 key.
+    #[error("invalid secp256k1 private key in keystore")]
+    BadKey,
+
+    /// `$TEMPO_HOME` was not set and the user's home directory could not be located.
+    #[error("$TEMPO_HOME unset and no home directory available")]
+    NoHome,
+
+    /// I/O error while reading the keystore.
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+
+    /// An env var contained invalid hex.
+    #[error("env var {var} contains invalid hex")]
+    BadEnvHex {
+        /// The offending env var name.
+        var: &'static str,
+    },
+
+    /// An env var contained an invalid Ethereum address.
+    #[error("env var {var} contains invalid Ethereum address")]
+    BadEnvAddress {
+        /// The offending env var name.
+        var: &'static str,
+    },
+}

--- a/crates/signer-tempo/src/keystore.rs
+++ b/crates/signer-tempo/src/keystore.rs
@@ -1,0 +1,256 @@
+use crate::{
+    entry::{EntrySummary, KeyType, RawKeyEntry},
+    error::TempoSignerError,
+    lookup::{TempoAccessKey, TempoLookup},
+};
+use alloy_primitives::{hex, Address, Bytes, B256};
+use alloy_signer_local::PrivateKeySigner;
+use serde::Deserialize;
+use std::path::{Path, PathBuf};
+
+const KEYS_FILE_NAME: &str = "keys.toml";
+const TEMPO_HOME_ENV: &str = "TEMPO_HOME";
+const TEMPO_HOME_DEFAULT_DIR: &str = ".tempo";
+
+/// Default keystore path: `$TEMPO_HOME/wallet/keys.toml`, falling back to
+/// `~/.tempo/wallet/keys.toml`. Mirrors the Tempo CLI exactly.
+pub fn default_keys_path() -> Result<PathBuf, TempoSignerError> {
+    let base = match std::env::var_os(TEMPO_HOME_ENV) {
+        Some(home) => PathBuf::from(home),
+        None => home_dir_or_err()?.join(TEMPO_HOME_DEFAULT_DIR),
+    };
+    Ok(base.join("wallet").join(KEYS_FILE_NAME))
+}
+
+#[cfg(not(target_family = "wasm"))]
+fn home_dir_or_err() -> Result<PathBuf, TempoSignerError> {
+    dirs::home_dir().ok_or(TempoSignerError::NoHome)
+}
+
+#[cfg(target_family = "wasm")]
+fn home_dir_or_err() -> Result<PathBuf, TempoSignerError> {
+    Err(TempoSignerError::NoHome)
+}
+
+#[derive(Deserialize)]
+struct RawKeystore {
+    #[serde(default)]
+    keys: Vec<RawKeyEntry>,
+}
+
+/// Parsed Tempo keystore, ready to be looked up.
+pub struct TempoKeystore {
+    entries: Vec<RawKeyEntry>,
+    path: PathBuf,
+}
+
+impl std::fmt::Debug for TempoKeystore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TempoKeystore")
+            .field("path", &self.path)
+            .field("entries", &self.entries.len())
+            .finish()
+    }
+}
+
+impl TempoKeystore {
+    /// Load the keystore from the [`default_keys_path`].
+    pub fn load() -> Result<Self, TempoSignerError> {
+        Self::load_from(default_keys_path()?)
+    }
+
+    /// Load the keystore from an explicit path.
+    pub fn load_from(path: impl AsRef<Path>) -> Result<Self, TempoSignerError> {
+        let path = path.as_ref().to_path_buf();
+        let contents = match std::fs::read_to_string(&path) {
+            Ok(c) => c,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                return Err(TempoSignerError::NotFound { path });
+            }
+            Err(e) => return Err(TempoSignerError::Io(e)),
+        };
+
+        let entries = parse_keystore(&contents, &path)?;
+        Ok(Self { entries, path })
+    }
+
+    /// Returns the path the keystore was loaded from.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Number of entries in the keystore.
+    pub const fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Whether the keystore has zero entries.
+    pub const fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Iterate over redacted summaries of all entries (no secrets).
+    pub fn iter(&self) -> impl Iterator<Item = EntrySummary<'_>> {
+        self.entries.iter().map(|e| EntrySummary {
+            wallet_type: e.wallet_type,
+            key_type: e.key_type,
+            wallet_address: e.wallet_address,
+            key_address: e.key_address,
+            chain_id: e.chain_id,
+            expiry: e.expiry,
+            limits: &e.limits,
+            has_key: e.key.is_some(),
+            has_key_authorization: e.key_authorization.is_some(),
+        })
+    }
+
+    /// Find a usable key by wallet/EOA address (`from`).
+    pub fn find_by_from(&self, from: Address) -> Result<TempoLookup, TempoSignerError> {
+        let candidates: Vec<&RawKeyEntry> =
+            self.entries.iter().filter(|e| e.wallet_address == from).collect();
+        select_one(candidates, from)
+    }
+
+    /// Find a usable key by access-key address.
+    pub fn find_by_key(&self, key_address: Address) -> Result<TempoLookup, TempoSignerError> {
+        let candidates: Vec<&RawKeyEntry> =
+            self.entries.iter().filter(|e| e.key_address == Some(key_address)).collect();
+        select_one(candidates, key_address)
+    }
+}
+
+fn select_one(
+    candidates: Vec<&RawKeyEntry>,
+    from: Address,
+) -> Result<TempoLookup, TempoSignerError> {
+    // Keep only secp256k1 entries with a private key; drop expired ones.
+    let mut saw_unsupported: Option<KeyType> = None;
+    let mut saw_expired: Option<u64> = None;
+    let now = current_unix_seconds();
+
+    let mut usable: Vec<&RawKeyEntry> = Vec::new();
+    for c in candidates {
+        if c.key_type != KeyType::Secp256k1 || c.key.is_none() {
+            saw_unsupported.get_or_insert(c.key_type);
+            continue;
+        }
+        if let Some(exp) = c.expiry {
+            if exp <= now {
+                saw_expired = Some(exp);
+                continue;
+            }
+        }
+        usable.push(c);
+    }
+
+    match usable.len() {
+        1 => entry_to_lookup(usable[0]),
+        0 => {
+            if let Some(exp) = saw_expired {
+                Err(TempoSignerError::Expired { expiry: exp })
+            } else if let Some(kind) = saw_unsupported {
+                Err(TempoSignerError::UnsupportedKeyType { kind })
+            } else {
+                Err(TempoSignerError::NoMatch { from })
+            }
+        }
+        _ => Err(TempoSignerError::Ambiguous { from }),
+    }
+}
+
+fn entry_to_lookup(e: &RawKeyEntry) -> Result<TempoLookup, TempoSignerError> {
+    let key_hex = e.key.as_deref().ok_or(TempoSignerError::BadKey)?;
+    let signer = parse_signer(key_hex)?;
+    let signer_addr = signer.address();
+
+    // Trust the derived address over the file's `key_address` field.
+    if signer_addr == e.wallet_address {
+        return Ok(TempoLookup::Direct(signer));
+    }
+
+    let key_address = e.key_address.unwrap_or(signer_addr);
+
+    let key_authorization = match &e.key_authorization {
+        Some(s) => Some(parse_hex_bytes(s, "key_authorization")?),
+        None => None,
+    };
+
+    Ok(TempoLookup::Keychain(
+        signer,
+        TempoAccessKey {
+            wallet_address: e.wallet_address,
+            key_address,
+            key_authorization,
+            chain_id: e.chain_id,
+            expiry: e.expiry,
+        },
+    ))
+}
+
+pub(crate) fn parse_signer(hex_str: &str) -> Result<PrivateKeySigner, TempoSignerError> {
+    let bytes = parse_hex32(hex_str, "key")?;
+    let b256 = B256::from(bytes);
+    PrivateKeySigner::from_bytes(&b256).map_err(|_| TempoSignerError::BadKey)
+}
+
+fn parse_hex32(s: &str, field: &'static str) -> Result<[u8; 32], TempoSignerError> {
+    let s = s.strip_prefix("0x").or_else(|| s.strip_prefix("0X")).unwrap_or(s);
+    let mut out = [0u8; 32];
+    hex::decode_to_slice(s, &mut out).map_err(|_| TempoSignerError::BadHex { field })?;
+    Ok(out)
+}
+
+fn parse_hex_bytes(s: &str, field: &'static str) -> Result<Bytes, TempoSignerError> {
+    let s = s.strip_prefix("0x").or_else(|| s.strip_prefix("0X")).unwrap_or(s);
+    let v = hex::decode(s).map_err(|_| TempoSignerError::BadHex { field })?;
+    Ok(Bytes::from(v))
+}
+
+fn current_unix_seconds() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+fn parse_keystore(contents: &str, path: &Path) -> Result<Vec<RawKeyEntry>, TempoSignerError> {
+    match toml::from_str::<RawKeystore>(contents) {
+        Ok(ks) => Ok(ks.keys),
+        Err(strict_err) => {
+            // Salvage: parse each `[[keys]]` entry independently and skip malformed ones.
+            let value: toml::Value = match toml::from_str(contents) {
+                Ok(v) => v,
+                Err(_) => {
+                    return Err(TempoSignerError::BadToml {
+                        path: path.to_path_buf(),
+                        source: strict_err,
+                    })
+                }
+            };
+            let arr = match value.get("keys") {
+                Some(toml::Value::Array(arr)) => arr.clone(),
+                _ => {
+                    return Err(TempoSignerError::BadToml {
+                        path: path.to_path_buf(),
+                        source: strict_err,
+                    })
+                }
+            };
+            let mut entries = Vec::new();
+            for (i, v) in arr.into_iter().enumerate() {
+                match v.try_into::<RawKeyEntry>() {
+                    Ok(e) => entries.push(e),
+                    Err(err) => {
+                        tracing::warn!(
+                            path = %path.display(),
+                            index = i,
+                            error = %err,
+                            "skipping malformed Tempo keystore entry",
+                        );
+                    }
+                }
+            }
+            Ok(entries)
+        }
+    }
+}

--- a/crates/signer-tempo/src/lib.rs
+++ b/crates/signer-tempo/src/lib.rs
@@ -1,0 +1,19 @@
+#![doc = include_str!("../README.md")]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/alloy-rs/core/main/assets/alloy.jpg",
+    html_favicon_url = "https://raw.githubusercontent.com/alloy-rs/core/main/assets/favicon.ico"
+)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+mod entry;
+mod env;
+mod error;
+mod keystore;
+mod lookup;
+
+pub use entry::{EntrySummary, KeyType, TokenLimit, WalletType};
+pub use env::{tempo_signer_from_env, ENV_ACCESS_KEY, ENV_PRIVATE_KEY, ENV_ROOT_ACCOUNT};
+pub use error::TempoSignerError;
+pub use keystore::{default_keys_path, TempoKeystore};
+pub use lookup::{TempoAccessKey, TempoLookup};

--- a/crates/signer-tempo/src/lookup.rs
+++ b/crates/signer-tempo/src/lookup.rs
@@ -1,0 +1,104 @@
+use alloy_primitives::{Address, Bytes};
+use alloy_signer_local::PrivateKeySigner;
+use std::fmt;
+
+/// Side-channel metadata for Keychain-mode signing.
+///
+/// `key_authorization` is opaque RLP-encoded `SignedKeyAuthorization` bytes;
+/// consumers decode it with `tempo-primitives` if a typed form is needed.
+#[derive(Clone)]
+pub struct TempoAccessKey {
+    /// Smart-wallet (root) address. The transaction `from`.
+    pub wallet_address: Address,
+    /// Address derived from the access key.
+    pub key_address: Address,
+    /// RLP-encoded `SignedKeyAuthorization`.
+    pub key_authorization: Option<Bytes>,
+    /// Chain ID the access key was authorized on.
+    pub chain_id: u64,
+    /// Expiry as a unix timestamp, if any.
+    pub expiry: Option<u64>,
+}
+
+impl fmt::Debug for TempoAccessKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TempoAccessKey")
+            .field("wallet_address", &self.wallet_address)
+            .field("key_address", &self.key_address)
+            .field("has_key_authorization", &self.key_authorization.is_some())
+            .field("chain_id", &self.chain_id)
+            .field("expiry", &self.expiry)
+            .finish()
+    }
+}
+
+/// Result of a successful Tempo keystore lookup.
+///
+/// In [`Self::Direct`] the signer is the wallet itself; in [`Self::Keychain`]
+/// the signer is an access key and the transaction `from` lives in the
+/// accompanying [`TempoAccessKey`].
+#[non_exhaustive]
+pub enum TempoLookup {
+    /// EOA mode: the signer is the wallet.
+    Direct(PrivateKeySigner),
+    /// Keychain mode: the signer is an access key authorized by a wallet.
+    Keychain(PrivateKeySigner, TempoAccessKey),
+}
+
+impl TempoLookup {
+    /// Borrow the underlying signer.
+    pub const fn signer(&self) -> &PrivateKeySigner {
+        match self {
+            Self::Direct(s) | Self::Keychain(s, _) => s,
+        }
+    }
+
+    /// Consume the lookup and return the underlying signer.
+    pub fn into_signer(self) -> PrivateKeySigner {
+        match self {
+            Self::Direct(s) | Self::Keychain(s, _) => s,
+        }
+    }
+
+    /// Borrow the access-key metadata, if this is a Keychain-mode lookup.
+    pub const fn access_key(&self) -> Option<&TempoAccessKey> {
+        match self {
+            Self::Direct(_) => None,
+            Self::Keychain(_, ak) => Some(ak),
+        }
+    }
+
+    /// Address to use as the transaction `from`: the signer for `Direct`,
+    /// the wallet (root) address for `Keychain`.
+    pub const fn from_address(&self) -> Address {
+        match self {
+            Self::Direct(s) => s.address(),
+            Self::Keychain(_, ak) => ak.wallet_address,
+        }
+    }
+
+    /// Returns `true` if this is a Direct-mode lookup.
+    pub const fn is_direct(&self) -> bool {
+        matches!(self, Self::Direct(_))
+    }
+
+    /// Returns `true` if this is a Keychain-mode lookup.
+    pub const fn is_keychain(&self) -> bool {
+        matches!(self, Self::Keychain(_, _))
+    }
+}
+
+impl fmt::Debug for TempoLookup {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Direct(s) => {
+                f.debug_struct("TempoLookup::Direct").field("from", &s.address()).finish()
+            }
+            Self::Keychain(s, ak) => f
+                .debug_struct("TempoLookup::Keychain")
+                .field("wallet", &ak.wallet_address)
+                .field("key", &s.address())
+                .finish(),
+        }
+    }
+}

--- a/crates/signer-tempo/tests/env.rs
+++ b/crates/signer-tempo/tests/env.rs
@@ -1,0 +1,172 @@
+//! Environment-variable resolution.
+
+use alloy_primitives::{address, Address};
+use alloy_signer_tempo::{
+    tempo_signer_from_env, TempoSignerError, ENV_ACCESS_KEY, ENV_PRIVATE_KEY, ENV_ROOT_ACCOUNT,
+};
+use serial_test::serial;
+use std::ffi::OsString;
+
+const KEY1_HEX: &str = "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d";
+const KEY2_HEX: &str = "0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a";
+
+const fn key1_addr() -> Address {
+    address!("0x70997970C51812dc3A010C7d01b50e0d17dc79C8")
+}
+const fn key2_addr() -> Address {
+    address!("0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65")
+}
+const fn root_addr() -> Address {
+    address!("0xa0Ee7A142d267C1f36714E4a8F75612F20a79720")
+}
+const KEY2_ADDR_HEX: &str = "0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65";
+const ROOT_HEX: &str = "0xa0Ee7A142d267C1f36714E4a8F75612F20a79720";
+
+struct EnvGuard {
+    saved: Vec<(&'static str, Option<OsString>)>,
+}
+
+impl EnvGuard {
+    fn new(keys: &'static [&'static str]) -> Self {
+        let saved = keys.iter().map(|k| (*k, std::env::var_os(k))).collect::<Vec<_>>();
+        for k in keys {
+            std::env::remove_var(k);
+        }
+        Self { saved }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        for (k, v) in &self.saved {
+            match v {
+                Some(val) => std::env::set_var(k, val),
+                None => std::env::remove_var(k),
+            }
+        }
+    }
+}
+
+const ALL: &[&str] = &[ENV_PRIVATE_KEY, ENV_ACCESS_KEY, ENV_ROOT_ACCOUNT];
+
+#[test]
+#[serial]
+fn no_env_returns_none() {
+    let _g = EnvGuard::new(ALL);
+    assert!(tempo_signer_from_env().unwrap().is_none());
+}
+
+#[test]
+#[serial]
+fn private_key_env_returns_direct() {
+    let _g = EnvGuard::new(ALL);
+    std::env::set_var(ENV_PRIVATE_KEY, KEY1_HEX);
+
+    let lookup = tempo_signer_from_env().unwrap().unwrap();
+    assert!(lookup.is_direct());
+    assert_eq!(lookup.signer().address(), key1_addr());
+}
+
+#[test]
+#[serial]
+fn access_key_with_root_returns_keychain() {
+    let _g = EnvGuard::new(ALL);
+    std::env::set_var(ENV_ACCESS_KEY, KEY2_HEX);
+    std::env::set_var(ENV_ROOT_ACCOUNT, ROOT_HEX);
+
+    let lookup = tempo_signer_from_env().unwrap().unwrap();
+    assert!(lookup.is_keychain());
+
+    let ak = lookup.access_key().unwrap();
+    assert_eq!(ak.wallet_address, root_addr());
+    assert_eq!(ak.key_address, key2_addr());
+    assert!(ak.key_authorization.is_none());
+    assert_eq!(ak.chain_id, 0);
+
+    assert_eq!(lookup.signer().address(), key2_addr());
+    assert_eq!(lookup.from_address(), root_addr());
+}
+
+#[test]
+#[serial]
+fn access_key_without_root_returns_direct() {
+    let _g = EnvGuard::new(ALL);
+    std::env::set_var(ENV_ACCESS_KEY, KEY2_HEX);
+
+    let lookup = tempo_signer_from_env().unwrap().unwrap();
+    assert!(lookup.is_direct());
+    assert_eq!(lookup.signer().address(), key2_addr());
+}
+
+#[test]
+#[serial]
+fn access_key_with_root_equal_to_signer_returns_direct() {
+    let _g = EnvGuard::new(ALL);
+    std::env::set_var(ENV_ACCESS_KEY, KEY2_HEX);
+    std::env::set_var(ENV_ROOT_ACCOUNT, KEY2_ADDR_HEX);
+
+    let lookup = tempo_signer_from_env().unwrap().unwrap();
+    assert!(lookup.is_direct());
+}
+
+#[test]
+#[serial]
+fn access_key_takes_precedence_over_private_key() {
+    let _g = EnvGuard::new(ALL);
+    std::env::set_var(ENV_PRIVATE_KEY, KEY1_HEX);
+    std::env::set_var(ENV_ACCESS_KEY, KEY2_HEX);
+
+    let lookup = tempo_signer_from_env().unwrap().unwrap();
+    // Should use ENV_ACCESS_KEY (KEY2), not ENV_PRIVATE_KEY (KEY1).
+    assert_eq!(lookup.signer().address(), key2_addr());
+}
+
+#[test]
+#[serial]
+fn bad_hex_in_private_key_env() {
+    let _g = EnvGuard::new(ALL);
+    std::env::set_var(ENV_PRIVATE_KEY, "0xnothex");
+
+    let err = tempo_signer_from_env().unwrap_err();
+    assert!(matches!(
+        err,
+        TempoSignerError::BadEnvHex { var } if var == ENV_PRIVATE_KEY
+    ));
+}
+
+#[test]
+#[serial]
+fn bad_hex_in_access_key_env() {
+    let _g = EnvGuard::new(ALL);
+    std::env::set_var(ENV_ACCESS_KEY, "0xnothex");
+
+    let err = tempo_signer_from_env().unwrap_err();
+    assert!(matches!(
+        err,
+        TempoSignerError::BadEnvHex { var } if var == ENV_ACCESS_KEY
+    ));
+}
+
+#[test]
+#[serial]
+fn bad_address_in_root_account_env() {
+    let _g = EnvGuard::new(ALL);
+    std::env::set_var(ENV_ACCESS_KEY, KEY2_HEX);
+    std::env::set_var(ENV_ROOT_ACCOUNT, "not-an-address");
+
+    let err = tempo_signer_from_env().unwrap_err();
+    assert!(matches!(
+        err,
+        TempoSignerError::BadEnvAddress { var } if var == ENV_ROOT_ACCOUNT
+    ));
+}
+
+#[test]
+#[serial]
+fn whitespace_in_env_is_trimmed() {
+    let _g = EnvGuard::new(ALL);
+    std::env::set_var(ENV_PRIVATE_KEY, format!("  {}\n", KEY1_HEX));
+
+    let lookup = tempo_signer_from_env().unwrap().unwrap();
+    assert_eq!(lookup.signer().address(), key1_addr());
+}

--- a/crates/signer-tempo/tests/fixtures/keys.toml
+++ b/crates/signer-tempo/tests/fixtures/keys.toml
@@ -1,0 +1,43 @@
+# Tempo wallet keys — managed by `tempo wallet`
+# Do not edit manually.
+
+# Direct EOA entry: signer's derived address equals wallet_address.
+[[keys]]
+wallet_type = "local"
+wallet_address = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
+chain_id = 4217
+key_type = "secp256k1"
+key_address = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
+key = "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
+
+# Keychain entry: access key signs on behalf of a different wallet address.
+[[keys]]
+wallet_type = "passkey"
+wallet_address = "0xa0Ee7A142d267C1f36714E4a8F75612F20a79720"
+chain_id = 4217
+key_type = "secp256k1"
+key_address = "0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65"
+key = "0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a"
+key_authorization = "0xdeadbeef"
+expiry = 4102444800
+[[keys.limits]]
+currency = "0x20c000000000000000000000b9537d11c60e8b50"
+limit = "100000000"
+
+# Passkey-only entry (key_type=p256, no usable secp256k1 material).
+[[keys]]
+wallet_type = "passkey"
+wallet_address = "0x000000000000000000000000000000000000aaaa"
+chain_id = 4217
+key_type = "p256"
+key_address = "0x000000000000000000000000000000000000bbbb"
+
+# Expired entry.
+[[keys]]
+wallet_type = "passkey"
+wallet_address = "0x000000000000000000000000000000000000cccc"
+chain_id = 4217
+key_type = "secp256k1"
+key_address = "0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc"
+key = "0x8b3a350cf5c34c9194ca85829a2df0ec3153be0318b5e2d3348e872092edffba"
+expiry = 1000000000

--- a/crates/signer-tempo/tests/fixtures/keys_ambiguous.toml
+++ b/crates/signer-tempo/tests/fixtures/keys_ambiguous.toml
@@ -1,0 +1,18 @@
+# Two unexpired secp256k1 entries with the same wallet_address — must
+# trigger Ambiguous on find_by_from.
+
+[[keys]]
+wallet_type = "passkey"
+wallet_address = "0x000000000000000000000000000000000000dddd"
+chain_id = 4217
+key_type = "secp256k1"
+key_address = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
+key = "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
+
+[[keys]]
+wallet_type = "passkey"
+wallet_address = "0x000000000000000000000000000000000000dddd"
+chain_id = 4217
+key_type = "secp256k1"
+key_address = "0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65"
+key = "0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a"

--- a/crates/signer-tempo/tests/fixtures/keys_salvage.toml
+++ b/crates/signer-tempo/tests/fixtures/keys_salvage.toml
@@ -1,0 +1,16 @@
+# One good + one malformed entry. Strict deserialization should fail and
+# the salvage pass should pick up only the good one.
+
+[[keys]]
+wallet_type = "local"
+wallet_address = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
+chain_id = 4217
+key_type = "secp256k1"
+key_address = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
+key = "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
+
+[[keys]]
+# Missing required `wallet_address`.
+wallet_type = "local"
+chain_id = 4217
+key_type = "secp256k1"

--- a/crates/signer-tempo/tests/load.rs
+++ b/crates/signer-tempo/tests/load.rs
@@ -1,0 +1,101 @@
+//! Loading and parsing tests for `TempoKeystore`.
+
+use alloy_signer_tempo::{default_keys_path, TempoKeystore, TempoSignerError};
+use serial_test::serial;
+use std::{fs, path::PathBuf};
+
+const FIXTURE_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures");
+
+fn fixture(name: &str) -> PathBuf {
+    PathBuf::from(FIXTURE_DIR).join(name)
+}
+
+#[test]
+fn load_strict_parses_all_entries() {
+    let store = TempoKeystore::load_from(fixture("keys.toml")).unwrap();
+    assert_eq!(store.len(), 4);
+    assert!(!store.is_empty());
+    assert_eq!(store.path(), fixture("keys.toml"));
+}
+
+#[test]
+fn iter_returns_redacted_summaries() {
+    let store = TempoKeystore::load_from(fixture("keys.toml")).unwrap();
+    let summaries: Vec<_> = store.iter().collect();
+    assert_eq!(summaries.len(), 4);
+
+    // First entry is the Direct EOA — secp256k1, has a key, no expiry, no auth.
+    let direct = &summaries[0];
+    assert!(direct.has_key);
+    assert!(!direct.has_key_authorization);
+    assert!(direct.expiry.is_none());
+
+    // Second entry is the Keychain entry — has both key and authorization.
+    let keychain = &summaries[1];
+    assert!(keychain.has_key);
+    assert!(keychain.has_key_authorization);
+    assert_eq!(keychain.expiry, Some(4102444800));
+    assert_eq!(keychain.limits.len(), 1);
+}
+
+#[test]
+fn load_salvage_skips_malformed_entries() {
+    let store = TempoKeystore::load_from(fixture("keys_salvage.toml")).unwrap();
+    assert_eq!(store.len(), 1, "only the good entry should survive");
+}
+
+#[test]
+fn load_missing_file_returns_not_found() {
+    let err = TempoKeystore::load_from(fixture("does_not_exist.toml")).unwrap_err();
+    assert!(matches!(err, TempoSignerError::NotFound { .. }));
+}
+
+#[test]
+fn load_empty_keys_array_yields_empty_keystore() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("keys.toml");
+    fs::write(&path, "# empty\n").unwrap();
+    let store = TempoKeystore::load_from(&path).unwrap();
+    assert!(store.is_empty());
+    assert_eq!(store.len(), 0);
+}
+
+#[test]
+fn load_completely_invalid_toml_errors() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("keys.toml");
+    fs::write(&path, "this is :: not = toml{[").unwrap();
+    let err = TempoKeystore::load_from(&path).unwrap_err();
+    assert!(matches!(err, TempoSignerError::BadToml { .. }));
+}
+
+#[test]
+#[serial]
+fn default_keys_path_uses_tempo_home_when_set() {
+    let prev = std::env::var_os("TEMPO_HOME");
+    std::env::set_var("TEMPO_HOME", "/custom/tempo/dir");
+    let path = default_keys_path().unwrap();
+    assert_eq!(path, PathBuf::from("/custom/tempo/dir/wallet/keys.toml"));
+    restore_env("TEMPO_HOME", prev);
+}
+
+#[test]
+#[serial]
+fn default_keys_path_falls_back_to_home_dir() {
+    let prev = std::env::var_os("TEMPO_HOME");
+    std::env::remove_var("TEMPO_HOME");
+    let path = default_keys_path().expect("expected a home dir on this host");
+    assert!(
+        path.ends_with(".tempo/wallet/keys.toml"),
+        "unexpected default path: {}",
+        path.display()
+    );
+    restore_env("TEMPO_HOME", prev);
+}
+
+fn restore_env(key: &str, prev: Option<std::ffi::OsString>) {
+    match prev {
+        Some(v) => std::env::set_var(key, v),
+        None => std::env::remove_var(key),
+    }
+}

--- a/crates/signer-tempo/tests/lookup.rs
+++ b/crates/signer-tempo/tests/lookup.rs
@@ -1,0 +1,152 @@
+//! `find_by_from` / `find_by_key` semantics.
+
+use alloy_primitives::{address, Bytes};
+use alloy_signer_tempo::{KeyType, TempoKeystore, TempoSignerError};
+use std::path::PathBuf;
+
+const FIXTURE_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures");
+
+fn fixture(name: &str) -> PathBuf {
+    PathBuf::from(FIXTURE_DIR).join(name)
+}
+
+fn store() -> TempoKeystore {
+    TempoKeystore::load_from(fixture("keys.toml")).unwrap()
+}
+
+#[test]
+fn find_by_from_returns_direct_for_eoa() {
+    let from = address!("0x70997970C51812dc3A010C7d01b50e0d17dc79C8");
+    let lookup = store().find_by_from(from).unwrap();
+
+    assert!(lookup.is_direct());
+    assert!(!lookup.is_keychain());
+    assert!(lookup.access_key().is_none());
+    assert_eq!(lookup.from_address(), from);
+    assert_eq!(lookup.signer().address(), from);
+
+    // into_signer consumes the lookup.
+    let signer = lookup.into_signer();
+    assert_eq!(signer.address(), from);
+}
+
+#[test]
+fn find_by_from_returns_keychain_for_smart_wallet() {
+    let wallet = address!("0xa0Ee7A142d267C1f36714E4a8F75612F20a79720");
+    let key_addr = address!("0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65");
+
+    let lookup = store().find_by_from(wallet).unwrap();
+    assert!(lookup.is_keychain());
+
+    let ak = lookup.access_key().expect("keychain has access-key metadata");
+    assert_eq!(ak.wallet_address, wallet);
+    assert_eq!(ak.key_address, key_addr);
+    assert_eq!(ak.chain_id, 4217);
+    assert_eq!(ak.expiry, Some(4102444800));
+    assert_eq!(ak.key_authorization, Some(Bytes::from_static(&[0xde, 0xad, 0xbe, 0xef])));
+
+    // The from-address for transactions is the wallet, NOT the signer.
+    assert_eq!(lookup.from_address(), wallet);
+    assert_eq!(lookup.signer().address(), key_addr);
+}
+
+#[test]
+fn find_by_from_no_match() {
+    let unknown = address!("0x000000000000000000000000000000000000ffff");
+    let err = store().find_by_from(unknown).unwrap_err();
+    assert!(matches!(err, TempoSignerError::NoMatch { from } if from == unknown));
+}
+
+#[test]
+fn find_by_from_unsupported_key_type() {
+    // The p256 entry has wallet_address 0x...aaaa.
+    let from = address!("0x000000000000000000000000000000000000aaaa");
+    let err = store().find_by_from(from).unwrap_err();
+    assert!(matches!(err, TempoSignerError::UnsupportedKeyType { kind: KeyType::P256 }));
+}
+
+#[test]
+fn find_by_from_expired() {
+    // The expired entry has wallet_address 0x...cccc.
+    let from = address!("0x000000000000000000000000000000000000cccc");
+    let err = store().find_by_from(from).unwrap_err();
+    assert!(matches!(err, TempoSignerError::Expired { expiry: 1000000000 }));
+}
+
+#[test]
+fn find_by_from_ambiguous() {
+    let store = TempoKeystore::load_from(fixture("keys_ambiguous.toml")).unwrap();
+    let wallet = address!("0x000000000000000000000000000000000000dddd");
+    let err = store.find_by_from(wallet).unwrap_err();
+    assert!(matches!(err, TempoSignerError::Ambiguous { from } if from == wallet));
+}
+
+#[test]
+fn find_by_key_finds_direct_entry() {
+    // For the Direct EOA entry, key_address == wallet_address.
+    let key = address!("0x70997970C51812dc3A010C7d01b50e0d17dc79C8");
+    let lookup = store().find_by_key(key).unwrap();
+    assert!(lookup.is_direct());
+}
+
+#[test]
+fn find_by_key_finds_keychain_entry() {
+    // For the Keychain entry, key_address differs from wallet_address.
+    let key = address!("0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65");
+    let lookup = store().find_by_key(key).unwrap();
+    assert!(lookup.is_keychain());
+    assert_eq!(lookup.signer().address(), key);
+}
+
+#[test]
+fn find_by_key_no_match() {
+    let key = address!("0x000000000000000000000000000000000000ffff");
+    let err = store().find_by_key(key).unwrap_err();
+    assert!(matches!(err, TempoSignerError::NoMatch { .. }));
+}
+
+#[test]
+fn debug_redacts_secrets() {
+    let from = address!("0xa0Ee7A142d267C1f36714E4a8F75612F20a79720");
+    let lookup = store().find_by_from(from).unwrap();
+    let dbg = format!("{:?}", lookup);
+    // The Debug representation must NOT contain the raw private-key hex.
+    assert!(!dbg.contains("47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a"));
+
+    // The TempoAccessKey Debug must report `has_key_authorization` boolean,
+    // not the raw bytes.
+    let ak_dbg = format!("{:?}", lookup.access_key().unwrap());
+    assert!(ak_dbg.contains("has_key_authorization: true"));
+    assert!(!ak_dbg.contains("deadbeef"));
+}
+
+#[test]
+fn into_signer_works_for_keychain() {
+    let from = address!("0xa0Ee7A142d267C1f36714E4a8F75612F20a79720");
+    let lookup = store().find_by_from(from).unwrap();
+    let signer = lookup.into_signer();
+    // Signer is the access key, not the wallet.
+    assert_eq!(signer.address(), address!("0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65"));
+}
+
+#[test]
+fn entries_with_missing_key_treated_as_unsupported() {
+    use std::fs;
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("keys.toml");
+    fs::write(
+        &path,
+        r#"[[keys]]
+wallet_type = "passkey"
+wallet_address = "0x000000000000000000000000000000000000eeee"
+chain_id = 4217
+key_type = "secp256k1"
+key_address = "0x000000000000000000000000000000000000eeee"
+"#,
+    )
+    .unwrap();
+    let store = TempoKeystore::load_from(&path).unwrap();
+    let err =
+        store.find_by_from(address!("0x000000000000000000000000000000000000eeee")).unwrap_err();
+    assert!(matches!(err, TempoSignerError::UnsupportedKeyType { .. }));
+}


### PR DESCRIPTION
Adds `alloy-signer-tempo`: a read-only reader for the Tempo wallet keystore (`~/.tempo/wallet/keys.toml`) that produces a `PrivateKeySigner` plus optional Keychain-mode metadata.