### PR TITLE
fix(eips): avoid panic in 7594 match_versioned_hashes

### DIFF
--- a/crates/eips/src/eip7594/sidecar.rs
+++ b/crates/eips/src/eip7594/sidecar.rs
@@ -894,7 +894,9 @@ impl BlobTransactionSidecarEip7594 {
                 if blob_versioned_hash == *target_hash {
                     let maybe_blob = self.blobs.get(i);
                     let proof_range = i * CELLS_PER_EXT_BLOB..(i + 1) * CELLS_PER_EXT_BLOB;
-                    let maybe_proofs = Some(&self.cell_proofs[proof_range])
+                    let maybe_proofs = self
+                        .cell_proofs
+                        .get(proof_range)
                         .filter(|proofs| proofs.len() == CELLS_PER_EXT_BLOB);
                     if let Some((blob, proofs)) = maybe_blob.copied().zip(maybe_proofs) {
                         return Some((
@@ -1469,6 +1471,19 @@ mod tests {
             ])
         );
         assert_eq!(mask.matching_cells_from_computed_cells(&cells[..cells.len() - 1]), None);
+    }
+
+    #[test]
+    fn match_versioned_hashes_skips_incomplete_proof_chunks() {
+        let sidecar = BlobTransactionSidecarEip7594::new(
+            vec![Blob::repeat_byte(0x01)],
+            vec![Bytes48::repeat_byte(0x02)],
+            vec![Bytes48::repeat_byte(0x03)],
+        );
+        let versioned_hash = sidecar.versioned_hashes().next().unwrap();
+
+        let matches = sidecar.match_versioned_hashes(&[versioned_hash]).collect::<Vec<_>>();
+        assert!(matches.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
  ## Motivation                                                                                                                                                                                  
                                                                                                                                                                                                 
  `BlobTransactionSidecarEip7594::match_versioned_hashes` was using direct range indexing on `self.cell_proofs` (`self.cell_proofs[proof_range]`).                                               
                                                                                                                                                                                                 
  If a sidecar contains incomplete proof chunks (for example, inconsistent `blobs` / `commitments` / `cell_proofs` lengths), this can panic instead of gracefully skipping unavailable data.     
  This is inconsistent with nearby EIP-7594 paths and the EIP-4844 variant, which already use safe access patterns.                                                                              

  ## Solution                                                                                                                                                                                    
                                                                                                                                                                                                 
  Replace direct range indexing with safe range access:                                                                                                                                          
                                                                                                                                                                                                 
  - from `Some(&self.cell_proofs[proof_range])`                                                                                                                                                  
  - to `self.cell_proofs.get(proof_range)`                                                                                                                                                       
                                                                                                                                                                                                 
  This preserves behavior for valid sidecars, and for incomplete proof chunks it now skips that entry instead of panicking.                                                                      
                                                                                                                                                                                                 
  Also added a regression test:                                                                                                                                                                  
  - `match_versioned_hashes_skips_incomplete_proof_chunks`                                                                                                                                       

  The test verifies that malformed/incomplete proof data does not panic and returns no matches.                                                                                                  
                                                                                                                                                                                                 
  ## PR Checklist                                                                                                                                                                                
                                                                                                                                                                                                 
  - [x] Added Tests
  - [ ] Added Documentation                                                                                                                                                                      
  - [ ] Breaking changes   