### PR TITLE
docs(rpc-types-eth): clarify block header docs

### DIFF
--- a/crates/rpc-types-eth/src/block.rs
+++ b/crates/rpc-types-eth/src/block.rs
@@ -192,7 +192,7 @@ impl<T, H> Block<T, H> {
         }
     }
 
-    /// Consumes the block and only returns the rpc header.
+    /// Consumes the block and returns its header.
     ///
     /// To obtain the underlying [`alloy_consensus::Header`] use [`Block::into_consensus_header`].
     pub fn into_header(self) -> H {
@@ -285,7 +285,7 @@ impl<T, H: Sealable + Encodable> Block<T, Header<H>> {
     /// Constructs an "uncle block" from the provided header.
     ///
     /// This function creates a new [`Block`] structure for uncle blocks (ommer blocks),
-    /// using the provided [`alloy_consensus::Header`].
+    /// using the provided header.
     pub fn uncle_from_header(header: H) -> Self {
         let block = alloy_consensus::Block::<TxEnvelope, H>::uncle(header);
         let size = U256::from(block.length());


### PR DESCRIPTION
## Motivation

Some `Block` documentation still described generic header helpers as if they always used the RPC or consensus header type. `Block::into_header` returns the generic `H`, and `uncle_from_header` accepts generic headers wrapped by the RPC `Header` type.

## Solution

Update the affected rustdoc comments so they describe the actual generic header behavior without changing runtime code.