### PR TITLE
fix(pubsub): match numeric subscription id aliases

### DIFF
--- a/crates/json-rpc/src/notification.rs
+++ b/crates/json-rpc/src/notification.rs
@@ -15,6 +15,16 @@ pub enum SubId {
     String(String),
 }
 
+impl SubId {
+    /// Returns this subscription ID as a number, if it is numerically encoded.
+    pub fn as_number(&self) -> Option<U256> {
+        match self {
+            Self::Number(number) => Some(*number),
+            Self::String(string) => string.parse().ok(),
+        }
+    }
+}
+
 impl From<U256> for SubId {
     fn from(value: U256) -> Self {
         Self::Number(value)
@@ -186,6 +196,12 @@ mod tests {
         let string = "subscription_id".to_string();
         let subid: SubId = string.clone().into();
         assert_eq!(subid, SubId::String(string));
+    }
+
+    #[test]
+    fn subid_string_as_number() {
+        let subid = SubId::String("0x7413bf1aeb8f1c0087c36b4243f7a41a".to_string());
+        assert_eq!(subid.as_number(), Some("0x7413bf1aeb8f1c0087c36b4243f7a41a".parse().unwrap()));
     }
 
     #[test]

--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -1936,6 +1936,27 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(feature = "ws-base")]
+    async fn subscribe_blocks_ws_publicnode_short_subscription_id() {
+        use futures::stream::StreamExt;
+
+        let url = "wss://ethereum-rpc.publicnode.com";
+        let Ok(provider) = ProviderBuilder::<_, _, Ethereum>::default()
+            .connect_ws(alloy_rpc_client::WsConnect::new(url))
+            .await
+        else {
+            return;
+        };
+        let sub = provider.subscribe_blocks().await.unwrap();
+        let mut stream = sub.into_stream();
+        let header = tokio::time::timeout(Duration::from_secs(30), stream.next())
+            .await
+            .expect("timed out waiting for PublicNode header")
+            .expect("subscription stream closed");
+        assert!(header.number > 0);
+    }
+
+    #[tokio::test]
     async fn test_custom_retry_policy() {
         #[derive(Debug, Clone)]
         struct CustomPolicy;

--- a/crates/pubsub/README.md
+++ b/crates/pubsub/README.md
@@ -63,16 +63,16 @@ For a normal request, the user sends a request to the **frontend**, and
 later receives a response via a tokio oneshot channel. This is straightforward
 and easy to reason about. Subscriptions, however, are side-effects of other
 requests, and are long-lived. They are managed by the **service** and
-identified by a `U256` id. The **service** uses this id to manage the
-subscription lifecycle, and to dispatch notifications to the correct
-subscribers.
+identified by a local `B256` id. The **service** uses this id to manage the
+subscription lifecycle, and maps it to the server's `SubId` to dispatch
+notifications to the correct subscribers.
 
 ### Server & Local IDs
 
 When a user issues a subscription request, the **frontend** sends a
 subscription request to the **service**. The **service** dispatches it to the
 RPC server via the **backend**. The **service** then intercepts the RPC server
-response containing the serve id, and assigns a `local_id` to the subscription.
+response containing the server id, and assigns a `local_id` to the subscription.
 This `local_id` is used to identify the subscription in the **service** and in
 tasks consuming the subscription, while the `server_id` is used to identify the
 subscription to the RPC server, and to associate notifications with specific
@@ -94,8 +94,8 @@ on unknown methods, the `Request`, `SerializedRequest` and `RpcCall` expose
 subscription.
 
 When marking a request as a subscription, the **service** will intercept the
-RPC response, which MUST be a `U256` value. Subscription requests that return
-anything other than a `U256` value will not function.
+RPC response, which MUST be a valid `SubId`. Subscription requests that return
+anything other than a numeric or string subscription ID will not function.
 
 ### Subscription Lifecycle
 
@@ -119,7 +119,7 @@ Subscription Request Lifecycle:
 1. The **service** stores the oneshot channel in its `RequestManager`.
 1. The **service** sends the request to the **backend**.
 1. The **backend** sends the request to the RPC server.
-1. The RPC server responds with a `U256` value (the `server_id`).
+1. The RPC server responds with a `SubId` value (the `server_id`).
 1. The **backend** sends the response to the **service**.
 1. The **service** assigns a `local_id` to the subscription, creates a
    subscription broadcast channel, and stores the relevant information in its

--- a/crates/pubsub/src/managers/sub.rs
+++ b/crates/pubsub/src/managers/sub.rs
@@ -2,6 +2,7 @@ use crate::{managers::ActiveSubscription, RawSubscription};
 use alloy_json_rpc::{EthNotification, SerializedRequest, SubId};
 use alloy_primitives::B256;
 use bimap::BiBTreeMap;
+use std::collections::BTreeMap;
 
 #[derive(Debug, Default)]
 pub(crate) struct SubscriptionManager {
@@ -9,6 +10,8 @@ pub(crate) struct SubscriptionManager {
     local_to_sub: BiBTreeMap<B256, ActiveSubscription>,
     /// Tracks the CURRENT server id for a subscription.
     local_to_server: BiBTreeMap<B256, SubId>,
+    /// Tracks all server id aliases that may identify a subscription in notifications.
+    server_to_local: BTreeMap<SubId, B256>,
 }
 
 impl SubscriptionManager {
@@ -33,7 +36,7 @@ impl SubscriptionManager {
         let sub = active.subscribe();
 
         let local_id = active.local_id;
-        self.local_to_server.insert(local_id, server_id);
+        self.insert_server_id(local_id, server_id);
         self.local_to_sub.insert(local_id, active);
 
         sub
@@ -60,7 +63,11 @@ impl SubscriptionManager {
 
     /// De-alias an alias, getting the original ID.
     pub(crate) fn local_id_for(&self, server_id: &SubId) -> Option<B256> {
-        self.local_to_server.get_by_right(server_id).copied()
+        self.server_to_local.get(server_id).copied().or_else(|| {
+            server_id
+                .as_number()
+                .and_then(|number| self.server_to_local.get(&SubId::Number(number)).copied())
+        })
     }
 
     /// De-alias an alias, getting the original ID.
@@ -71,17 +78,19 @@ impl SubscriptionManager {
     /// Drop all server_ids.
     pub(crate) fn drop_server_ids(&mut self) {
         self.local_to_server.clear();
+        self.server_to_local.clear();
     }
 
     /// Change the server_id of a subscription.
     fn change_server_id(&mut self, local_id: B256, server_id: SubId) {
-        self.local_to_server.insert(local_id, server_id);
+        self.remove_server_id(&local_id);
+        self.insert_server_id(local_id, server_id);
     }
 
     /// Remove a subscription by its local_id.
     pub(crate) fn remove_sub(&mut self, local_id: B256) {
         let _ = self.local_to_sub.remove_by_left(&local_id);
-        let _ = self.local_to_server.remove_by_left(&local_id);
+        self.remove_server_id(&local_id);
     }
 
     /// Notify the subscription channel of a new value, if the sub is known,
@@ -98,5 +107,64 @@ impl SubscriptionManager {
     /// Get a receiver for a subscription.
     pub(crate) fn get_subscription(&self, local_id: B256) -> Option<RawSubscription> {
         self.local_to_sub.get_by_left(&local_id).map(ActiveSubscription::subscribe)
+    }
+
+    /// Insert the current server ID and any numeric-compatible aliases.
+    fn insert_server_id(&mut self, local_id: B256, server_id: SubId) {
+        self.insert_server_aliases(local_id, &server_id);
+        self.local_to_server.insert(local_id, server_id);
+    }
+
+    /// Remove the current server ID and any numeric-compatible aliases.
+    fn remove_server_id(&mut self, local_id: &B256) {
+        if let Some((local_id, server_id)) = self.local_to_server.remove_by_left(local_id) {
+            self.remove_server_aliases(local_id, &server_id);
+        }
+    }
+
+    fn insert_server_aliases(&mut self, local_id: B256, server_id: &SubId) {
+        self.server_to_local.insert(server_id.clone(), local_id);
+        if let Some(number) = server_id.as_number() {
+            self.server_to_local.insert(SubId::Number(number), local_id);
+        }
+    }
+
+    fn remove_server_aliases(&mut self, local_id: B256, server_id: &SubId) {
+        self.remove_server_alias(local_id, server_id);
+        if let Some(number) = server_id.as_number() {
+            self.remove_server_alias(local_id, &SubId::Number(number));
+        }
+    }
+
+    fn remove_server_alias(&mut self, local_id: B256, server_id: &SubId) {
+        if self.server_to_local.get(server_id) == Some(&local_id) {
+            self.server_to_local.remove(server_id);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_json_rpc::{Id, Request};
+    use alloy_transport::utils::to_json_raw_value;
+
+    #[test]
+    fn notifies_subscription_when_server_id_forms_differ() {
+        let mut manager = SubscriptionManager::default();
+        let request =
+            Request::new("eth_subscribe", Id::Number(1), ("newHeads",)).serialize().unwrap();
+        let server_id = "0x7413bf1aeb8f1c0087c36b4243f7a41a";
+
+        let mut sub = manager.upsert(request, SubId::String(server_id.to_string()), 16);
+        let notification = EthNotification {
+            subscription: serde_json::from_str(&format!(r#""{server_id}""#)).unwrap(),
+            result: to_json_raw_value(&42).unwrap(),
+        };
+        assert!(matches!(notification.subscription, SubId::Number(_)));
+
+        manager.notify(notification);
+
+        assert_eq!(sub.try_recv().unwrap().get(), "42");
     }
 }


### PR DESCRIPTION
## Summary

- keep the public/local `B256` subscription handle unchanged while preserving the original server `SubId` for lifecycle calls
- add numeric-compatible aliases in `SubscriptionManager` so notifications match even when subscribe responses and notification payloads deserialize into different `SubId` variants
- add a PublicNode WebSocket regression test for short subscription IDs and update pubsub docs to describe `SubId`

## Root Cause

Some providers return short hex subscription IDs. The subscribe response and later notification subscription field can be represented differently by the flexible `SubId` enum, which made exact registry lookup miss and silently drop notifications.

Closes #3948

## Tests

- `cargo test -p alloy-provider --features ws-base subscribe_blocks_ws_publicnode_short_subscription_id --lib -- --nocapture`
- `cargo test -p alloy-pubsub`
- `cargo test -p alloy-json-rpc notification::tests:: -- --nocapture`
- `git diff --check`