### PR TITLE
chore: bump tokio-tungstenite to 0.29

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,7 +126,7 @@ tokio = "1"
 tokio-util = "0.7"
 tokio-stream = "0.1"
 tokio-test = "0.4"
-tokio-tungstenite = "0.28"
+tokio-tungstenite = "0.29"
 tower = { version = "0.5", features = ["util"] }
 
 # tracing


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

`tokio-tungstenite` version 0.29 was released [about 2 months ago](https://crates.io/crates/tokio-tungstenite/versions). This mini PR bumps to this version.

Our downstream crates pull in two versions of `tokio-tungstenite` at the moment. Bumping the version used by `alloy` would prevent this.

## Solution

Bump `tokio-tungstenite` in Cargo.toml

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
