### PR TITLE
fix(node-bindings): harden child process cleanup

### DIFF
--- a/crates/node-bindings/src/node.rs
+++ b/crates/node-bindings/src/node.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use thiserror::Error;
 
 /// How long we will wait for the node to indicate that it is ready.
-pub const NODE_STARTUP_TIMEOUT: Duration = Duration::from_secs(10);
+pub const NODE_STARTUP_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Timeout for waiting for the node to add a peer.
 pub const NODE_DIAL_LOOP_TIMEOUT: Duration = Duration::from_secs(20);

--- a/crates/node-bindings/src/nodes/anvil.rs
+++ b/crates/node-bindings/src/nodes/anvil.rs
@@ -446,7 +446,13 @@ impl Anvil {
 
         let mut child = cmd.spawn().map_err(NodeError::SpawnError)?;
 
-        let stdout = child.stdout.take().ok_or(NodeError::NoStdout)?;
+        let stdout = match child.stdout.take() {
+            Some(stdout) => stdout,
+            None => {
+                GracefulShutdown::shutdown(&mut child, 0, "anvil");
+                return Err(NodeError::NoStdout);
+            }
+        };
 
         let start = Instant::now();
         let mut reader = BufReader::new(stdout);
@@ -457,14 +463,15 @@ impl Anvil {
         let mut is_private_key = false;
         let mut chain_id = None;
         let mut wallet = None;
-        loop {
+        let startup = loop {
             if start + timeout <= Instant::now() {
-                let _ = child.kill();
-                return Err(NodeError::Timeout);
+                break Err(NodeError::Timeout);
             }
 
             let mut line = String::new();
-            reader.read_line(&mut line).map_err(NodeError::ReadLineError)?;
+            if let Err(err) = reader.read_line(&mut line) {
+                break Err(NodeError::ReadLineError(err));
+            }
             trace!(target: "alloy::node::anvil", line);
             if let Some(addr) = line.strip_prefix("Listening on") {
                 // <Listening on 127.0.0.1:8545>
@@ -472,7 +479,7 @@ impl Anvil {
                 if let Ok(addr) = SocketAddr::from_str(addr.trim()) {
                     port = addr.port();
                 }
-                break;
+                break Ok(());
             }
 
             if line.starts_with("Private Keys") {
@@ -480,11 +487,17 @@ impl Anvil {
             }
 
             if is_private_key && line.starts_with('(') {
-                let key_str =
-                    line.split("0x").last().ok_or(NodeError::ParsePrivateKeyError)?.trim();
-                let key_hex = hex::decode(key_str).map_err(NodeError::FromHexError)?;
-                let key = K256SecretKey::from_bytes((&key_hex[..]).into())
-                    .map_err(|_| NodeError::DeserializePrivateKeyError)?;
+                let Some((_, key_str)) = line.rsplit_once("0x") else {
+                    break Err(NodeError::ParsePrivateKeyError);
+                };
+                let key_hex = match hex::decode(key_str.trim()) {
+                    Ok(key_hex) => key_hex,
+                    Err(err) => break Err(NodeError::FromHexError(err)),
+                };
+                let key = match K256SecretKey::from_bytes((&key_hex[..]).into()) {
+                    Ok(key) => key,
+                    Err(_) => break Err(NodeError::DeserializePrivateKeyError),
+                };
                 addresses.push(Address::from_public_key(SigningKey::from(&key).verifying_key()));
                 private_keys.push(key);
             }
@@ -508,6 +521,11 @@ impl Anvil {
                 }
                 wallet = Some(w);
             }
+        };
+
+        if let Err(err) = startup {
+            GracefulShutdown::shutdown(&mut child, 0, "anvil");
+            return Err(err);
         }
 
         if self.keep_stdout {

--- a/crates/node-bindings/src/nodes/geth.rs
+++ b/crates/node-bindings/src/nodes/geth.rs
@@ -615,7 +615,13 @@ impl Geth {
 
         let mut child = cmd.spawn().map_err(NodeError::SpawnError)?;
 
-        let stderr = child.stderr.take().ok_or(NodeError::NoStderr)?;
+        let stderr = match child.stderr.take() {
+            Some(stderr) => stderr,
+            None => {
+                GracefulShutdown::shutdown(&mut child, 0, "geth");
+                return Err(NodeError::NoStderr);
+            }
+        };
 
         let start = Instant::now();
         let mut reader = BufReader::new(stderr);
@@ -625,14 +631,15 @@ impl Geth {
         let mut p2p_started = matches!(self.mode, NodeMode::Dev(_));
         let mut ports_started = false;
 
-        loop {
+        let startup = loop {
             if start + NODE_STARTUP_TIMEOUT <= Instant::now() {
-                let _ = child.kill();
-                return Err(NodeError::Timeout);
+                break Err(NodeError::Timeout);
             }
 
             let mut line = String::with_capacity(120);
-            reader.read_line(&mut line).map_err(NodeError::ReadLineError)?;
+            if let Err(err) = reader.read_line(&mut line) {
+                break Err(NodeError::ReadLineError(err));
+            }
 
             if matches!(self.mode, NodeMode::NonDev(_)) && line.contains("Started P2P networking") {
                 p2p_started = true;
@@ -664,14 +671,18 @@ impl Geth {
             // Encountered an error such as Fatal: Error starting protocol stack: listen tcp
             // 127.0.0.1:8545: bind: address already in use
             if line.contains("Fatal:") {
-                let _ = child.kill();
-                return Err(NodeError::Fatal(line));
+                break Err(NodeError::Fatal(line));
             }
 
             // If all ports have started we are ready to be queried.
             if ports_started && p2p_started {
-                break;
+                break Ok(());
             }
+        };
+
+        if let Err(err) = startup {
+            GracefulShutdown::shutdown(&mut child, 0, "geth");
+            return Err(err);
         }
 
         if self.keep_err {

--- a/crates/node-bindings/src/nodes/reth.rs
+++ b/crates/node-bindings/src/nodes/reth.rs
@@ -490,7 +490,13 @@ impl Reth {
 
         let mut child = cmd.spawn().map_err(NodeError::SpawnError)?;
 
-        let stdout = child.stdout.take().ok_or(NodeError::NoStdout)?;
+        let stdout = match child.stdout.take() {
+            Some(stdout) => stdout,
+            None => {
+                GracefulShutdown::shutdown(&mut child, 0, "reth");
+                return Err(NodeError::NoStdout);
+            }
+        };
 
         let start = Instant::now();
         let mut reader = BufReader::new(stdout);
@@ -503,14 +509,15 @@ impl Reth {
         let mut ports_started = false;
         let mut p2p_started = !self.discovery_enabled;
 
-        loop {
+        let startup = loop {
             if start + NODE_STARTUP_TIMEOUT <= Instant::now() {
-                let _ = child.kill();
-                return Err(NodeError::Timeout);
+                break Err(NodeError::Timeout);
             }
 
             let mut line = String::with_capacity(120);
-            reader.read_line(&mut line).map_err(NodeError::ReadLineError)?;
+            if let Err(err) = reader.read_line(&mut line) {
+                break Err(NodeError::ReadLineError(err));
+            }
 
             if line.contains("RPC HTTP server started") {
                 if let Some(addr) = extract_endpoint("url=", &line) {
@@ -532,8 +539,7 @@ impl Reth {
 
             // Encountered a critical error, exit early.
             if line.contains("ERROR") {
-                let _ = child.kill();
-                return Err(NodeError::Fatal(line));
+                break Err(NodeError::Fatal(line));
             }
 
             if http_port != 0 && ws_port != 0 && auth_port != 0 {
@@ -553,8 +559,13 @@ impl Reth {
 
             // If all ports have started we are ready to be queried.
             if ports_started && p2p_started {
-                break;
+                break Ok(());
             }
+        };
+
+        if let Err(err) = startup {
+            GracefulShutdown::shutdown(&mut child, 0, "reth");
+            return Err(err);
         }
 
         if self.keep_stdout {

--- a/crates/node-bindings/src/utils.rs
+++ b/crates/node-bindings/src/utils.rs
@@ -37,9 +37,8 @@ impl GracefulShutdown {
             }
         }
 
-        match child.try_wait() {
-            Ok(Some(_)) => return,
-            Ok(None) | Err(_) => {}
+        if let Ok(Some(_)) = child.try_wait() {
+            return;
         }
 
         if let Err(err) = child.kill() {

--- a/crates/node-bindings/src/utils.rs
+++ b/crates/node-bindings/src/utils.rs
@@ -37,7 +37,14 @@ impl GracefulShutdown {
             }
         }
 
-        child.kill().unwrap_or_else(|_| panic!("could not kill {}", process_name));
+        match child.try_wait() {
+            Ok(Some(_)) => return,
+            Ok(None) | Err(_) => {}
+        }
+
+        if let Err(err) = child.kill() {
+            eprintln!("could not kill {process_name}: {err}");
+        }
         let _ = child.wait();
     }
 }
@@ -203,5 +210,14 @@ mod tests {
         GracefulShutdown::shutdown(&mut child, 0, "sh");
 
         assert!(child.try_wait().unwrap().is_some());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn graceful_shutdown_ignores_already_exited_child() {
+        let mut child = std::process::Command::new("sh").arg("-c").arg("exit 0").spawn().unwrap();
+        let _ = child.wait().unwrap();
+
+        GracefulShutdown::shutdown(&mut child, 0, "sh");
     }
 }

--- a/crates/node-bindings/src/utils.rs
+++ b/crates/node-bindings/src/utils.rs
@@ -1,12 +1,13 @@
 //! Utility functions for the node bindings.
 
+#[cfg(unix)]
+use std::time::{Duration, Instant};
 use std::{
     borrow::Cow,
     future::Future,
     net::{SocketAddr, TcpListener},
     path::PathBuf,
     process::Child,
-    time::{Duration, Instant},
 };
 use tempfile::TempDir;
 
@@ -19,6 +20,9 @@ pub(crate) struct GracefulShutdown;
 impl GracefulShutdown {
     /// Attempts graceful shutdown with SIGTERM, then SIGKILL after timeout.
     pub(crate) fn shutdown(child: &mut Child, timeout_secs: u64, process_name: &str) {
+        #[cfg(not(unix))]
+        let _ = timeout_secs;
+
         #[cfg(unix)]
         {
             unsafe {


### PR DESCRIPTION
## Motivation

`GracefulShutdown::shutdown` could panic when the forced kill failed, and startup error paths in anvil, geth, and reth killed children without waiting for them. These paths run during teardown or before an instance is returned, so cleanup should stay best-effort and reap the child process.

## Solution

Make `GracefulShutdown` tolerate already-exited children and soft-log kill failures before waiting. Reuse the helper in node startup failure branches, including missing pipe handles, timeout, fatal output, and read/parse errors, and add focused shutdown tests.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes