### PR TITLE
fix(network): preserve transaction request extra fields

### DIFF
--- a/crates/network/src/any/mod.rs
+++ b/crates/network/src/any/mod.rs
@@ -437,8 +437,9 @@ impl From<AnyRpcTransaction> for Recovered<AnyTxEnvelope> {
 
 impl From<AnyRpcTransaction> for WithOtherFields<TransactionRequest> {
     fn from(tx: AnyRpcTransaction) -> Self {
-        let req: TransactionRequest = tx.0.inner.into_recovered().into();
-        Self::new(req)
+        let (inner, other) = tx.into_parts();
+        let req: TransactionRequest = inner.into_recovered().into();
+        Self { inner: req, other }
     }
 }
 
@@ -576,5 +577,18 @@ mod tests {
 
         let _block: alloy_consensus::Block<TxEnvelope, alloy_consensus::Header> =
             block.try_into().unwrap();
+    }
+
+    #[test]
+    fn preserves_other_fields_when_converting_to_transaction_request() {
+        let rpc_tx = r#"{"blockHash":"0x8e38b4dbf6b11fcc3b9dee84fb7986e29ca0a02cecd8977c161ff7333329681e","blockNumber":"0xf4240","hash":"0xe9e91f1ee4b56c0df2e9f06c2b8c27c6076195a88a7b8537ba8313d80e6f124e","transactionIndex":"0x1","type":"0x0","nonce":"0x43eb","input":"0x","r":"0x3b08715b4403c792b8c7567edea634088bedcd7f60d9352b1f16c69830f3afd5","s":"0x10b9afb67d2ec8b956f0e1dbc07eb79152904f3a7bf789fc869db56320adfe09","chainId":"0x0","v":"0x1c","gas":"0xc350","from":"0x32be343b94f860124dc4fee278fdcbd38c102d88","to":"0xdf190dc7190dfba737d7777a163445b7fff16133","value":"0x6113a84987be800","gasPrice":"0xdf8475800","tempoFeePayer":"0x1234"}"#;
+
+        let tx: AnyRpcTransaction = serde_json::from_str(rpc_tx).unwrap();
+        let req: WithOtherFields<TransactionRequest> = tx.into();
+
+        assert_eq!(
+            req.other.get("tempoFeePayer").and_then(serde_json::Value::as_str),
+            Some("0x1234")
+        );
     }
 }

