### PR TITLE
fix(node-bindings): apply custom reth genesis on startup

### DIFF
--- a/crates/node-bindings/src/nodes/reth.rs
+++ b/crates/node-bindings/src/nodes/reth.rs
@@ -8,7 +8,7 @@ use alloy_genesis::Genesis;
 use rand::Rng;
 use std::{
     ffi::OsString,
-    fs::create_dir_all,
+    fs::{create_dir_all, File},
     io::{BufRead, BufReader},
     path::PathBuf,
     process::{Child, ChildStdout, Command, Stdio},
@@ -334,6 +334,9 @@ impl Reth {
     /// If this is set, reth will be initialized with `reth init` and the `--datadir` option will be
     /// set to the same value as `data_dir`.
     ///
+    /// This requires setting [`Reth::data_dir`] so both init and node startup point to the same
+    /// directory.
+    ///
     /// This is destructive and will overwrite any existing data in the data directory.
     pub fn genesis(mut self, genesis: Genesis) -> Self {
         self.genesis = Some(genesis);
@@ -387,6 +390,49 @@ impl Reth {
             .as_ref()
             .map_or_else(|| RETH.as_ref(), |bin| bin.as_os_str())
             .to_os_string();
+        if self.genesis.is_some() && self.chain_or_path.is_some() {
+            return Err(NodeError::GenesisError(
+                "`genesis` cannot be combined with `chain_or_path`".to_string(),
+            ));
+        }
+
+        let mut genesis_chain_path = None;
+
+        if let Some(genesis) = &self.genesis {
+            let data_dir = self.data_dir.as_ref().ok_or_else(|| {
+                NodeError::GenesisError(
+                    "`genesis` requires `data_dir` to run `reth init`".to_string(),
+                )
+            })?;
+            if !data_dir.exists() {
+                create_dir_all(data_dir).map_err(NodeError::CreateDirError)?;
+            }
+
+            let genesis_path = data_dir.join("genesis.json");
+            let mut file = File::create(&genesis_path).map_err(|_| {
+                NodeError::GenesisError("could not create genesis file".to_string())
+            })?;
+            serde_json::to_writer_pretty(&mut file, genesis).map_err(|_| {
+                NodeError::GenesisError("could not write genesis to file".to_string())
+            })?;
+
+            let mut init_cmd = Command::new(&bin_path);
+            init_cmd.stdout(Stdio::null());
+            init_cmd.stderr(Stdio::null());
+            init_cmd.arg("init").arg("--datadir").arg(data_dir).arg("--chain").arg(&genesis_path);
+
+            let res = init_cmd
+                .spawn()
+                .map_err(NodeError::SpawnError)?
+                .wait()
+                .map_err(NodeError::WaitError)?;
+            if !res.success() {
+                return Err(NodeError::InitError);
+            }
+
+            genesis_chain_path = Some(genesis_path);
+        }
+
         let mut cmd = Command::new(&bin_path);
         // `reth` uses stdout for its logs
         cmd.stdout(Stdio::piped());
@@ -480,6 +526,8 @@ impl Reth {
 
         if let Some(chain_or_path) = self.chain_or_path {
             cmd.arg("--chain").arg(chain_or_path);
+        } else if let Some(genesis_path) = genesis_chain_path {
+            cmd.arg("--chain").arg(genesis_path);
         }
 
         // Disable color output to make parsing logs easier.
@@ -622,5 +670,11 @@ mod tests {
         assert_eq!(reth.genesis, None);
         assert!(reth.args.is_empty());
         assert!(!reth.keep_stdout);
+    }
+
+    #[test]
+    fn rejects_genesis_with_chain_or_path() {
+        let err = Reth::new().chain_or_path("sepolia").genesis(Genesis::default()).try_spawn();
+        assert!(matches!(err, Err(NodeError::GenesisError(_))));
     }
 }

--- a/crates/node-bindings/tests/it/reth.rs
+++ b/crates/node-bindings/tests/it/reth.rs
@@ -2,6 +2,11 @@
 
 use alloy_genesis::Genesis;
 use alloy_node_bindings::{utils::run_with_tempdir_sync, Reth, RethInstance};
+use std::{
+    io::{Read, Write},
+    net::TcpStream,
+    time::Duration,
+};
 
 /// The default HTTP port for Reth.
 const DEFAULT_HTTP_PORT: u16 = 8545;
@@ -59,20 +64,18 @@ fn can_launch_reth_dev() {
 
 #[test]
 #[cfg_attr(windows, ignore = "no reth on windows")]
-fn can_launch_reth_dev_custom_genesis() {
+fn can_launch_reth_custom_genesis_chain_id() {
     if !ci_info::is_ci() {
         return;
     }
 
     run_with_tempdir_sync("reth-test-", |temp_dir_path| {
-        let reth = Reth::new()
-            .dev()
-            .disable_discovery()
-            .data_dir(temp_dir_path)
-            .genesis(Genesis::default())
-            .spawn();
+        let mut genesis = Genesis::default();
+        genesis.config.chain_id = 31337;
 
-        assert_ports(&reth, true);
+        let reth = Reth::new().disable_discovery().data_dir(temp_dir_path).genesis(genesis).spawn();
+
+        assert_eq!(eth_chain_id(&reth), 31337);
     });
 }
 
@@ -188,4 +191,30 @@ fn assert_ports(reth: &RethInstance, dev: bool) {
         reth.p2p_port(),
         if dev { None } else { Some(DEFAULT_P2P_PORT + reth.instance() - 1) }
     );
+}
+
+fn eth_chain_id(reth: &RethInstance) -> u64 {
+    let mut stream = TcpStream::connect((reth.host(), reth.http_port())).unwrap();
+    stream.set_read_timeout(Some(Duration::from_secs(2))).unwrap();
+
+    let payload = r#"{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}"#;
+    let request = format!(
+        "POST / HTTP/1.1\r\nHost: {}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        reth.host(),
+        payload.len(),
+        payload
+    );
+    stream.write_all(request.as_bytes()).unwrap();
+    stream.shutdown(std::net::Shutdown::Write).unwrap();
+
+    let mut response = String::new();
+    stream.read_to_string(&mut response).unwrap();
+    let body = response.split_once("\r\n\r\n").map(|(_, body)| body).unwrap_or("");
+    let result = serde_json::from_str::<serde_json::Value>(body).unwrap()["result"]
+        .as_str()
+        .unwrap()
+        .trim_start_matches("0x")
+        .to_owned();
+
+    u64::from_str_radix(&result, 16).unwrap()
 }


### PR DESCRIPTION
## Motivation
                                                                                                                                                                                                 
  `Reth::genesis()` promises that setting a custom genesis will initialize the node with `reth init` and the same `--datadir`, but `try_spawn()` previously did not execute that init flow.      
  This made the API behavior inconsistent with its documentation and could leave custom genesis settings unapplied at runtime, causing confusing and hard-to-diagnose behavior.
                                                                                                                                                                                                 
  ## Solution                                                                                                                                                                                    
                                                                                                                                                                                                 
  This PR implements the missing initialization path in `Reth::try_spawn()`:                                                                                                                     
                                                                                                                                                                                                 
  - When `genesis` is set, require `data_dir`.                                                                                                                                                   
  - Write the provided genesis to `<data_dir>/genesis.json`.                                                                                                                                     
  - Run `reth init --datadir <data_dir> --chain <genesis.json>` before starting `reth node`.
  - Pass the same genesis path to node startup (`--chain`) when `chain_or_path` is not explicitly set.                                                                                           
  - Reject invalid mixed configuration (`genesis` + `chain_or_path`) to avoid conflicting chain sources.                                                                                         
                                                                                                                                                                                                 
  Tests were updated to validate real effect:                                                                                                                                                    

  - Integration test now verifies `eth_chainId` matches the custom genesis chain id.
  - Unit test verifies `genesis` and `chain_or_path` cannot be set together.                                                                                                                     

  ## PR Checklist
                                                                                                                                                                                                 
  - [x] Added Tests
  - [ ] Added Documentation                                                                                                                                                                      
  - [ ] Breaking changes 