### PR TITLE
docs(rpc-types-eth): correct sealed_header docs

### DIFF
--- a/crates/rpc-types-eth/src/block.rs
+++ b/crates/rpc-types-eth/src/block.rs
@@ -304,7 +304,7 @@ impl<T> Block<T> {
         self.header.hash
     }
 
-    /// Returns a sealed reference of the header: `Sealed<&Header>`
+    /// Returns a sealed reference of the header: `Sealed<&alloy_consensus::Header>`
     pub const fn sealed_header(&self) -> Sealed<&alloy_consensus::Header> {
         Sealed::new_unchecked(&self.header.inner, self.header.hash)
     }


### PR DESCRIPTION
## Motivation

`Block::sealed_header` returns `Sealed<&alloy_consensus::Header>`, but its doc comment described the return type as `Sealed<&Header>`. In this module, `Header` is the RPC header wrapper, so the documented type points at the wrong header layer.

## Solution

Update the doc comment so it names the actual consensus header reference returned by the method.
