### PR TITLE
fix(provider): poll receipts while waiting for confirmations

### DIFF
--- a/crates/provider/src/heart.rs
+++ b/crates/provider/src/heart.rs
@@ -3,13 +3,13 @@
 use crate::{blocks::Paused, Provider, RootProvider};
 use alloy_consensus::BlockHeader;
 use alloy_json_rpc::RpcError;
-use alloy_network::{BlockResponse, Network};
+use alloy_network::{BlockResponse, Network, ReceiptResponse};
 use alloy_primitives::{
     map::{B256HashMap, B256HashSet},
     TxHash, B256,
 };
 use alloy_transport::{utils::Spawnable, TransportError};
-use futures::{future::pending, stream::StreamExt, FutureExt, Stream};
+use futures::{stream::StreamExt, FutureExt, Stream};
 use std::{
     collections::{BTreeMap, VecDeque},
     fmt,
@@ -226,42 +226,46 @@ impl<N: Network> PendingTransactionBuilder<N> {
         let hash = self.config.tx_hash;
         let required_confirmations = self.config.required_confirmations;
         let mut pending_tx = self.provider.watch_pending_transaction(self.config).await?;
-
-        // FIXME: this is a hotfix to prevent a race condition where the heartbeat would miss the
-        // block the tx was mined in. Only apply this for single confirmation to respect the
-        // confirmation setting.
-        let mut interval = if required_confirmations > 1 {
-            None
-        } else {
-            Some(interval(self.provider.client().poll_interval()))
-        };
+        let mut interval = interval(self.provider.client().poll_interval());
 
         loop {
             let mut confirmed = false;
-
-            // If more than 1 block confirmations is specified then we can rely on the regular
-            // watch_pending_transaction and dont need this workaround for the above mentioned race
-            // condition
-            let tick_fut = if let Some(interval) = interval.as_mut() {
-                interval.tick().map(|_| ()).left_future()
-            } else {
-                pending::<()>().right_future()
-            };
+            let mut watcher_err = None;
 
             select! {
-                _ = tick_fut => {},
+                _ = interval.tick() => {},
                 res = &mut pending_tx => {
-                    let _ = res?;
-                    confirmed = true;
+                    match res {
+                        Ok(_) => confirmed = true,
+                        Err(err) => watcher_err = Some(err),
+                    }
                 }
             }
 
             // try to fetch the receipt
             let receipt = self.provider.get_transaction_receipt(hash).await?;
             if let Some(receipt) = receipt {
+                if required_confirmations > 1 {
+                    let Some(block_number) = receipt.block_number() else {
+                        if let Some(err) = watcher_err {
+                            return Err(err);
+                        }
+                        continue;
+                    };
+                    let latest_block = self.provider.get_block_number().await?;
+                    if latest_block < block_number + required_confirmations - 1 {
+                        if let Some(err) = watcher_err {
+                            return Err(err);
+                        }
+                        continue;
+                    }
+                }
                 return Ok(receipt);
             }
 
+            if let Some(err) = watcher_err {
+                return Err(err);
+            }
             if confirmed {
                 return Err(RpcError::NullResp.into());
             }

--- a/crates/provider/tests/it/main.rs
+++ b/crates/provider/tests/it/main.rs
@@ -3,5 +3,8 @@
 
 mod mock;
 
+#[cfg(feature = "anvil-node")]
+mod pending_transaction;
+
 #[cfg(feature = "ws")]
 mod ws;

--- a/crates/provider/tests/it/pending_transaction.rs
+++ b/crates/provider/tests/it/pending_transaction.rs
@@ -1,0 +1,59 @@
+use alloy_network::{ReceiptResponse, TransactionBuilder};
+use alloy_node_bindings::Anvil;
+use alloy_primitives::U256;
+use alloy_provider::{ext::AnvilApi, Provider, ProviderBuilder, WalletProvider};
+use alloy_rpc_client::RpcClient;
+use alloy_rpc_types_eth::TransactionRequest;
+use std::time::Duration;
+
+#[tokio::test]
+async fn get_receipt_with_required_confirmations_returns_confirmed_receipt() {
+    let anvil = Anvil::new().block_time(1).spawn();
+    let wallet = anvil.wallet().expect("dev wallet");
+
+    let client = RpcClient::builder()
+        .connect(&anvil.endpoint())
+        .await
+        .expect("connect anvil")
+        .with_poll_interval(Duration::from_millis(100));
+
+    let provider = ProviderBuilder::new().wallet(wallet).connect_client(client);
+
+    provider.anvil_set_auto_mine(false).await.expect("disable automine");
+
+    for attempt in 1..=50 {
+        let tx = TransactionRequest::default()
+            .with_to(provider.default_signer_address())
+            .with_value(U256::from(1_u64));
+
+        let pending = provider.send_transaction(tx).await.expect("send transaction");
+        let tx_hash = *pending.tx_hash();
+
+        let watcher = tokio::spawn(async move {
+            pending
+                .with_required_confirmations(3)
+                .with_timeout(Some(Duration::from_secs(10)))
+                .get_receipt()
+                .await
+        });
+
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        provider.anvil_mine(Some(3), None).await.expect("mine confirmations");
+
+        let receipt = watcher.await.expect("watch task panicked").unwrap_or_else(|err| {
+            panic!(
+                "get_receipt timed out before returning existing confirmed receipt on attempt \
+                 {attempt}: {err}"
+            )
+        });
+        let direct_receipt =
+            provider.get_transaction_receipt(tx_hash).await.expect("fetch direct receipt");
+        let latest_block = provider.get_block_number().await.expect("fetch latest block");
+
+        let receipt_block = receipt.block_number().expect("receipt has block number");
+        assert_eq!(receipt.transaction_hash(), tx_hash);
+        assert!(receipt.status());
+        assert!(latest_block >= receipt_block + 2);
+        assert!(direct_receipt.is_some());
+    }
+}


### PR DESCRIPTION
Fixes #3916.

## Motivation

`PendingTransactionBuilder::with_required_confirmations(...).get_receipt()` could time out even after the transaction receipt already existed and the chain had advanced past the requested confirmation count.

This happened because `get_receipt()` only used its periodic receipt polling fallback for single-confirmation waits. For multi-confirmation waits, it relied entirely on the heartbeat watcher, so a missed watcher notification could surface as a timeout even though `eth_getTransactionReceipt` returned a confirmed receipt.

## Solution

Keep polling `eth_getTransactionReceipt` while waiting for the pending transaction watcher, regardless of the requested confirmation count.

For multi-confirmation waits, `get_receipt()` now verifies that the latest block is at or past:

```text
receipt.block_number + required_confirmations - 1
```

before returning the receipt.

Added an Anvil regression test that disables automine, sends transactions, mines the required confirmations, and verifies `get_receipt()` returns the confirmed receipt instead of timing out.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
