### PR TITLE
fix(ci): stabilize main red tests

### DIFF
--- a/crates/ens/src/lib.rs
+++ b/crates/ens/src/lib.rs
@@ -459,7 +459,7 @@ mod tests {
     #[tokio::test]
     async fn test_pub_resolver_text() {
         let provider =
-            ProviderBuilder::new().connect_http("http://ethereum.reth.rs/rpc".parse().unwrap());
+            ProviderBuilder::new().connect_http("https://ethereum.reth.rs/rpc".parse().unwrap());
 
         let name = "vitalik.eth";
         let node = namehash(name);
@@ -471,7 +471,7 @@ mod tests {
     #[tokio::test]
     async fn test_pub_resolver_fetching_txt() {
         let provider =
-            ProviderBuilder::new().connect_http("http://ethereum.reth.rs/rpc".parse().unwrap());
+            ProviderBuilder::new().connect_http("https://ethereum.reth.rs/rpc".parse().unwrap());
 
         let name = "vitalik.eth";
         let res = provider.lookup_txt(name, "avatar").await.unwrap();

--- a/crates/provider/Cargo.toml
+++ b/crates/provider/Cargo.toml
@@ -60,7 +60,6 @@ futures-utils-wasm.workspace = true
 futures.workspace = true
 lru.workspace = true
 pin-project.workspace = true
-reqwest = { workspace = true, optional = true }
 serde_json.workspace = true
 serde.workspace = true
 thiserror.workspace = true
@@ -69,6 +68,9 @@ tracing.workspace = true
 url = { workspace = true, optional = true }
 either.workspace = true
 http = { workspace = true, optional = true }
+
+[target.'cfg(not(all(target_os = "wasi", target_env = "p1")))'.dependencies]
+reqwest = { workspace = true, optional = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 parking_lot.workspace = true

--- a/crates/provider/src/builder.rs
+++ b/crates/provider/src/builder.rs
@@ -559,7 +559,7 @@ impl<L, F, N> ProviderBuilder<L, F, N> {
     }
 
     /// Build this provider with an Reqwest HTTP transport.
-    #[cfg(any(test, feature = "reqwest"))]
+    #[cfg(any(test, all(feature = "reqwest", not(all(target_os = "wasi", target_env = "p1")))))]
     pub fn connect_http(self, url: reqwest::Url) -> F::Provider
     where
         L: ProviderLayer<crate::RootProvider<N>, N>,
@@ -571,7 +571,7 @@ impl<L, F, N> ProviderBuilder<L, F, N> {
     }
 
     /// Build this provider with a pre-built Reqwest client.
-    #[cfg(any(test, feature = "reqwest"))]
+    #[cfg(any(test, all(feature = "reqwest", not(all(target_os = "wasi", target_env = "p1")))))]
     pub fn connect_reqwest<C>(self, client: C, url: reqwest::Url) -> F::Provider
     where
         L: ProviderLayer<crate::RootProvider<N>, N>,
@@ -584,7 +584,7 @@ impl<L, F, N> ProviderBuilder<L, F, N> {
     }
 
     /// Build this provider with a provided Reqwest client builder.
-    #[cfg(any(test, feature = "reqwest"))]
+    #[cfg(any(test, all(feature = "reqwest", not(all(target_os = "wasi", target_env = "p1")))))]
     pub fn with_reqwest<B>(self, url: reqwest::Url, builder: B) -> F::Provider
     where
         L: ProviderLayer<crate::RootProvider<N>, N>,

--- a/crates/provider/src/provider/root.rs
+++ b/crates/provider/src/provider/root.rs
@@ -42,7 +42,7 @@ pub fn builder<N: Network>() -> ProviderBuilder<Identity, Identity, N> {
 
 impl<N: Network> RootProvider<N> {
     /// Creates a new HTTP root provider from the given URL.
-    #[cfg(feature = "reqwest")]
+    #[cfg(all(feature = "reqwest", not(all(target_os = "wasi", target_env = "p1"))))]
     pub fn new_http(url: url::Url) -> Self {
         Self::new(RpcClient::new_http(url))
     }

--- a/crates/rpc-client/Cargo.toml
+++ b/crates/rpc-client/Cargo.toml
@@ -40,9 +40,10 @@ tracing.workspace = true
 alloy-pubsub = { workspace = true, optional = true }
 alloy-transport-ws = { workspace = true, optional = true }
 
-reqwest = { workspace = true, optional = true }
-
 url = { workspace = true, optional = true, features = ["serde"] }
+
+[target.'cfg(not(all(target_os = "wasi", target_env = "p1")))'.dependencies]
+reqwest = { workspace = true, optional = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 alloy-transport-ipc = { workspace = true, optional = true }

--- a/crates/rpc-client/src/builder.rs
+++ b/crates/rpc-client/src/builder.rs
@@ -50,7 +50,7 @@ impl<L> ClientBuilder<L> {
 
     /// Convenience function to create a new [`RpcClient`] with a [`reqwest`]
     /// HTTP transport.
-    #[cfg(feature = "reqwest")]
+    #[cfg(all(feature = "reqwest", not(all(target_os = "wasi", target_env = "p1"))))]
     pub fn http(self, url: url::Url) -> RpcClient
     where
         L: Layer<alloy_transport_http::Http<reqwest::Client>>,
@@ -64,7 +64,7 @@ impl<L> ClientBuilder<L> {
 
     /// Convenience function to create a new [`RpcClient`] with a [`reqwest`]
     /// HTTP transport using a pre-built `reqwest::Client`.
-    #[cfg(feature = "reqwest")]
+    #[cfg(all(feature = "reqwest", not(all(target_os = "wasi", target_env = "p1"))))]
     pub fn http_with_client(self, client: reqwest::Client, url: url::Url) -> RpcClient
     where
         L: Layer<alloy_transport_http::Http<reqwest::Client>>,

--- a/crates/rpc-client/src/builtin.rs
+++ b/crates/rpc-client/src/builtin.rs
@@ -126,12 +126,25 @@ impl BuiltInConnectionString {
         let _ = &config; // Suppress unused warning for non-WS transports
         match self {
             // reqwest is enabled, hyper is not
-            #[cfg(all(not(feature = "hyper"), feature = "reqwest"))]
+            #[cfg(all(
+                not(feature = "hyper"),
+                feature = "reqwest",
+                not(all(target_os = "wasi", target_env = "p1"))
+            ))]
             Self::Http(url) => {
                 Ok(alloy_transport::Transport::boxed(
                     alloy_transport_http::Http::<reqwest::Client>::new(url.clone()),
                 ))
             }
+
+            #[cfg(all(
+                not(feature = "hyper"),
+                feature = "reqwest",
+                all(target_os = "wasi", target_env = "p1")
+            ))]
+            Self::Http(_) => Err(TransportErrorKind::custom_str(
+                "reqwest HTTP transport is not supported on wasm32-wasip1",
+            )),
 
             // hyper is enabled, reqwest is not
             #[cfg(feature = "hyper")]

--- a/crates/rpc-client/src/client.rs
+++ b/crates/rpc-client/src/client.rs
@@ -64,7 +64,7 @@ impl RpcClient {
     }
 
     /// Create a new [`RpcClient`] with an HTTP transport.
-    #[cfg(feature = "reqwest")]
+    #[cfg(all(feature = "reqwest", not(all(target_os = "wasi", target_env = "p1"))))]
     pub fn new_http(url: reqwest::Url) -> Self {
         let http = alloy_transport_http::Http::new(url);
         let is_local = http.guess_local();
@@ -72,7 +72,7 @@ impl RpcClient {
     }
 
     /// Create a new [`RpcClient`] with an HTTP transport using a pre-built [`reqwest::Client`].
-    #[cfg(feature = "reqwest")]
+    #[cfg(all(feature = "reqwest", not(all(target_os = "wasi", target_env = "p1"))))]
     pub fn new_http_with_client(client: reqwest::Client, url: reqwest::Url) -> Self {
         let http = alloy_transport_http::Http::with_client(client, url);
         let is_local = http.guess_local();

--- a/crates/rpc-client/src/lib.rs
+++ b/crates/rpc-client/src/lib.rs
@@ -37,5 +37,5 @@ pub use alloy_transport_ws::WebSocketConfig;
 pub use alloy_transport_ipc::IpcConnect;
 
 /// A client using a [`reqwest`] HTTP transport.
-#[cfg(feature = "reqwest")]
+#[cfg(all(feature = "reqwest", not(all(target_os = "wasi", target_env = "p1"))))]
 pub type ReqwestClient = RpcClient;

--- a/crates/transport-http/Cargo.toml
+++ b/crates/transport-http/Cargo.toml
@@ -31,8 +31,10 @@ serde_json = { workspace = true, optional = true }
 tower = { workspace = true, optional = true }
 url.workspace = true
 
-reqwest = { workspace = true, features = ["json"], optional = true }
 tracing = { workspace = true, optional = true }
+
+[target.'cfg(not(all(target_os = "wasi", target_env = "p1")))'.dependencies]
+reqwest = { workspace = true, features = ["json"], optional = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 http-body-util = { workspace = true, optional = true }

--- a/crates/transport-http/src/lib.rs
+++ b/crates/transport-http/src/lib.rs
@@ -6,12 +6,12 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
-#[cfg(feature = "reqwest")]
+#[cfg(all(feature = "reqwest", not(all(target_os = "wasi", target_env = "p1"))))]
 pub use reqwest;
-#[cfg(feature = "reqwest")]
+#[cfg(all(feature = "reqwest", not(all(target_os = "wasi", target_env = "p1"))))]
 mod reqwest_transport;
 
-#[cfg(feature = "reqwest")]
+#[cfg(all(feature = "reqwest", not(all(target_os = "wasi", target_env = "p1"))))]
 #[doc(inline)]
 pub use reqwest_transport::*;
 


### PR DESCRIPTION
## Summary
- switch the flaky ENS public resolver tests to `https://ethereum.reth.rs/rpc`
- stop exposing reqwest-backed HTTP constructors on `wasm32-wasip1`
- make reqwest a non-`wasm32-wasip1` dependency in the HTTP/provider/rpc-client crates so the WASI build no longer pulls unsupported Tokio and aws-lc paths

## Why
`main` is currently red in two places:
- `all-features` jobs fail because two ENS tests still hit the plain-HTTP `ethereum.reth.rs` endpoint, which now returns `520`
- `wasm-wasi` fails while building the `alloy` package because default reqwest/rustls paths on `wasm32-wasip1` pull unsupported Tokio and `aws-lc-sys` codepaths

## Validation
- `cargo fmt --check`
- `git diff --check`
- targeted cargo tests were blocked in this sandbox by crates.io `429 Rate limit exceeded` responses while resolving dependencies
