### PR TITLE
fix(consensus): correct recovered transaction docs

### DIFF
--- a/crates/consensus/src/transaction/recovered.rs
+++ b/crates/consensus/src/transaction/recovered.rs
@@ -246,7 +246,7 @@ pub trait SignerRecoverable {
     }
 
     /// Recover the signer via [`SignerRecoverable::recover_signer_unchecked`] and returns a
-    /// `Recovered<&Self>`
+    /// `Recovered<Self>`
     fn try_into_recovered_unchecked(self) -> Result<Recovered<Self>, RecoveryError>
     where
         Self: Sized,


### PR DESCRIPTION
## Motivation

`SignerRecoverable::try_into_recovered_unchecked` consumes `self` and returns `Recovered<Self>`, but its doc comment described the return type as `Recovered<&Self>`. 

## Solution

Update the comment so the documented return type matches the function signature.
