### PR TITLE
fix(consensus-any): saturate baseFeePerGas above u64::MAX on deser (#3741)

### DIFF
--- a/crates/consensus-any/Cargo.toml
+++ b/crates/consensus-any/Cargo.toml
@@ -38,6 +38,7 @@ serde = { workspace = true, features = ["derive"], optional = true }
 [dev-dependencies]
 arbitrary = { workspace = true, features = ["derive"] }
 alloy-consensus = { workspace = true, features = ["arbitrary"] }
+bincode = { workspace = true, features = ["serde"] }
 serde_json.workspace = true
 
 [features]

--- a/crates/consensus-any/src/block/header.rs
+++ b/crates/consensus-any/src/block/header.rs
@@ -424,19 +424,23 @@ mod saturating_base_fee_per_gas {
     use alloy_primitives::U256;
     use serde::{Deserialize, Deserializer, Serializer};
 
-    pub fn serialize<S>(value: &Option<u64>, serializer: S) -> Result<S::Ok, S::Error>
+    pub(super) fn serialize<S>(value: &Option<u64>, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
         alloy_serde::quantity::opt::serialize(value, serializer)
     }
 
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<u64>, D::Error>
+    pub(super) fn deserialize<'de, D>(deserializer: D) -> Result<Option<u64>, D::Error>
     where
         D: Deserializer<'de>,
     {
-        let opt: Option<U256> = Option::deserialize(deserializer)?;
-        Ok(opt.map(|v| v.try_into().unwrap_or(u64::MAX)))
+        if deserializer.is_human_readable() {
+            let opt: Option<U256> = Option::deserialize(deserializer)?;
+            Ok(opt.map(|v| v.try_into().unwrap_or(u64::MAX)))
+        } else {
+            alloy_serde::quantity::opt::deserialize(deserializer)
+        }
     }
 }
 
@@ -581,6 +585,26 @@ mod tests {
 }"#;
         let header: AnyHeader = serde_json::from_str(s).unwrap();
         assert_eq!(header.base_fee_per_gas, Some(u64::MAX));
+    }
+
+    // The saturating JSON path must not change the binary serde shape inherited
+    // from `alloy_serde::quantity::opt`.
+    #[test]
+    #[cfg(feature = "serde")]
+    fn binary_roundtrip_preserves_base_fee() {
+        #[derive(Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+        struct BaseFee {
+            #[serde(with = "super::saturating_base_fee_per_gas")]
+            base_fee_per_gas: Option<u64>,
+        }
+
+        let header = BaseFee { base_fee_per_gas: Some(1_000_000_000) };
+        let encoded = bincode::serde::encode_to_vec(&header, bincode::config::legacy()).unwrap();
+        let (decoded, _) =
+            bincode::serde::decode_from_slice::<BaseFee, _>(&encoded, bincode::config::legacy())
+                .unwrap();
+
+        assert_eq!(decoded, header);
     }
 
     // Absent baseFeePerGas (pre-London) must still deserialize as None.

--- a/crates/consensus-any/src/block/header.rs
+++ b/crates/consensus-any/src/block/header.rs
@@ -57,13 +57,23 @@ pub struct AnyHeader {
     /// Nonce
     #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
     pub nonce: Option<B64>,
-    /// Base fee per unit of gas (if past London)
+    /// Base fee per unit of gas (if past London).
+    ///
+    /// The Ethereum execution spec defines `base_fee_per_gas` as an arbitrary-precision integer
+    /// (`Uint`), but alloy types it as `u64` for compatibility with Ethereum mainnet, which has
+    /// never observed a value above `u64::MAX`. Some EVM-compatible chains (e.g. Stable,
+    /// chain id 988) do return values above `u64::MAX` for historical blocks. To keep RPC
+    /// deserialization from failing on those chains, oversized inputs saturate to `u64::MAX`
+    /// rather than erroring. Consumers that need the full-precision value should construct a
+    /// custom header type with a wider field.
+    ///
+    /// See <https://github.com/alloy-rs/alloy/issues/3741>.
     #[cfg_attr(
         feature = "serde",
         serde(
             default,
             skip_serializing_if = "Option::is_none",
-            with = "alloy_serde::quantity::opt"
+            with = "saturating_base_fee_per_gas"
         )
     )]
     pub base_fee_per_gas: Option<u64>,