--- a/crates/network/src/any/mod.rs
+++ b/crates/network/src/any/mod.rs
@@ -438,8 +438,11 @@ impl From<AnyRpcTransaction> for Recovered<AnyTxEnvelope> {
 impl From<AnyRpcTransaction> for WithOtherFields<TransactionRequest> {
     fn from(tx: AnyRpcTransaction) -> Self {
         let (inner, other) = tx.into_parts();
-        let req: TransactionRequest = inner.into_recovered().into();
-        Self { inner: req, other }
+        let (envelope, from) = inner.into_recovered().into_parts();
+        let mut req: Self = envelope.into();
+        req.inner.from = Some(from);
+        req.other.extend(other);
+        req
     }
 }
 
@@ -581,14 +584,75 @@ mod tests {
 
     #[test]
     fn preserves_other_fields_when_converting_to_transaction_request() {
-        let rpc_tx = r#"{"blockHash":"0x8e38b4dbf6b11fcc3b9dee84fb7986e29ca0a02cecd8977c161ff7333329681e","blockNumber":"0xf4240","hash":"0xe9e91f1ee4b56c0df2e9f06c2b8c27c6076195a88a7b8537ba8313d80e6f124e","transactionIndex":"0x1","type":"0x0","nonce":"0x43eb","input":"0x","r":"0x3b08715b4403c792b8c7567edea634088bedcd7f60d9352b1f16c69830f3afd5","s":"0x10b9afb67d2ec8b956f0e1dbc07eb79152904f3a7bf789fc869db56320adfe09","chainId":"0x0","v":"0x1c","gas":"0xc350","from":"0x32be343b94f860124dc4fee278fdcbd38c102d88","to":"0xdf190dc7190dfba737d7777a163445b7fff16133","value":"0x6113a84987be800","gasPrice":"0xdf8475800","tempoFeePayer":"0x1234"}"#;
+        let tx: AnyRpcTransaction = serde_json::from_value(serde_json::json!({
+            "blockHash": "0x8e38b4dbf6b11fcc3b9dee84fb7986e29ca0a02cecd8977c161ff7333329681e",
+            "blockNumber": "0xf4240",
+            "hash": "0xe9e91f1ee4b56c0df2e9f06c2b8c27c6076195a88a7b8537ba8313d80e6f124e",
+            "transactionIndex": "0x1",
+            "type": "0x0",
+            "nonce": "0x43eb",
+            "input": "0x",
+            "r": "0x3b08715b4403c792b8c7567edea634088bedcd7f60d9352b1f16c69830f3afd5",
+            "s": "0x10b9afb67d2ec8b956f0e1dbc07eb79152904f3a7bf789fc869db56320adfe09",
+            "chainId": "0x0",
+            "v": "0x1c",
+            "gas": "0xc350",
+            "from": "0x32be343b94f860124dc4fee278fdcbd38c102d88",
+            "to": "0xdf190dc7190dfba737d7777a163445b7fff16133",
+            "value": "0x6113a84987be800",
+            "gasPrice": "0xdf8475800",
+            "tempoFeePayer": "0x1234",
+        }))
+        .unwrap();
 
-        let tx: AnyRpcTransaction = serde_json::from_str(rpc_tx).unwrap();
         let req: WithOtherFields<TransactionRequest> = tx.into();
 
         assert_eq!(
             req.other.get("tempoFeePayer").and_then(serde_json::Value::as_str),
             Some("0x1234")
         );
+        assert_eq!(
+            req.inner.from,
+            Some("0x32be343b94f860124dc4fee278fdcbd38c102d88".parse().unwrap())
+        );
+    }
+
+    #[test]
+    fn preserves_unknown_fields_when_converting_to_transaction_request() {
+        let tx: AnyRpcTransaction = serde_json::from_value(serde_json::json!({
+            "blockHash": "0xef664d656f841b5ad6a2b527b963f1eb48b97d7889d742f6cbff6950388e24cd",
+            "blockNumber": "0x73a78fd",
+            "from": "0x36bde71c97b33cc4729cf772ae268934f7ab70b2",
+            "gas": "0xc27a8",
+            "gasPrice": "0x521",
+            "hash": "0x0bf1845c5d7a82ec92365d5027f7310793d53004f3c86aa80965c67bf7e7dc80",
+            "input": "0x",
+            "nonce": "0x74060",
+            "to": "0x4200000000000000000000000000000000000007",
+            "transactionIndex": "0x1",
+            "type": "0x7e",
+            "value": "0x0",
+            "sourceHash": "0x074adb22f2e6ed9bdd31c52eefc1f050e5db56eb85056450bccd79a6649520b3",
+            "mint": "0x0",
+            "tempoFeePayer": "0x1234",
+        }))
+        .unwrap();
+
+        let req: WithOtherFields<TransactionRequest> = tx.into();
+
+        assert_eq!(req.other.get("type").and_then(serde_json::Value::as_u64), Some(0x7e));
+        assert_eq!(
+            req.other.get("sourceHash").and_then(serde_json::Value::as_str),
+            Some("0x074adb22f2e6ed9bdd31c52eefc1f050e5db56eb85056450bccd79a6649520b3")
+        );
+        assert_eq!(
+            req.other.get("tempoFeePayer").and_then(serde_json::Value::as_str),
+            Some("0x1234")
+        );
+        assert_eq!(
+            req.inner.from,
+            Some("0x36bde71c97b33cc4729cf772ae268934f7ab70b2".parse().unwrap())
+        );
+        assert!(!req.other.contains_key("from"));
     }
 }


### PR DESCRIPTION
 ## Motivation
                                                                                                                                                                                                 
  `AnyRpcTransaction -> WithOtherFields<TransactionRequest>` was dropping RPC extension fields during conversion.                                                                                
  The previous implementation rebuilt the wrapper with `Self::new(req)`, which discarded `other`.                                                                                                
  This caused loss of provider-specific fields (for example `tempoFeePayer`) and made passthrough behavior unreliable.                                                                           
                                                                                                                                                                                                 
  ## Solution                                                                                                                                                                                    
                                                                                                                                                                                                 
  The conversion now uses `tx.into_parts()` and returns `Self { inner: req, other }`, preserving all extra RPC fields while still converting the inner transaction into `TransactionRequest`.    
  A unit test was added (`preserves_other_fields_when_converting_to_transaction_request`) to verify the behavior, and it passes with:                                                                                                                                                                                    
  `cargo test -p alloy-network preserves_other_fields_when_converting_to_transaction_request`                                                                                                    
                                                                                                                                                                                                 
  ## PR Checklist                                                                                                                                                                                
                                                                                                                                                                                                 
  - [x] Added Tests                                                                                                                                                                              
  - [ ] Added Documentation                                                                                                                                                                      
  - [ ] Breaking changes 