### PR TITLE
fix(ci): satisfy zepter secp256k1 propagation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,11 +74,11 @@ alloy-transport-ws = { version = "2.0.4", path = "crates/transport-ws", default-
 alloy-eip5792 = { version = "2.0.4", path = "crates/eip5792", default-features = false }
 alloy-tx-macros = { version = "2.0.4", path = "crates/tx-macros", default-features = false }
 
-alloy-core = { version = "1.4.1", default-features = false }
-alloy-dyn-abi = { version = "1.4.1", default-features = false }
-alloy-json-abi = { version = "1.4.1", default-features = false }
-alloy-primitives = { version = "1.4.1", default-features = false }
-alloy-sol-types = { version = "1.4.1", default-features = false }
+alloy-core = { version = "1.6.0", default-features = false }
+alloy-dyn-abi = { version = "1.6.0", default-features = false }
+alloy-json-abi = { version = "1.6.0", default-features = false }
+alloy-primitives = { version = "1.6.0", default-features = false }
+alloy-sol-types = { version = "1.6.0", default-features = false }
 
 alloy-rlp = { version = "0.3.9", default-features = false }
 alloy-trie = { version = "0.9.2", default-features = false }

--- a/crates/alloy/Cargo.toml
+++ b/crates/alloy/Cargo.toml
@@ -290,7 +290,8 @@ signer-mnemonic-all-languages = [
 signer-yubihsm = ["signer-local", "alloy-signer-local?/yubihsm"]
 secp256k1 = [
 	"alloy-consensus?/secp256k1",
-	"alloy-signer-local?/secp256k1"
+	"alloy-signer-local?/secp256k1",
+	"alloy-core/secp256k1"
 ]
 # transports
 transports = ["dep:alloy-transport"]

--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -94,7 +94,10 @@ std = [
 	"borsh?/std"
 ]
 k256 = ["dep:k256", "alloy-primitives/k256", "alloy-eips/k256"]
-secp256k1 = ["dep:secp256k1"]
+secp256k1 = [
+	"dep:secp256k1",
+	"alloy-primitives/secp256k1"
+]
 crypto-backend = []
 kzg = ["dep:c-kzg", "alloy-eips/kzg", "std"]
 arbitrary = [

--- a/crates/signer-local/Cargo.toml
+++ b/crates/signer-local/Cargo.toml
@@ -85,7 +85,8 @@ yubihsm = ["dep:yubihsm", "dep:elliptic-curve"]
 secp256k1 = [
 	"dep:secp256k1",
 	"alloy-consensus/secp256k1",
-	"yubihsm?/secp256k1"
+	"yubihsm?/secp256k1",
+	"alloy-primitives/secp256k1"
 ]
 
 eip712 = ["alloy-signer/eip712"]


### PR DESCRIPTION
## Summary

Bumps the alloy core-family dependency floor to 1.6.0. The zepter-breaking effective dependency change is from the previously resolved 1.5.2 core stack to 1.6.0.

Adds the `secp256k1` feature propagation required by alloy-core 1.6.0 and alloy-primitives 1.6.0 for the root alloy crate, alloy-consensus, and alloy-signer-local.

## Root Cause

The zepter job started resolving alloy-core/alloy-primitives 1.6.0, where `secp256k1` is part of the checked feature set. The local crate feature maps did not propagate `secp256k1` into those dependencies, so zepter reported the missing propagation.