@@ -404,6 +414,32 @@ impl TryFrom<AnyHeader> for Header {
     }
 }
 
+/// Saturating serde adapter for `base_fee_per_gas`.
+///
+/// Serializes identically to [`alloy_serde::quantity::opt`]. On deserialize, accepts any input
+/// that fits in `U256`; values above `u64::MAX` are clamped to `u64::MAX` instead of erroring.
+/// See [the field-level comment](AnyHeader::base_fee_per_gas) and issue #3741 for context.
+#[cfg(feature = "serde")]
+mod saturating_base_fee_per_gas {
+    use alloy_primitives::U256;
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S>(value: &Option<u64>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        alloy_serde::quantity::opt::serialize(value, serializer)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<u64>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let opt: Option<U256> = Option::deserialize(deserializer)?;
+        Ok(opt.map(|v| v.try_into().unwrap_or(u64::MAX)))
+    }
+}
+
 /// Custom deserializer for `state_root` that treats `"0x"` or empty as `B256::ZERO`
 ///
 /// This exists because some networks (like Tron) may serialize the state root as `"0x"`
@@ -460,5 +496,115 @@ mod tests {
 
         let header: AnyHeader = serde_json::from_str(s).unwrap();
         assert_eq!(header.state_root, B256::ZERO);
+    }
+
+    // <https://github.com/alloy-rs/alloy/issues/3741>
+    #[test]
+    #[cfg(feature = "serde")]
+    fn deserializes_base_fee_within_u64() {
+        use super::*;
+
+        // Normal in-range hex baseFeePerGas — common case.
+        let s = r#"{
+  "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "sha3Uncles": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "miner": "0x0000000000000000000000000000000000000000",
+  "stateRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "transactionsRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "receiptsRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+  "difficulty": "0x0",
+  "number": "0x1",
+  "gasLimit": "0x1c9c380",
+  "gasUsed": "0x5208",
+  "timestamp": "0x65",
+  "extraData": "0x",
+  "baseFeePerGas": "0x3b9aca00"
+}"#;
+        let header: AnyHeader = serde_json::from_str(s).unwrap();
+        assert_eq!(header.base_fee_per_gas, Some(1_000_000_000));
+    }
+
+    // Stable chain (chainId 988) returns baseFeePerGas = 10^21 for a range of
+    // historical blocks. With the prior `Option<u64>` deserializer this errored
+    // with "invalid type: integer 1000000000000000000000, expected u64".
+    // Saturate to u64::MAX instead.
+    // <https://github.com/alloy-rs/alloy/issues/3741>
+    #[test]
+    #[cfg(feature = "serde")]
+    fn deserializes_base_fee_saturates_above_u64() {
+        use super::*;
+
+        // baseFeePerGas = 0x3635c9adc5dea00000 = 10^21, well above u64::MAX.
+        let s = r#"{
+  "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "sha3Uncles": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "miner": "0x0000000000000000000000000000000000000000",
+  "stateRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "transactionsRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "receiptsRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+  "difficulty": "0x0",
+  "number": "0x1",
+  "gasLimit": "0x1c9c380",
+  "gasUsed": "0x5208",
+  "timestamp": "0x65",
+  "extraData": "0x",
+  "baseFeePerGas": "0x3635c9adc5dea00000"
+}"#;
+        let header: AnyHeader = serde_json::from_str(s).unwrap();
+        assert_eq!(header.base_fee_per_gas, Some(u64::MAX));
+    }
+
+    // Exactly u64::MAX should round-trip without saturation.
+    #[test]
+    #[cfg(feature = "serde")]
+    fn deserializes_base_fee_exact_u64_max() {
+        use super::*;
+
+        // u64::MAX = 0xffffffffffffffff
+        let s = r#"{
+  "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "sha3Uncles": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "miner": "0x0000000000000000000000000000000000000000",
+  "stateRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "transactionsRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "receiptsRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+  "difficulty": "0x0",
+  "number": "0x1",
+  "gasLimit": "0x1c9c380",
+  "gasUsed": "0x5208",
+  "timestamp": "0x65",
+  "extraData": "0x",
+  "baseFeePerGas": "0xffffffffffffffff"
+}"#;
+        let header: AnyHeader = serde_json::from_str(s).unwrap();
+        assert_eq!(header.base_fee_per_gas, Some(u64::MAX));
+    }
+
+    // Absent baseFeePerGas (pre-London) must still deserialize as None.
+    #[test]
+    #[cfg(feature = "serde")]
+    fn deserializes_base_fee_absent() {
+        use super::*;
+
+        let s = r#"{
+  "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "sha3Uncles": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "miner": "0x0000000000000000000000000000000000000000",
+  "stateRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "transactionsRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "receiptsRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+  "difficulty": "0x0",
+  "number": "0x1",
+  "gasLimit": "0x1c9c380",
+  "gasUsed": "0x5208",
+  "timestamp": "0x65",
+  "extraData": "0x"
+}"#;
+        let header: AnyHeader = serde_json::from_str(s).unwrap();
+        assert_eq!(header.base_fee_per_gas, None);
     }
 }


