### PR TITLE
fix(node-bindings): reap child after startup error kill

### DIFF
--- a/crates/node-bindings/src/nodes/anvil.rs
+++ b/crates/node-bindings/src/nodes/anvil.rs
@@ -459,7 +459,7 @@ impl Anvil {
         let mut wallet = None;
         loop {
             if start + timeout <= Instant::now() {
-                let _ = child.kill();
+                GracefulShutdown::kill_and_wait(&mut child);
                 return Err(NodeError::Timeout);
             }
 

--- a/crates/node-bindings/src/nodes/geth.rs
+++ b/crates/node-bindings/src/nodes/geth.rs
@@ -627,7 +627,7 @@ impl Geth {
 
         loop {
             if start + NODE_STARTUP_TIMEOUT <= Instant::now() {
-                let _ = child.kill();
+                GracefulShutdown::kill_and_wait(&mut child);
                 return Err(NodeError::Timeout);
             }
 
@@ -664,7 +664,7 @@ impl Geth {
             // Encountered an error such as Fatal: Error starting protocol stack: listen tcp
             // 127.0.0.1:8545: bind: address already in use
             if line.contains("Fatal:") {
-                let _ = child.kill();
+                GracefulShutdown::kill_and_wait(&mut child);
                 return Err(NodeError::Fatal(line));
             }
 

--- a/crates/node-bindings/src/nodes/reth.rs
+++ b/crates/node-bindings/src/nodes/reth.rs
@@ -505,7 +505,7 @@ impl Reth {
 
         loop {
             if start + NODE_STARTUP_TIMEOUT <= Instant::now() {
-                let _ = child.kill();
+                GracefulShutdown::kill_and_wait(&mut child);
                 return Err(NodeError::Timeout);
             }
 
@@ -532,7 +532,7 @@ impl Reth {
 
             // Encountered a critical error, exit early.
             if line.contains("ERROR") {
-                let _ = child.kill();
+                GracefulShutdown::kill_and_wait(&mut child);
                 return Err(NodeError::Fatal(line));
             }
 

--- a/crates/node-bindings/src/utils.rs
+++ b/crates/node-bindings/src/utils.rs
@@ -40,6 +40,16 @@ impl GracefulShutdown {
         child.kill().unwrap_or_else(|_| panic!("could not kill {}", process_name));
         let _ = child.wait();
     }
+
+    /// Best-effort force kill and reap helper for startup/error paths.
+    pub(crate) fn kill_and_wait(child: &mut Child) {
+        if matches!(child.try_wait(), Ok(Some(_))) {
+            return;
+        }
+
+        let _ = child.kill();
+        let _ = child.wait();
+    }
 }
 
 /// A bit of hack to find an unused TCP port.
@@ -201,6 +211,17 @@ mod tests {
             .unwrap();
 
         GracefulShutdown::shutdown(&mut child, 0, "sh");
+
+        assert!(child.try_wait().unwrap().is_some());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn kill_and_wait_reaps_child() {
+        let mut child =
+            std::process::Command::new("sh").arg("-c").arg("while :; do :; done").spawn().unwrap();
+
+        GracefulShutdown::kill_and_wait(&mut child);
 
         assert!(child.try_wait().unwrap().is_some());
     }


### PR DESCRIPTION
 ## Motivation
                                                                                                                                                                                                 
  Startup error paths in `anvil`, `geth`, and `reth` were killing child processes and returning immediately, without an explicit `wait` to reap the process.
  While drop-time shutdown may eventually clean up, this leaves inconsistent process-lifecycle handling and can increase short-lived zombie/resource pressure under repeated startup failures.   
                                                                                                                                                                                                 
  ## Solution                                                                                                                                                                                    
                                                                                                                                                                                                 
  This PR introduces `GracefulShutdown::kill_and_wait` in `node-bindings` utils and uses it in startup timeout/fatal branches for:                                                               
                                                                                                                                                                                                 
  - `crates/node-bindings/src/nodes/anvil.rs`                                                                                                                                                    
  - `crates/node-bindings/src/nodes/geth.rs`
  - `crates/node-bindings/src/nodes/reth.rs`                                                                                                                                                     
                                                                                                                                                                                                 
  The helper performs a best-effort reap flow (`try_wait` fast-path, then `kill` + `wait`) so error returns happen after explicit process cleanup.                                               
                                                                                                                                                                                                 
  A unix-only unit test was added to validate that `kill_and_wait` reaps the child process:                                                                                                      
  - `kill_and_wait_reaps_child`                                                                                                                                                                  
                                                                                                                                                                                                 
  ## PR Checklist
                                                                                                                                                                                                 
  - [x] Added Tests                                                                                                                                                                              
  - [ ] Added Documentation                                                                                                                                                                      
  - [ ] Breaking changes     