### PR TITLE
fix(pubsub): reject zero channel sizes

### DIFF
--- a/crates/pubsub/src/frontend.rs
+++ b/crates/pubsub/src/frontend.rs
@@ -66,6 +66,10 @@ impl PubSubFrontend {
         let method_name = req.method_clone();
 
         async move {
+            if channel_size == 0 {
+                return Err(TransportErrorKind::custom_str("channel size must be non-zero"));
+            }
+
             debug!("sending request to backend");
             let (in_flight, rx) = InFlight::new(req, channel_size);
             tx.send(PubSubInstruction::Request(in_flight))
@@ -105,8 +109,12 @@ impl PubSubFrontend {
     /// subscription channels. Defaults to 16. See
     /// [`tokio::sync::broadcast`] for a description of relevant
     /// behavior.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `channel_size` is zero.
     pub fn set_channel_size(&self, channel_size: usize) {
-        debug_assert_ne!(channel_size, 0, "channel size must be non-zero");
+        assert_ne!(channel_size, 0, "channel size must be non-zero");
         self.channel_size.store(channel_size, Ordering::Relaxed);
     }
 }
@@ -126,5 +134,17 @@ impl tower::Service<RequestPacket> for PubSubFrontend {
     #[inline]
     fn call(&mut self, req: RequestPacket) -> Self::Future {
         self.send_packet(req)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[should_panic(expected = "channel size must be non-zero")]
+    fn set_channel_size_rejects_zero() {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        PubSubFrontend::new(tx).set_channel_size(0);
     }
 }

--- a/crates/pubsub/src/managers/active_sub.rs
+++ b/crates/pubsub/src/managers/active_sub.rs
@@ -65,6 +65,7 @@ impl fmt::Debug for ActiveSubscription {
 impl ActiveSubscription {
     /// Create a new active subscription.
     pub(crate) fn new(request: SerializedRequest, channel_size: usize) -> Self {
+        assert_ne!(channel_size, 0, "channel size must be non-zero");
         let local_id = request.params_hash();
         let (tx, rx) = broadcast::channel(channel_size);
         Self { request, local_id, tx, rx: Mutex::new(Some(rx)) }

--- a/crates/rpc-client/src/poller.rs
+++ b/crates/rpc-client/src/poller.rs
@@ -105,7 +105,12 @@ where
     }
 
     /// Sets the channel size for the poller task.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `channel_size` is zero.
     pub const fn set_channel_size(&mut self, channel_size: usize) {
+        assert!(channel_size != 0, "channel size must be non-zero");
         self.channel_size = channel_size;
     }
 
@@ -512,4 +517,16 @@ where
 fn _assert_unpin() {
     fn _assert<T: Unpin>() {}
     _assert::<PollChannel<()>>();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[should_panic(expected = "channel size must be non-zero")]
+    fn set_channel_size_rejects_zero() {
+        let mut builder = PollerBuilder::<(), ()>::new(WeakClient::new(), "eth_blockNumber", ());
+        builder.set_channel_size(0);
+    }
 }


### PR DESCRIPTION
## Motivation

A zero subscription channel size can panic later when the pubsub or poller path creates a Tokio broadcast channel.

## Solution

Validate configured channel sizes before they reach broadcast channel creation, and document the panic behavior on the public setters.

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes