### PR TITLE
perf(eips): optimize c-kzg byte conversions

### DIFF
--- a/crates/eips/src/eip4844/mod.rs
+++ b/crates/eips/src/eip4844/mod.rs
@@ -233,20 +233,58 @@ impl alloy_rlp::Decodable for HeapBlob {
 /// A commitment/proof serialized as 0x-prefixed hex string
 pub type Bytes48 = FixedBytes<48>;
 
-/// Conversion helpers for c-kzg blobs.
+/// Conversion helpers for c-kzg byte wrappers.
 #[cfg(feature = "kzg")]
-pub trait BlobCkzgExt {
-    /// Returns this blob as a c-kzg blob.
-    fn as_ckzg(&self) -> &c_kzg::Blob;
+pub trait AsCkzg: Sized {
+    /// The equivalent c-kzg byte wrapper type.
+    type Ckzg;
 
-    /// Returns this blob as a mutable c-kzg blob.
-    fn as_ckzg_mut(&mut self) -> &mut c_kzg::Blob;
+    /// Returns this value as its c-kzg equivalent.
+    fn as_ckzg(&self) -> &Self::Ckzg;
+
+    /// Returns this value as its mutable c-kzg equivalent.
+    fn as_ckzg_mut(&mut self) -> &mut Self::Ckzg;
+
+    /// Converts a c-kzg value into this type.
+    fn from_ckzg(value: Self::Ckzg) -> Self;
+
+    /// Returns this slice as its c-kzg equivalent.
+    fn slice_as_ckzg(slice: &[Self]) -> &[Self::Ckzg];
+
+    /// Returns this slice as its mutable c-kzg equivalent.
+    fn slice_as_ckzg_mut(slice: &mut [Self]) -> &mut [Self::Ckzg];
+
+    /// Converts this vector into its c-kzg equivalent.
+    fn vec_as_ckzg(vec: alloc::vec::Vec<Self>) -> alloc::vec::Vec<Self::Ckzg>;
+
+    /// Converts a c-kzg vector into this type's equivalent vector.
+    fn vec_from_ckzg(vec: alloc::vec::Vec<Self::Ckzg>) -> alloc::vec::Vec<Self>;
 }
 
 #[cfg(feature = "kzg")]
-impl BlobCkzgExt for Blob {
+unsafe fn transmute_ckzg_value<T, U>(value: T) -> U {
+    let value = core::mem::ManuallyDrop::new(value);
+    unsafe { core::ptr::read((&*value as *const T).cast::<U>()) }
+}
+
+#[cfg(feature = "kzg")]
+unsafe fn transmute_ckzg_vec<T, U>(input: alloc::vec::Vec<T>) -> alloc::vec::Vec<U> {
+    let mut input = core::mem::ManuallyDrop::new(input);
+    unsafe {
+        alloc::vec::Vec::from_raw_parts(
+            input.as_mut_ptr().cast::<U>(),
+            input.len(),
+            input.capacity(),
+        )
+    }
+}
+
+#[cfg(feature = "kzg")]
+impl AsCkzg for Blob {
+    type Ckzg = c_kzg::Blob;
+
     #[inline]
-    fn as_ckzg(&self) -> &c_kzg::Blob {
+    fn as_ckzg(&self) -> &Self::Ckzg {
         // SAFETY: `Blob` is `FixedBytes<BYTES_PER_BLOB>`, which is `repr(transparent)` over
         // `[u8; BYTES_PER_BLOB]`. `c_kzg::Blob` is `repr(C)` with a single
         // `[u8; BYTES_PER_BLOB]` field.
@@ -254,59 +292,88 @@ impl BlobCkzgExt for Blob {
     }
 
     #[inline]
-    fn as_ckzg_mut(&mut self) -> &mut c_kzg::Blob {
-        // SAFETY: See `BlobCkzgExt::as_ckzg`.
+    fn as_ckzg_mut(&mut self) -> &mut Self::Ckzg {
+        // SAFETY: See `AsCkzg for Blob::as_ckzg`.
         unsafe { core::mem::transmute(self) }
+    }
+
+    #[inline]
+    fn from_ckzg(value: Self::Ckzg) -> Self {
+        // SAFETY: See `AsCkzg for Blob::as_ckzg`.
+        unsafe { transmute_ckzg_value(value) }
+    }
+
+    #[inline]
+    fn slice_as_ckzg(slice: &[Self]) -> &[Self::Ckzg] {
+        // SAFETY: See `AsCkzg for Blob::as_ckzg`.
+        unsafe { core::mem::transmute(slice) }
+    }
+
+    #[inline]
+    fn slice_as_ckzg_mut(slice: &mut [Self]) -> &mut [Self::Ckzg] {
+        // SAFETY: See `AsCkzg for Blob::as_ckzg`.
+        unsafe { core::mem::transmute(slice) }
+    }
+
+    #[inline]
+    fn vec_as_ckzg(vec: alloc::vec::Vec<Self>) -> alloc::vec::Vec<Self::Ckzg> {
+        // SAFETY: See `AsCkzg for Blob::as_ckzg`.
+        unsafe { transmute_ckzg_vec(vec) }
+    }
+
+    #[inline]
+    fn vec_from_ckzg(vec: alloc::vec::Vec<Self::Ckzg>) -> alloc::vec::Vec<Self> {
+        // SAFETY: See `AsCkzg for Blob::as_ckzg`.
+        unsafe { transmute_ckzg_vec(vec) }
     }
 }
 
-/// Conversion helpers for c-kzg commitment/proof bytes.
 #[cfg(feature = "kzg")]
-pub trait Bytes48CkzgExt {
-    /// Returns these bytes as c-kzg bytes.
-    fn as_ckzg(&self) -> &c_kzg::Bytes48;
+impl AsCkzg for Bytes48 {
+    type Ckzg = c_kzg::Bytes48;
 
-    /// Returns these bytes as mutable c-kzg bytes.
-    fn as_ckzg_mut(&mut self) -> &mut c_kzg::Bytes48;
-}
-
-#[cfg(feature = "kzg")]
-impl Bytes48CkzgExt for Bytes48 {
     #[inline]
-    fn as_ckzg(&self) -> &c_kzg::Bytes48 {
+    fn as_ckzg(&self) -> &Self::Ckzg {
         // SAFETY: `Bytes48` is `FixedBytes<48>`, which is `repr(transparent)` over `[u8; 48]`.
         // `c_kzg::Bytes48` is `repr(C)` with a single `[u8; 48]` field.
         unsafe { core::mem::transmute(self) }
     }
 
     #[inline]
-    fn as_ckzg_mut(&mut self) -> &mut c_kzg::Bytes48 {
-        // SAFETY: See `Bytes48CkzgExt::as_ckzg`.
+    fn as_ckzg_mut(&mut self) -> &mut Self::Ckzg {
+        // SAFETY: See `AsCkzg for Bytes48::as_ckzg`.
         unsafe { core::mem::transmute(self) }
     }
-}
 
-/// Returns blobs as c-kzg blobs.
-#[cfg(feature = "kzg")]
-#[inline]
-pub fn blobs_as_ckzg(blobs: &[Blob]) -> &[c_kzg::Blob] {
-    // SAFETY: See `BlobCkzgExt::as_ckzg`.
-    unsafe { core::mem::transmute(blobs) }
-}
+    #[inline]
+    fn from_ckzg(value: Self::Ckzg) -> Self {
+        // SAFETY: See `AsCkzg for Bytes48::as_ckzg`.
+        unsafe { transmute_ckzg_value(value) }
+    }
 
-/// Returns commitment/proof bytes as c-kzg bytes.
-#[cfg(feature = "kzg")]
-#[inline]
-pub fn bytes48_as_ckzg(bytes: &[Bytes48]) -> &[c_kzg::Bytes48] {
-    // SAFETY: See `Bytes48CkzgExt::as_ckzg`.
-    unsafe { core::mem::transmute(bytes) }
-}
+    #[inline]
+    fn slice_as_ckzg(slice: &[Self]) -> &[Self::Ckzg] {
+        // SAFETY: See `AsCkzg for Bytes48::as_ckzg`.
+        unsafe { core::mem::transmute(slice) }
+    }
 
-/// Converts c-kzg bytes into the Alloy 48-byte wrapper.
-#[cfg(feature = "kzg")]
-#[inline]
-pub fn bytes48_from_ckzg(bytes: c_kzg::Bytes48) -> Bytes48 {
-    Bytes48::new(bytes.into_inner())
+    #[inline]
+    fn slice_as_ckzg_mut(slice: &mut [Self]) -> &mut [Self::Ckzg] {
+        // SAFETY: See `AsCkzg for Bytes48::as_ckzg`.
+        unsafe { core::mem::transmute(slice) }
+    }
+
+    #[inline]
+    fn vec_as_ckzg(vec: alloc::vec::Vec<Self>) -> alloc::vec::Vec<Self::Ckzg> {
+        // SAFETY: See `AsCkzg for Bytes48::as_ckzg`.
+        unsafe { transmute_ckzg_vec(vec) }
+    }
+
+    #[inline]
+    fn vec_from_ckzg(vec: alloc::vec::Vec<Self::Ckzg>) -> alloc::vec::Vec<Self> {
+        // SAFETY: See `AsCkzg for Bytes48::as_ckzg`.
+        unsafe { transmute_ckzg_vec(vec) }
+    }
 }
 
 /// Calculates the versioned hash for a KzgCommitment of 48 bytes.

--- a/crates/eips/src/eip4844/mod.rs
+++ b/crates/eips/src/eip4844/mod.rs
@@ -376,6 +376,30 @@ impl AsCkzg for Bytes48 {
     }
 }
 
+/// Returns blobs as c-kzg blobs.
+#[cfg(feature = "kzg")]
+#[deprecated(note = "use `Blob::slice_as_ckzg` via the `AsCkzg` trait instead")]
+#[inline]
+pub fn blobs_as_ckzg(blobs: &[Blob]) -> &[c_kzg::Blob] {
+    Blob::slice_as_ckzg(blobs)
+}
+
+/// Returns commitment/proof bytes as c-kzg bytes.
+#[cfg(feature = "kzg")]
+#[deprecated(note = "use `Bytes48::slice_as_ckzg` via the `AsCkzg` trait instead")]
+#[inline]
+pub fn bytes48_as_ckzg(bytes: &[Bytes48]) -> &[c_kzg::Bytes48] {
+    Bytes48::slice_as_ckzg(bytes)
+}
+
+/// Converts c-kzg bytes into the Alloy 48-byte wrapper.
+#[cfg(feature = "kzg")]
+#[deprecated(note = "use `Bytes48::from_ckzg` via the `AsCkzg` trait instead")]
+#[inline]
+pub fn bytes48_from_ckzg(bytes: c_kzg::Bytes48) -> Bytes48 {
+    Bytes48::from_ckzg(bytes)
+}
+
 /// Calculates the versioned hash for a KzgCommitment of 48 bytes.
 ///
 /// Specified in [EIP-4844](https://eips.ethereum.org/EIPS/eip-4844#header-extension)

--- a/crates/eips/src/eip4844/mod.rs
+++ b/crates/eips/src/eip4844/mod.rs
@@ -262,24 +262,6 @@ pub trait AsCkzg: Sized {
 }
 
 #[cfg(feature = "kzg")]
-unsafe fn transmute_ckzg_value<T, U>(value: T) -> U {
-    let value = core::mem::ManuallyDrop::new(value);
-    unsafe { core::ptr::read((&*value as *const T).cast::<U>()) }
-}
-
-#[cfg(feature = "kzg")]
-unsafe fn transmute_ckzg_vec<T, U>(input: alloc::vec::Vec<T>) -> alloc::vec::Vec<U> {
-    let mut input = core::mem::ManuallyDrop::new(input);
-    unsafe {
-        alloc::vec::Vec::from_raw_parts(
-            input.as_mut_ptr().cast::<U>(),
-            input.len(),
-            input.capacity(),
-        )
-    }
-}
-
-#[cfg(feature = "kzg")]
 impl AsCkzg for Blob {
     type Ckzg = c_kzg::Blob;
 
@@ -300,7 +282,7 @@ impl AsCkzg for Blob {
     #[inline]
     fn from_ckzg(value: Self::Ckzg) -> Self {
         // SAFETY: See `AsCkzg for Blob::as_ckzg`.
-        unsafe { transmute_ckzg_value(value) }
+        unsafe { core::mem::transmute(value) }
     }
 
     #[inline]
@@ -318,13 +300,13 @@ impl AsCkzg for Blob {
     #[inline]
     fn vec_as_ckzg(vec: alloc::vec::Vec<Self>) -> alloc::vec::Vec<Self::Ckzg> {
         // SAFETY: See `AsCkzg for Blob::as_ckzg`.
-        unsafe { transmute_ckzg_vec(vec) }
+        unsafe { core::mem::transmute(vec) }
     }
 
     #[inline]
     fn vec_from_ckzg(vec: alloc::vec::Vec<Self::Ckzg>) -> alloc::vec::Vec<Self> {
         // SAFETY: See `AsCkzg for Blob::as_ckzg`.
-        unsafe { transmute_ckzg_vec(vec) }
+        unsafe { core::mem::transmute(vec) }
     }
 }
 
@@ -348,7 +330,7 @@ impl AsCkzg for Bytes48 {
     #[inline]
     fn from_ckzg(value: Self::Ckzg) -> Self {
         // SAFETY: See `AsCkzg for Bytes48::as_ckzg`.
-        unsafe { transmute_ckzg_value(value) }
+        unsafe { core::mem::transmute(value) }
     }
 
     #[inline]
@@ -366,13 +348,13 @@ impl AsCkzg for Bytes48 {
     #[inline]
     fn vec_as_ckzg(vec: alloc::vec::Vec<Self>) -> alloc::vec::Vec<Self::Ckzg> {
         // SAFETY: See `AsCkzg for Bytes48::as_ckzg`.
-        unsafe { transmute_ckzg_vec(vec) }
+        unsafe { core::mem::transmute(vec) }
     }
 
     #[inline]
     fn vec_from_ckzg(vec: alloc::vec::Vec<Self::Ckzg>) -> alloc::vec::Vec<Self> {
         // SAFETY: See `AsCkzg for Bytes48::as_ckzg`.
-        unsafe { transmute_ckzg_vec(vec) }
+        unsafe { core::mem::transmute(vec) }
     }
 }
 

--- a/crates/eips/src/eip4844/mod.rs
+++ b/crates/eips/src/eip4844/mod.rs
@@ -233,6 +233,82 @@ impl alloy_rlp::Decodable for HeapBlob {
 /// A commitment/proof serialized as 0x-prefixed hex string
 pub type Bytes48 = FixedBytes<48>;
 
+/// Conversion helpers for c-kzg blobs.
+#[cfg(feature = "kzg")]
+pub trait BlobCkzgExt {
+    /// Returns this blob as a c-kzg blob.
+    fn as_ckzg(&self) -> &c_kzg::Blob;
+
+    /// Returns this blob as a mutable c-kzg blob.
+    fn as_ckzg_mut(&mut self) -> &mut c_kzg::Blob;
+}
+
+#[cfg(feature = "kzg")]
+impl BlobCkzgExt for Blob {
+    #[inline]
+    fn as_ckzg(&self) -> &c_kzg::Blob {
+        // SAFETY: `Blob` is `FixedBytes<BYTES_PER_BLOB>`, which is `repr(transparent)` over
+        // `[u8; BYTES_PER_BLOB]`. `c_kzg::Blob` is `repr(C)` with a single
+        // `[u8; BYTES_PER_BLOB]` field.
+        unsafe { core::mem::transmute(self) }
+    }
+
+    #[inline]
+    fn as_ckzg_mut(&mut self) -> &mut c_kzg::Blob {
+        // SAFETY: See `BlobCkzgExt::as_ckzg`.
+        unsafe { core::mem::transmute(self) }
+    }
+}
+
+/// Conversion helpers for c-kzg commitment/proof bytes.
+#[cfg(feature = "kzg")]
+pub trait Bytes48CkzgExt {
+    /// Returns these bytes as c-kzg bytes.
+    fn as_ckzg(&self) -> &c_kzg::Bytes48;
+
+    /// Returns these bytes as mutable c-kzg bytes.
+    fn as_ckzg_mut(&mut self) -> &mut c_kzg::Bytes48;
+}
+
+#[cfg(feature = "kzg")]
+impl Bytes48CkzgExt for Bytes48 {
+    #[inline]
+    fn as_ckzg(&self) -> &c_kzg::Bytes48 {
+        // SAFETY: `Bytes48` is `FixedBytes<48>`, which is `repr(transparent)` over `[u8; 48]`.
+        // `c_kzg::Bytes48` is `repr(C)` with a single `[u8; 48]` field.
+        unsafe { core::mem::transmute(self) }
+    }
+
+    #[inline]
+    fn as_ckzg_mut(&mut self) -> &mut c_kzg::Bytes48 {
+        // SAFETY: See `Bytes48CkzgExt::as_ckzg`.
+        unsafe { core::mem::transmute(self) }
+    }
+}
+
+/// Returns blobs as c-kzg blobs.
+#[cfg(feature = "kzg")]
+#[inline]
+pub fn blobs_as_ckzg(blobs: &[Blob]) -> &[c_kzg::Blob] {
+    // SAFETY: See `BlobCkzgExt::as_ckzg`.
+    unsafe { core::mem::transmute(blobs) }
+}
+
+/// Returns commitment/proof bytes as c-kzg bytes.
+#[cfg(feature = "kzg")]
+#[inline]
+pub fn bytes48_as_ckzg(bytes: &[Bytes48]) -> &[c_kzg::Bytes48] {
+    // SAFETY: See `Bytes48CkzgExt::as_ckzg`.
+    unsafe { core::mem::transmute(bytes) }
+}
+
+/// Converts c-kzg bytes into the Alloy 48-byte wrapper.
+#[cfg(feature = "kzg")]
+#[inline]
+pub fn bytes48_from_ckzg(bytes: c_kzg::Bytes48) -> Bytes48 {
+    Bytes48::new(bytes.into_inner())
+}
+
 /// Calculates the versioned hash for a KzgCommitment of 48 bytes.
 ///
 /// Specified in [EIP-4844](https://eips.ethereum.org/EIPS/eip-4844#header-extension)

--- a/crates/eips/src/eip4844/mod.rs
+++ b/crates/eips/src/eip4844/mod.rs
@@ -261,102 +261,160 @@ pub trait AsCkzg: Sized {
     fn vec_from_ckzg(vec: alloc::vec::Vec<Self::Ckzg>) -> alloc::vec::Vec<Self>;
 }
 
+/// Conversion helpers for c-kzg byte wrappers back to Alloy byte wrappers.
 #[cfg(feature = "kzg")]
-impl AsCkzg for Blob {
-    type Ckzg = c_kzg::Blob;
+pub trait AsAlloy: Sized {
+    /// The equivalent Alloy byte wrapper type.
+    type Alloy;
 
-    #[inline]
-    fn as_ckzg(&self) -> &Self::Ckzg {
-        // SAFETY: `Blob` is `FixedBytes<BYTES_PER_BLOB>`, which is `repr(transparent)` over
-        // `[u8; BYTES_PER_BLOB]`. `c_kzg::Blob` is `repr(C)` with a single
-        // `[u8; BYTES_PER_BLOB]` field.
-        unsafe { core::mem::transmute(self) }
-    }
+    /// Returns this value as its Alloy equivalent.
+    fn as_alloy(&self) -> &Self::Alloy;
 
-    #[inline]
-    fn as_ckzg_mut(&mut self) -> &mut Self::Ckzg {
-        // SAFETY: See `AsCkzg for Blob::as_ckzg`.
-        unsafe { core::mem::transmute(self) }
-    }
+    /// Returns this value as its mutable Alloy equivalent.
+    fn as_alloy_mut(&mut self) -> &mut Self::Alloy;
 
-    #[inline]
-    fn from_ckzg(value: Self::Ckzg) -> Self {
-        // SAFETY: See `AsCkzg for Blob::as_ckzg`.
-        unsafe { core::mem::transmute(value) }
-    }
+    /// Converts this value into its Alloy equivalent.
+    fn into_alloy(self) -> Self::Alloy;
 
-    #[inline]
-    fn slice_as_ckzg(slice: &[Self]) -> &[Self::Ckzg] {
-        // SAFETY: See `AsCkzg for Blob::as_ckzg`.
-        unsafe { core::mem::transmute(slice) }
-    }
+    /// Returns this slice as its Alloy equivalent.
+    fn slice_as_alloy(slice: &[Self]) -> &[Self::Alloy];
 
-    #[inline]
-    fn slice_as_ckzg_mut(slice: &mut [Self]) -> &mut [Self::Ckzg] {
-        // SAFETY: See `AsCkzg for Blob::as_ckzg`.
-        unsafe { core::mem::transmute(slice) }
-    }
+    /// Returns this slice as its mutable Alloy equivalent.
+    fn slice_as_alloy_mut(slice: &mut [Self]) -> &mut [Self::Alloy];
 
-    #[inline]
-    fn vec_as_ckzg(vec: alloc::vec::Vec<Self>) -> alloc::vec::Vec<Self::Ckzg> {
-        // SAFETY: See `AsCkzg for Blob::as_ckzg`.
-        unsafe { core::mem::transmute(vec) }
-    }
+    /// Converts this vector into its Alloy equivalent.
+    fn vec_as_alloy(vec: alloc::vec::Vec<Self>) -> alloc::vec::Vec<Self::Alloy>;
 
-    #[inline]
-    fn vec_from_ckzg(vec: alloc::vec::Vec<Self::Ckzg>) -> alloc::vec::Vec<Self> {
-        // SAFETY: See `AsCkzg for Blob::as_ckzg`.
-        unsafe { core::mem::transmute(vec) }
-    }
+    /// Converts this boxed slice into its Alloy equivalent.
+    fn boxed_slice_as_alloy(boxed: alloc::boxed::Box<[Self]>) -> alloc::boxed::Box<[Self::Alloy]>;
+
+    /// Converts an Alloy vector into this type's equivalent vector.
+    fn vec_from_alloy(vec: alloc::vec::Vec<Self::Alloy>) -> alloc::vec::Vec<Self>;
 }
 
 #[cfg(feature = "kzg")]
-impl AsCkzg for Bytes48 {
-    type Ckzg = c_kzg::Bytes48;
+macro_rules! impl_ckzg_conversions {
+    ($alloy:ty, $ckzg:ty) => {
+        impl AsCkzg for $alloy {
+            type Ckzg = $ckzg;
 
-    #[inline]
-    fn as_ckzg(&self) -> &Self::Ckzg {
-        // SAFETY: `Bytes48` is `FixedBytes<48>`, which is `repr(transparent)` over `[u8; 48]`.
-        // `c_kzg::Bytes48` is `repr(C)` with a single `[u8; 48]` field.
-        unsafe { core::mem::transmute(self) }
-    }
+            #[inline]
+            fn as_ckzg(&self) -> &Self::Ckzg {
+                // SAFETY: This macro is only invoked for transparent byte wrappers with the same
+                // layout and alignment as their c-kzg equivalents.
+                unsafe { core::mem::transmute(self) }
+            }
 
-    #[inline]
-    fn as_ckzg_mut(&mut self) -> &mut Self::Ckzg {
-        // SAFETY: See `AsCkzg for Bytes48::as_ckzg`.
-        unsafe { core::mem::transmute(self) }
-    }
+            #[inline]
+            fn as_ckzg_mut(&mut self) -> &mut Self::Ckzg {
+                // SAFETY: See `AsCkzg::as_ckzg`.
+                unsafe { core::mem::transmute(self) }
+            }
 
-    #[inline]
-    fn from_ckzg(value: Self::Ckzg) -> Self {
-        // SAFETY: See `AsCkzg for Bytes48::as_ckzg`.
-        unsafe { core::mem::transmute(value) }
-    }
+            #[inline]
+            fn from_ckzg(value: Self::Ckzg) -> Self {
+                // SAFETY: See `AsCkzg::as_ckzg`.
+                unsafe { core::mem::transmute(value) }
+            }
 
-    #[inline]
-    fn slice_as_ckzg(slice: &[Self]) -> &[Self::Ckzg] {
-        // SAFETY: See `AsCkzg for Bytes48::as_ckzg`.
-        unsafe { core::mem::transmute(slice) }
-    }
+            #[inline]
+            fn slice_as_ckzg(slice: &[Self]) -> &[Self::Ckzg] {
+                // SAFETY: See `AsCkzg::as_ckzg`.
+                unsafe { core::mem::transmute(slice) }
+            }
 
-    #[inline]
-    fn slice_as_ckzg_mut(slice: &mut [Self]) -> &mut [Self::Ckzg] {
-        // SAFETY: See `AsCkzg for Bytes48::as_ckzg`.
-        unsafe { core::mem::transmute(slice) }
-    }
+            #[inline]
+            fn slice_as_ckzg_mut(slice: &mut [Self]) -> &mut [Self::Ckzg] {
+                // SAFETY: See `AsCkzg::as_ckzg`.
+                unsafe { core::mem::transmute(slice) }
+            }
 
-    #[inline]
-    fn vec_as_ckzg(vec: alloc::vec::Vec<Self>) -> alloc::vec::Vec<Self::Ckzg> {
-        // SAFETY: See `AsCkzg for Bytes48::as_ckzg`.
-        unsafe { core::mem::transmute(vec) }
-    }
+            #[inline]
+            fn vec_as_ckzg(vec: alloc::vec::Vec<Self>) -> alloc::vec::Vec<Self::Ckzg> {
+                // SAFETY: See `AsCkzg::as_ckzg`.
+                unsafe { core::mem::transmute(vec) }
+            }
 
-    #[inline]
-    fn vec_from_ckzg(vec: alloc::vec::Vec<Self::Ckzg>) -> alloc::vec::Vec<Self> {
-        // SAFETY: See `AsCkzg for Bytes48::as_ckzg`.
-        unsafe { core::mem::transmute(vec) }
-    }
+            #[inline]
+            fn vec_from_ckzg(vec: alloc::vec::Vec<Self::Ckzg>) -> alloc::vec::Vec<Self> {
+                // SAFETY: See `AsCkzg::as_ckzg`.
+                unsafe { core::mem::transmute(vec) }
+            }
+        }
+
+        impl_ckzg_conversions!(reverse $alloy, $ckzg);
+    };
+    (reverse $alloy:ty, $ckzg:ty) => {
+        impl AsAlloy for $ckzg {
+            type Alloy = $alloy;
+
+            #[inline]
+            fn as_alloy(&self) -> &Self::Alloy {
+                // SAFETY: This macro is only invoked for c-kzg byte wrappers with the same layout
+                // and alignment as their Alloy equivalents.
+                unsafe { core::mem::transmute(self) }
+            }
+
+            #[inline]
+            fn as_alloy_mut(&mut self) -> &mut Self::Alloy {
+                // SAFETY: See `AsAlloy::as_alloy`.
+                unsafe { core::mem::transmute(self) }
+            }
+
+            #[inline]
+            fn into_alloy(self) -> Self::Alloy {
+                // SAFETY: See `AsAlloy::as_alloy`.
+                unsafe { core::mem::transmute(self) }
+            }
+
+            #[inline]
+            fn slice_as_alloy(slice: &[Self]) -> &[Self::Alloy] {
+                // SAFETY: See `AsAlloy::as_alloy`.
+                unsafe { core::mem::transmute(slice) }
+            }
+
+            #[inline]
+            fn slice_as_alloy_mut(slice: &mut [Self]) -> &mut [Self::Alloy] {
+                // SAFETY: See `AsAlloy::as_alloy`.
+                unsafe { core::mem::transmute(slice) }
+            }
+
+            #[inline]
+            fn vec_as_alloy(vec: alloc::vec::Vec<Self>) -> alloc::vec::Vec<Self::Alloy> {
+                // SAFETY: See `AsAlloy::as_alloy`.
+                unsafe { core::mem::transmute(vec) }
+            }
+
+            #[inline]
+            fn boxed_slice_as_alloy(
+                boxed: alloc::boxed::Box<[Self]>,
+            ) -> alloc::boxed::Box<[Self::Alloy]> {
+                // SAFETY: See `AsAlloy::as_alloy`.
+                unsafe {
+                    core::mem::transmute::<
+                        alloc::boxed::Box<[Self]>,
+                        alloc::boxed::Box<[Self::Alloy]>,
+                    >(boxed)
+                }
+            }
+
+            #[inline]
+            fn vec_from_alloy(vec: alloc::vec::Vec<Self::Alloy>) -> alloc::vec::Vec<Self> {
+                // SAFETY: See `AsAlloy::as_alloy`.
+                unsafe { core::mem::transmute(vec) }
+            }
+        }
+    };
 }
+
+#[cfg(feature = "kzg")]
+impl_ckzg_conversions!(Blob, c_kzg::Blob);
+#[cfg(feature = "kzg")]
+impl_ckzg_conversions!(Bytes48, c_kzg::Bytes48);
+#[cfg(feature = "kzg")]
+impl_ckzg_conversions!(reverse Bytes48, c_kzg::KzgProof);
+#[cfg(feature = "kzg")]
+impl_ckzg_conversions!(reverse crate::eip7594::Cell, c_kzg::Cell);
 
 /// Returns blobs as c-kzg blobs.
 #[cfg(feature = "kzg")]

--- a/crates/eips/src/eip4844/sidecar.rs
+++ b/crates/eips/src/eip4844/sidecar.rs
@@ -11,10 +11,10 @@ use alloc::{boxed::Box, vec::Vec};
 use alloy_primitives::{bytes::BufMut, B256};
 use alloy_rlp::{Decodable, Encodable, Header};
 
+#[cfg(feature = "kzg")]
+use crate::eip4844::AsCkzg;
 #[cfg(any(test, feature = "arbitrary"))]
 use crate::eip4844::MAX_BLOBS_PER_BLOCK_DENCUN;
-#[cfg(feature = "kzg")]
-use crate::eip4844::{blobs_as_ckzg, bytes48_as_ckzg, bytes48_from_ckzg, BlobCkzgExt};
 
 /// The versioned hash version for KZG.
 #[cfg(feature = "kzg")]
@@ -100,7 +100,7 @@ impl BlobTransactionSidecar {
             let (_cells, kzg_proofs) = settings.compute_cells_and_kzg_proofs(blob.as_ckzg())?;
 
             for kzg_proof in kzg_proofs.iter() {
-                cell_proofs.push(bytes48_from_ckzg(kzg_proof.to_bytes()));
+                cell_proofs.push(Bytes48::from_ckzg(kzg_proof.to_bytes()));
             }
         }
 
@@ -248,9 +248,9 @@ impl BlobTransactionSidecar {
         commitments: Vec<c_kzg::Bytes48>,
         proofs: Vec<c_kzg::Bytes48>,
     ) -> Self {
-        let blobs = blobs.into_iter().map(|blob| Blob::new(blob.into_inner())).collect();
-        let commitments = commitments.into_iter().map(bytes48_from_ckzg).collect();
-        let proofs = proofs.into_iter().map(bytes48_from_ckzg).collect();
+        let blobs = Blob::vec_from_ckzg(blobs);
+        let commitments = Bytes48::vec_from_ckzg(commitments);
+        let proofs = Bytes48::vec_from_ckzg(proofs);
         Self { blobs, commitments, proofs }
     }
 
@@ -299,9 +299,9 @@ impl BlobTransactionSidecar {
 
         let res = proof_settings
             .verify_blob_kzg_proof_batch(
-                blobs_as_ckzg(self.blobs.as_slice()),
-                bytes48_as_ckzg(self.commitments.as_slice()),
-                bytes48_as_ckzg(self.proofs.as_slice()),
+                Blob::slice_as_ckzg(self.blobs.as_slice()),
+                Bytes48::slice_as_ckzg(self.commitments.as_slice()),
+                Bytes48::slice_as_ckzg(self.proofs.as_slice()),
             )
             .map_err(BlobTransactionValidationError::KZGError)?;
 
@@ -386,8 +386,8 @@ impl BlobTransactionSidecar {
             let commitment = settings.blob_to_kzg_commitment(blob)?;
             let proof = settings.compute_blob_kzg_proof(blob, &commitment.to_bytes())?;
 
-            commitments.push(bytes48_from_ckzg(commitment.to_bytes()));
-            proofs.push(bytes48_from_ckzg(proof.to_bytes()));
+            commitments.push(Bytes48::from_ckzg(commitment.to_bytes()));
+            proofs.push(Bytes48::from_ckzg(proof.to_bytes()));
         }
 
         Ok(Self::new(blobs, commitments, proofs))

--- a/crates/eips/src/eip4844/sidecar.rs
+++ b/crates/eips/src/eip4844/sidecar.rs
@@ -13,6 +13,8 @@ use alloy_rlp::{Decodable, Encodable, Header};
 
 #[cfg(any(test, feature = "arbitrary"))]
 use crate::eip4844::MAX_BLOBS_PER_BLOCK_DENCUN;
+#[cfg(feature = "kzg")]
+use crate::eip4844::{blobs_as_ckzg, bytes48_as_ckzg, bytes48_from_ckzg, BlobCkzgExt};
 
 /// The versioned hash version for KZG.
 #[cfg(feature = "kzg")]
@@ -94,19 +96,11 @@ impl BlobTransactionSidecar {
         let mut cell_proofs = Vec::with_capacity(self.blobs.len() * CELLS_PER_EXT_BLOB);
 
         for blob in self.blobs.iter() {
-            // SAFETY: Blob and c_kzg::Blob have the same memory layout
-            let blob_kzg = unsafe { core::mem::transmute::<&Blob, &c_kzg::Blob>(blob) };
-
             // Compute cells and their KZG proofs for this blob
-            let (_cells, kzg_proofs) = settings.compute_cells_and_kzg_proofs(blob_kzg)?;
+            let (_cells, kzg_proofs) = settings.compute_cells_and_kzg_proofs(blob.as_ckzg())?;
 
-            // SAFETY: same size
-            unsafe {
-                for kzg_proof in kzg_proofs.iter() {
-                    cell_proofs.push(core::mem::transmute::<c_kzg::Bytes48, Bytes48>(
-                        kzg_proof.to_bytes(),
-                    ));
-                }
+            for kzg_proof in kzg_proofs.iter() {
+                cell_proofs.push(bytes48_from_ckzg(kzg_proof.to_bytes()));
             }
         }
 
@@ -254,19 +248,10 @@ impl BlobTransactionSidecar {
         commitments: Vec<c_kzg::Bytes48>,
         proofs: Vec<c_kzg::Bytes48>,
     ) -> Self {
-        // transmutes the vec of items, see also [core::mem::transmute](https://doc.rust-lang.org/std/mem/fn.transmute.html)
-        unsafe fn transmute_vec<U, T>(input: Vec<T>) -> Vec<U> {
-            let mut v = core::mem::ManuallyDrop::new(input);
-            Vec::from_raw_parts(v.as_mut_ptr() as *mut U, v.len(), v.capacity())
-        }
-
-        // SAFETY: all types have the same size and alignment
-        unsafe {
-            let blobs = transmute_vec::<Blob, c_kzg::Blob>(blobs);
-            let commitments = transmute_vec::<Bytes48, c_kzg::Bytes48>(commitments);
-            let proofs = transmute_vec::<Bytes48, c_kzg::Bytes48>(proofs);
-            Self { blobs, commitments, proofs }
-        }
+        let blobs = blobs.into_iter().map(|blob| Blob::new(blob.into_inner())).collect();
+        let commitments = commitments.into_iter().map(bytes48_from_ckzg).collect();
+        let proofs = proofs.into_iter().map(bytes48_from_ckzg).collect();
+        Self { blobs, commitments, proofs }
     }
 
     /// Verifies that the versioned hashes are valid for this sidecar's blob data, commitments, and
@@ -312,18 +297,13 @@ impl BlobTransactionSidecar {
             }
         }
 
-        // SAFETY: ALL types have the same size
-        let res = unsafe {
-            proof_settings.verify_blob_kzg_proof_batch(
-                // blobs
-                core::mem::transmute::<&[Blob], &[c_kzg::Blob]>(self.blobs.as_slice()),
-                // commitments
-                core::mem::transmute::<&[Bytes48], &[c_kzg::Bytes48]>(self.commitments.as_slice()),
-                // proofs
-                core::mem::transmute::<&[Bytes48], &[c_kzg::Bytes48]>(self.proofs.as_slice()),
+        let res = proof_settings
+            .verify_blob_kzg_proof_batch(
+                blobs_as_ckzg(self.blobs.as_slice()),
+                bytes48_as_ckzg(self.commitments.as_slice()),
+                bytes48_as_ckzg(self.proofs.as_slice()),
             )
-        }
-        .map_err(BlobTransactionValidationError::KZGError)?;
+            .map_err(BlobTransactionValidationError::KZGError)?;
 
         res.then_some(()).ok_or(BlobTransactionValidationError::InvalidProof)
     }
@@ -402,17 +382,12 @@ impl BlobTransactionSidecar {
         let mut commitments = Vec::with_capacity(blobs.len());
         let mut proofs = Vec::with_capacity(blobs.len());
         for blob in &blobs {
-            // SAFETY: same size
-            let blob = unsafe { core::mem::transmute::<&Blob, &c_kzg::Blob>(blob) };
+            let blob = blob.as_ckzg();
             let commitment = settings.blob_to_kzg_commitment(blob)?;
             let proof = settings.compute_blob_kzg_proof(blob, &commitment.to_bytes())?;
 
-            // SAFETY: same size
-            unsafe {
-                commitments
-                    .push(core::mem::transmute::<c_kzg::Bytes48, Bytes48>(commitment.to_bytes()));
-                proofs.push(core::mem::transmute::<c_kzg::Bytes48, Bytes48>(proof.to_bytes()));
-            }
+            commitments.push(bytes48_from_ckzg(commitment.to_bytes()));
+            proofs.push(bytes48_from_ckzg(proof.to_bytes()));
         }
 
         Ok(Self::new(blobs, commitments, proofs))

--- a/crates/eips/src/eip4844/sidecar.rs
+++ b/crates/eips/src/eip4844/sidecar.rs
@@ -11,10 +11,10 @@ use alloc::{boxed::Box, vec::Vec};
 use alloy_primitives::{bytes::BufMut, B256};
 use alloy_rlp::{Decodable, Encodable, Header};
 
-#[cfg(feature = "kzg")]
-use crate::eip4844::AsCkzg;
 #[cfg(any(test, feature = "arbitrary"))]
 use crate::eip4844::MAX_BLOBS_PER_BLOCK_DENCUN;
+#[cfg(feature = "kzg")]
+use crate::eip4844::{AsAlloy, AsCkzg};
 
 /// The versioned hash version for KZG.
 #[cfg(feature = "kzg")]
@@ -93,15 +93,22 @@ impl BlobTransactionSidecar {
     ) -> Result<crate::eip7594::BlobTransactionSidecarEip7594, c_kzg::Error> {
         use crate::eip7594::CELLS_PER_EXT_BLOB;
 
+        if let [blob] = self.blobs.as_slice() {
+            let (_cells, kzg_proofs) = settings.compute_cells_and_kzg_proofs(blob.as_ckzg())?;
+            let cell_proofs = c_kzg::KzgProof::boxed_slice_as_alloy(kzg_proofs).into();
+            return Ok(crate::eip7594::BlobTransactionSidecarEip7594::new(
+                self.blobs,
+                self.commitments,
+                cell_proofs,
+            ));
+        }
+
         let mut cell_proofs = Vec::with_capacity(self.blobs.len() * CELLS_PER_EXT_BLOB);
 
         for blob in self.blobs.iter() {
             // Compute cells and their KZG proofs for this blob
             let (_cells, kzg_proofs) = settings.compute_cells_and_kzg_proofs(blob.as_ckzg())?;
-
-            for kzg_proof in kzg_proofs.iter() {
-                cell_proofs.push(Bytes48::from_ckzg(kzg_proof.to_bytes()));
-            }
+            cell_proofs.extend_from_slice(c_kzg::KzgProof::slice_as_alloy(kzg_proofs.as_ref()));
         }
 
         Ok(crate::eip7594::BlobTransactionSidecarEip7594::new(

--- a/crates/eips/src/eip7594/sidecar.rs
+++ b/crates/eips/src/eip7594/sidecar.rs
@@ -12,7 +12,7 @@ use alloy_rlp::{BufMut, Decodable, Encodable, Header};
 use super::{Decodable7594, Encodable7594};
 use crate::eip4844::VersionedHashIter;
 #[cfg(feature = "kzg")]
-use crate::eip4844::{AsCkzg, BlobTransactionValidationError};
+use crate::eip4844::{AsAlloy, AsCkzg, BlobTransactionValidationError};
 
 /// This represents a set of blobs, and its corresponding commitments and proofs.
 /// Proof type depends on the sidecar variant.
@@ -657,17 +657,24 @@ impl BlobTransactionSidecarEip7594 {
         blobs: Vec<Blob>,
         settings: &c_kzg::KzgSettings,
     ) -> Result<Self, c_kzg::Error> {
+        if let [blob] = blobs.as_slice() {
+            let blob = blob.as_ckzg();
+            let commitment = settings.blob_to_kzg_commitment(blob)?;
+            let (_cells, kzg_proofs) = settings.compute_cells_and_kzg_proofs(blob)?;
+            let commitments = vec![Bytes48::from_ckzg(commitment.to_bytes())];
+            let proofs = c_kzg::KzgProof::boxed_slice_as_alloy(kzg_proofs).into();
+            return Ok(Self::new(blobs, commitments, proofs));
+        }
+
         let mut commitments = Vec::with_capacity(blobs.len());
-        let mut proofs = Vec::with_capacity(blobs.len());
+        let mut proofs = Vec::with_capacity(blobs.len() * CELLS_PER_EXT_BLOB);
         for blob in &blobs {
             let blob = blob.as_ckzg();
             let commitment = settings.blob_to_kzg_commitment(blob)?;
             let (_cells, kzg_proofs) = settings.compute_cells_and_kzg_proofs(blob)?;
 
             commitments.push(Bytes48::from_ckzg(commitment.to_bytes()));
-            for kzg_proof in kzg_proofs.iter() {
-                proofs.push(Bytes48::from_ckzg(kzg_proof.to_bytes()));
-            }
+            proofs.extend_from_slice(c_kzg::KzgProof::slice_as_alloy(kzg_proofs.as_ref()));
         }
 
         Ok(Self::new(blobs, commitments, proofs))
@@ -707,10 +714,15 @@ impl BlobTransactionSidecarEip7594 {
         &self,
         settings: &c_kzg::KzgSettings,
     ) -> Result<Vec<Cell>, c_kzg::Error> {
+        if let [blob] = self.blobs.as_slice() {
+            let blob_cells = settings.compute_cells(blob.as_ckzg())?;
+            return Ok(c_kzg::Cell::boxed_slice_as_alloy(blob_cells).into());
+        }
+
         let mut cells = Vec::with_capacity(self.blobs.len() * CELLS_PER_EXT_BLOB);
         for blob in &self.blobs {
             let blob_cells = settings.compute_cells(blob.as_ckzg())?;
-            cells.extend(blob_cells.iter().map(|cell| Cell::new(cell.to_bytes())));
+            cells.extend_from_slice(c_kzg::Cell::slice_as_alloy(blob_cells.as_ref()));
         }
         Ok(cells)
     }

--- a/crates/eips/src/eip7594/sidecar.rs
+++ b/crates/eips/src/eip7594/sidecar.rs
@@ -10,9 +10,11 @@ use alloy_primitives::{B128, B256};
 use alloy_rlp::{BufMut, Decodable, Encodable, Header};
 
 use super::{Decodable7594, Encodable7594};
-#[cfg(feature = "kzg")]
-use crate::eip4844::BlobTransactionValidationError;
 use crate::eip4844::VersionedHashIter;
+#[cfg(feature = "kzg")]
+use crate::eip4844::{
+    bytes48_as_ckzg, bytes48_from_ckzg, BlobCkzgExt, BlobTransactionValidationError,
+};
 
 /// This represents a set of blobs, and its corresponding commitments and proofs.
 /// Proof type depends on the sidecar variant.
@@ -660,20 +662,13 @@ impl BlobTransactionSidecarEip7594 {
         let mut commitments = Vec::with_capacity(blobs.len());
         let mut proofs = Vec::with_capacity(blobs.len());
         for blob in &blobs {
-            // SAFETY: same size
-            let blob = unsafe { core::mem::transmute::<&Blob, &c_kzg::Blob>(blob) };
+            let blob = blob.as_ckzg();
             let commitment = settings.blob_to_kzg_commitment(blob)?;
             let (_cells, kzg_proofs) = settings.compute_cells_and_kzg_proofs(blob)?;
 
-            // SAFETY: same size
-            unsafe {
-                commitments
-                    .push(core::mem::transmute::<c_kzg::Bytes48, Bytes48>(commitment.to_bytes()));
-                for kzg_proof in kzg_proofs.iter() {
-                    proofs.push(core::mem::transmute::<c_kzg::Bytes48, Bytes48>(
-                        kzg_proof.to_bytes(),
-                    ));
-                }
+            commitments.push(bytes48_from_ckzg(commitment.to_bytes()));
+            for kzg_proof in kzg_proofs.iter() {
+                proofs.push(bytes48_from_ckzg(kzg_proof.to_bytes()));
             }
         }
 
@@ -716,9 +711,7 @@ impl BlobTransactionSidecarEip7594 {
     ) -> Result<Vec<Cell>, c_kzg::Error> {
         let mut cells = Vec::with_capacity(self.blobs.len() * CELLS_PER_EXT_BLOB);
         for blob in &self.blobs {
-            // SAFETY: Blob and c_kzg::Blob have the same memory layout.
-            let blob = unsafe { core::mem::transmute::<&Blob, &c_kzg::Blob>(blob) };
-            let blob_cells = settings.compute_cells(blob)?;
+            let blob_cells = settings.compute_cells(blob.as_ckzg())?;
             cells.extend(blob_cells.iter().map(|cell| Cell::new(cell.to_bytes())));
         }
         Ok(cells)
@@ -790,26 +783,18 @@ impl BlobTransactionSidecarEip7594 {
             commitments.extend(core::iter::repeat_n(*commitment, CELLS_PER_EXT_BLOB));
         }
 
-        // SAFETY: ALL types have the same size
-        let res = unsafe {
-            let mut cells = Vec::with_capacity(blobs_len * CELLS_PER_EXT_BLOB);
-            for blob in &self.blobs {
-                let blob = core::mem::transmute::<&Blob, &c_kzg::Blob>(blob);
-                let blob_cells = proof_settings.compute_cells(blob)?;
-                cells.extend_from_slice(blob_cells.as_ref());
-            }
+        let mut cells = Vec::with_capacity(blobs_len * CELLS_PER_EXT_BLOB);
+        for blob in &self.blobs {
+            let blob_cells = proof_settings.compute_cells(blob.as_ckzg())?;
+            cells.extend_from_slice(blob_cells.as_ref());
+        }
 
-            proof_settings.verify_cell_kzg_proof_batch(
-                // commitments
-                core::mem::transmute::<&[Bytes48], &[c_kzg::Bytes48]>(&commitments),
-                // cell indices
-                &cell_indices,
-                // cells
-                &cells,
-                // proofs
-                core::mem::transmute::<&[Bytes48], &[c_kzg::Bytes48]>(self.cell_proofs.as_slice()),
-            )?
-        };
+        let res = proof_settings.verify_cell_kzg_proof_batch(
+            bytes48_as_ckzg(&commitments),
+            &cell_indices,
+            &cells,
+            bytes48_as_ckzg(self.cell_proofs.as_slice()),
+        )?;
 
         res.then_some(()).ok_or(BlobTransactionValidationError::InvalidProof)
     }
@@ -869,9 +854,7 @@ impl BlobTransactionSidecarEip7594 {
             return Ok(Some(BlobCellsAndProofsV1::default()));
         }
 
-        // SAFETY: Blob and c_kzg::Blob have the same memory layout.
-        let blob = unsafe { core::mem::transmute::<&Blob, &c_kzg::Blob>(blob) };
-        let cells = settings.compute_cells(blob)?;
+        let cells = settings.compute_cells(blob.as_ckzg())?;
 
         Ok(Some(Self::blob_cells_and_proofs_from_computed_cells(cell_mask, cells.as_ref(), proofs)))
     }
@@ -976,9 +959,7 @@ impl BlobTransactionSidecarEip7594 {
                 {
                     cells_and_proofs.clone()
                 } else {
-                    // SAFETY: Blob and c_kzg::Blob have the same memory layout.
-                    let blob = unsafe { core::mem::transmute::<&Blob, &c_kzg::Blob>(blob) };
-                    let cells = settings.compute_cells(blob)?;
+                    let cells = settings.compute_cells(blob.as_ckzg())?;
                     let cells_and_proofs = Self::blob_cells_and_proofs_from_computed_cells(
                         cell_mask,
                         cells.as_ref(),
@@ -1341,9 +1322,7 @@ mod tests {
         assert_eq!(sidecar.compute_cells().unwrap(), cells);
 
         for (blob_index, blob) in sidecar.blobs.iter().enumerate() {
-            // SAFETY: Blob and c_kzg::Blob have the same memory layout.
-            let blob = unsafe { core::mem::transmute::<&Blob, &c_kzg::Blob>(blob) };
-            let expected_cells = settings.compute_cells(blob).unwrap();
+            let expected_cells = settings.compute_cells(blob.as_ckzg()).unwrap();
             let start = blob_index * CELLS_PER_EXT_BLOB;
             let end = start + CELLS_PER_EXT_BLOB;
 
@@ -1387,9 +1366,7 @@ mod tests {
             vec![Some(sidecar.cell_proofs[0]), Some(sidecar.cell_proofs[7])]
         );
 
-        // SAFETY: Blob and c_kzg::Blob have the same memory layout.
-        let blob = unsafe { core::mem::transmute::<&Blob, &c_kzg::Blob>(&sidecar.blobs[0]) };
-        let expected_cells = settings.compute_cells(blob).unwrap();
+        let expected_cells = settings.compute_cells(sidecar.blobs[0].as_ckzg()).unwrap();
         assert_eq!(
             cells_and_proofs.blob_cells,
             vec![
@@ -1427,9 +1404,7 @@ mod tests {
         let cell_mask = BlobCellMask::from_bits(1);
 
         let invalid_blob = Blob::repeat_byte(0xff);
-        // SAFETY: Blob and c_kzg::Blob have the same memory layout.
-        let blob = unsafe { core::mem::transmute::<&Blob, &c_kzg::Blob>(&invalid_blob) };
-        assert!(settings.compute_cells(blob).is_err());
+        assert!(settings.compute_cells(invalid_blob.as_ckzg()).is_err());
 
         sidecar.blobs.push(invalid_blob);
         sidecar.commitments.push(Bytes48::ZERO);

--- a/crates/eips/src/eip7594/sidecar.rs
+++ b/crates/eips/src/eip7594/sidecar.rs
@@ -12,9 +12,7 @@ use alloy_rlp::{BufMut, Decodable, Encodable, Header};
 use super::{Decodable7594, Encodable7594};
 use crate::eip4844::VersionedHashIter;
 #[cfg(feature = "kzg")]
-use crate::eip4844::{
-    bytes48_as_ckzg, bytes48_from_ckzg, BlobCkzgExt, BlobTransactionValidationError,
-};
+use crate::eip4844::{AsCkzg, BlobTransactionValidationError};
 
 /// This represents a set of blobs, and its corresponding commitments and proofs.
 /// Proof type depends on the sidecar variant.
@@ -666,9 +664,9 @@ impl BlobTransactionSidecarEip7594 {
             let commitment = settings.blob_to_kzg_commitment(blob)?;
             let (_cells, kzg_proofs) = settings.compute_cells_and_kzg_proofs(blob)?;
 
-            commitments.push(bytes48_from_ckzg(commitment.to_bytes()));
+            commitments.push(Bytes48::from_ckzg(commitment.to_bytes()));
             for kzg_proof in kzg_proofs.iter() {
-                proofs.push(bytes48_from_ckzg(kzg_proof.to_bytes()));
+                proofs.push(Bytes48::from_ckzg(kzg_proof.to_bytes()));
             }
         }
 
@@ -790,10 +788,10 @@ impl BlobTransactionSidecarEip7594 {
         }
 
         let res = proof_settings.verify_cell_kzg_proof_batch(
-            bytes48_as_ckzg(&commitments),
+            Bytes48::slice_as_ckzg(&commitments),
             &cell_indices,
             &cells,
-            bytes48_as_ckzg(self.cell_proofs.as_slice()),
+            Bytes48::slice_as_ckzg(self.cell_proofs.as_slice()),
         )?;
 
         res.then_some(()).ok_or(BlobTransactionValidationError::InvalidProof)

--- a/crates/eips/src/eip7594/sidecar.rs
+++ b/crates/eips/src/eip7594/sidecar.rs
@@ -793,11 +793,17 @@ impl BlobTransactionSidecarEip7594 {
             commitments.extend(core::iter::repeat_n(*commitment, CELLS_PER_EXT_BLOB));
         }
 
-        let mut cells = Vec::with_capacity(blobs_len * CELLS_PER_EXT_BLOB);
-        for blob in &self.blobs {
-            let blob_cells = proof_settings.compute_cells(blob.as_ckzg())?;
-            cells.extend_from_slice(blob_cells.as_ref());
-        }
+        let cells = if let [blob] = self.blobs.as_slice() {
+            let cells: Box<[c_kzg::Cell]> = proof_settings.compute_cells(blob.as_ckzg())?;
+            cells.into()
+        } else {
+            let mut cells = Vec::with_capacity(blobs_len * CELLS_PER_EXT_BLOB);
+            for blob in &self.blobs {
+                let blob_cells = proof_settings.compute_cells(blob.as_ckzg())?;
+                cells.extend_from_slice(blob_cells.as_ref());
+            }
+            cells
+        };
 
         let res = proof_settings.verify_cell_kzg_proof_batch(
             Bytes48::slice_as_ckzg(&commitments),

--- a/crates/rpc-types-engine/src/payload.rs
+++ b/crates/rpc-types-engine/src/payload.rs
@@ -10,7 +10,7 @@ use alloy_consensus::{
     HeaderInfo, Transaction, EMPTY_OMMER_ROOT_HASH,
 };
 #[cfg(feature = "kzg")]
-use alloy_eips::eip4844::{bytes48_from_ckzg, BlobCkzgExt, Bytes48CkzgExt};
+use alloy_eips::eip4844::AsCkzg;
 use alloy_eips::{
     calc_next_block_base_fee,
     eip1559::BaseFeeParams,
@@ -1825,7 +1825,7 @@ impl BlobsBundleV1 {
             let (_cells, kzg_proofs) = settings.compute_cells_and_kzg_proofs(blob.as_ckzg())?;
 
             for kzg_proof in kzg_proofs.iter() {
-                cell_proofs.push(bytes48_from_ckzg(kzg_proof.to_bytes()));
+                cell_proofs.push(Bytes48::from_ckzg(kzg_proof.to_bytes()));
             }
         }
 
@@ -2065,7 +2065,7 @@ impl BlobsBundleV2 {
             // Compute the blob proof
             let proof = settings.compute_blob_kzg_proof(blob.as_ckzg(), commitment.as_ckzg())?;
 
-            proofs.push(bytes48_from_ckzg(proof.to_bytes()));
+            proofs.push(Bytes48::from_ckzg(proof.to_bytes()));
         }
 
         Ok(BlobsBundleV1 { commitments: self.commitments, proofs, blobs: self.blobs })

--- a/crates/rpc-types-engine/src/payload.rs
+++ b/crates/rpc-types-engine/src/payload.rs
@@ -9,6 +9,8 @@ use alloy_consensus::{
     constants::MAXIMUM_EXTRA_DATA_SIZE, Blob, Block, BlockBody, BlockHeader, Bytes48, Header,
     HeaderInfo, Transaction, EMPTY_OMMER_ROOT_HASH,
 };
+#[cfg(feature = "kzg")]
+use alloy_eips::eip4844::{bytes48_from_ckzg, BlobCkzgExt, Bytes48CkzgExt};
 use alloy_eips::{
     calc_next_block_base_fee,
     eip1559::BaseFeeParams,
@@ -1819,21 +1821,11 @@ impl BlobsBundleV1 {
         let mut cell_proofs = Vec::with_capacity(self.blobs.len() * CELLS_PER_EXT_BLOB);
 
         for blob in self.blobs.iter() {
-            // SAFETY: Blob and alloy_eips::eip4844::c_kzg::Blob have the same memory layout
-            let blob_kzg =
-                unsafe { core::mem::transmute::<&Blob, &alloy_eips::eip4844::c_kzg::Blob>(blob) };
-
             // Compute cells and their KZG proofs for this blob
-            let (_cells, kzg_proofs) = settings.compute_cells_and_kzg_proofs(blob_kzg)?;
+            let (_cells, kzg_proofs) = settings.compute_cells_and_kzg_proofs(blob.as_ckzg())?;
 
-            // SAFETY: same size
-            unsafe {
-                for kzg_proof in kzg_proofs.iter() {
-                    cell_proofs.push(core::mem::transmute::<
-                        alloy_eips::eip4844::c_kzg::Bytes48,
-                        Bytes48,
-                    >(kzg_proof.to_bytes()));
-                }
+            for kzg_proof in kzg_proofs.iter() {
+                cell_proofs.push(bytes48_from_ckzg(kzg_proof.to_bytes()));
             }
         }
 
@@ -2070,22 +2062,10 @@ impl BlobsBundleV2 {
         let mut proofs = Vec::with_capacity(self.blobs.len());
 
         for (blob, commitment) in self.blobs.iter().zip(self.commitments.iter()) {
-            // SAFETY: Blob and alloy_eips::eip4844::c_kzg::Blob have the same memory layout
-            let blob_kzg =
-                unsafe { core::mem::transmute::<&Blob, &alloy_eips::eip4844::c_kzg::Blob>(blob) };
-            let commitment_kzg = unsafe {
-                core::mem::transmute::<&Bytes48, &alloy_eips::eip4844::c_kzg::Bytes48>(commitment)
-            };
-
             // Compute the blob proof
-            let proof = settings.compute_blob_kzg_proof(blob_kzg, commitment_kzg)?;
+            let proof = settings.compute_blob_kzg_proof(blob.as_ckzg(), commitment.as_ckzg())?;
 
-            // SAFETY: same size
-            unsafe {
-                proofs.push(core::mem::transmute::<alloy_eips::eip4844::c_kzg::Bytes48, Bytes48>(
-                    proof.to_bytes(),
-                ));
-            }
+            proofs.push(bytes48_from_ckzg(proof.to_bytes()));
         }
 
         Ok(BlobsBundleV1 { commitments: self.commitments, proofs, blobs: self.blobs })

--- a/crates/rpc-types-engine/src/payload.rs
+++ b/crates/rpc-types-engine/src/payload.rs
@@ -10,7 +10,7 @@ use alloy_consensus::{
     HeaderInfo, Transaction, EMPTY_OMMER_ROOT_HASH,
 };
 #[cfg(feature = "kzg")]
-use alloy_eips::eip4844::AsCkzg;
+use alloy_eips::eip4844::{AsAlloy, AsCkzg};
 use alloy_eips::{
     calc_next_block_base_fee,
     eip1559::BaseFeeParams,
@@ -1818,15 +1818,25 @@ impl BlobsBundleV1 {
     ) -> Result<BlobsBundleV2, alloy_eips::eip4844::c_kzg::Error> {
         use alloy_eips::eip7594::CELLS_PER_EXT_BLOB;
 
+        if let [blob] = self.blobs.as_slice() {
+            let (_cells, kzg_proofs) = settings.compute_cells_and_kzg_proofs(blob.as_ckzg())?;
+            let cell_proofs =
+                alloy_eips::eip4844::c_kzg::KzgProof::boxed_slice_as_alloy(kzg_proofs).into();
+            return Ok(BlobsBundleV2 {
+                commitments: self.commitments,
+                proofs: cell_proofs,
+                blobs: self.blobs,
+            });
+        }
+
         let mut cell_proofs = Vec::with_capacity(self.blobs.len() * CELLS_PER_EXT_BLOB);
 
         for blob in self.blobs.iter() {
             // Compute cells and their KZG proofs for this blob
             let (_cells, kzg_proofs) = settings.compute_cells_and_kzg_proofs(blob.as_ckzg())?;
-
-            for kzg_proof in kzg_proofs.iter() {
-                cell_proofs.push(Bytes48::from_ckzg(kzg_proof.to_bytes()));
-            }
+            cell_proofs.extend_from_slice(alloy_eips::eip4844::c_kzg::KzgProof::slice_as_alloy(
+                kzg_proofs.as_ref(),
+            ));
         }
 
         Ok(BlobsBundleV2 { commitments: self.commitments, proofs: cell_proofs, blobs: self.blobs })


### PR DESCRIPTION
ideally the bindings would let you pass outptr so we can write into the vec directly, but for now we just get a box. also refactors so we remove the scope of unsafe transmutes down to a single trait.