### PR TITLE
test(provider): cover PublicNode pubsub headers

### DIFF
--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -1936,6 +1936,24 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(feature = "ws-base")]
+    async fn subscribe_blocks_ws_publicnode_short_subscription_id() {
+        use futures::stream::StreamExt;
+
+        let url = "wss://ethereum-rpc.publicnode.com";
+        let ws = alloy_rpc_client::WsConnect::new(url);
+        let Ok(client) = alloy_rpc_client::RpcClient::connect_pubsub(ws).await else { return };
+        let provider = RootProvider::<Ethereum>::new(client);
+        let sub = provider.subscribe_blocks().await.unwrap();
+        let mut stream = sub.into_stream();
+        let header = tokio::time::timeout(Duration::from_secs(30), stream.next())
+            .await
+            .expect("timed out waiting for PublicNode header")
+            .expect("subscription stream closed");
+        assert!(header.number > 0);
+    }
+
+    #[tokio::test]
     async fn test_custom_retry_policy() {
         #[derive(Debug, Clone)]
         struct CustomPolicy;


### PR DESCRIPTION
## Summary

- add a provider WebSocket subscription test for `wss://ethereum-rpc.publicnode.com`
- wait for one `subscribe_blocks()` header so this endpoint can be used as a focused pubsub debugging harness

## Context

This is intentionally test-only. It follows #3948 without claiming a fix; the earlier speculative alias-map PR was closed.

Refs #3948

## Tests

- `cargo test -p alloy-provider --features ws-base subscribe_blocks_ws_publicnode_short_subscription_id --lib -- --nocapture`
- `git diff --check`