### PR TITLE
fix(engine): reject higher-version fields in V1/V2 serde

### DIFF
--- a/crates/rpc-types-engine/src/payload.rs
+++ b/crates/rpc-types-engine/src/payload.rs
@@ -584,7 +584,7 @@ pub struct ExecutionPayloadEnvelopeV6 {
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "ssz", derive(ssz_derive::Encode, ssz_derive::Decode))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase", deny_unknown_fields))]
 #[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
 pub struct ExecutionPayloadV1 {
     /// The parent hash of the block.
@@ -804,7 +804,7 @@ impl<'de> serde::Deserialize<'de> for ExecutionPayloadV2 {
         D: serde::Deserializer<'de>,
     {
         #[derive(serde::Deserialize)]
-        #[serde(rename_all = "camelCase")]
+        #[serde(rename_all = "camelCase", deny_unknown_fields)]
         struct Helper {
             parent_hash: B256,
             fee_recipient: Address,
@@ -4501,28 +4501,27 @@ mod tests {
     #[test]
     #[cfg(feature = "serde")]
     fn serde_faulty_roundtrip_payload_input_v3() {
-        // The deserialization behavior of ExecutionPayload structs is faulty.
-        // They should not be implicitly deserializable to an earlier version,
-        // as this breaks round-trip behavior
+        // Higher-version payloads should not be implicitly deserializable to lower versions.
         let response_v3 = r#"{"parentHash":"0xe927a1448525fb5d32cb50ee1408461a945ba6c39bd5cf5621407d500ecc8de9","feeRecipient":"0x0000000000000000000000000000000000000000","stateRoot":"0x10f8a0830000e8edef6d00cc727ff833f064b1950afd591ae41357f97e543119","receiptsRoot":"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421","logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","prevRandao":"0xe0d8b4521a7da1582a713244ffb6a86aa1726932087386e2dc7973f43fc6cb24","blockNumber":"0x1","gasLimit":"0x2ffbd2","gasUsed":"0x0","timestamp":"0x1235","extraData":"0xd883010d00846765746888676f312e32312e30856c696e7578","baseFeePerGas":"0x342770c0","blockHash":"0x44d0fa5f2f73a938ebb96a2a21679eb8dea3e7b7dd8fd9f35aa756dda8bf0a8a","transactions":[],"withdrawals":[],"blobGasUsed":"0x0","excessBlobGas":"0x0"}"#;
 
-        let payload_v2: ExecutionPayloadV2 = serde_json::from_str(response_v3).unwrap();
-        assert_ne!(response_v3, serde_json::to_string(&payload_v2).unwrap());
+        let payload_v2: Result<ExecutionPayloadV2, serde_json::Error> =
+            serde_json::from_str(response_v3);
+        assert!(payload_v2.is_err());
 
-        let payload_v1: ExecutionPayloadV1 = serde_json::from_str(response_v3).unwrap();
-        assert_ne!(response_v3, serde_json::to_string(&payload_v1).unwrap());
+        let payload_v1: Result<ExecutionPayloadV1, serde_json::Error> =
+            serde_json::from_str(response_v3);
+        assert!(payload_v1.is_err());
     }
 
     #[test]
     #[cfg(feature = "serde")]
     fn serde_faulty_roundtrip_payload_input_v2() {
-        // The deserialization behavior of ExecutionPayload structs is faulty.
-        // They should not be implicitly deserializable to an earlier version,
-        // as this breaks round-trip behavior
+        // Higher-version payloads should not be implicitly deserializable to lower versions.
         let response_v2 = r#"{"parentHash":"0xe927a1448525fb5d32cb50ee1408461a945ba6c39bd5cf5621407d500ecc8de9","feeRecipient":"0x0000000000000000000000000000000000000000","stateRoot":"0x10f8a0830000e8edef6d00cc727ff833f064b1950afd591ae41357f97e543119","receiptsRoot":"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421","logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","prevRandao":"0xe0d8b4521a7da1582a713244ffb6a86aa1726932087386e2dc7973f43fc6cb24","blockNumber":"0x1","gasLimit":"0x2ffbd2","gasUsed":"0x0","timestamp":"0x1235","extraData":"0xd883010d00846765746888676f312e32312e30856c696e7578","baseFeePerGas":"0x342770c0","blockHash":"0x44d0fa5f2f73a938ebb96a2a21679eb8dea3e7b7dd8fd9f35aa756dda8bf0a8a","transactions":[],"withdrawals":[]}"#;
 
-        let payload: ExecutionPayloadV1 = serde_json::from_str(response_v2).unwrap();
-        assert_ne!(response_v2, serde_json::to_string(&payload).unwrap());
+        let payload: Result<ExecutionPayloadV1, serde_json::Error> =
+            serde_json::from_str(response_v2);
+        assert!(payload.is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Motivation
                                                                                                                                                                                                 
  `ExecutionPayloadV1` and `ExecutionPayloadV2` deserialization was implicitly accepting higher-version payload fields (for example V3 fields) and silently dropping them.                       
  This causes version-boundary ambiguity and breaks round-trip expectations, and it is inconsistent with the stricter validation already implemented in `ExecutionPayload` enum deserialization. 
                                                                                                                                                                                                 
  ## Solution                                                                                                                                                                                    
                                                                                                                                                                                                 
  - Made `ExecutionPayloadV1` deserialization strict by adding `deny_unknown_fields`.                                                                                                            
  - Made `ExecutionPayloadV2` deserialization strict by adding `deny_unknown_fields` to its serde helper.                                                                                        
  - Updated the existing `serde_faulty_roundtrip_payload_input_v2/v3` tests to assert deserialization errors instead of allowing silent downgrade behavior.                                      
                                                                                                                                                                                                 
  This is a targeted validation fix: valid V1/V2 payloads continue to deserialize as before, while mixed-version inputs are now rejected.                                                        
                                                                                                                                                                                                 
  ## PR Checklist                                                                                                                                                                                
                                                                                                                                                                                                 
  - [x] Added Tests                                                                                                                                                                              
  - [ ] Added Documentation                                                                                                                                                                      
  - [ ] Breaking changes