### PR TITLE
fix(transport-http): preserve JSON-RPC errors from non-2xx

### DIFF
--- a/crates/transport-http/src/hyper_transport.rs
+++ b/crates/transport-http/src/hyper_transport.rs
@@ -152,6 +152,10 @@ where
         }
 
         if !status.is_success() {
+            if let Some(response) = crate::json_rpc_error_response(body.as_ref()) {
+                return Ok(response);
+            }
+
             return Err(TransportErrorKind::http_error(
                 status.as_u16(),
                 String::from_utf8_lossy(&body).into_owned(),

--- a/crates/transport-http/src/lib.rs
+++ b/crates/transport-http/src/lib.rs
@@ -37,6 +37,12 @@ use core::str::FromStr;
 use std::marker::PhantomData;
 use url::Url;
 
+#[cfg(any(feature = "reqwest", all(not(target_family = "wasm"), feature = "hyper")))]
+fn json_rpc_error_response(body: &[u8]) -> Option<alloy_json_rpc::ResponsePacket> {
+    let response = serde_json::from_slice::<alloy_json_rpc::ResponsePacket>(body).ok()?;
+    response.is_error().then_some(response)
+}
+
 /// Connection details for an HTTP transport.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[doc(hidden)]
@@ -117,5 +123,31 @@ impl<T> Http<T> {
     /// Get a reference to the URL.
     pub fn url(&self) -> &str {
         self.url.as_ref()
+    }
+}
+
+#[cfg(all(test, any(feature = "reqwest", all(not(target_family = "wasm"), feature = "hyper"))))]
+mod tests {
+    #[test]
+    fn parses_json_rpc_errors_from_http_error_body() {
+        let body = br#"{
+            "jsonrpc": "2.0",
+            "id": 1766,
+            "error": {
+                "code": -32000,
+                "message": "filter not found"
+            }
+        }"#;
+
+        let response = super::json_rpc_error_response(body).expect("valid JSON-RPC error response");
+
+        assert!(response.is_error());
+        assert_eq!(response.first_error_code(), Some(-32000));
+        assert_eq!(response.first_error_message(), Some("filter not found"));
+    }
+
+    #[test]
+    fn ignores_non_json_rpc_error_body() {
+        assert!(super::json_rpc_error_response(b"too many requests").is_none());
     }
 }

--- a/crates/transport-http/src/reqwest_transport.rs
+++ b/crates/transport-http/src/reqwest_transport.rs
@@ -61,6 +61,10 @@ impl Http<Client> {
         }
 
         if !status.is_success() {
+            if let Some(response) = crate::json_rpc_error_response(&body) {
+                return Ok(response);
+            }
+
             return Err(TransportErrorKind::http_error(
                 status.as_u16(),
                 String::from_utf8_lossy(&body).into_owned(),


### PR DESCRIPTION
## Summary

Preserves valid JSON-RPC error responses returned with non-2xx HTTP status codes in the reqwest and hyper HTTP transports.

## Example

Some providers return protocol-level JSON-RPC errors with an HTTP error status. One observed case from Alchemy was an `eth_getFilterChanges` request returning HTTP `400` with this JSON-RPC body:

```json
{
  "jsonrpc": "2.0",
  "id": 1766,
  "error": {
    "code": -32000,
    "message": "filter not found"
  }
}
```

Before this change, the HTTP transports converted that response into a transport `HttpError`, so callers could not inspect the JSON-RPC error payload. For long-running filter pollers, that means existing terminal-error handling for `filter not found` is bypassed.

## Fix

When a non-2xx HTTP response is received, the transports now first try to parse the body as a JSON-RPC response packet. If the body contains a valid JSON-RPC error response, it is returned through the normal response path so existing RPC error handling can classify it. Non-JSON-RPC HTTP failures still return the existing transport `HttpError`.

## Validation

Validated the focused transport crate across default, no-feature, and hyper-only feature sets, including clippy for the touched feature paths.