### PR TITLE
fix(rpc-types-engine): remove non_exhaustive from testing build request

### DIFF
--- a/crates/rpc-types-engine/src/testing.rs
+++ b/crates/rpc-types-engine/src/testing.rs
@@ -13,7 +13,6 @@ pub const TESTING_BUILD_BLOCK_V1: &str = "testing_buildBlockV1";
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
-#[non_exhaustive]
 pub struct TestingBuildBlockRequestV1 {
     /// Parent block hash of the block to build.
     pub parent_block_hash: B256,


### PR DESCRIPTION
## Summary

Removes the `#[non_exhaustive]` attribute from `TestingBuildBlockRequestV1` so downstream users can construct the request directly with its public fields.

## Validation

- `cargo check -p alloy-rpc-types-engine`

Note: the check completed successfully with two pre-existing unused import warnings in `alloy-eips`.
