### PR TITLE
feat(rpc-types-engine): derive Default for testing build request

### DIFF
--- a/crates/rpc-types-engine/src/testing.rs
+++ b/crates/rpc-types-engine/src/testing.rs
@@ -10,7 +10,7 @@ use alloy_primitives::{Bytes, B256};
 pub const TESTING_BUILD_BLOCK_V1: &str = "testing_buildBlockV1";
 
 /// Request payload for `testing_buildBlockV1`.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[non_exhaustive]


### PR DESCRIPTION
## Summary

- Derives `Default` for `TestingBuildBlockRequestV1`.
- Makes the testing build-block request payload easier to construct in tests and callers that start from default values.

## Validation

- `cargo check -p alloy-rpc-types-engine`

Note: the check completed successfully and reported existing unused-import warnings in `alloy-eips`.
