### PR TITLE
docs(rpc-types-engine): include ExecutionPayloadV4 in docs

### DIFF
--- a/crates/rpc-types-engine/src/payload.rs
+++ b/crates/rpc-types-engine/src/payload.rs
@@ -2146,8 +2146,8 @@ impl TryFrom<BlobsBundleV2> for BlobsBundleV1 {
     }
 }
 
-/// An execution payload, which can be either [ExecutionPayloadV1], [ExecutionPayloadV2], or
-/// [ExecutionPayloadV3].
+/// An execution payload, which can be either [ExecutionPayloadV1], [ExecutionPayloadV2],
+/// [ExecutionPayloadV3], or [ExecutionPayloadV4].
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[cfg_attr(feature = "serde", serde(untagged))]


### PR DESCRIPTION
Update the `ExecutionPayload` doc comment to include `ExecutionPayloadV4`.