### PR TITLE
chore(deps): bump alloy-eip7928 to 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ alloy-chains = { version = "0.2", default-features = false }
 alloy-eip2124 = { version = "0.2.0", default-features = false }
 alloy-eip2930 = { version = "0.2.3", default-features = false }
 alloy-eip7702 = { version = "0.6.3", default-features = false }
-alloy-eip7928 = { version = "0.3", default-features = false }
+alloy-eip7928 = { version = "0.4", default-features = false }
 
 # hardforks
 alloy-hardforks = "0.2.0"


### PR DESCRIPTION
## Summary

Bumps the workspace `alloy-eip7928` dependency from `0.3` to `0.4`.

## Impact

This keeps Alloy EIP-7928 integration on the latest `0.4.x` line so downstream consumers can validate compatibility before the next Alloy patch release.
