### PR TITLE
fix(eip1559): prevent divide-by-zero in next base fee calculation

### DIFF
--- a/crates/eips/Cargo.toml
+++ b/crates/eips/Cargo.toml
@@ -63,6 +63,7 @@ borsh = { workspace = true, optional = true, features = ["derive"] }
 
 # misc
 auto_impl.workspace = true
+tracing = { workspace = true, optional = true }
 
 [dev-dependencies]
 alloy-primitives = { workspace = true, features = [
@@ -90,7 +91,8 @@ std = [
 	"sha2?/std",
 	"either/std",
 	"serde_with?/std",
-	"borsh?/std"
+	"borsh?/std",
+	"dep:tracing",
 ]
 serde = [
 	"dep:alloy-serde",

--- a/crates/eips/Cargo.toml
+++ b/crates/eips/Cargo.toml
@@ -63,7 +63,6 @@ borsh = { workspace = true, optional = true, features = ["derive"] }
 
 # misc
 auto_impl.workspace = true
-tracing = { workspace = true, optional = true }
 
 [dev-dependencies]
 alloy-primitives = { workspace = true, features = [
@@ -91,8 +90,7 @@ std = [
 	"sha2?/std",
 	"either/std",
 	"serde_with?/std",
-	"borsh?/std",
-	"dep:tracing",
+	"borsh?/std"
 ]
 serde = [
 	"dep:alloy-serde",

--- a/crates/eips/src/eip1559/helpers.rs
+++ b/crates/eips/src/eip1559/helpers.rs
@@ -95,15 +95,6 @@ pub fn calc_next_block_base_fee(
     base_fee: u64,
     base_fee_params: BaseFeeParams,
 ) -> u64 {
-    #[cfg(feature = "std")]
-    tracing::trace!(
-        gas_used,
-        gas_limit,
-        base_fee,
-        max_change_denominator = base_fee_params.max_change_denominator,
-        elasticity_multiplier = base_fee_params.elasticity_multiplier,
-        "calc_next_block_base_fee",
-    );
     let elasticity = base_fee_params.elasticity_multiplier;
     let max_change_denominator = base_fee_params.max_change_denominator;
 
@@ -127,25 +118,11 @@ pub fn calc_next_block_base_fee(
         // If the gas used in the current block is equal to the gas target, the base fee remains the
         // same (no increase).
         core::cmp::Ordering::Equal => {
-            #[cfg(feature = "std")]
-            tracing::trace!(
-                branch = "equal",
-                gas_used,
-                gas_target,
-                "calc_next_block_base_fee branch",
-            );
             base_fee
         }
         // If the gas used in the current block is greater than the gas target, calculate a new
         // increased base fee.
         core::cmp::Ordering::Greater => {
-            #[cfg(feature = "std")]
-            tracing::trace!(
-                branch = "greater",
-                gas_used,
-                gas_target,
-                "calc_next_block_base_fee branch",
-            );
             // Calculate the increase in base fee based on the formula defined by EIP-1559.
             base_fee
                 + (core::cmp::max(
@@ -158,13 +135,6 @@ pub fn calc_next_block_base_fee(
         // If the gas used in the current block is less than the gas target, calculate a new
         // decreased base fee.
         core::cmp::Ordering::Less => {
-            #[cfg(feature = "std")]
-            tracing::trace!(
-                branch = "less",
-                gas_used,
-                gas_target,
-                "calc_next_block_base_fee branch",
-            );
             // Calculate the decrease in base fee based on the formula defined by EIP-1559.
             base_fee.saturating_sub(
                 (base_fee as u128 * (gas_target - gas_used) as u128

--- a/crates/eips/src/eip1559/helpers.rs
+++ b/crates/eips/src/eip1559/helpers.rs
@@ -95,6 +95,15 @@ pub fn calc_next_block_base_fee(
     base_fee: u64,
     base_fee_params: BaseFeeParams,
 ) -> u64 {
+    #[cfg(feature = "std")]
+    tracing::trace!(
+        gas_used,
+        gas_limit,
+        base_fee,
+        max_change_denominator = base_fee_params.max_change_denominator,
+        elasticity_multiplier = base_fee_params.elasticity_multiplier,
+        "calc_next_block_base_fee",
+    );
     let elasticity = base_fee_params.elasticity_multiplier;
     let max_change_denominator = base_fee_params.max_change_denominator;
 
@@ -117,10 +126,26 @@ pub fn calc_next_block_base_fee(
     match gas_used.cmp(&gas_target) {
         // If the gas used in the current block is equal to the gas target, the base fee remains the
         // same (no increase).
-        core::cmp::Ordering::Equal => base_fee,
+        core::cmp::Ordering::Equal => {
+            #[cfg(feature = "std")]
+            tracing::trace!(
+                branch = "equal",
+                gas_used,
+                gas_target,
+                "calc_next_block_base_fee branch",
+            );
+            base_fee
+        }
         // If the gas used in the current block is greater than the gas target, calculate a new
         // increased base fee.
         core::cmp::Ordering::Greater => {
+            #[cfg(feature = "std")]
+            tracing::trace!(
+                branch = "greater",
+                gas_used,
+                gas_target,
+                "calc_next_block_base_fee branch",
+            );
             // Calculate the increase in base fee based on the formula defined by EIP-1559.
             base_fee
                 + (core::cmp::max(
@@ -133,6 +158,13 @@ pub fn calc_next_block_base_fee(
         // If the gas used in the current block is less than the gas target, calculate a new
         // decreased base fee.
         core::cmp::Ordering::Less => {
+            #[cfg(feature = "std")]
+            tracing::trace!(
+                branch = "less",
+                gas_used,
+                gas_target,
+                "calc_next_block_base_fee branch",
+            );
             // Calculate the decrease in base fee based on the formula defined by EIP-1559.
             base_fee.saturating_sub(
                 (base_fee as u128 * (gas_target - gas_used) as u128

--- a/crates/eips/src/eip1559/helpers.rs
+++ b/crates/eips/src/eip1559/helpers.rs
@@ -95,8 +95,24 @@ pub fn calc_next_block_base_fee(
     base_fee: u64,
     base_fee_params: BaseFeeParams,
 ) -> u64 {
+    let elasticity = base_fee_params.elasticity_multiplier;
+    let max_change_denominator = base_fee_params.max_change_denominator;
+
+    // Without these checks, `gas_limit / elasticity` or the EIP-1559 update term can divide by
+    // zero (e.g. elasticity or denominator set to zero from misconfiguration / malformed
+    // Holocene header data, or `gas_limit < elasticity` on chains that do not enforce a minimum
+    // gas limit). Nethermind returns the parent base fee unchanged in these cases; see
+    // `DefaultBaseFeeCalculator` in Nethermind.Core.
+    if elasticity == 0 || max_change_denominator == 0 {
+        return base_fee;
+    }
+
     // Calculate the target gas by dividing the gas limit by the elasticity multiplier.
-    let gas_target = gas_limit / base_fee_params.elasticity_multiplier as u64;
+    let gas_target = (gas_limit as u128 / elasticity) as u64;
+
+    if gas_target == 0 {
+        return base_fee;
+    }
 
     match gas_used.cmp(&gas_target) {
         // If the gas used in the current block is equal to the gas target, the base fee remains the
@@ -304,5 +320,30 @@ mod tests {
                 )
             );
         }
+    }
+
+    #[test]
+    fn next_base_fee_no_panic_zero_elasticity() {
+        let p = BaseFeeParams::new(8, 0);
+        assert_eq!(
+            calc_next_block_base_fee(1, 30_000_000, 1_000_000_000, p),
+            1_000_000_000
+        );
+    }
+
+    #[test]
+    fn next_base_fee_no_panic_zero_denominator() {
+        let p = BaseFeeParams::new(0, 2);
+        assert_eq!(
+            calc_next_block_base_fee(15_000_000, 30_000_000, 1_000_000_000, p),
+            1_000_000_000
+        );
+    }
+
+    #[test]
+    fn next_base_fee_no_panic_gas_limit_below_elasticity() {
+        let p = BaseFeeParams::ethereum();
+        // gas_target = 1 / 2 = 0; gas_used > 0 used to hit a divide-by-zero in the increase path.
+        assert_eq!(calc_next_block_base_fee(1, 1, 1_000_000_000, p), 1_000_000_000);
     }
 }

--- a/crates/eips/src/eip1559/helpers.rs
+++ b/crates/eips/src/eip1559/helpers.rs
@@ -117,9 +117,7 @@ pub fn calc_next_block_base_fee(
     match gas_used.cmp(&gas_target) {
         // If the gas used in the current block is equal to the gas target, the base fee remains the
         // same (no increase).
-        core::cmp::Ordering::Equal => {
-            base_fee
-        }
+        core::cmp::Ordering::Equal => base_fee,
         // If the gas used in the current block is greater than the gas target, calculate a new
         // increased base fee.
         core::cmp::Ordering::Greater => {
@@ -327,10 +325,7 @@ mod tests {
     #[test]
     fn next_base_fee_no_panic_zero_elasticity() {
         let p = BaseFeeParams::new(8, 0);
-        assert_eq!(
-            calc_next_block_base_fee(1, 30_000_000, 1_000_000_000, p),
-            1_000_000_000
-        );
+        assert_eq!(calc_next_block_base_fee(1, 30_000_000, 1_000_000_000, p), 1_000_000_000);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Replacement for #3884 because the source branch has maintainer edits disabled.

This keeps the original EIP-1559 defensive guard against divide-by-zero in `calc_next_block_base_fee`, and adds a rustfmt-only commit so the repository fmt gate passes.

## Validation

- `cargo fmt --all --check`
- `cargo test -p alloy-eips eip1559::helpers --all-features`