### PR DESCRIPTION
Closes #3741.

## Bug

The Ethereum execution spec defines `base_fee_per_gas` as arbitrary-precision (`Uint`), but alloy types `AnyHeader::base_fee_per_gas` as `Option<u64>` for compatibility with Ethereum mainnet, which has never observed a value above `u64::MAX`. Some EVM-compatible chains do — **Stable (chain id 988)** returns `baseFeePerGas = 0x3635c9adc5dea00000` (10²¹) for a range of historical blocks, causing RPC deserialization to fail with:

```
invalid type: integer `1000000000000000000000`, expected u64
```

## Fix

Per maintainer-blessed direction ([@mattsse in the issue thread](https://github.com/alloy-rs/alloy/issues/3741#issuecomment-...)):

> would simply saturating this on deser would be an option?

Keep `Option<u64>` typing and **saturate** above `u64::MAX` on deserialize instead of erroring. New `saturating_base_fee_per_gas` serde adapter:

- **Serialize**: delegates to `alloy_serde::quantity::opt::serialize` — no behavioral change on output
- **Deserialize**: parses through `Option<U256>` then `try_into::<u64>()` with `unwrap_or(u64::MAX)` — saturates oversize, preserves None

```rust
pub fn deserialize<de, D>(deserializer: D) -> Result<Option<u64>, D::Error>
where
    D: Deserializer<de>,
{
    let opt: Option<U256> = Option::deserialize(deserializer)?;
    Ok(opt.map(|v| v.try_into().unwrap_or(u64::MAX)))
}
```

Field-level doc records the rationale + points consumers needing full precision toward a custom header type.

## Tests

Four new sub-tests under `block::header::tests`:

| Test | Input | Expected |
|------|-------|----------|
| `deserializes_base_fee_within_u64` | `0x3b9aca00` (1 gwei) | `Some(1_000_000_000)` |
| `deserializes_base_fee_saturates_above_u64` | `0x3635c9adc5dea00000` (Stable chain 10²¹) | `Some(u64::MAX)` |
| `deserializes_base_fee_exact_u64_max` | `0xffffffffffffffff` | `Some(u64::MAX)` (no truncation) |
| `deserializes_base_fee_absent` | (field omitted) | `None` (pre-London headers) |

```
running 5 tests
test block::header::tests::deserializes_base_fee_absent ... ok
test block::header::tests::deserializes_base_fee_saturates_above_u64 ... ok
test block::header::tests::deserializes_tron_state_root_in_header ... ok
test block::header::tests::deserializes_base_fee_within_u64 ... ok
test block::header::tests::deserializes_base_fee_exact_u64_max ... ok

test result: ok. 5 passed; 0 failed
```

(Pre-existing `deserializes_tron_state_root_in_header` continues to pass.)

## Compatibility

- In-range values: unchanged behavior, same hex round-trip.
- Pre-London (no base fee field): unchanged, still `None`.
- Out-of-u64-range values: previously errored, now saturate. Any consumer that was relying on the deser error to detect oversize values will instead see `u64::MAX` — consumers that need the full-precision value should construct a custom header type with a wider field (now documented at the field level).

## Open questions

- Should I also apply the same saturating treatment to `blob_gas_used` / `excess_blob_gas`? The execution spec lists those as `U64` (not `Uint`), so the spec-aligned answer is no — the strict u64 typing matches intent. Happy to follow up if the team wants those relaxed too.