### PR TITLE
fix(provider): avoid watch hang on stale block numbers

### DIFF
--- a/crates/provider/src/heart.rs
+++ b/crates/provider/src/heart.rs
@@ -208,7 +208,37 @@ impl<N: Network> PendingTransactionBuilder<N> {
     /// - [`get_receipt`](Self::get_receipt) for fetching the receipt after the transaction has been
     ///   confirmed.
     pub async fn watch(self) -> Result<TxHash, PendingTransactionError> {
-        self.register().await?.await
+        let hash = self.config.tx_hash;
+        let required_confirmations = self.config.required_confirmations;
+        let mut pending_tx = self.provider.watch_pending_transaction(self.config).await?;
+
+        // Polling `eth_getTransactionReceipt` for single-confirmation watchers avoids hangs when
+        // heartbeat block progression is delayed (e.g. stale `eth_blockNumber` responses).
+        let mut interval = if required_confirmations > 1 {
+            None
+        } else {
+            Some(interval(self.provider.client().poll_interval()))
+        };
+
+        loop {
+            let tick_fut = if let Some(interval) = interval.as_mut() {
+                interval.tick().map(|_| ()).left_future()
+            } else {
+                pending::<()>().right_future()
+            };
+
+            select! {
+                _ = tick_fut => {},
+                res = &mut pending_tx => {
+                    let _ = res?;
+                    return Ok(hash);
+                }
+            }
+
+            if self.provider.get_transaction_receipt(hash).await?.is_some() {
+                return Ok(hash);
+            }
+        }
     }
 
     /// Waits for the transaction to confirm with the given number of confirmations, and

--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -1781,13 +1781,25 @@ mod tests {
         AnyNetwork, EthereumWallet, NetworkTransactionBuilder, TransactionBuilder,
     };
     use alloy_node_bindings::{utils::run_with_tempdir, Anvil, Reth};
-    use alloy_primitives::{address, b256, bytes, keccak256};
+    use alloy_primitives::{address, b256, bytes, keccak256, B256, U64};
     use alloy_rlp::Decodable;
     use alloy_rpc_client::{BuiltInConnectionString, RpcClient};
-    use alloy_rpc_types_eth::{request::TransactionRequest, Block};
+    use alloy_rpc_types_eth::{request::TransactionRequest, Block, TransactionReceipt};
     use alloy_signer_local::PrivateKeySigner;
-    use alloy_transport::layers::{RetryBackoffLayer, RetryPolicy};
-    use std::{io::Read, str::FromStr, time::Duration};
+    use alloy_transport::{
+        layers::{RetryBackoffLayer, RetryPolicy},
+        TransportError, TransportFut,
+    };
+    use std::{
+        io::Read,
+        str::FromStr,
+        sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc,
+        },
+        task::Poll,
+        time::Duration,
+    };
 
     // For layer transport tests
     use alloy_consensus::transaction::SignerRecoverable;
