### PR TITLE
docs(consensus): clarify generic EIP-4844 return doc

### DIFF
--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -748,7 +748,7 @@ impl<Eip4844: RlpEcdsaEncodableTx> EthereumTxEnvelope<Eip4844> {
         }
     }
 
-    /// Consumes the type and returns the [`TxEip4844`] variant if the transaction is an EIP-4844
+    /// Consumes the type and returns the EIP-4844 variant if the transaction is an EIP-4844
     /// transaction. Returns an error otherwise.
     pub fn try_into_eip4844(self) -> Result<Signed<Eip4844>, ValueError<Self>> {
         match self {


### PR DESCRIPTION
## Motivation
                                                                                                                                                                                                 
  The doc comment for `try_into_eip4844` in `crates/consensus/src/transaction/envelope.rs` was too specific and implied the return was tied to `TxEip4844`, while the actual signature is generic (`Result<Signed<Eip4844>, ValueError<Self>>`).                                                                                                                                                 
  This mismatch can confuse readers about the API contract.                                                                                                                                      
                                                                                                                                                                                                 
  ## Solution                                                                                                                                                                                    
                                                                                                                                                                                                 
  Updated the doc comment to describe the return as the **EIP-4844 variant** in generic terms, matching the method signature and avoiding type-specific wording.                                 
  This is a docs-only change with no runtime behavior change.                                                                                                                                    
                                                                                                                                                                                                 
  ## PR Checklist                                                                                                                                                                                
                                                                                                                                                                                                 
  - [ ] Added Tests (docs-only change)                                                                                                                                                           
  - [x] Added Documentation                                                                                                                                                                      
  - [ ] Breaking changes 