### PR TITLE
fix(signer-trezor): dispatch EIP-1559 by tx type

### DIFF
--- a/crates/signer-trezor/src/signer.rs
+++ b/crates/signer-trezor/src/signer.rs
@@ -1,5 +1,5 @@
 use super::types::{DerivationType, TrezorError};
-use alloy_consensus::{SignableTransaction, TxEip1559};
+use alloy_consensus::SignableTransaction;
 use alloy_primitives::{
     hex, normalize_v, Address, ChainId, Signature, SignatureError, TxKind, B256, U256,
 };
@@ -170,58 +170,31 @@ impl TrezorSigner {
     ) -> Result<Signature, TrezorError> {
         let mut client = self.get_client()?;
         let path = Self::convert_path(&self.derivation);
+        let request = build_sign_request(tx);
 
-        let nonce = tx.nonce();
-        let nonce = u64_to_trezor(nonce);
-
-        let gas_price = tx.max_fee_per_gas();
-        let gas_price = u128_to_trezor(gas_price);
-
-        let gas_limit = tx.gas_limit();
-        let gas_limit = u64_to_trezor(gas_limit);
-
-        let to = match tx.kind() {
-            TxKind::Call(to) => address_to_trezor(&to),
-            TxKind::Create => String::new(),
-        };
-
-        let value = tx.value();
-        let value = u256_to_trezor(value);
-
-        let data = tx.input().to_vec();
-        let chain_id = tx.chain_id();
-
-        let signature = if let Some(tx) = (tx as &dyn std::any::Any).downcast_ref::<TxEip1559>() {
-            let max_gas_fee = tx.max_fee_per_gas;
-            let max_gas_fee = u128_to_trezor(max_gas_fee);
-
-            let max_priority_fee = tx.max_priority_fee_per_gas;
-            let max_priority_fee = u128_to_trezor(max_priority_fee);
-
-            let access_list = tx
-                .access_list
-                .0
-                .iter()
-                .map(|item| trezor_client::client::AccessListItem {
-                    address: address_to_trezor(&item.address),
-                    storage_keys: item.storage_keys.iter().map(|key| key.to_vec()).collect(),
-                })
-                .collect();
-
-            client.ethereum_sign_eip1559_tx(
+        let signature = match request {
+            TrezorSignRequest::Legacy(req) => client.ethereum_sign_tx(
                 path,
-                nonce,
-                gas_limit,
-                to,
-                value,
-                data,
-                chain_id,
-                max_gas_fee,
-                max_priority_fee,
-                access_list,
-            )
-        } else {
-            client.ethereum_sign_tx(path, nonce, gas_price, gas_limit, to, value, data, chain_id)
+                req.nonce,
+                req.gas_price,
+                req.gas_limit,
+                req.to,
+                req.value,
+                req.data,
+                req.chain_id,
+            ),
+            TrezorSignRequest::Eip1559(req) => client.ethereum_sign_eip1559_tx(
+                path,
+                req.nonce,
+                req.gas_limit,
+                req.to,
+                req.value,
+                req.data,
+                req.chain_id,
+                req.max_gas_fee,
+                req.max_priority_fee,
+                req.access_list,
+            ),
         }?;
         signature_from_trezor(signature)
     }
@@ -250,6 +223,98 @@ impl TrezorSigner {
         }
 
         path
+    }
+}
+
+/// Parameters for a Trezor legacy transaction signing request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct LegacyRequest {
+    nonce: Vec<u8>,
+    gas_price: Vec<u8>,
+    gas_limit: Vec<u8>,
+    to: String,
+    value: Vec<u8>,
+    data: Vec<u8>,
+    chain_id: Option<u64>,
+}
+
+/// Parameters for a Trezor EIP-1559 transaction signing request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Eip1559Request {
+    nonce: Vec<u8>,
+    gas_limit: Vec<u8>,
+    to: String,
+    value: Vec<u8>,
+    data: Vec<u8>,
+    chain_id: Option<u64>,
+    max_gas_fee: Vec<u8>,
+    max_priority_fee: Vec<u8>,
+    access_list: Vec<trezor_client::client::AccessListItem>,
+}
+
+/// The dispatch payload for a Trezor signing call.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum TrezorSignRequest {
+    Legacy(LegacyRequest),
+    Eip1559(Eip1559Request),
+}
+
+/// Selects the correct Trezor signing API based on the transaction's EIP-2718 type, and gathers
+/// the parameters by calling the [`SignableTransaction`] / [`alloy_consensus::Transaction`] trait
+/// methods rather than downcasting to a concrete transaction type.
+///
+/// This must dispatch on `tx.is_eip1559()` (i.e. the EIP-2718 type byte) so that wrapper types
+/// such as `TypedTransaction::Eip1559` or network-specific signable wrappers around
+/// [`alloy_consensus::TxEip1559`] are still routed to the EIP-1559 Trezor API. Routing them to
+/// the legacy API instead causes Trezor to sign the EIP-155 legacy preimage and the resulting
+/// signature recovers to a different address than the one displayed on the device.
+pub(crate) fn build_sign_request(tx: &dyn SignableTransaction<Signature>) -> TrezorSignRequest {
+    let nonce = u64_to_trezor(tx.nonce());
+    let gas_limit = u64_to_trezor(tx.gas_limit());
+    let to = match tx.kind() {
+        TxKind::Call(to) => address_to_trezor(&to),
+        TxKind::Create => String::new(),
+    };
+    let value = u256_to_trezor(tx.value());
+    let data = tx.input().to_vec();
+    let chain_id = tx.chain_id();
+
+    if tx.is_eip1559() {
+        let max_gas_fee = u128_to_trezor(tx.max_fee_per_gas());
+        let max_priority_fee = u128_to_trezor(tx.max_priority_fee_per_gas().unwrap_or_default());
+        let access_list = tx
+            .access_list()
+            .map(|al| {
+                al.0.iter()
+                    .map(|item| trezor_client::client::AccessListItem {
+                        address: address_to_trezor(&item.address),
+                        storage_keys: item.storage_keys.iter().map(|key| key.to_vec()).collect(),
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        TrezorSignRequest::Eip1559(Eip1559Request {
+            nonce,
+            gas_limit,
+            to,
+            value,
+            data,
+            chain_id,
+            max_gas_fee,
+            max_priority_fee,
+            access_list,
+        })
+    } else {
+        let gas_price = u128_to_trezor(tx.max_fee_per_gas());
+        TrezorSignRequest::Legacy(LegacyRequest {
+            nonce,
+            gas_price,
+            gas_limit,
+            to,
+            value,
+            data,
+            chain_id,
+        })
     }
 }
 
@@ -283,8 +348,9 @@ fn signature_from_trezor(x: trezor_client::client::Signature) -> Result<Signatur
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy_consensus::{Transaction, TxEip1559, TxLegacy, Typed2718};
     use alloy_network::{EthereumWallet, NetworkTransactionBuilder, TransactionBuilder};
-    use alloy_primitives::{address, b256};
+    use alloy_primitives::{address, b256, Bytes};
     use alloy_rpc_types_eth::{AccessList, AccessListItem, TransactionRequest};
 
     #[tokio::test]
@@ -416,5 +482,182 @@ mod tests {
             .build(&EthereumWallet::new(trezor))
             .await
             .unwrap();
+    }
+
+    /// Helpers for the dispatch tests below: construct sample transactions matching the
+    /// Foundry repro from the bug report.
+    fn sample_eip1559_tx() -> TxEip1559 {
+        TxEip1559 {
+            chain_id: 42431,
+            nonce: 1,
+            gas_limit: 356_613,
+            max_fee_per_gas: 40_000_000_001,
+            max_priority_fee_per_gas: 1,
+            to: TxKind::Call(Address::ZERO),
+            value: U256::ZERO,
+            access_list: Default::default(),
+            input: Bytes::new(),
+        }
+    }
+
+    fn sample_legacy_tx() -> TxLegacy {
+        TxLegacy {
+            chain_id: Some(42431),
+            nonce: 1,
+            gas_price: 40_000_000_001,
+            gas_limit: 356_613,
+            to: TxKind::Call(Address::ZERO),
+            value: U256::ZERO,
+            input: Bytes::new(),
+        }
+    }
+
+    /// A transparent wrapper around any [`SignableTransaction`]. It is a *different* concrete
+    /// type from the wrapped value, so the previous `(tx as &dyn Any).downcast_ref::<TxEip1559>()`
+    /// dispatch in the Trezor signer fails for it. Used to reproduce the Foundry bug where a
+    /// wrapper around a `TxEip1559` was incorrectly signed as legacy.
+    #[derive(Debug)]
+    struct SignableWrapper<T>(T);
+
+    impl<T: Typed2718> Typed2718 for SignableWrapper<T> {
+        fn ty(&self) -> u8 {
+            self.0.ty()
+        }
+    }
+
+    impl<T: Transaction> Transaction for SignableWrapper<T> {
+        fn chain_id(&self) -> Option<ChainId> {
+            self.0.chain_id()
+        }
+        fn nonce(&self) -> u64 {
+            self.0.nonce()
+        }
+        fn gas_limit(&self) -> u64 {
+            self.0.gas_limit()
+        }
+        fn gas_price(&self) -> Option<u128> {
+            self.0.gas_price()
+        }
+        fn max_fee_per_gas(&self) -> u128 {
+            self.0.max_fee_per_gas()
+        }
+        fn max_priority_fee_per_gas(&self) -> Option<u128> {
+            self.0.max_priority_fee_per_gas()
+        }
+        fn max_fee_per_blob_gas(&self) -> Option<u128> {
+            self.0.max_fee_per_blob_gas()
+        }
+        fn priority_fee_or_price(&self) -> u128 {
+            self.0.priority_fee_or_price()
+        }
+        fn effective_gas_price(&self, base_fee: Option<u64>) -> u128 {
+            self.0.effective_gas_price(base_fee)
+        }
+        fn is_dynamic_fee(&self) -> bool {
+            self.0.is_dynamic_fee()
+        }
+        fn kind(&self) -> TxKind {
+            self.0.kind()
+        }
+        fn is_create(&self) -> bool {
+            self.0.is_create()
+        }
+        fn value(&self) -> U256 {
+            self.0.value()
+        }
+        fn input(&self) -> &Bytes {
+            self.0.input()
+        }
+        fn access_list(
+            &self,
+        ) -> Option<&alloy_consensus::private::alloy_eips::eip2930::AccessList> {
+            self.0.access_list()
+        }
+        fn blob_versioned_hashes(&self) -> Option<&[B256]> {
+            self.0.blob_versioned_hashes()
+        }
+        fn authorization_list(
+            &self,
+        ) -> Option<&[alloy_consensus::private::alloy_eips::eip7702::SignedAuthorization]> {
+            self.0.authorization_list()
+        }
+    }
+
+    impl<T: SignableTransaction<Signature>> SignableTransaction<Signature> for SignableWrapper<T> {
+        fn set_chain_id(&mut self, chain_id: ChainId) {
+            self.0.set_chain_id(chain_id);
+        }
+        fn encode_for_signing(&self, out: &mut dyn alloy_consensus::private::alloy_rlp::BufMut) {
+            self.0.encode_for_signing(out);
+        }
+        fn payload_len_for_signature(&self) -> usize {
+            self.0.payload_len_for_signature()
+        }
+    }
+
+    /// Concrete `TxEip1559` must dispatch to the EIP-1559 Trezor API.
+    #[test]
+    fn build_sign_request_dispatches_concrete_eip1559_to_eip1559_api() {
+        let tx = sample_eip1559_tx();
+        let request = build_sign_request(&tx as &dyn SignableTransaction<Signature>);
+        assert!(
+            matches!(request, TrezorSignRequest::Eip1559(_)),
+            "concrete TxEip1559 must dispatch to the EIP-1559 path, got {request:?}",
+        );
+    }
+
+    /// Regression test for the Foundry bug: a wrapper around `TxEip1559` that implements
+    /// `SignableTransaction<Signature>` (so its EIP-2718 type is 0x02 and `encoded_for_signing`
+    /// is a valid type-2 preimage) must still dispatch to the EIP-1559 Trezor API. The
+    /// previous `(tx as &dyn Any).downcast_ref::<TxEip1559>()` check failed for any wrapper
+    /// type and wrongly fell through to the legacy signing path, which caused Trezor to sign
+    /// the EIP-155 legacy preimage and the resulting envelope recovered to a different signer
+    /// than the address shown on the device.
+    #[test]
+    fn build_sign_request_dispatches_wrapped_eip1559_to_eip1559_api() {
+        let inner = sample_eip1559_tx();
+        let wrapped = SignableWrapper(inner.clone());
+        // Sanity check: the wrapper is a different concrete type than `TxEip1559`, so a
+        // downcast based dispatch would have rejected it.
+        assert!(
+            (&wrapped as &dyn std::any::Any).downcast_ref::<TxEip1559>().is_none(),
+            "wrapper must not be downcastable to TxEip1559",
+        );
+        // It is, however, still an EIP-1559 transaction by EIP-2718 type.
+        assert!(wrapped.is_eip1559());
+        assert_eq!(wrapped.ty(), 0x02);
+
+        let wrapped_request = build_sign_request(&wrapped as &dyn SignableTransaction<Signature>);
+        assert!(
+            matches!(wrapped_request, TrezorSignRequest::Eip1559(_)),
+            "wrapper around TxEip1559 must dispatch to the EIP-1559 path, got {wrapped_request:?}",
+        );
+
+        // The wrapper request must also produce the same parameters as the concrete one,
+        // so that signing the wrapper is byte-for-byte equivalent to signing the inner tx.
+        let concrete_request = build_sign_request(&inner as &dyn SignableTransaction<Signature>);
+        assert_eq!(wrapped_request, concrete_request);
+    }
+
+    /// Legacy transactions must still dispatch to the legacy Trezor API.
+    #[test]
+    fn build_sign_request_dispatches_legacy_to_legacy_api() {
+        let tx = sample_legacy_tx();
+        let request = build_sign_request(&tx as &dyn SignableTransaction<Signature>);
+        assert!(
+            matches!(request, TrezorSignRequest::Legacy(_)),
+            "TxLegacy must dispatch to the legacy path, got {request:?}",
+        );
+    }
+
+    /// A wrapper around a legacy transaction must also dispatch to the legacy API.
+    #[test]
+    fn build_sign_request_dispatches_wrapped_legacy_to_legacy_api() {
+        let wrapped = SignableWrapper(sample_legacy_tx());
+        let request = build_sign_request(&wrapped as &dyn SignableTransaction<Signature>);
+        assert!(
+            matches!(request, TrezorSignRequest::Legacy(_)),
+            "wrapper around TxLegacy must dispatch to the legacy path, got {request:?}",
+        );
     }
 }


### PR DESCRIPTION
## Problem

`alloy-signer-trezor` selects the EIP-1559 Trezor signing API by doing a concrete downcast:

```rust
(tx as &dyn std::any::Any).downcast_ref::<TxEip1559>()
```

This succeeds only for the concrete `alloy_consensus::TxEip1559` value. Any wrapper that implements `SignableTransaction<Signature>` around a `TxEip1559` (e.g. `TypedTransaction::Eip1559` or network-specific signable wrappers used by tools like Foundry) fails the downcast and silently falls through to the legacy signing path — even though `tx.ty() == 0x02` and `tx.encoded_for_signing()` is a valid EIP-1559 type-2 preimage.

When that happens, Trezor signs the EIP-155 legacy preimage. The resulting r/s/v is then attached to a type-`0x02` envelope, so the decoded transaction recovers to a different signer than the address shown on the device.

The Ledger signer is unaffected because it signs `encoded_for_signing()` directly and never branches on the concrete transaction type.

## Fix

Dispatch on `tx.is_eip1559()` (i.e. the EIP-2718 type byte) and pull all EIP-1559-specific fields (max fees, access list) through the `Transaction` trait methods rather than the concrete struct fields. This keeps:

- legacy signing for legacy transactions,
- EIP-1559 signing for both concrete `TxEip1559` and any `SignableTransaction` wrapper around it.