@@ -1805,6 +1817,118 @@ mod tests {
     use http_body_util::Full;
     #[cfg(feature = "hyper")]
     use tower::{Layer, Service};
+
+    #[derive(Clone, Default)]
+    struct StaleBlockNumberState {
+        receipt_calls: Arc<AtomicUsize>,
+    }
+
+    #[derive(Clone)]
+    struct StaleBlockNumberTransport {
+        state: StaleBlockNumberState,
+        tx_hash: B256,
+    }
+
+    impl StaleBlockNumberTransport {
+        fn new(tx_hash: B256) -> Self {
+            Self { state: StaleBlockNumberState::default(), tx_hash }
+        }
+
+        fn response<T: serde::Serialize>(
+            id: &alloy_json_rpc::Id,
+            value: &T,
+        ) -> alloy_json_rpc::Response {
+            let raw = serde_json::to_string(value).unwrap();
+            alloy_json_rpc::Response {
+                id: id.clone(),
+                payload: alloy_json_rpc::ResponsePayload::Success(
+                    serde_json::value::RawValue::from_string(raw).unwrap(),
+                ),
+            }
+        }
+
+        fn block(number: u64) -> Block {
+            let mut block: Block = Block::default();
+            block.header.inner.number = number;
+            block
+        }
+
+        fn mined_receipt(&self) -> TransactionReceipt {
+            serde_json::from_value(serde_json::json!({
+                "transactionHash": self.tx_hash,
+                "blockHash": B256::with_last_byte(0x11),
+                "blockNumber": "0x2",
+                "logsBloom": "0x00000000000000000000000000000000000800000000000000000000000800000000000000000400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000400000000000000000",
+                "gasUsed": "0x5208",
+                "status": "0x1",
+                "contractAddress": null,
+                "cumulativeGasUsed": "0x5208",
+                "transactionIndex": "0x0",
+                "from": address!("1111111111111111111111111111111111111111"),
+                "to": address!("2222222222222222222222222222222222222222"),
+                "type": "0x2",
+                "effectiveGasPrice": "0x1",
+                "logs": []
+            }))
+            .unwrap()
+        }
+
+        fn handle_request(
+            &self,
+            req: &alloy_json_rpc::SerializedRequest,
+        ) -> alloy_json_rpc::Response {
+            match req.method() {
+                "eth_getTransactionReceipt" => {
+                    let call = self.state.receipt_calls.fetch_add(1, Ordering::Relaxed);
+                    let receipt = if call == 0 { None } else { Some(self.mined_receipt()) };
+                    Self::response(req.id(), &receipt)
+                }
+                "eth_blockNumber" => Self::response(req.id(), &U64::from(1_u64)),
+                "eth_getBlockByNumber" => {
+                    let params = req.params().expect("eth_getBlockByNumber requires params");
+                    let (tag, _full): (BlockNumberOrTag, bool) =
+                        serde_json::from_str(params.get()).unwrap();
+                    let number = match tag {
+                        BlockNumberOrTag::Number(number) => number,
+                        BlockNumberOrTag::Latest => 1,
+                        _ => unreachable!("unsupported block tag: {tag:?}"),
+                    };
+                    let block = Some(Self::block(number));
+                    Self::response(req.id(), &block)
+                }
+                other => panic!("unexpected RPC method: {other}"),
+            }
+        }
+    }
+
+    impl tower::Service<alloy_json_rpc::RequestPacket> for StaleBlockNumberTransport {
+        type Response = alloy_json_rpc::ResponsePacket;
+        type Error = TransportError;
+        type Future = TransportFut<'static>;
+
+        fn poll_ready(
+            &mut self,
+            _cx: &mut std::task::Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn call(&mut self, req: alloy_json_rpc::RequestPacket) -> Self::Future {
+            let this = self.clone();
+            Box::pin(async move {
+                Ok(match req {
+                    alloy_json_rpc::RequestPacket::Single(req) => {
+                        alloy_json_rpc::ResponsePacket::Single(this.handle_request(&req))
+                    }
+                    alloy_json_rpc::RequestPacket::Batch(reqs) => {
+                        alloy_json_rpc::ResponsePacket::Batch(
+                            reqs.iter().map(|r| this.handle_request(r)).collect(),
+                        )
+                    }
+                })
+            })
+        }
+    }
 
     #[tokio::test]
     async fn test_provider_builder() {
@@ -2204,6 +2328,30 @@ mod tests {
             .expect("Watching tx timed out")
             .expect("failed to await pending tx");
         assert_eq!(hash1, hash2);
+    }
+
+    #[tokio::test]
+    async fn test_watch_receipt_fallback_when_block_number_is_stale() {
+        let tx_hash = b256!("ea1093d492a1dcb1bef708f771a99a96ff05dcab81ca76c31940300177fcf49f");
+        let transport = StaleBlockNumberTransport::new(tx_hash);
+        let state = transport.state.clone();
+
+        let client = RpcClient::new(transport, true).with_poll_interval(Duration::from_millis(5));
+        let provider = ProviderBuilder::new().disable_recommended_fillers().connect_client(client);
+
+        let watched = tokio::time::timeout(
+            Duration::from_secs(1),
+            PendingTransactionBuilder::new(provider.root().clone(), tx_hash).watch(),
+        )
+        .await
+        .expect("watch timed out")
+        .expect("watch failed");
+
+        assert_eq!(watched, tx_hash);
+        assert!(
+            state.receipt_calls.load(Ordering::Relaxed) >= 2,
+            "watch should poll receipt when block number is stale",
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Motivation
                                                                                                                    
  PendingTransactionBuilder::watch could hang for a long time on HTTP providers when eth_blockNumber is stale.      
  In this case, heartbeat-based block progression may not advance even though the transaction receipt is already available, so .watch() can fail to resolve in practice.                                                           
                                                                                                                    
  ## Solution                                                                                                       

  Add a receipt-based fallback path to PendingTransactionBuilder::watch for single-confirmation watches (confirmations == 1): while waiting on heartbeat, poll eth_getTransactionReceipt on the provider poll interval and  return once a receipt is observed.                                                                                
  This preserves existing multi-confirmation behavior and aligns watch with the robustness already present in the get_receipt flow.                                                                                                 
  Also add a regression test that simulates stale eth_blockNumber responses and verifies watch() still completes when the receipt becomes available.                                                                               
                                                                                                                    
  ## PR Checklist                                                                                                   
                                                                                                                    
  - [x] Added Tests                                                                                                 
  - [ ] Added Documentation                                                                                         
  - [ ] Breaking changes 