### PR TITLE
feat(rpc-types-beacon): add Amsterdam submit block variant

### DIFF
--- a/crates/rpc-types-beacon/src/relay.rs
+++ b/crates/rpc-types-beacon/src/relay.rs
@@ -226,6 +226,8 @@ pub struct SignedBidSubmissionV6 {
 #[cfg_attr(feature = "ssz", derive(ssz_derive::Decode, ssz_derive::Encode))]
 #[cfg_attr(feature = "ssz", ssz(enum_behaviour = "transparent"))]
 pub enum SubmitBlockRequest {
+    /// Amsterdam [`SignedBidSubmissionV6`].
+    Amsterdam(SignedBidSubmissionV6),
     /// Fulu [`SignedBidSubmissionV5`].
     Fulu(SignedBidSubmissionV5),
     /// Electra [`SignedBidSubmissionV4`].
@@ -237,6 +239,14 @@ pub enum SubmitBlockRequest {
 }
 
 impl SubmitBlockRequest {
+    /// Returns the [`SignedBidSubmissionV6`] if this is [`Self::Amsterdam`]
+    pub const fn as_amsterdam(&self) -> Option<&SignedBidSubmissionV6> {
+        match self {
+            Self::Amsterdam(submission) => Some(submission),
+            _ => None,
+        }
+    }
+
     /// Returns the [`SignedBidSubmissionV2`] if this is [`Self::Capella`]
     pub const fn as_capella(&self) -> Option<&SignedBidSubmissionV2> {
         match self {
@@ -272,6 +282,7 @@ impl SubmitBlockRequest {
     /// Returns the underlying [`BidTrace`].
     pub const fn bid_trace(&self) -> &BidTrace {
         match self {
+            Self::Amsterdam(req) => &req.message,
             Self::Capella(req) => &req.message,
             Self::Deneb(req) => &req.message,
             Self::Electra(req) => &req.message,
@@ -298,6 +309,11 @@ impl From<SignedBidSubmissionV4> for SubmitBlockRequest {
 impl From<SignedBidSubmissionV5> for SubmitBlockRequest {
     fn from(value: SignedBidSubmissionV5) -> Self {
         Self::Fulu(value)
+    }
+}
+impl From<SignedBidSubmissionV6> for SubmitBlockRequest {
+    fn from(value: SignedBidSubmissionV6) -> Self {
+        Self::Amsterdam(value)
     }
 }
 
@@ -859,6 +875,16 @@ mod tests {
 
         assert_eq!(bid, deserialized);
         assert_eq!(json, serde_json::to_value(deserialized).unwrap());
+    }
+
+    #[test]
+    fn submit_block_request_decodes_amsterdam() {
+        let bid = amsterdam_bid_submission_v6();
+        let json = serde_json::to_string(&bid).unwrap();
+        let request = serde_json::from_str::<SubmitBlockRequest>(&json).unwrap();
+
+        assert_eq!(request.as_amsterdam(), Some(&bid));
+        assert_eq!(request.bid_trace(), &bid.message);
     }
 
     #[cfg(feature = "ssz")]


### PR DESCRIPTION
Adds `SubmitBlockRequest::Amsterdam` for `SignedBidSubmissionV6` now that the base Amsterdam/V6 relay types are merged.

This wires the untagged submit-block enum to the V6 submission type, including the `as_amsterdam` accessor, `From<SignedBidSubmissionV6>` conversion, `bid_trace` routing, and a serde decode regression test.

This keeps the enum-level submit block routing separate from the builder validation V6 type work merged in #3981.