### PR TITLE
fix: deduplicate fork activation checks in genesis config

### DIFF
--- a/crates/genesis/src/lib.rs
+++ b/crates/genesis/src/lib.rs
@@ -981,91 +981,85 @@ impl ChainConfig {
 
     /// Checks if the blockchain is active at or after the Homestead fork block.
     pub fn is_homestead_active_at_block(&self, block: u64) -> bool {
-        self.is_active_at_block(self.homestead_block, block)
+        Self::is_fork_active_at(self.homestead_block, block)
     }
 
     /// Checks if the blockchain is active at or after the EIP150 fork block.
     pub fn is_eip150_active_at_block(&self, block: u64) -> bool {
-        self.is_active_at_block(self.eip150_block, block)
+        Self::is_fork_active_at(self.eip150_block, block)
     }
 
     /// Checks if the blockchain is active at or after the EIP155 fork block.
     pub fn is_eip155_active_at_block(&self, block: u64) -> bool {
-        self.is_active_at_block(self.eip155_block, block)
+        Self::is_fork_active_at(self.eip155_block, block)
     }
 
     /// Checks if the blockchain is active at or after the EIP158 fork block.
     pub fn is_eip158_active_at_block(&self, block: u64) -> bool {
-        self.is_active_at_block(self.eip158_block, block)
+        Self::is_fork_active_at(self.eip158_block, block)
     }
 
     /// Checks if the blockchain is active at or after the Byzantium fork block.
     pub fn is_byzantium_active_at_block(&self, block: u64) -> bool {
-        self.is_active_at_block(self.byzantium_block, block)
+        Self::is_fork_active_at(self.byzantium_block, block)
     }
 
     /// Checks if the blockchain is active at or after the Constantinople fork block.
     pub fn is_constantinople_active_at_block(&self, block: u64) -> bool {
-        self.is_active_at_block(self.constantinople_block, block)
+        Self::is_fork_active_at(self.constantinople_block, block)
     }
 
     /// Checks if the blockchain is active at or after the Muir Glacier (EIP-2384) fork block.
     pub fn is_muir_glacier_active_at_block(&self, block: u64) -> bool {
-        self.is_active_at_block(self.muir_glacier_block, block)
+        Self::is_fork_active_at(self.muir_glacier_block, block)
     }
 
     /// Checks if the blockchain is active at or after the Petersburg fork block.
     pub fn is_petersburg_active_at_block(&self, block: u64) -> bool {
-        self.is_active_at_block(self.petersburg_block, block)
+        Self::is_fork_active_at(self.petersburg_block, block)
     }
 
     /// Checks if the blockchain is active at or after the Istanbul fork block.
     pub fn is_istanbul_active_at_block(&self, block: u64) -> bool {
-        self.is_active_at_block(self.istanbul_block, block)
+        Self::is_fork_active_at(self.istanbul_block, block)
     }
 
     /// Checks if the blockchain is active at or after the Berlin fork block.
     pub fn is_berlin_active_at_block(&self, block: u64) -> bool {
-        self.is_active_at_block(self.berlin_block, block)
+        Self::is_fork_active_at(self.berlin_block, block)
     }
 
     /// Checks if the blockchain is active at or after the London fork block.
     pub fn is_london_active_at_block(&self, block: u64) -> bool {
-        self.is_active_at_block(self.london_block, block)
+        Self::is_fork_active_at(self.london_block, block)
     }
 
     /// Checks if the blockchain is active at or after the Arrow Glacier (EIP-4345) fork block.
     pub fn is_arrow_glacier_active_at_block(&self, block: u64) -> bool {
-        self.is_active_at_block(self.arrow_glacier_block, block)
+        Self::is_fork_active_at(self.arrow_glacier_block, block)
     }
 
     /// Checks if the blockchain is active at or after the Gray Glacier (EIP-5133) fork block.
     pub fn is_gray_glacier_active_at_block(&self, block: u64) -> bool {
-        self.is_active_at_block(self.gray_glacier_block, block)
+        Self::is_fork_active_at(self.gray_glacier_block, block)
     }
 
     /// Checks if the blockchain is active at or after the Shanghai fork block and the specified
     /// timestamp.
     pub fn is_shanghai_active_at_block_and_timestamp(&self, block: u64, timestamp: u64) -> bool {
         self.is_london_active_at_block(block)
-            && self.is_active_at_timestamp(self.shanghai_time, timestamp)
+            && Self::is_fork_active_at(self.shanghai_time, timestamp)
     }
 
     /// Checks if the blockchain is active at or after the Cancun fork block and the specified
     /// timestamp.
     pub fn is_cancun_active_at_block_and_timestamp(&self, block: u64, timestamp: u64) -> bool {
         self.is_london_active_at_block(block)
-            && self.is_active_at_timestamp(self.cancun_time, timestamp)
+            && Self::is_fork_active_at(self.cancun_time, timestamp)
     }
 
-    // Private function handling the comparison logic for block numbers
-    fn is_active_at_block(&self, config_block: Option<u64>, block: u64) -> bool {
-        config_block.is_some_and(|cb| cb <= block)
-    }
-
-    // Private function handling the comparison logic for timestamps
-    fn is_active_at_timestamp(&self, config_timestamp: Option<u64>, timestamp: u64) -> bool {
-        config_timestamp.is_some_and(|cb| cb <= timestamp)
+    fn is_fork_active_at(configured_at: Option<u64>, current: u64) -> bool {
+        configured_at.is_some_and(|fork_at| fork_at <= current)
     }
 }
 


### PR DESCRIPTION


`ChainConfig` used separate private helpers for block-based and timestamp-based fork activation checks, but both implemented the same comparison logic. Keeping two copies makes the shared semantics less obvious.


