### PR TITLE
feat: Provider::watch_canonical_logs_from

### DIFF
--- a/crates/provider/src/provider/erased.rs
+++ b/crates/provider/src/provider/erased.rs
@@ -1,5 +1,6 @@
 use super::{
     EthCallMany, EthGetBlock, FilterPollerBuilder, WatchBlocksFrom, WatchCanonicalBlocksFrom,
+    WatchCanonicalLogsFrom, WatchLogsFrom,
 };
 #[cfg(feature = "pubsub")]
 use crate::GetSubscription;
@@ -227,6 +228,18 @@ impl<N: Network> Provider<N> for DynProvider<N> {
 
     fn watch_canonical_blocks_from(&self, start_block: u64) -> WatchCanonicalBlocksFrom<N> {
         self.0.watch_canonical_blocks_from(start_block)
+    }
+
+    fn watch_logs_from(&self, start_block: u64, filter: &Filter) -> WatchLogsFrom<N> {
+        self.0.watch_logs_from(start_block, filter)
+    }
+
+    fn watch_canonical_logs_from(
+        &self,
+        start_block: u64,
+        filter: &Filter,
+    ) -> WatchCanonicalLogsFrom<N> {
+        self.0.watch_canonical_logs_from(start_block, filter)
     }
 
     async fn watch_full_pending_transactions(

--- a/crates/provider/src/provider/mod.rs
+++ b/crates/provider/src/provider/mod.rs
@@ -11,6 +11,15 @@ pub use watch_canonical_blocks_from::{
     CanonicalEvent, WatchCanonicalBlocksFrom, WatchCanonicalBlocksFromStream,
 };
 
+mod watch_canonical_logs_from;
+pub use watch_canonical_logs_from::{WatchCanonicalLogsFrom, WatchCanonicalLogsFromStream};
+
+mod watch_logs_from;
+pub use watch_logs_from::{BlockLogs, BlockLogsFut, WatchLogsFrom, WatchLogsFromStream};
+
+#[cfg(test)]
+mod watch_logs_test_utils;
+
 mod watch_blocks_from;
 pub use watch_blocks_from::{BlockFut, WatchBlocksFrom, WatchBlocksFromStream};
 

--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -6,7 +6,7 @@
 use super::get_block::SubFullBlocks;
 use super::{
     DynProvider, Empty, EthCallMany, MulticallBuilder, WatchBlocks, WatchBlocksFrom,
-    WatchCanonicalBlocksFrom, WatchHeaders,
+    WatchCanonicalBlocksFrom, WatchCanonicalLogsFrom, WatchHeaders, WatchLogsFrom,
 };
 #[cfg(feature = "pubsub")]
 use crate::GetSubscription;
@@ -881,6 +881,106 @@ pub trait Provider<N: Network = Ethereum>: Send + Sync {
     /// ```
     fn watch_canonical_blocks_from(&self, start_block: u64) -> WatchCanonicalBlocksFrom<N> {
         self.watch_blocks_from(start_block).canonical()
+    }
+
+    /// Stream block log batches from a historical block.
+    ///
+    /// This follows block numbers from `start_block`, fetches logs matching `filter` for each block
+    /// by block hash, and yields one future per block height. The future resolves to a block/log
+    /// batch: the block is fetched, then logs are queried by that block hash.
+    ///
+    /// This stream does not perform canonical reconciliation after a batch has been emitted. Use
+    /// [`watch_canonical_logs_from`](Self::watch_canonical_logs_from) if the caller needs removed
+    /// events when already-emitted blocks are rolled back by a later reorg.
+    ///
+    /// The filter's block option is replaced internally for each exact block; use `start_block` and
+    /// [`block_tag`](crate::provider::WatchLogsFrom::block_tag) to configure range progress.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # use alloy_eips::BlockNumberOrTag;
+    /// # use alloy_primitives::address;
+    /// # use alloy_provider::{Provider, ProviderBuilder};
+    /// # use alloy_rpc_types_eth::Filter;
+    /// # use futures::StreamExt;
+    ///
+    /// let provider = ProviderBuilder::new().connect_http("http://localhost:8545".parse()?);
+    /// let filter = Filter::new().address(address!("0x0000000000aE079eB8a274cD51c0f44a9E4d67d4"));
+    ///
+    /// let mut stream = provider
+    ///     .watch_logs_from(20_000_000, &filter)
+    ///     .block_tag(BlockNumberOrTag::Finalized)
+    ///     .into_stream()
+    ///     .buffered(4);
+    ///
+    /// while let Some(batch) = stream.next().await {
+    ///     let block_logs = batch?;
+    ///     for log in block_logs.logs {
+    ///         let _ = log;
+    ///     }
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn watch_logs_from(&self, start_block: u64, filter: &Filter) -> WatchLogsFrom<N> {
+        WatchLogsFrom::new(self.weak_client(), start_block, filter.clone())
+    }
+
+    /// Stream canonical block log events from a historical block.
+    ///
+    /// This follows canonical blocks from `start_block`, fetches logs matching `filter` for each
+    /// block by block hash, and emits block-scoped log batches. Removed events use retained logs
+    /// when a block is rolled back by a reorg. The filter's block option is replaced internally for
+    /// each exact block; use `start_block` and
+    /// [`block_tag`](crate::provider::WatchCanonicalLogsFrom::block_tag) to configure range
+    /// progress.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # use alloy_eips::BlockNumberOrTag;
+    /// # use alloy_primitives::address;
+    /// # use alloy_provider::{CanonicalEvent, Provider, ProviderBuilder};
+    /// # use alloy_rpc_types_eth::Filter;
+    /// # use futures::StreamExt;
+    ///
+    /// let provider = ProviderBuilder::new().connect_http("http://localhost:8545".parse()?);
+    /// let filter = Filter::new().address(address!("0x0000000000aE079eB8a274cD51c0f44a9E4d67d4"));
+    ///
+    /// let mut stream = provider
+    ///     .watch_canonical_logs_from(20_000_000, &filter)
+    ///     .block_tag(BlockNumberOrTag::Finalized)
+    ///     .rpc_concurrency(4)
+    ///     .max_reorg_depth(64)
+    ///     .into_stream();
+    ///
+    /// while let Some(event) = stream.next().await {
+    ///     match event {
+    ///         Ok(CanonicalEvent::Added(block_logs)) => {
+    ///             for log in block_logs.logs {
+    ///                 let _ = log;
+    ///             }
+    ///         }
+    ///         Ok(CanonicalEvent::Removed(block_logs)) => {
+    ///             for log in block_logs.logs {
+    ///                 let _ = log;
+    ///             }
+    ///         }
+    ///         Err(err) => eprintln!("canonical log stream failed: {err}"),
+    ///     }
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn watch_canonical_logs_from(
+        &self,
+        start_block: u64,
+        filter: &Filter,
+    ) -> WatchCanonicalLogsFrom<N> {
+        self.watch_logs_from(start_block, filter).canonical()
     }
 
     /// Watch for new pending transaction bodies by polling the provider with

--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -885,9 +885,10 @@ pub trait Provider<N: Network = Ethereum>: Send + Sync {
 
     /// Stream block log batches from a historical block.
     ///
-    /// This follows block numbers from `start_block`, fetches logs matching `filter` for each block
-    /// by block hash, and yields one future per block height. The future resolves to a block/log
-    /// batch: the block is fetched, then logs are queried by that block hash.
+    /// This follows block numbers from `start_block` and yields one future per block height. Each
+    /// future fetches the block and a one-block log range concurrently, using the range logs when
+    /// they match the fetched block hash and falling back to a block-hash log query when the range
+    /// result is empty or ambiguous.
     ///
     /// This stream does not perform canonical reconciliation after a batch has been emitted. Use
     /// [`watch_canonical_logs_from`](Self::watch_canonical_logs_from) if the caller needs removed
@@ -930,10 +931,9 @@ pub trait Provider<N: Network = Ethereum>: Send + Sync {
 
     /// Stream canonical block log events from a historical block.
     ///
-    /// This follows canonical blocks from `start_block`, fetches logs matching `filter` for each
-    /// block by block hash, and emits block-scoped log batches. Removed events use retained logs
-    /// when a block is rolled back by a reorg. The filter's block option is replaced internally for
-    /// each exact block; use `start_block` and
+    /// This follows canonical blocks from `start_block` and emits block-scoped log batches.
+    /// Removed events use retained logs when a block is rolled back by a reorg. The filter's block
+    /// option is replaced internally for each exact block; use `start_block` and
     /// [`block_tag`](crate::provider::WatchCanonicalLogsFrom::block_tag) to configure range
     /// progress.
     ///

--- a/crates/provider/src/provider/watch_blocks_from.rs
+++ b/crates/provider/src/provider/watch_blocks_from.rs
@@ -26,22 +26,22 @@ use wasmtimer::{
 #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
 use tokio::time::{interval_at, Instant, Interval};
 
-const DEFAULT_POLL_INTERVAL: Duration = Duration::from_secs(1);
+pub(super) const DEFAULT_POLL_INTERVAL: Duration = Duration::from_secs(1);
 
 #[derive(Debug)]
-struct PollIntervalDelay {
+pub(super) struct PollIntervalDelay {
     timer: Option<Interval>,
 }
 
 impl PollIntervalDelay {
-    fn new(poll_interval: Duration) -> Self {
+    pub(super) fn new(poll_interval: Duration) -> Self {
         if poll_interval.is_zero() {
             return Self { timer: None };
         }
         Self { timer: Some(interval_at(Instant::now() + poll_interval, poll_interval)) }
     }
 
-    fn poll(&mut self, cx: &mut Context<'_>) -> Poll<()> {
+    pub(super) fn poll(&mut self, cx: &mut Context<'_>) -> Poll<()> {
         if let Some(timer) = &mut self.timer {
             ready!(timer.poll_tick(cx));
         }
@@ -177,7 +177,7 @@ where
 
 #[pin_project]
 #[derive(Debug)]
-struct FetchHeadFut<HeaderResp>
+pub(super) struct FetchHeadFut<HeaderResp>
 where
     HeaderResp: HeaderResponse + RpcRecv,
 {
@@ -209,7 +209,7 @@ impl<HeaderResp> FetchHeadFut<HeaderResp>
 where
     HeaderResp: HeaderResponse + RpcRecv,
 {
-    fn new(client: Arc<RpcClientInner>, tag: BlockNumberOrTag) -> Self {
+    pub(super) fn new(client: Arc<RpcClientInner>, tag: BlockNumberOrTag) -> Self {
         let state = match tag {
             BlockNumberOrTag::Number(number) => {
                 FetchHeadFutState::Ready { result: Some(Ok(number)) }

--- a/crates/provider/src/provider/watch_blocks_from.rs
+++ b/crates/provider/src/provider/watch_blocks_from.rs
@@ -49,7 +49,16 @@ impl PollIntervalDelay {
     }
 }
 
-/// Future returned by [`WatchBlocksFromStream`] items.
+/// Future that fetches one block by number.
+///
+/// This is the item yielded by [`WatchBlocksFromStream`], and is also reused by
+/// [`WatchLogsFrom`](super::WatchLogsFrom) to fetch the block paired with a log batch. The future
+/// requests `eth_getBlockByNumber` with either transaction hashes or full transaction bodies,
+/// depending on [`BlockTransactionsKind`].
+///
+/// A `null` block response means the requested height is not available yet. In that case the future
+/// sleeps for the configured poll interval and retries the same height. Other transport/RPC errors
+/// are returned to the caller, so retry policy should be configured on the provider transport.
 #[pin_project]
 #[derive(Debug)]
 pub struct BlockFut<T>
@@ -70,16 +79,16 @@ enum BlockFutState<T>
 where
     T: BlockResponse + RpcRecv,
 {
+    /// Polling an `eth_getBlockByNumber` request for the target height.
     Request {
         #[pin]
         call: RpcCall<(BlockNumberOrTag, bool), Option<T>>,
     },
-    Sleeping {
-        delay: PollIntervalDelay,
-    },
-    Ready {
-        result: Option<TransportResult<T>>,
-    },
+    /// Waiting before retrying the same height after the node returned `null`.
+    Sleeping { delay: PollIntervalDelay },
+    /// Returning a prebuilt result, used when the parent stream cannot create a normal request.
+    Ready { result: Option<TransportResult<T>> },
+    /// Future has completed and must not be polled again.
     Complete,
 }
 
@@ -175,6 +184,12 @@ where
     }
 }
 
+/// Future that resolves a block tag into a numeric head height.
+///
+/// `WatchBlocksFromStream` and `WatchLogsFromStream` use this before yielding per-height futures so
+/// they only schedule work through the configured head tag. Numeric tags and `earliest` resolve
+/// immediately. `latest` uses `eth_blockNumber`; other tags use `eth_getBlockByNumber` and return
+/// the tagged block's header number.
 #[pin_project]
 #[derive(Debug)]
 pub(super) struct FetchHeadFut<HeaderResp>
@@ -191,17 +206,19 @@ enum FetchHeadFutState<HeaderResp>
 where
     HeaderResp: HeaderResponse + RpcRecv,
 {
+    /// Polling `eth_blockNumber` for a `latest` head.
     Latest {
         #[pin]
         call: RpcCall<[(); 0], U64>,
     },
+    /// Polling `eth_getBlockByNumber` for a non-latest tag such as finalized or safe.
     Tagged {
         #[pin]
         call: RpcCall<(BlockNumberOrTag, bool), Option<HeaderResp>>,
     },
-    Ready {
-        result: Option<TransportResult<u64>>,
-    },
+    /// Returning an immediately known height, such as a numeric tag or `earliest`.
+    Ready { result: Option<TransportResult<u64>> },
+    /// Future has completed and must not be polled again.
     Complete,
 }
 

--- a/crates/provider/src/provider/watch_canonical_blocks_from.rs
+++ b/crates/provider/src/provider/watch_canonical_blocks_from.rs
@@ -270,17 +270,17 @@ impl<N: Network> Stream for WatchCanonicalBlocksFromStream<N> {
 }
 
 #[derive(Debug)]
-struct FixedBuf<T> {
+pub(super) struct FixedBuf<T> {
     buf: VecDeque<T>,
 }
 
 impl<T> FixedBuf<T> {
-    fn new(capacity: usize) -> Self {
+    pub(super) fn new(capacity: usize) -> Self {
         Self { buf: VecDeque::with_capacity(capacity.max(1)) }
     }
 
     /// Pushes `item` and discards the oldest item if the buffer is full.
-    fn push(&mut self, item: T) {
+    pub(super) fn push(&mut self, item: T) {
         if self.buf.len() == self.buf.capacity() {
             self.buf.pop_front();
         }
@@ -288,15 +288,15 @@ impl<T> FixedBuf<T> {
     }
 
     /// Returns the most recent item, if any.
-    fn pop(&mut self) -> Option<T> {
+    pub(super) fn pop(&mut self) -> Option<T> {
         self.buf.pop_back()
     }
 
-    fn last(&self) -> Option<&T> {
+    pub(super) fn last(&self) -> Option<&T> {
         self.buf.back()
     }
 
-    fn len(&self) -> usize {
+    pub(super) fn len(&self) -> usize {
         self.buf.len()
     }
 }

--- a/crates/provider/src/provider/watch_canonical_logs_from.rs
+++ b/crates/provider/src/provider/watch_canonical_logs_from.rs
@@ -1,0 +1,572 @@
+use super::{
+    watch_canonical_blocks_from::FixedBuf, BlockLogs, BlockLogsFut, CanonicalEvent, WatchLogsFrom,
+    WatchLogsFromStream,
+};
+use crate::transport::TransportErrorKind;
+use alloy_consensus::BlockHeader;
+use alloy_eips::BlockNumberOrTag;
+use alloy_network::{BlockResponse as _, Network};
+use alloy_network_primitives::HeaderResponse;
+use alloy_transport::{TransportError, TransportResult};
+use futures::{stream::Buffered, Stream, StreamExt as _};
+use pin_project::pin_project;
+use std::{
+    collections::VecDeque,
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+    time::Duration,
+};
+
+const RPC_CONCURRENCY_DEFAULT: usize = 4;
+const MAX_REORG_DEPTH_DEFAULT: usize = 64;
+
+/// A builder for streaming canonical log batches from a historical block.
+///
+/// This wraps a block/log source stream and performs reorg detection like
+/// [`super::WatchCanonicalBlocksFrom`]. Each item represents one canonical block and the logs in
+/// that block matching the configured [`Filter`](alloy_rpc_types_eth::Filter). When the chain tip
+/// changes incompatibly, the stream yields [`CanonicalEvent::Removed`] for retained block log
+/// batches followed by
+/// [`CanonicalEvent::Added`] for the new canonical chain segment.
+///
+/// Logs are fetched by exact block hash, so each emitted batch is internally consistent with the
+/// block it carries. If a later block reveals that an emitted batch was on a fork, the stream uses
+/// retained history to emit [`CanonicalEvent::Removed`] for that batch before adding the new
+/// canonical segment.
+///
+/// Blocks with no matching logs are still emitted with an empty log vector. This keeps stream
+/// progress and [`max_reorg_depth`](Self::max_reorg_depth) aligned to block depth rather than log
+/// count.
+///
+/// RPC errors are surfaced to the caller. Configure retries on the underlying client transport for
+/// transport-level retry behavior.
+#[derive(Debug)]
+#[must_use = "this builder does nothing unless you call `.into_stream`"]
+pub struct WatchCanonicalLogsFrom<N: Network> {
+    watch_logs_from: WatchLogsFrom<N>,
+    rpc_concurrency: usize,
+    max_reorg_depth: usize,
+}
+
+impl<N: Network> WatchCanonicalLogsFrom<N> {
+    pub(crate) const fn new(watch_logs_from: WatchLogsFrom<N>) -> Self {
+        Self {
+            watch_logs_from,
+            rpc_concurrency: RPC_CONCURRENCY_DEFAULT,
+            max_reorg_depth: MAX_REORG_DEPTH_DEFAULT,
+        }
+    }
+
+    /// Streams block log batches with full transaction bodies in the block response.
+    pub fn full(mut self) -> Self {
+        self.watch_logs_from = self.watch_logs_from.full();
+        self
+    }
+
+    /// Streams block log batches with transaction hashes only in the block response.
+    pub fn hashes(mut self) -> Self {
+        self.watch_logs_from = self.watch_logs_from.hashes();
+        self
+    }
+
+    /// Sets the poll interval used when the stream is caught up to the configured head tag.
+    pub fn poll_interval(mut self, poll_interval: Duration) -> Self {
+        self.watch_logs_from = self.watch_logs_from.poll_interval(poll_interval);
+        self
+    }
+
+    /// Sets the head block tag used to determine stream progress.
+    ///
+    /// The stream fetches all block log batches from `start_block` through this head, then polls
+    /// again after [`poll_interval`](Self::poll_interval) once caught up.
+    pub fn block_tag(mut self, block_tag: BlockNumberOrTag) -> Self {
+        self.watch_logs_from = self.watch_logs_from.block_tag(block_tag);
+        self
+    }
+
+    /// Sets the number of in-flight block/log RPC request groups.
+    ///
+    /// Results are still emitted in block-number order. A value of `0` is clamped to `1`.
+    pub const fn rpc_concurrency(mut self, rpc_concurrency: usize) -> Self {
+        self.rpc_concurrency = if rpc_concurrency == 0 { 1 } else { rpc_concurrency };
+        self
+    }
+
+    /// Sets the maximum number of canonical blocks and their logs retained for reorg detection.
+    ///
+    /// Removed events can only be emitted for blocks still retained in this buffer. A reorg deeper
+    /// than the retained history yields a terminal error. A value of `0` is clamped to `1`.
+    pub const fn max_reorg_depth(mut self, max_reorg_depth: usize) -> Self {
+        self.max_reorg_depth = if max_reorg_depth == 0 { 1 } else { max_reorg_depth };
+        self
+    }
+
+    /// Converts the builder into a stream of canonical block log events.
+    ///
+    /// The returned stream emits [`CanonicalEvent`] values containing [`BlockLogs`].
+    /// Added events contain logs with `removed = false`; removed events contain retained logs with
+    /// `removed = true`.
+    pub fn into_stream(self) -> WatchCanonicalLogsFromStream<N> {
+        let Self { watch_logs_from, rpc_concurrency, max_reorg_depth } = self;
+        let stream = watch_logs_from.clone().into_stream().buffered(rpc_concurrency.max(1));
+
+        WatchCanonicalLogsFromStream {
+            watch_logs_from,
+            stream,
+            buffer: FixedBuf::new(max_reorg_depth),
+            state: WatchCanonicalLogsFromState::PollNext,
+        }
+    }
+}
+
+#[derive(Debug)]
+enum WatchCanonicalLogsFromState<N: Network> {
+    /// Polling the next block/log pair from `WatchLogsFromStream`.
+    PollNext,
+    /// Reconciling `next` with the canonical buffer by walking parents.
+    Reconcile { next: BlockLogs<N>, pending: VecDeque<BlockLogs<N>> },
+    /// Polling an in-flight parent block/log fetch.
+    FetchingParent { next: BlockLogs<N>, pending: VecDeque<BlockLogs<N>>, fut: BlockLogsFut<N> },
+    /// Emitting block log batches for `pending`, then `next`.
+    EmitPending { pending: VecDeque<BlockLogs<N>>, next: Option<BlockLogs<N>> },
+    /// Yield one terminal error item and then end the stream.
+    EmitError { err: TransportError },
+    /// Stream terminated.
+    Done,
+}
+
+/// A stream of canonical log batches produced by [`WatchCanonicalLogsFrom`].
+///
+/// The stream emits one item per block, wrapped in [`CanonicalEvent`]. Added batches are emitted
+/// with logs queried by exact block hash. Removed batches are served from retained history so the
+/// stream does not need to query logs for rolled-back blocks after a reorg.
+#[derive(Debug)]
+#[pin_project]
+pub struct WatchCanonicalLogsFromStream<N: Network> {
+    watch_logs_from: WatchLogsFrom<N>,
+    #[pin]
+    stream: Buffered<WatchLogsFromStream<N>>,
+    buffer: FixedBuf<BlockLogs<N>>,
+    state: WatchCanonicalLogsFromState<N>,
+}
+
+impl<N: Network> Stream for WatchCanonicalLogsFromStream<N> {
+    type Item = TransportResult<CanonicalEvent<BlockLogs<N>>>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let mut this = self.project();
+
+        loop {
+            let state = std::mem::replace(this.state, WatchCanonicalLogsFromState::Done);
+            match state {
+                WatchCanonicalLogsFromState::PollNext => match this.stream.as_mut().poll_next(cx) {
+                    Poll::Pending => {
+                        *this.state = WatchCanonicalLogsFromState::PollNext;
+                        return Poll::Pending;
+                    }
+                    Poll::Ready(None) => {
+                        *this.state = WatchCanonicalLogsFromState::Done;
+                    }
+                    Poll::Ready(Some(Ok(next))) => {
+                        *this.state = WatchCanonicalLogsFromState::Reconcile {
+                            next,
+                            pending: VecDeque::new(),
+                        };
+                    }
+                    Poll::Ready(Some(Err(err))) => {
+                        *this.state = WatchCanonicalLogsFromState::EmitError { err };
+                    }
+                },
+                WatchCanonicalLogsFromState::Reconcile { next, pending } => {
+                    let front = pending.front().unwrap_or(&next);
+                    let Some(canonical_tip) = this.buffer.last() else {
+                        *this.state =
+                            WatchCanonicalLogsFromState::EmitPending { pending, next: Some(next) };
+                        continue;
+                    };
+
+                    let parent_hash = front.block.header().parent_hash();
+                    if parent_hash == canonical_tip.block.header().hash() {
+                        *this.state =
+                            WatchCanonicalLogsFromState::EmitPending { pending, next: Some(next) };
+                        continue;
+                    }
+
+                    let height = front.block.header().number();
+                    let canonical_height = canonical_tip.block.header().number();
+                    if canonical_height + 1 == height {
+                        let removed = this
+                            .buffer
+                            .pop()
+                            .expect("position is always < canonical buffer length");
+                        let after = if this.buffer.len() == 0 {
+                            WatchCanonicalLogsFromState::EmitError {
+                                err: TransportErrorKind::custom_str(
+                                    "Deep reorg detected; no canonical log history retained.",
+                                ),
+                            }
+                        } else {
+                            WatchCanonicalLogsFromState::Reconcile { next, pending }
+                        };
+                        *this.state = after;
+                        return Poll::Ready(Some(Ok(block_log_event(removed, true))));
+                    }
+
+                    let Some(parent_height) = height.checked_sub(1) else {
+                        *this.state = WatchCanonicalLogsFromState::EmitError {
+                            err: TransportErrorKind::custom_str(
+                                "Cannot backfill parent for genesis block during canonical log reconciliation.",
+                            ),
+                        };
+                        continue;
+                    };
+
+                    let watch_logs_from = this.watch_logs_from.clone();
+                    let fut = watch_logs_from.get_block_logs(parent_height);
+                    *this.state =
+                        WatchCanonicalLogsFromState::FetchingParent { next, pending, fut };
+                }
+                WatchCanonicalLogsFromState::FetchingParent { next, mut pending, mut fut } => {
+                    match Pin::new(&mut fut).poll(cx) {
+                        Poll::Pending => {
+                            *this.state =
+                                WatchCanonicalLogsFromState::FetchingParent { next, pending, fut };
+                            return Poll::Pending;
+                        }
+                        Poll::Ready(Err(err)) => {
+                            *this.state = WatchCanonicalLogsFromState::EmitError { err };
+                        }
+                        Poll::Ready(Ok(parent)) => {
+                            let front = pending.front().unwrap_or(&next);
+                            if parent.block.header().hash() != front.block.header().parent_hash() {
+                                // Parent no longer matches: a second reorg happened while
+                                // reconciling. Abandon this item and continue with next blocks.
+                                *this.state = WatchCanonicalLogsFromState::PollNext;
+                                continue;
+                            }
+
+                            pending.push_front(parent);
+                            *this.state = WatchCanonicalLogsFromState::Reconcile { next, pending };
+                        }
+                    }
+                }
+                WatchCanonicalLogsFromState::EmitPending { mut pending, mut next } => {
+                    if let Some(block_logs) = pending.pop_front() {
+                        this.buffer.push(block_logs.clone());
+                        *this.state = WatchCanonicalLogsFromState::EmitPending { pending, next };
+                        return Poll::Ready(Some(Ok(block_log_event(block_logs, false))));
+                    }
+
+                    if let Some(block_logs) = next.take() {
+                        this.buffer.push(block_logs.clone());
+                        *this.state = WatchCanonicalLogsFromState::PollNext;
+                        return Poll::Ready(Some(Ok(block_log_event(block_logs, false))));
+                    }
+
+                    *this.state = WatchCanonicalLogsFromState::PollNext;
+                }
+                WatchCanonicalLogsFromState::EmitError { err } => {
+                    *this.state = WatchCanonicalLogsFromState::Done;
+                    return Poll::Ready(Some(Err(err)));
+                }
+                WatchCanonicalLogsFromState::Done => {
+                    *this.state = WatchCanonicalLogsFromState::Done;
+                    return Poll::Ready(None);
+                }
+            }
+        }
+    }
+}
+
+fn block_log_event<N: Network>(
+    mut block_logs: BlockLogs<N>,
+    removed: bool,
+) -> CanonicalEvent<BlockLogs<N>> {
+    for log in &mut block_logs.logs {
+        log.removed = removed;
+    }
+
+    if removed {
+        CanonicalEvent::Removed(block_logs)
+    } else {
+        CanonicalEvent::Added(block_logs)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        super::watch_logs_test_utils::{assert_batch, block, log, MockChain},
+        *,
+    };
+    use crate::Provider;
+    use alloy_eips::BlockNumberOrTag;
+    use alloy_rpc_types_eth::Filter;
+    use futures::StreamExt;
+    use std::time::Duration;
+    use tokio::time::timeout;
+
+    async fn next_event(
+        stream: &mut WatchCanonicalLogsFromStream<alloy_network::Ethereum>,
+    ) -> CanonicalEvent<BlockLogs<alloy_network::Ethereum>> {
+        timeout(Duration::from_secs(1), stream.next()).await.unwrap().unwrap().unwrap()
+    }
+
+    fn assert_added(
+        event: CanonicalEvent<BlockLogs<alloy_network::Ethereum>>,
+        number: u64,
+        hash_last_byte: u8,
+        log_count: usize,
+    ) {
+        match event {
+            CanonicalEvent::Added(block_logs) => {
+                assert_batch(&block_logs, number, hash_last_byte, false, log_count);
+            }
+            other => panic!("expected Added({number}), got {other:?}"),
+        }
+    }
+
+    fn assert_removed(
+        event: CanonicalEvent<BlockLogs<alloy_network::Ethereum>>,
+        number: u64,
+        hash_last_byte: u8,
+        log_count: usize,
+    ) {
+        match event {
+            CanonicalEvent::Removed(block_logs) => {
+                assert_batch(&block_logs, number, hash_last_byte, true, log_count);
+            }
+            other => panic!("expected Removed({number}), got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn emits_removed_then_added_logs_on_reorg_within_buffer() {
+        let chain = MockChain::new();
+        chain.extend(&[(block(1, 1, 0), vec![log(1, 1, 0)]), (block(2, 2, 1), vec![log(2, 2, 0)])]);
+
+        let provider = chain.provider();
+        let mut stream = provider
+            .watch_canonical_logs_from(1, &Filter::new())
+            .block_tag(BlockNumberOrTag::Latest)
+            .poll_interval(Duration::from_millis(1))
+            .rpc_concurrency(2)
+            .max_reorg_depth(8)
+            .into_stream();
+
+        assert_added(next_event(&mut stream).await, 1, 1, 1);
+        assert_added(next_event(&mut stream).await, 2, 2, 1);
+
+        chain.reorg(&[
+            (block(2, 22, 1), vec![log(2, 22, 0)]),
+            (block(3, 33, 22), vec![log(3, 33, 0)]),
+        ]);
+
+        assert_removed(next_event(&mut stream).await, 2, 2, 1);
+        assert_added(next_event(&mut stream).await, 2, 22, 1);
+        assert_added(next_event(&mut stream).await, 3, 33, 1);
+    }
+
+    #[tokio::test]
+    async fn emits_empty_log_batches_for_canonical_progress() {
+        let chain = MockChain::new();
+        chain.extend(&[(block(1, 1, 0), vec![]), (block(2, 2, 1), vec![log(2, 2, 0)])]);
+
+        let provider = chain.provider();
+        let mut stream = provider
+            .watch_canonical_logs_from(1, &Filter::new())
+            .block_tag(BlockNumberOrTag::Latest)
+            .poll_interval(Duration::from_millis(1))
+            .rpc_concurrency(2)
+            .max_reorg_depth(8)
+            .into_stream();
+
+        assert_added(next_event(&mut stream).await, 1, 1, 0);
+        assert_added(next_event(&mut stream).await, 2, 2, 1);
+    }
+
+    #[tokio::test]
+    async fn backfills_parent_log_batches_when_reorg_ancestor_is_retained() {
+        let chain = MockChain::new();
+        chain.extend(&[
+            (block(1, 1, 0), vec![log(1, 1, 0)]),
+            (block(2, 2, 1), vec![log(2, 2, 0)]),
+            (block(3, 3, 2), vec![log(3, 3, 0)]),
+            (block(4, 4, 3), vec![log(4, 4, 0)]),
+        ]);
+
+        let provider = chain.provider();
+        let mut stream = provider
+            .watch_canonical_logs_from(1, &Filter::new())
+            .block_tag(BlockNumberOrTag::Latest)
+            .poll_interval(Duration::from_millis(1))
+            .rpc_concurrency(1)
+            .max_reorg_depth(8)
+            .into_stream();
+
+        assert_added(next_event(&mut stream).await, 1, 1, 1);
+        assert_added(next_event(&mut stream).await, 2, 2, 1);
+        assert_added(next_event(&mut stream).await, 3, 3, 1);
+        assert_added(next_event(&mut stream).await, 4, 4, 1);
+
+        chain.reorg(&[
+            (block(3, 33, 2), vec![log(3, 33, 0)]),
+            (block(4, 44, 33), vec![log(4, 44, 0)]),
+            (block(5, 5, 44), vec![log(5, 5, 0)]),
+        ]);
+
+        assert_removed(next_event(&mut stream).await, 4, 4, 1);
+        assert_removed(next_event(&mut stream).await, 3, 3, 1);
+        assert_added(next_event(&mut stream).await, 3, 33, 1);
+        assert_added(next_event(&mut stream).await, 4, 44, 1);
+        assert_added(next_event(&mut stream).await, 5, 5, 1);
+    }
+
+    #[tokio::test]
+    async fn recovers_when_chain_changes_during_log_backfill() {
+        let chain = MockChain::new();
+        chain.extend(&[
+            (block(1, 1, 0), vec![log(1, 1, 0)]),
+            (block(2, 2, 1), vec![log(2, 2, 0)]),
+            (block(3, 3, 2), vec![log(3, 3, 0)]),
+        ]);
+
+        let provider = chain.provider();
+        let mut stream = provider
+            .watch_canonical_logs_from(1, &Filter::new())
+            .block_tag(BlockNumberOrTag::Latest)
+            .poll_interval(Duration::from_millis(1))
+            .rpc_concurrency(1)
+            .max_reorg_depth(8)
+            .into_stream();
+
+        assert_added(next_event(&mut stream).await, 1, 1, 1);
+        assert_added(next_event(&mut stream).await, 2, 2, 1);
+        assert_added(next_event(&mut stream).await, 3, 3, 1);
+
+        chain.reorg(&[
+            (block(3, 34, 2), vec![log(3, 34, 0)]),
+            (block(4, 4, 33), vec![log(4, 4, 0)]),
+        ]);
+
+        assert_removed(next_event(&mut stream).await, 3, 3, 1);
+
+        let chain_clone = chain.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            chain_clone.reorg(&[
+                (block(3, 33, 2), vec![log(3, 33, 0)]),
+                (block(4, 44, 33), vec![log(4, 44, 0)]),
+                (block(5, 5, 44), vec![log(5, 5, 0)]),
+            ]);
+        });
+
+        assert_added(next_event(&mut stream).await, 3, 33, 1);
+        assert_added(next_event(&mut stream).await, 4, 44, 1);
+        assert_added(next_event(&mut stream).await, 5, 5, 1);
+    }
+
+    #[tokio::test]
+    async fn clamps_zero_values_for_rpc_concurrency_and_reorg_depth() {
+        let chain = MockChain::new();
+        chain.extend(&[(block(1, 1, 0), vec![log(1, 1, 0)])]);
+
+        let provider = chain.provider();
+        let mut stream = provider
+            .watch_canonical_logs_from(1, &Filter::new())
+            .block_tag(BlockNumberOrTag::Latest)
+            .poll_interval(Duration::from_millis(1))
+            .rpc_concurrency(0)
+            .max_reorg_depth(0)
+            .into_stream();
+
+        assert_added(next_event(&mut stream).await, 1, 1, 1);
+    }
+
+    #[tokio::test]
+    async fn canonical_builder_exposes_watch_logs_from_methods() {
+        let chain = MockChain::new();
+        chain.extend(&[(block(1, 1, 0), vec![log(1, 1, 0)])]);
+
+        let provider = chain.provider();
+        let mut stream = provider
+            .watch_canonical_logs_from(1, &Filter::new())
+            .block_tag(BlockNumberOrTag::Number(1))
+            .poll_interval(Duration::from_millis(1))
+            .full()
+            .rpc_concurrency(1)
+            .max_reorg_depth(8)
+            .into_stream();
+
+        assert_added(next_event(&mut stream).await, 1, 1, 1);
+        assert_eq!(chain.block_request_full_flags(), vec![true]);
+    }
+
+    #[tokio::test]
+    async fn watch_logs_from_canonical_matches_provider_method() {
+        let chain = MockChain::new();
+        chain.extend(&[(block(1, 1, 0), vec![log(1, 1, 0)])]);
+
+        let provider = chain.provider();
+        let mut stream = provider
+            .watch_logs_from(1, &Filter::new())
+            .block_tag(BlockNumberOrTag::Number(1))
+            .poll_interval(Duration::from_millis(1))
+            .hashes()
+            .canonical()
+            .rpc_concurrency(1)
+            .max_reorg_depth(8)
+            .into_stream();
+
+        assert_added(next_event(&mut stream).await, 1, 1, 1);
+        assert_eq!(chain.block_request_full_flags(), vec![false]);
+    }
+
+    #[tokio::test]
+    async fn stream_ends_when_provider_is_dropped() {
+        let chain = MockChain::new();
+        let provider = chain.provider();
+        let mut stream = provider.watch_canonical_logs_from(0, &Filter::new()).into_stream();
+        drop(provider);
+
+        let next = timeout(Duration::from_secs(1), stream.next()).await.unwrap();
+        assert!(next.is_none());
+    }
+
+    #[tokio::test]
+    async fn emits_removed_logs_before_deep_reorg_error() {
+        let chain = MockChain::new();
+        chain.extend(&[
+            (block(1, 1, 0), vec![log(1, 1, 0)]),
+            (block(2, 2, 1), vec![log(2, 2, 0)]),
+            (block(3, 3, 2), vec![log(3, 3, 0)]),
+        ]);
+
+        let provider = chain.provider();
+        let mut stream = provider
+            .watch_canonical_logs_from(1, &Filter::new())
+            .block_tag(BlockNumberOrTag::Latest)
+            .poll_interval(Duration::from_millis(1))
+            .rpc_concurrency(2)
+            .max_reorg_depth(2)
+            .into_stream();
+
+        assert_added(next_event(&mut stream).await, 1, 1, 1);
+        assert_added(next_event(&mut stream).await, 2, 2, 1);
+        assert_added(next_event(&mut stream).await, 3, 3, 1);
+
+        chain.reorg(&[
+            (block(2, 22, 11), vec![log(2, 22, 0)]),
+            (block(3, 33, 22), vec![log(3, 33, 0)]),
+            (block(4, 44, 33), vec![log(4, 44, 0)]),
+        ]);
+
+        assert_removed(next_event(&mut stream).await, 3, 3, 1);
+        assert_removed(next_event(&mut stream).await, 2, 2, 1);
+
+        let err =
+            timeout(Duration::from_secs(1), stream.next()).await.unwrap().unwrap().unwrap_err();
+        assert!(format!("{err}").contains("Deep reorg detected"));
+    }
+}

--- a/crates/provider/src/provider/watch_canonical_logs_from.rs
+++ b/crates/provider/src/provider/watch_canonical_logs_from.rs
@@ -30,10 +30,11 @@ const MAX_REORG_DEPTH_DEFAULT: usize = 64;
 /// batches followed by
 /// [`CanonicalEvent::Added`] for the new canonical chain segment.
 ///
-/// Logs are fetched by exact block hash, so each emitted batch is internally consistent with the
-/// block it carries. If a later block reveals that an emitted batch was on a fork, the stream uses
-/// retained history to emit [`CanonicalEvent::Removed`] for that batch before adding the new
-/// canonical segment.
+/// The source stream fetches each block and a one-block log range concurrently, falling back to an
+/// exact block-hash log query when the range result is empty or ambiguous. This keeps each emitted
+/// batch internally consistent with the block it carries. If a later block reveals that an emitted
+/// batch was on a fork, the stream uses retained history to emit [`CanonicalEvent::Removed`] for
+/// that batch before adding the new canonical segment.
 ///
 /// Blocks with no matching logs are still emitted with an empty log vector. This keeps stream
 /// progress and [`max_reorg_depth`](Self::max_reorg_depth) aligned to block depth rather than log
@@ -138,9 +139,9 @@ enum WatchCanonicalLogsFromState<N: Network> {
 
 /// A stream of canonical log batches produced by [`WatchCanonicalLogsFrom`].
 ///
-/// The stream emits one item per block, wrapped in [`CanonicalEvent`]. Added batches are emitted
-/// with logs queried by exact block hash. Removed batches are served from retained history so the
-/// stream does not need to query logs for rolled-back blocks after a reorg.
+/// The stream emits one item per block, wrapped in [`CanonicalEvent`]. Added batches contain logs
+/// proven to match their block hash. Removed batches are served from retained history so the stream
+/// does not need to query logs for rolled-back blocks after a reorg.
 #[derive(Debug)]
 #[pin_project]
 pub struct WatchCanonicalLogsFromStream<N: Network> {

--- a/crates/provider/src/provider/watch_logs_from.rs
+++ b/crates/provider/src/provider/watch_logs_from.rs
@@ -308,16 +308,17 @@ pub struct BlockLogsFut<N: Network> {
 enum BlockLogsFutState<N: Network> {
     /// Polling the candidate block request and optimistic one-block range log request.
     ///
-    /// Either RPC may finish first, so completed results are stored in `block` and `logs` until
-    /// both are ready. The range log result is only accepted if it proves all logs belong to the
-    /// fetched block hash; otherwise the future transitions to [`FetchLogs`](Self::FetchLogs).
+    /// Either RPC may finish first, so completed results are stored in `block` and `range_logs`
+    /// until both are ready. The range log result is only accepted if it proves all logs
+    /// belong to the fetched block hash; otherwise the future transitions to
+    /// [`FetchLogs`](Self::FetchLogs).
     FetchBlockAndLogs {
         block: Option<TransportResult<N::BlockResponse>>,
-        logs: Option<TransportResult<Vec<Log>>>,
+        range_logs: Option<TransportResult<Vec<Log>>>,
         #[pin]
         block_fut: BlockFut<N::BlockResponse>,
         #[pin]
-        logs_fut: LogsOnceFut,
+        logs_call: RpcCall<(Filter,), Vec<Log>>,
     },
     /// Polling fallback logs pinned to the fetched block hash.
     ///
@@ -326,8 +327,10 @@ enum BlockLogsFutState<N: Network> {
     /// resolves.
     FetchLogs {
         block: Option<N::BlockResponse>,
+        block_number: u64,
+        block_hash: B256,
         #[pin]
-        fut: LogsOnceFut,
+        logs_call: RpcCall<(Filter,), Vec<Log>>,
     },
     /// Returning a prebuilt result, used when the parent stream cannot create a normal request.
     Ready { result: Option<TransportResult<BlockLogs<N>>> },
@@ -344,16 +347,16 @@ impl<N: Network> BlockLogsFut<N> {
         kind: BlockTransactionsKind,
     ) -> Self {
         let block_fut = Self::block_fut(&client, block_number, poll_interval, kind);
-        let logs_fut = LogsOnceFut::by_block_number(client.clone(), filter.clone(), block_number);
+        let logs_call = Self::logs_call(&client, filter.clone().select(block_number));
         Self {
             client: Some(client),
             block_number,
             filter,
             state: BlockLogsFutState::FetchBlockAndLogs {
                 block: None,
-                logs: None,
+                range_logs: None,
                 block_fut,
-                logs_fut,
+                logs_call,
             },
         }
     }
@@ -375,6 +378,10 @@ impl<N: Network> BlockLogsFut<N> {
     ) -> BlockFut<N::BlockResponse> {
         BlockFut::new(client.clone(), block_number, kind, poll_interval)
     }
+
+    fn logs_call(client: &Arc<RpcClientInner>, filter: Filter) -> RpcCall<(Filter,), Vec<Log>> {
+        client.request("eth_getLogs", (filter,))
+    }
 }
 
 impl<N: Network> Future for BlockLogsFut<N> {
@@ -385,7 +392,12 @@ impl<N: Network> Future for BlockLogsFut<N> {
 
         loop {
             match this.state.as_mut().project() {
-                BlockLogsFutStateProj::FetchBlockAndLogs { block, logs, block_fut, logs_fut } => {
+                BlockLogsFutStateProj::FetchBlockAndLogs {
+                    block,
+                    range_logs,
+                    block_fut,
+                    logs_call,
+                } => {
                     if block.is_none() {
                         if let Poll::Ready(result) = block_fut.poll(cx) {
                             *block = Some(result.and_then(|block| {
@@ -401,9 +413,9 @@ impl<N: Network> Future for BlockLogsFut<N> {
                         }
                     }
 
-                    if logs.is_none() {
-                        if let Poll::Ready(result) = logs_fut.poll(cx) {
-                            *logs = Some(result);
+                    if range_logs.is_none() {
+                        if let Poll::Ready(result) = logs_call.poll(cx) {
+                            *range_logs = Some(result);
                         }
                     }
 
@@ -413,14 +425,14 @@ impl<N: Network> Future for BlockLogsFut<N> {
                         return Poll::Ready(Err(err));
                     }
 
-                    if block.is_none() || logs.is_none() {
+                    if block.is_none() || range_logs.is_none() {
                         return Poll::Pending;
                     }
 
                     let Ok(block_result) = block.take().expect("checked block is ready") else {
                         unreachable!("block errors are handled above");
                     };
-                    let logs_result = logs.take().expect("checked logs are ready");
+                    let logs_result = range_logs.take().expect("checked logs are ready");
 
                     let block_number = block_result.header().number();
                     let block_hash = block_result.header().hash();
@@ -439,25 +451,32 @@ impl<N: Network> Future for BlockLogsFut<N> {
                             "provider was dropped",
                         )));
                     };
-                    let fut = LogsOnceFut::by_block_hash(
-                        client.clone(),
-                        this.filter.clone(),
+                    let logs_call = BlockLogsFut::<N>::logs_call(
+                        client,
+                        this.filter.clone().at_block_hash(block_hash),
+                    );
+                    this.state.set(BlockLogsFutState::FetchLogs {
+                        block: Some(block_result),
                         block_number,
                         block_hash,
-                    );
-                    this.state.set(BlockLogsFutState::FetchLogs { block: Some(block_result), fut });
+                        logs_call,
+                    });
                 }
-                BlockLogsFutStateProj::FetchLogs { block, fut } => match ready!(fut.poll(cx)) {
-                    Ok(logs) => {
-                        let block = block.take().expect("block is present while fetching logs");
-                        this.state.set(BlockLogsFutState::Complete);
-                        return Poll::Ready(Ok(BlockLogs { block, logs }));
+                BlockLogsFutStateProj::FetchLogs { block, block_number, block_hash, logs_call } => {
+                    match ready!(logs_call.poll(cx))
+                        .and_then(|logs| normalize_logs(logs, *block_number, *block_hash))
+                    {
+                        Ok(logs) => {
+                            let block = block.take().expect("block is present while fetching logs");
+                            this.state.set(BlockLogsFutState::Complete);
+                            return Poll::Ready(Ok(BlockLogs { block, logs }));
+                        }
+                        Err(err) => {
+                            this.state.set(BlockLogsFutState::Complete);
+                            return Poll::Ready(Err(err));
+                        }
                     }
-                    Err(err) => {
-                        this.state.set(BlockLogsFutState::Complete);
-                        return Poll::Ready(Err(err));
-                    }
-                },
+                }
                 BlockLogsFutStateProj::Ready { result } => {
                     let result = result.take().expect("polled BlockLogsFut after completion");
                     this.state.set(BlockLogsFutState::Complete);
@@ -465,96 +484,6 @@ impl<N: Network> Future for BlockLogsFut<N> {
                 }
                 BlockLogsFutStateProj::Complete => panic!("polled BlockLogsFut after completion"),
             }
-        }
-    }
-}
-
-/// Future that performs one `eth_getLogs` request.
-///
-/// `LogsOnceFut` is used in two modes:
-///
-/// - [`LogValidation::Range`] queries a single numeric block range and returns raw logs. The caller
-///   decides whether those logs prove they belong to the fetched block.
-/// - [`LogValidation::BlockHash`] queries by exact block hash and normalizes returned logs to that
-///   block number/hash, rejecting conflicting metadata.
-///
-/// The future wraps exactly one `eth_getLogs` RPC. It does not retry internally; provider-level
-/// retry layers are responsible for transport retry behavior.
-#[pin_project]
-#[derive(Debug)]
-struct LogsOnceFut {
-    validation: LogValidation,
-    #[pin]
-    state: LogsOnceFutState,
-}
-
-#[derive(Clone, Copy, Debug)]
-enum LogValidation {
-    /// Return logs from a numeric one-block range without validation.
-    ///
-    /// The caller compares these logs with the concurrently fetched block and decides whether they
-    /// are precise enough to use.
-    Range,
-    /// Normalize logs from an exact block-hash query against the expected block metadata.
-    BlockHash { block_number: u64, block_hash: B256 },
-}
-
-#[pin_project(project = LogsOnceFutStateProj)]
-#[derive(Debug)]
-enum LogsOnceFutState {
-    /// Polling the in-flight `eth_getLogs` request.
-    ///
-    /// The request parameters depend on [`LogValidation`]: either a one-block numeric range or an
-    /// exact block hash.
-    Request {
-        #[pin]
-        call: RpcCall<(Filter,), Vec<Log>>,
-    },
-    /// Future has completed and must not be polled again.
-    Complete,
-}
-
-impl LogsOnceFut {
-    fn by_block_hash(
-        client: Arc<RpcClientInner>,
-        filter: Filter,
-        block_number: u64,
-        block_hash: B256,
-    ) -> Self {
-        let filter = filter.at_block_hash(block_hash);
-        Self {
-            validation: LogValidation::BlockHash { block_number, block_hash },
-            state: LogsOnceFutState::Request { call: client.request("eth_getLogs", (filter,)) },
-        }
-    }
-
-    fn by_block_number(client: Arc<RpcClientInner>, filter: Filter, block_number: u64) -> Self {
-        let filter = filter.select(block_number);
-        Self {
-            validation: LogValidation::Range,
-            state: LogsOnceFutState::Request { call: client.request("eth_getLogs", (filter,)) },
-        }
-    }
-}
-
-impl Future for LogsOnceFut {
-    type Output = TransportResult<Vec<Log>>;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let mut this = self.project();
-
-        match this.state.as_mut().project() {
-            LogsOnceFutStateProj::Request { call } => {
-                let result = ready!(call.poll(cx)).and_then(|logs| match *this.validation {
-                    LogValidation::Range => Ok(logs),
-                    LogValidation::BlockHash { block_number, block_hash } => {
-                        normalize_logs(logs, block_number, block_hash)
-                    }
-                });
-                this.state.set(LogsOnceFutState::Complete);
-                Poll::Ready(result)
-            }
-            LogsOnceFutStateProj::Complete => panic!("polled LogsOnceFut after completion"),
         }
     }
 }

--- a/crates/provider/src/provider/watch_logs_from.rs
+++ b/crates/provider/src/provider/watch_logs_from.rs
@@ -451,10 +451,8 @@ impl<N: Network> Future for BlockLogsFut<N> {
                             "provider was dropped",
                         )));
                     };
-                    let logs_call = BlockLogsFut::<N>::logs_call(
-                        client,
-                        this.filter.clone().at_block_hash(block_hash),
-                    );
+                    let logs_call =
+                        Self::logs_call(client, this.filter.clone().at_block_hash(block_hash));
                     this.state.set(BlockLogsFutState::FetchLogs {
                         block: Some(block_result),
                         block_number,
@@ -524,7 +522,7 @@ fn normalize_range_logs_if_matches(
 
     let all_logs_match = logs.iter().all(|log| {
         log.block_hash == Some(block_hash)
-            && !log.block_number.is_some_and(|number| number != block_number)
+            && log.block_number.is_none_or(|number| number == block_number)
     });
     if !all_logs_match {
         return None;

--- a/crates/provider/src/provider/watch_logs_from.rs
+++ b/crates/provider/src/provider/watch_logs_from.rs
@@ -50,8 +50,10 @@ impl<N: Network> BlockLogs<N> {
 /// [`BlockLogsFut`] values, one future per block height from `start_block` through the configured
 /// `block_tag` head.
 ///
-/// Each future fetches the block, then fetches logs pinned to that block hash. This makes each
-/// resolved batch internally consistent even if the canonical block at that height changes later.
+/// Each future fetches the block and a one-block log range concurrently. Non-empty range results
+/// are used when every log matches the fetched block hash; otherwise the future falls back to logs
+/// pinned to the fetched block hash. This keeps each resolved batch internally consistent even if
+/// the canonical block at that height changes later.
 ///
 /// # Examples
 ///
@@ -277,8 +279,20 @@ impl<N: Network> Stream for WatchLogsFromStream<N> {
 
 /// Future that resolves to a block/log batch for one block height.
 ///
-/// The future first fetches the block at `block_number`, then queries `eth_getLogs` pinned to that
-/// block hash.
+/// `BlockLogsFut` is the item produced by [`WatchLogsFromStream`]. It performs the two pieces of
+/// work needed for one height:
+///
+/// - fetch the block with `eth_getBlockByNumber`;
+/// - fetch matching logs for the same numeric height with `eth_getLogs`.
+///
+/// Those two requests are started concurrently to reduce latency. The numeric-range log result is
+/// only used as a fast path when it is non-empty and every returned log carries the fetched block
+/// hash. If the range result is empty, has missing/mismatched metadata, or returns an RPC error,
+/// the future falls back to a second `eth_getLogs` request pinned to the fetched block hash.
+///
+/// This means every successful output is internally consistent: `logs` are normalized to the
+/// returned block number and block hash. A block-fetch error is returned directly; fallback log
+/// errors are returned after the block has been fetched.
 #[pin_project]
 #[derive(Debug)]
 pub struct BlockLogsFut<N: Network> {
@@ -292,20 +306,32 @@ pub struct BlockLogsFut<N: Network> {
 #[pin_project(project = BlockLogsFutStateProj)]
 #[derive(Debug)]
 enum BlockLogsFutState<N: Network> {
-    /// Fetching the candidate block by number.
-    FetchBlock {
+    /// Polling the candidate block request and optimistic one-block range log request.
+    ///
+    /// Either RPC may finish first, so completed results are stored in `block` and `logs` until
+    /// both are ready. The range log result is only accepted if it proves all logs belong to the
+    /// fetched block hash; otherwise the future transitions to [`FetchLogs`](Self::FetchLogs).
+    FetchBlockAndLogs {
+        block: Option<TransportResult<N::BlockResponse>>,
+        logs: Option<TransportResult<Vec<Log>>>,
         #[pin]
-        fut: BlockFut<N::BlockResponse>,
+        block_fut: BlockFut<N::BlockResponse>,
+        #[pin]
+        logs_fut: LogsOnceFut,
     },
-    /// Fetching logs pinned to the candidate block hash.
+    /// Polling fallback logs pinned to the fetched block hash.
+    ///
+    /// This state is entered when the optimistic range result is empty, ambiguous, mismatched, or
+    /// failed. A successful response is normalized against the stored block before the future
+    /// resolves.
     FetchLogs {
         block: Option<N::BlockResponse>,
         #[pin]
         fut: LogsOnceFut,
     },
-    /// Returning a prebuilt result.
+    /// Returning a prebuilt result, used when the parent stream cannot create a normal request.
     Ready { result: Option<TransportResult<BlockLogs<N>>> },
-    /// Future completed.
+    /// Future has completed and must not be polled again.
     Complete,
 }
 
@@ -317,12 +343,18 @@ impl<N: Network> BlockLogsFut<N> {
         poll_interval: Duration,
         kind: BlockTransactionsKind,
     ) -> Self {
-        let fut = Self::block_fut(&client, block_number, poll_interval, kind);
+        let block_fut = Self::block_fut(&client, block_number, poll_interval, kind);
+        let logs_fut = LogsOnceFut::by_block_number(client.clone(), filter.clone(), block_number);
         Self {
             client: Some(client),
             block_number,
             filter,
-            state: BlockLogsFutState::FetchBlock { fut },
+            state: BlockLogsFutState::FetchBlockAndLogs {
+                block: None,
+                logs: None,
+                block_fut,
+                logs_fut,
+            },
         }
     }
 
@@ -353,35 +385,68 @@ impl<N: Network> Future for BlockLogsFut<N> {
 
         loop {
             match this.state.as_mut().project() {
-                BlockLogsFutStateProj::FetchBlock { fut } => match ready!(fut.poll(cx)) {
-                    Ok(block) => {
-                        let block_number = block.header().number();
-                        if block_number != *this.block_number {
-                            this.state.set(BlockLogsFutState::Complete);
-                            return Poll::Ready(Err(TransportErrorKind::custom_str(
-                                "eth_getBlockByNumber returned a block with an unexpected number",
-                            )));
+                BlockLogsFutStateProj::FetchBlockAndLogs { block, logs, block_fut, logs_fut } => {
+                    if block.is_none() {
+                        if let Poll::Ready(result) = block_fut.poll(cx) {
+                            *block = Some(result.and_then(|block| {
+                                let block_number = block.header().number();
+                                if block_number != *this.block_number {
+                                    Err(TransportErrorKind::custom_str(
+                                        "eth_getBlockByNumber returned a block with an unexpected number",
+                                    ))
+                                } else {
+                                    Ok(block)
+                                }
+                            }));
                         }
-
-                        let Some(client) = this.client.as_ref() else {
-                            this.state.set(BlockLogsFutState::Complete);
-                            return Poll::Ready(Err(TransportError::local_usage_str(
-                                "provider was dropped",
-                            )));
-                        };
-                        let fut = LogsOnceFut::new(
-                            client.clone(),
-                            this.filter.clone(),
-                            block_number,
-                            block.header().hash(),
-                        );
-                        this.state.set(BlockLogsFutState::FetchLogs { block: Some(block), fut });
                     }
-                    Err(err) => {
+
+                    if logs.is_none() {
+                        if let Poll::Ready(result) = logs_fut.poll(cx) {
+                            *logs = Some(result);
+                        }
+                    }
+
+                    if block.as_ref().is_some_and(Result::is_err) {
+                        let Some(Err(err)) = block.take() else { unreachable!() };
                         this.state.set(BlockLogsFutState::Complete);
                         return Poll::Ready(Err(err));
                     }
-                },
+
+                    if block.is_none() || logs.is_none() {
+                        return Poll::Pending;
+                    }
+
+                    let Ok(block_result) = block.take().expect("checked block is ready") else {
+                        unreachable!("block errors are handled above");
+                    };
+                    let logs_result = logs.take().expect("checked logs are ready");
+
+                    let block_number = block_result.header().number();
+                    let block_hash = block_result.header().hash();
+                    if let Ok(logs) = logs_result {
+                        if let Some(logs) =
+                            normalize_range_logs_if_matches(logs, block_number, block_hash)
+                        {
+                            this.state.set(BlockLogsFutState::Complete);
+                            return Poll::Ready(Ok(BlockLogs { block: block_result, logs }));
+                        }
+                    }
+
+                    let Some(client) = this.client.as_ref() else {
+                        this.state.set(BlockLogsFutState::Complete);
+                        return Poll::Ready(Err(TransportError::local_usage_str(
+                            "provider was dropped",
+                        )));
+                    };
+                    let fut = LogsOnceFut::by_block_hash(
+                        client.clone(),
+                        this.filter.clone(),
+                        block_number,
+                        block_hash,
+                    );
+                    this.state.set(BlockLogsFutState::FetchLogs { block: Some(block_result), fut });
+                }
                 BlockLogsFutStateProj::FetchLogs { block, fut } => match ready!(fut.poll(cx)) {
                     Ok(logs) => {
                         let block = block.take().expect("block is present while fetching logs");
@@ -404,33 +469,53 @@ impl<N: Network> Future for BlockLogsFut<N> {
     }
 }
 
-/// Future that performs one `eth_getLogs` request pinned to a block hash.
+/// Future that performs one `eth_getLogs` request.
 ///
-/// The returned logs are normalized to the requested block number and hash, and rejected if the RPC
-/// response contains conflicting block metadata.
+/// `LogsOnceFut` is used in two modes:
+///
+/// - [`LogValidation::Range`] queries a single numeric block range and returns raw logs. The caller
+///   decides whether those logs prove they belong to the fetched block.
+/// - [`LogValidation::BlockHash`] queries by exact block hash and normalizes returned logs to that
+///   block number/hash, rejecting conflicting metadata.
+///
+/// The future wraps exactly one `eth_getLogs` RPC. It does not retry internally; provider-level
+/// retry layers are responsible for transport retry behavior.
 #[pin_project]
 #[derive(Debug)]
 struct LogsOnceFut {
-    block_number: u64,
-    block_hash: B256,
+    validation: LogValidation,
     #[pin]
     state: LogsOnceFutState,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum LogValidation {
+    /// Return logs from a numeric one-block range without validation.
+    ///
+    /// The caller compares these logs with the concurrently fetched block and decides whether they
+    /// are precise enough to use.
+    Range,
+    /// Normalize logs from an exact block-hash query against the expected block metadata.
+    BlockHash { block_number: u64, block_hash: B256 },
 }
 
 #[pin_project(project = LogsOnceFutStateProj)]
 #[derive(Debug)]
 enum LogsOnceFutState {
     /// Polling the in-flight `eth_getLogs` request.
+    ///
+    /// The request parameters depend on [`LogValidation`]: either a one-block numeric range or an
+    /// exact block hash.
     Request {
         #[pin]
         call: RpcCall<(Filter,), Vec<Log>>,
     },
-    /// Future completed.
+    /// Future has completed and must not be polled again.
     Complete,
 }
 
 impl LogsOnceFut {
-    fn new(
+    fn by_block_hash(
         client: Arc<RpcClientInner>,
         filter: Filter,
         block_number: u64,
@@ -438,8 +523,15 @@ impl LogsOnceFut {
     ) -> Self {
         let filter = filter.at_block_hash(block_hash);
         Self {
-            block_number,
-            block_hash,
+            validation: LogValidation::BlockHash { block_number, block_hash },
+            state: LogsOnceFutState::Request { call: client.request("eth_getLogs", (filter,)) },
+        }
+    }
+
+    fn by_block_number(client: Arc<RpcClientInner>, filter: Filter, block_number: u64) -> Self {
+        let filter = filter.select(block_number);
+        Self {
+            validation: LogValidation::Range,
             state: LogsOnceFutState::Request { call: client.request("eth_getLogs", (filter,)) },
         }
     }
@@ -453,8 +545,12 @@ impl Future for LogsOnceFut {
 
         match this.state.as_mut().project() {
             LogsOnceFutStateProj::Request { call } => {
-                let result = ready!(call.poll(cx))
-                    .and_then(|logs| normalize_logs(logs, *this.block_number, *this.block_hash));
+                let result = ready!(call.poll(cx)).and_then(|logs| match *this.validation {
+                    LogValidation::Range => Ok(logs),
+                    LogValidation::BlockHash { block_number, block_hash } => {
+                        normalize_logs(logs, block_number, block_hash)
+                    }
+                });
                 this.state.set(LogsOnceFutState::Complete);
                 Poll::Ready(result)
             }
@@ -485,6 +581,30 @@ fn normalize_logs(
         log.removed = false;
     }
     Ok(logs)
+}
+
+/// Accepts optimistic range logs only when they prove they belong to the fetched block hash.
+fn normalize_range_logs_if_matches(
+    logs: Vec<Log>,
+    block_number: u64,
+    block_hash: B256,
+) -> Option<Vec<Log>> {
+    if logs.is_empty() {
+        return None;
+    }
+
+    let all_logs_match = logs.iter().all(|log| {
+        log.block_hash == Some(block_hash)
+            && !log.block_number.is_some_and(|number| number != block_number)
+    });
+    if !all_logs_match {
+        return None;
+    }
+
+    Some(
+        normalize_logs(logs, block_number, block_hash)
+            .expect("range logs were checked against the target block"),
+    )
 }
 
 #[cfg(test)]
@@ -521,10 +641,11 @@ mod tests {
 
         assert_batch(&next_batch(&mut stream).await, 1, 1, false, 1);
         assert_batch(&next_batch(&mut stream).await, 2, 2, false, 1);
+        assert_eq!(chain.log_request_block_hash_flags(), vec![false, false]);
     }
 
     #[tokio::test]
-    async fn emits_empty_log_batches_for_progress() {
+    async fn falls_back_to_block_hash_logs_for_empty_range_logs() {
         let chain = MockChain::new();
         chain.extend(&[(block(1, 1, 0), vec![]), (block(2, 2, 1), vec![log(2, 2, 0)])]);
 
@@ -538,6 +659,25 @@ mod tests {
 
         assert_batch(&next_batch(&mut stream).await, 1, 1, false, 0);
         assert_batch(&next_batch(&mut stream).await, 2, 2, false, 1);
+        assert_eq!(chain.log_request_block_hash_flags(), vec![false, true, false]);
+    }
+
+    #[tokio::test]
+    async fn falls_back_to_block_hash_logs_for_mismatched_range_logs() {
+        let chain = MockChain::new();
+        chain.extend(&[(block(1, 1, 0), vec![log(1, 1, 0)])]);
+        chain.override_next_range_logs(vec![log(1, 11, 0)]);
+
+        let provider = chain.provider();
+        let mut stream = provider
+            .watch_logs_from(1, &Filter::new())
+            .block_tag(BlockNumberOrTag::Number(1))
+            .poll_interval(Duration::from_millis(1))
+            .into_stream()
+            .buffered(1);
+
+        assert_batch(&next_batch(&mut stream).await, 1, 1, false, 1);
+        assert_eq!(chain.log_request_block_hash_flags(), vec![false, true]);
     }
 
     #[tokio::test]
@@ -647,6 +787,7 @@ mod tests {
         let err =
             timeout(Duration::from_secs(1), stream.next()).await.unwrap().unwrap().unwrap_err();
         assert!(format!("{err}").contains("unexpected block number"));
+        assert_eq!(chain.log_request_block_hash_flags(), vec![false, true]);
     }
 
     #[tokio::test]

--- a/crates/provider/src/provider/watch_logs_from.rs
+++ b/crates/provider/src/provider/watch_logs_from.rs
@@ -1,0 +1,702 @@
+use super::{
+    watch_blocks_from::{FetchHeadFut, PollIntervalDelay, DEFAULT_POLL_INTERVAL},
+    BlockFut, WatchCanonicalLogsFrom,
+};
+use crate::transport::TransportErrorKind;
+use alloy_consensus::BlockHeader;
+use alloy_eips::BlockNumberOrTag;
+use alloy_json_rpc::RpcError;
+use alloy_network::{BlockResponse as _, Network};
+use alloy_network_primitives::{BlockTransactionsKind, HeaderResponse};
+use alloy_primitives::B256;
+use alloy_rpc_client::{RpcCall, RpcClientInner, WeakClient};
+use alloy_rpc_types_eth::{Filter, Log};
+use alloy_transport::{TransportError, TransportResult};
+use futures::{ready, Stream};
+use pin_project::pin_project;
+use std::{
+    future::Future,
+    marker::PhantomData,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+    time::Duration,
+};
+
+/// Logs matching a filter for a single block.
+///
+/// This is the payload resolved by [`BlockLogsFut`] and carried by canonical log events. The
+/// `block` field identifies the block whose logs were queried, and `logs` contains all matching
+/// logs for that block. `logs` may be empty when the block contained no matching logs.
+#[derive(Clone, Debug)]
+pub struct BlockLogs<N: Network> {
+    /// The block these logs belong to.
+    pub block: N::BlockResponse,
+    /// Logs matching the configured filter for `block`.
+    pub logs: Vec<Log>,
+}
+
+impl<N: Network> BlockLogs<N> {
+    /// Returns the header for the block these logs belong to.
+    pub fn header(&self) -> &N::HeaderResponse {
+        self.block.header()
+    }
+}
+
+/// A builder for streaming block log batches from a historical block.
+///
+/// `WatchLogsFrom` is the log-specific counterpart to [`super::WatchBlocksFrom`]. It does not
+/// perform canonical reconciliation or emit removed events. Instead, it produces a stream of
+/// [`BlockLogsFut`] values, one future per block height from `start_block` through the configured
+/// `block_tag` head.
+///
+/// Each future fetches the block, then fetches logs pinned to that block hash. This makes each
+/// resolved batch internally consistent even if the canonical block at that height changes later.
+///
+/// # Examples
+///
+/// ```no_run
+/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// # use alloy_eips::BlockNumberOrTag;
+/// # use alloy_provider::{Provider, ProviderBuilder};
+/// # use alloy_rpc_types_eth::Filter;
+/// # use futures::StreamExt;
+///
+/// let provider = ProviderBuilder::new().connect_http("http://localhost:8545".parse()?);
+/// let filter = Filter::new();
+///
+/// let mut stream = provider
+///     .watch_logs_from(20_000_000, &filter)
+///     .block_tag(BlockNumberOrTag::Finalized)
+///     .into_stream()
+///     .buffered(4);
+///
+/// while let Some(batch) = stream.next().await {
+///     let block_logs = batch?;
+///     let _block = block_logs.block;
+///     let _logs = block_logs.logs;
+/// }
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Clone, Debug)]
+#[must_use = "this builder does nothing unless you call `.into_stream`"]
+pub struct WatchLogsFrom<N: Network> {
+    client: WeakClient,
+    filter: Filter,
+    start_block: u64,
+    poll_interval: Duration,
+    block_tag: BlockNumberOrTag,
+    kind: BlockTransactionsKind,
+    _phantom: PhantomData<fn() -> N>,
+}
+
+impl<N: Network> WatchLogsFrom<N> {
+    pub(crate) const fn new(client: WeakClient, start_block: u64, filter: Filter) -> Self {
+        Self {
+            client,
+            filter,
+            start_block,
+            poll_interval: DEFAULT_POLL_INTERVAL,
+            block_tag: BlockNumberOrTag::Latest,
+            kind: BlockTransactionsKind::Hashes,
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Streams block log batches with full transaction bodies in the block response.
+    pub const fn full(mut self) -> Self {
+        self.kind = BlockTransactionsKind::Full;
+        self
+    }
+
+    /// Streams block log batches with transaction hashes only in the block response.
+    pub const fn hashes(mut self) -> Self {
+        self.kind = BlockTransactionsKind::Hashes;
+        self
+    }
+
+    /// Sets the poll interval used when the stream is caught up to the configured head tag.
+    pub const fn poll_interval(mut self, poll_interval: Duration) -> Self {
+        self.poll_interval = poll_interval;
+        self
+    }
+
+    /// Sets the head block tag used to determine stream progress.
+    ///
+    /// The stream fetches all block log batches from `start_block` through this head, then polls
+    /// again after [`poll_interval`](Self::poll_interval) once caught up.
+    pub const fn block_tag(mut self, block_tag: BlockNumberOrTag) -> Self {
+        self.block_tag = block_tag;
+        self
+    }
+
+    /// Converts this builder into a canonical-stream builder that emits
+    /// [`CanonicalEvent`](crate::CanonicalEvent) deltas on reorgs.
+    pub const fn canonical(self) -> WatchCanonicalLogsFrom<N> {
+        WatchCanonicalLogsFrom::new(self)
+    }
+
+    /// Creates a future that fetches one block/log batch by block number.
+    pub(super) fn get_block_logs(&self, block_number: u64) -> BlockLogsFut<N> {
+        self.client
+            .upgrade()
+            .map(|client| {
+                BlockLogsFut::new(
+                    client,
+                    block_number,
+                    self.filter.clone(),
+                    self.poll_interval,
+                    self.kind,
+                )
+            })
+            .unwrap_or_else(|| BlockLogsFut::err(RpcError::local_usage_str("provider was dropped")))
+    }
+
+    /// Stream block/log fetching futures from a historical block.
+    ///
+    /// The stream polls the configured head, yields futures for `current_block..=head`, then sleeps
+    /// for `poll_interval` once caught up. It intentionally mirrors
+    /// [`super::WatchBlocksFromStream`] so callers can apply
+    /// [`StreamExt::buffered`](futures::StreamExt::buffered) for concurrent RPC work while still
+    /// receiving resolved batches in block-number order.
+    pub const fn into_stream(self) -> WatchLogsFromStream<N> {
+        let current_block = self.start_block;
+        WatchLogsFromStream {
+            inner: self,
+            current_block,
+            head: 0,
+            state: WatchLogsFromState::FetchHead,
+        }
+    }
+}
+
+/// A stream of block/log-fetching futures.
+///
+/// Each yielded [`BlockLogsFut`] fetches one block, then fetches matching logs by that block's
+/// hash.
+#[derive(Debug)]
+pub struct WatchLogsFromStream<N: Network> {
+    inner: WatchLogsFrom<N>,
+    current_block: u64,
+    head: u64,
+    state: WatchLogsFromState<N>,
+}
+
+#[derive(Debug)]
+enum WatchLogsFromState<N: Network> {
+    /// Upgrade the client and begin fetching the current head.
+    FetchHead,
+    /// Polling the in-flight head-block-number future.
+    FetchingHead { fut: FetchHeadFut<N::HeaderResponse> },
+    /// Yielding block/log futures for `current_block..=head`.
+    Yielding,
+    /// Sleeping between poll cycles.
+    Sleeping { delay: PollIntervalDelay },
+    /// Stream terminated.
+    Done,
+}
+
+impl<N: Network> Stream for WatchLogsFromStream<N> {
+    type Item = BlockLogsFut<N>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+
+        loop {
+            match &mut this.state {
+                WatchLogsFromState::FetchHead => {
+                    let Some(client) = this.inner.client.upgrade() else {
+                        this.state = WatchLogsFromState::Done;
+                        continue;
+                    };
+                    let fut = FetchHeadFut::new(client, this.inner.block_tag);
+                    this.state = WatchLogsFromState::FetchingHead { fut };
+                }
+                WatchLogsFromState::FetchingHead { fut } => match ready!(Pin::new(fut).poll(cx)) {
+                    Ok(head) => {
+                        this.head = head;
+                        if this.current_block > head {
+                            this.state = WatchLogsFromState::Sleeping {
+                                delay: PollIntervalDelay::new(this.inner.poll_interval),
+                            };
+                        } else {
+                            this.state = WatchLogsFromState::Yielding;
+                        }
+                    }
+                    Err(err) => {
+                        this.state = WatchLogsFromState::Sleeping {
+                            delay: PollIntervalDelay::new(this.inner.poll_interval),
+                        };
+                        return Poll::Ready(Some(BlockLogsFut::err(err)));
+                    }
+                },
+                WatchLogsFromState::Yielding => {
+                    if this.current_block > this.head {
+                        this.state = WatchLogsFromState::Sleeping {
+                            delay: PollIntervalDelay::new(this.inner.poll_interval),
+                        };
+                        continue;
+                    }
+
+                    let next_block = this.current_block.saturating_add(1);
+                    if next_block <= this.current_block {
+                        let err = RpcError::local_usage_str(
+                            "watch logs stream step did not advance block cursor",
+                        );
+                        this.state = WatchLogsFromState::Sleeping {
+                            delay: PollIntervalDelay::new(this.inner.poll_interval),
+                        };
+                        return Poll::Ready(Some(BlockLogsFut::err(err)));
+                    }
+
+                    let Some(client) = this.inner.client.upgrade() else {
+                        this.state = WatchLogsFromState::Done;
+                        continue;
+                    };
+
+                    let item_fut = BlockLogsFut::new(
+                        client,
+                        this.current_block,
+                        this.inner.filter.clone(),
+                        this.inner.poll_interval,
+                        this.inner.kind,
+                    );
+                    this.current_block = next_block;
+                    return Poll::Ready(Some(item_fut));
+                }
+                WatchLogsFromState::Sleeping { delay } => {
+                    ready!(delay.poll(cx));
+                    this.state = WatchLogsFromState::FetchHead;
+                }
+                WatchLogsFromState::Done => return Poll::Ready(None),
+            }
+        }
+    }
+}
+
+/// Future that resolves to a block/log batch for one block height.
+///
+/// The future first fetches the block at `block_number`, then queries `eth_getLogs` pinned to that
+/// block hash.
+#[pin_project]
+#[derive(Debug)]
+pub struct BlockLogsFut<N: Network> {
+    client: Option<Arc<RpcClientInner>>,
+    block_number: u64,
+    filter: Filter,
+    #[pin]
+    state: BlockLogsFutState<N>,
+}
+
+#[pin_project(project = BlockLogsFutStateProj)]
+#[derive(Debug)]
+enum BlockLogsFutState<N: Network> {
+    /// Fetching the candidate block by number.
+    FetchBlock {
+        #[pin]
+        fut: BlockFut<N::BlockResponse>,
+    },
+    /// Fetching logs pinned to the candidate block hash.
+    FetchLogs {
+        block: Option<N::BlockResponse>,
+        #[pin]
+        fut: LogsOnceFut,
+    },
+    /// Returning a prebuilt result.
+    Ready { result: Option<TransportResult<BlockLogs<N>>> },
+    /// Future completed.
+    Complete,
+}
+
+impl<N: Network> BlockLogsFut<N> {
+    fn new(
+        client: Arc<RpcClientInner>,
+        block_number: u64,
+        filter: Filter,
+        poll_interval: Duration,
+        kind: BlockTransactionsKind,
+    ) -> Self {
+        let fut = Self::block_fut(&client, block_number, poll_interval, kind);
+        Self {
+            client: Some(client),
+            block_number,
+            filter,
+            state: BlockLogsFutState::FetchBlock { fut },
+        }
+    }
+
+    fn err(err: TransportError) -> Self {
+        Self {
+            client: None,
+            block_number: 0,
+            filter: Filter::new(),
+            state: BlockLogsFutState::Ready { result: Some(Err(err)) },
+        }
+    }
+
+    fn block_fut(
+        client: &Arc<RpcClientInner>,
+        block_number: u64,
+        poll_interval: Duration,
+        kind: BlockTransactionsKind,
+    ) -> BlockFut<N::BlockResponse> {
+        BlockFut::new(client.clone(), block_number, kind, poll_interval)
+    }
+}
+
+impl<N: Network> Future for BlockLogsFut<N> {
+    type Output = TransportResult<BlockLogs<N>>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let mut this = self.project();
+
+        loop {
+            match this.state.as_mut().project() {
+                BlockLogsFutStateProj::FetchBlock { fut } => match ready!(fut.poll(cx)) {
+                    Ok(block) => {
+                        let block_number = block.header().number();
+                        if block_number != *this.block_number {
+                            this.state.set(BlockLogsFutState::Complete);
+                            return Poll::Ready(Err(TransportErrorKind::custom_str(
+                                "eth_getBlockByNumber returned a block with an unexpected number",
+                            )));
+                        }
+
+                        let Some(client) = this.client.as_ref() else {
+                            this.state.set(BlockLogsFutState::Complete);
+                            return Poll::Ready(Err(TransportError::local_usage_str(
+                                "provider was dropped",
+                            )));
+                        };
+                        let fut = LogsOnceFut::new(
+                            client.clone(),
+                            this.filter.clone(),
+                            block_number,
+                            block.header().hash(),
+                        );
+                        this.state.set(BlockLogsFutState::FetchLogs { block: Some(block), fut });
+                    }
+                    Err(err) => {
+                        this.state.set(BlockLogsFutState::Complete);
+                        return Poll::Ready(Err(err));
+                    }
+                },
+                BlockLogsFutStateProj::FetchLogs { block, fut } => match ready!(fut.poll(cx)) {
+                    Ok(logs) => {
+                        let block = block.take().expect("block is present while fetching logs");
+                        this.state.set(BlockLogsFutState::Complete);
+                        return Poll::Ready(Ok(BlockLogs { block, logs }));
+                    }
+                    Err(err) => {
+                        this.state.set(BlockLogsFutState::Complete);
+                        return Poll::Ready(Err(err));
+                    }
+                },
+                BlockLogsFutStateProj::Ready { result } => {
+                    let result = result.take().expect("polled BlockLogsFut after completion");
+                    this.state.set(BlockLogsFutState::Complete);
+                    return Poll::Ready(result);
+                }
+                BlockLogsFutStateProj::Complete => panic!("polled BlockLogsFut after completion"),
+            }
+        }
+    }
+}
+
+/// Future that performs one `eth_getLogs` request pinned to a block hash.
+///
+/// The returned logs are normalized to the requested block number and hash, and rejected if the RPC
+/// response contains conflicting block metadata.
+#[pin_project]
+#[derive(Debug)]
+struct LogsOnceFut {
+    block_number: u64,
+    block_hash: B256,
+    #[pin]
+    state: LogsOnceFutState,
+}
+
+#[pin_project(project = LogsOnceFutStateProj)]
+#[derive(Debug)]
+enum LogsOnceFutState {
+    /// Polling the in-flight `eth_getLogs` request.
+    Request {
+        #[pin]
+        call: RpcCall<(Filter,), Vec<Log>>,
+    },
+    /// Future completed.
+    Complete,
+}
+
+impl LogsOnceFut {
+    fn new(
+        client: Arc<RpcClientInner>,
+        filter: Filter,
+        block_number: u64,
+        block_hash: B256,
+    ) -> Self {
+        let filter = filter.at_block_hash(block_hash);
+        Self {
+            block_number,
+            block_hash,
+            state: LogsOnceFutState::Request { call: client.request("eth_getLogs", (filter,)) },
+        }
+    }
+}
+
+impl Future for LogsOnceFut {
+    type Output = TransportResult<Vec<Log>>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let mut this = self.project();
+
+        match this.state.as_mut().project() {
+            LogsOnceFutStateProj::Request { call } => {
+                let result = ready!(call.poll(cx))
+                    .and_then(|logs| normalize_logs(logs, *this.block_number, *this.block_hash));
+                this.state.set(LogsOnceFutState::Complete);
+                Poll::Ready(result)
+            }
+            LogsOnceFutStateProj::Complete => panic!("polled LogsOnceFut after completion"),
+        }
+    }
+}
+
+/// Ensures all logs match the exact block queried and clears any stale removed flag.
+fn normalize_logs(
+    mut logs: Vec<Log>,
+    block_number: u64,
+    block_hash: B256,
+) -> TransportResult<Vec<Log>> {
+    for log in &mut logs {
+        if log.block_number.is_some_and(|number| number != block_number) {
+            return Err(TransportErrorKind::custom_str(
+                "eth_getLogs returned a log with an unexpected block number",
+            ));
+        }
+        if log.block_hash.is_some_and(|hash| hash != block_hash) {
+            return Err(TransportErrorKind::custom_str(
+                "eth_getLogs returned a log with an unexpected block hash",
+            ));
+        }
+        log.block_number = Some(block_number);
+        log.block_hash = Some(block_hash);
+        log.removed = false;
+    }
+    Ok(logs)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        super::watch_logs_test_utils::{assert_batch, block, log, MockChain},
+        *,
+    };
+    use crate::Provider;
+    use alloy_network::Ethereum;
+    use alloy_rpc_types_eth::Block;
+    use futures::{Stream, StreamExt};
+    use tokio::time::timeout;
+
+    async fn next_batch<S>(stream: &mut S) -> BlockLogs<Ethereum>
+    where
+        S: Stream<Item = TransportResult<BlockLogs<Ethereum>>> + Unpin,
+    {
+        timeout(Duration::from_secs(1), stream.next()).await.unwrap().unwrap().unwrap()
+    }
+
+    #[tokio::test]
+    async fn streams_log_batches_from_start_block() {
+        let chain = MockChain::new();
+        chain.extend(&[(block(1, 1, 0), vec![log(1, 1, 0)]), (block(2, 2, 1), vec![log(2, 2, 0)])]);
+
+        let provider = chain.provider();
+        let mut stream = provider
+            .watch_logs_from(1, &Filter::new())
+            .block_tag(BlockNumberOrTag::Latest)
+            .poll_interval(Duration::from_millis(1))
+            .into_stream()
+            .buffered(1);
+
+        assert_batch(&next_batch(&mut stream).await, 1, 1, false, 1);
+        assert_batch(&next_batch(&mut stream).await, 2, 2, false, 1);
+    }
+
+    #[tokio::test]
+    async fn emits_empty_log_batches_for_progress() {
+        let chain = MockChain::new();
+        chain.extend(&[(block(1, 1, 0), vec![]), (block(2, 2, 1), vec![log(2, 2, 0)])]);
+
+        let provider = chain.provider();
+        let mut stream = provider
+            .watch_logs_from(1, &Filter::new())
+            .block_tag(BlockNumberOrTag::Latest)
+            .poll_interval(Duration::from_millis(1))
+            .into_stream()
+            .buffered(1);
+
+        assert_batch(&next_batch(&mut stream).await, 1, 1, false, 0);
+        assert_batch(&next_batch(&mut stream).await, 2, 2, false, 1);
+    }
+
+    #[tokio::test]
+    async fn full_and_hashes_configure_block_fetch_kind() {
+        let full_chain = MockChain::new();
+        full_chain.extend(&[(block(1, 1, 0), vec![log(1, 1, 0)])]);
+
+        let provider = full_chain.provider();
+        let mut stream = provider
+            .watch_logs_from(1, &Filter::new())
+            .full()
+            .block_tag(BlockNumberOrTag::Number(1))
+            .poll_interval(Duration::from_millis(1))
+            .into_stream()
+            .buffered(1);
+
+        assert_batch(&next_batch(&mut stream).await, 1, 1, false, 1);
+        assert_eq!(full_chain.block_request_full_flags(), vec![true]);
+
+        let hashes_chain = MockChain::new();
+        hashes_chain.extend(&[(block(1, 1, 0), vec![log(1, 1, 0)])]);
+
+        let provider = hashes_chain.provider();
+        let mut stream = provider
+            .watch_logs_from(1, &Filter::new())
+            .hashes()
+            .block_tag(BlockNumberOrTag::Number(1))
+            .poll_interval(Duration::from_millis(1))
+            .into_stream()
+            .buffered(1);
+
+        assert_batch(&next_batch(&mut stream).await, 1, 1, false, 1);
+        assert_eq!(hashes_chain.block_request_full_flags(), vec![false]);
+    }
+
+    #[tokio::test]
+    async fn provider_retry_layer_retries_log_error_without_skipping_block() {
+        let chain = MockChain::new();
+        chain.extend(&[(block(1, 1, 0), vec![log(1, 1, 0)]), (block(2, 2, 1), vec![log(2, 2, 0)])]);
+        chain.fail_next_logs(1);
+
+        let provider = chain.provider_with_retry();
+        let mut stream = provider
+            .watch_logs_from(1, &Filter::new())
+            .block_tag(BlockNumberOrTag::Latest)
+            .poll_interval(Duration::from_millis(1))
+            .into_stream()
+            .buffered(1);
+
+        assert_batch(&next_batch(&mut stream).await, 1, 1, false, 1);
+        assert_batch(&next_batch(&mut stream).await, 2, 2, false, 1);
+    }
+
+    #[tokio::test]
+    async fn emits_hash_pinned_candidate_when_chain_changes_after_log_fetch() {
+        let chain = MockChain::new();
+        chain.extend(&[(block(1, 1, 0), vec![log(1, 1, 0)]), (block(2, 2, 1), vec![log(2, 2, 0)])]);
+
+        let provider = chain.provider();
+        let mut stream = provider
+            .watch_logs_from(1, &Filter::new())
+            .block_tag(BlockNumberOrTag::Latest)
+            .poll_interval(Duration::from_millis(1))
+            .into_stream()
+            .buffered(1);
+
+        assert_batch(&next_batch(&mut stream).await, 1, 1, false, 1);
+
+        chain.reorg_after_next_log_success(vec![
+            (block(2, 22, 1), vec![log(2, 22, 0)]),
+            (block(3, 33, 22), vec![log(3, 33, 0)]),
+        ]);
+
+        assert_batch(&next_batch(&mut stream).await, 2, 2, false, 1);
+        assert_batch(&next_batch(&mut stream).await, 3, 33, false, 1);
+    }
+
+    #[tokio::test]
+    async fn normalizes_log_metadata_and_clears_removed_flag() {
+        let chain = MockChain::new();
+        chain.extend(&[(block(1, 1, 0), vec![Log { removed: true, ..Default::default() }])]);
+
+        let provider = chain.provider();
+        let mut stream = provider
+            .watch_logs_from(1, &Filter::new())
+            .block_tag(BlockNumberOrTag::Latest)
+            .poll_interval(Duration::from_millis(1))
+            .into_stream()
+            .buffered(1);
+
+        assert_batch(&next_batch(&mut stream).await, 1, 1, false, 1);
+    }
+
+    #[tokio::test]
+    async fn rejects_logs_with_conflicting_metadata() {
+        let chain = MockChain::new();
+        chain.extend(&[(block(1, 1, 0), vec![log(2, 1, 0)])]);
+
+        let provider = chain.provider();
+        let mut stream = provider
+            .watch_logs_from(1, &Filter::new())
+            .block_tag(BlockNumberOrTag::Latest)
+            .poll_interval(Duration::from_millis(1))
+            .into_stream()
+            .buffered(1);
+
+        let err =
+            timeout(Duration::from_secs(1), stream.next()).await.unwrap().unwrap().unwrap_err();
+        assert!(format!("{err}").contains("unexpected block number"));
+    }
+
+    #[tokio::test]
+    async fn stream_ends_when_provider_is_dropped() {
+        let chain = MockChain::new();
+        let provider = chain.provider();
+        let mut stream = provider.watch_logs_from(0, &Filter::new()).into_stream();
+        drop(provider);
+
+        let next = timeout(Duration::from_secs(1), stream.next()).await.unwrap();
+        assert!(next.is_none());
+    }
+
+    #[tokio::test]
+    async fn yielded_future_outlives_provider() {
+        let chain = MockChain::new();
+        chain.extend(&[(block(1, 1, 0), vec![log(1, 1, 0)])]);
+
+        let provider = chain.provider();
+        let mut stream = provider
+            .watch_logs_from(1, &Filter::new())
+            .block_tag(BlockNumberOrTag::Latest)
+            .poll_interval(Duration::from_millis(1))
+            .into_stream();
+
+        let fut = timeout(Duration::from_secs(1), stream.next()).await.unwrap().unwrap();
+        drop(stream);
+        drop(provider);
+
+        let block_logs = timeout(Duration::from_secs(1), fut).await.unwrap().unwrap();
+        assert_batch(&block_logs, 1, 1, false, 1);
+    }
+
+    #[tokio::test]
+    async fn errors_when_cursor_cannot_advance() {
+        let chain = MockChain::new();
+        let mut block: Block = block(u64::MAX, 1, 0);
+        block.header.inner.number = u64::MAX;
+        chain.extend(&[(block, vec![log(u64::MAX, 1, 0)])]);
+
+        let provider = chain.provider();
+        let mut stream = provider
+            .watch_logs_from(u64::MAX, &Filter::new())
+            .block_tag(BlockNumberOrTag::Number(u64::MAX))
+            .poll_interval(Duration::from_millis(1))
+            .into_stream()
+            .buffered(1);
+
+        let err =
+            timeout(Duration::from_secs(1), stream.next()).await.unwrap().unwrap().unwrap_err();
+        assert!(err.is_local_usage_error());
+    }
+}

--- a/crates/provider/src/provider/watch_logs_test_utils.rs
+++ b/crates/provider/src/provider/watch_logs_test_utils.rs
@@ -22,6 +22,8 @@ struct ChainState {
     logs: HashMap<B256, Vec<Log>>,
     head: u64,
     block_request_full: Vec<bool>,
+    log_request_block_hash: Vec<bool>,
+    range_logs_override: Option<Vec<Log>>,
     fail_logs: usize,
     reorg_after_log_success: Option<Vec<(Block, Vec<Log>)>>,
 }
@@ -39,6 +41,8 @@ impl MockChain {
                 logs: HashMap::new(),
                 head: 0,
                 block_request_full: Vec::new(),
+                log_request_block_hash: Vec::new(),
+                range_logs_override: None,
                 fail_logs: 0,
                 reorg_after_log_success: None,
             })),
@@ -95,8 +99,16 @@ impl MockChain {
         self.state.write().unwrap().reorg_after_log_success = Some(blocks);
     }
 
+    pub(crate) fn override_next_range_logs(&self, logs: Vec<Log>) {
+        self.state.write().unwrap().range_logs_override = Some(logs);
+    }
+
     pub(crate) fn block_request_full_flags(&self) -> Vec<bool> {
         self.state.read().unwrap().block_request_full.clone()
+    }
+
+    pub(crate) fn log_request_block_hash_flags(&self) -> Vec<bool> {
+        self.state.read().unwrap().log_request_block_hash.clone()
     }
 
     pub(crate) fn provider(&self) -> impl Provider {
@@ -150,16 +162,35 @@ impl MockChain {
                 )
             }
             "eth_getLogs" => {
+                let params = req.params().expect("eth_getLogs requires params");
+                let (filter,): (Filter,) = serde_json::from_str(params.get()).unwrap();
+                let block_hash = filter.get_block_hash();
+                state.log_request_block_hash.push(block_hash.is_some());
                 if state.fail_logs > 0 {
                     state.fail_logs -= 1;
                     alloy_json_rpc::ResponsePayload::internal_error_message(
                         "temporary log error".into(),
                     )
                 } else {
-                    let params = req.params().expect("eth_getLogs requires params");
-                    let (filter,): (Filter,) = serde_json::from_str(params.get()).unwrap();
-                    let hash = filter.get_block_hash().expect("logs are queried by block hash");
-                    if let Some(logs) = state.logs.get(&hash).cloned() {
+                    let logs = if let Some(hash) = block_hash {
+                        state.logs.get(&hash).cloned()
+                    } else if let Some(logs) = state.range_logs_override.take() {
+                        Some(logs)
+                    } else {
+                        let (from_block, to_block) = filter.extract_block_range();
+                        let number = match (from_block, to_block) {
+                            (Some(from), Some(to)) if from == to => from,
+                            other => panic!("logs are queried by exact block, got {other:?}"),
+                        };
+                        state
+                            .blocks
+                            .get(&number)
+                            .and_then(|block| state.logs.get(&block.header.hash))
+                            .cloned()
+                            .or(Some(Vec::new()))
+                    };
+
+                    if let Some(logs) = logs {
                         if let Some(blocks) = state.reorg_after_log_success.take() {
                             Self::apply_reorg(&mut state, &blocks);
                         }

--- a/crates/provider/src/provider/watch_logs_test_utils.rs
+++ b/crates/provider/src/provider/watch_logs_test_utils.rs
@@ -1,0 +1,248 @@
+use crate::{BlockLogs, Provider, ProviderBuilder};
+use alloy_consensus::BlockHeader;
+use alloy_eips::BlockNumberOrTag;
+use alloy_network::BlockResponse as _;
+use alloy_network_primitives::HeaderResponse;
+use alloy_primitives::{B256, U64};
+use alloy_rpc_client::RpcClient;
+use alloy_rpc_types_eth::{Block, Filter, Log};
+use alloy_transport::{
+    layers::{RetryBackoffLayer, RetryPolicy},
+    TransportError, TransportFut,
+};
+use std::{
+    collections::HashMap,
+    sync::{Arc, RwLock},
+    task::Poll,
+    time::Duration,
+};
+
+struct ChainState {
+    blocks: HashMap<u64, Block>,
+    logs: HashMap<B256, Vec<Log>>,
+    head: u64,
+    block_request_full: Vec<bool>,
+    fail_logs: usize,
+    reorg_after_log_success: Option<Vec<(Block, Vec<Log>)>>,
+}
+
+#[derive(Clone)]
+pub(crate) struct MockChain {
+    state: Arc<RwLock<ChainState>>,
+}
+
+impl MockChain {
+    pub(crate) fn new() -> Self {
+        Self {
+            state: Arc::new(RwLock::new(ChainState {
+                blocks: HashMap::new(),
+                logs: HashMap::new(),
+                head: 0,
+                block_request_full: Vec::new(),
+                fail_logs: 0,
+                reorg_after_log_success: None,
+            })),
+        }
+    }
+
+    pub(crate) fn extend(&self, blocks: &[(Block, Vec<Log>)]) {
+        let mut state = self.state.write().unwrap();
+        for (block, logs) in blocks {
+            let number = block.header.inner.number;
+            state.logs.insert(block.header.hash, logs.clone());
+            state.blocks.insert(number, block.clone());
+            if number > state.head {
+                state.head = number;
+            }
+        }
+    }
+
+    pub(crate) fn reorg(&self, blocks: &[(Block, Vec<Log>)]) {
+        let mut state = self.state.write().unwrap();
+        Self::apply_reorg(&mut state, blocks);
+    }
+
+    fn apply_reorg(state: &mut ChainState, blocks: &[(Block, Vec<Log>)]) {
+        let min_height =
+            blocks.iter().map(|(b, _)| b.header.inner.number).min().expect("reorg needs blocks");
+        let removed_hashes: Vec<_> = state
+            .blocks
+            .iter()
+            .filter_map(|(&height, block)| (height >= min_height).then_some(block.header.hash))
+            .collect();
+        state.blocks.retain(|&height, _| height < min_height);
+        for hash in removed_hashes {
+            state.logs.remove(&hash);
+        }
+
+        let mut max = state.head;
+        for (block, logs) in blocks {
+            let number = block.header.inner.number;
+            state.logs.insert(block.header.hash, logs.clone());
+            state.blocks.insert(number, block.clone());
+            if number > max {
+                max = number;
+            }
+        }
+        state.head = max;
+    }
+
+    pub(crate) fn fail_next_logs(&self, count: usize) {
+        self.state.write().unwrap().fail_logs += count;
+    }
+
+    pub(crate) fn reorg_after_next_log_success(&self, blocks: Vec<(Block, Vec<Log>)>) {
+        self.state.write().unwrap().reorg_after_log_success = Some(blocks);
+    }
+
+    pub(crate) fn block_request_full_flags(&self) -> Vec<bool> {
+        self.state.read().unwrap().block_request_full.clone()
+    }
+
+    pub(crate) fn provider(&self) -> impl Provider {
+        let transport = MockChainTransport { chain: self.clone() };
+        ProviderBuilder::new().connect_client(RpcClient::new(transport, true))
+    }
+
+    pub(crate) fn provider_with_retry(&self) -> impl Provider {
+        #[derive(Clone, Debug)]
+        struct AlwaysRetryPolicy;
+
+        impl RetryPolicy for AlwaysRetryPolicy {
+            fn should_retry(&self, _error: &TransportError) -> bool {
+                true
+            }
+
+            fn backoff_hint(&self, _error: &TransportError) -> Option<Duration> {
+                None
+            }
+        }
+
+        let retry_layer = RetryBackoffLayer::new_with_policy(1, 0, 10_000, AlwaysRetryPolicy);
+        let transport = MockChainTransport { chain: self.clone() };
+        let client = RpcClient::builder().layer(retry_layer).transport(transport, true);
+        ProviderBuilder::new().connect_client(client)
+    }
+
+    fn handle_request(&self, req: &alloy_json_rpc::SerializedRequest) -> alloy_json_rpc::Response {
+        let mut state = self.state.write().unwrap();
+        let payload = match req.method() {
+            "eth_blockNumber" => {
+                let raw = serde_json::to_string(&U64::from(state.head)).unwrap();
+                alloy_json_rpc::ResponsePayload::Success(
+                    serde_json::value::RawValue::from_string(raw).unwrap(),
+                )
+            }
+            "eth_getBlockByNumber" => {
+                let params = req.params().expect("eth_getBlockByNumber requires params");
+                let (tag, full): (BlockNumberOrTag, bool) =
+                    serde_json::from_str(params.get()).unwrap();
+                state.block_request_full.push(full);
+                let number = match tag {
+                    BlockNumberOrTag::Number(n) => n,
+                    BlockNumberOrTag::Latest => state.head,
+                    _ => unimplemented!("unsupported block tag in MockChain: {tag:?}"),
+                };
+                let block = state.blocks.get(&number).cloned();
+                let raw = serde_json::to_string(&block).unwrap();
+                alloy_json_rpc::ResponsePayload::Success(
+                    serde_json::value::RawValue::from_string(raw).unwrap(),
+                )
+            }
+            "eth_getLogs" => {
+                if state.fail_logs > 0 {
+                    state.fail_logs -= 1;
+                    alloy_json_rpc::ResponsePayload::internal_error_message(
+                        "temporary log error".into(),
+                    )
+                } else {
+                    let params = req.params().expect("eth_getLogs requires params");
+                    let (filter,): (Filter,) = serde_json::from_str(params.get()).unwrap();
+                    let hash = filter.get_block_hash().expect("logs are queried by block hash");
+                    if let Some(logs) = state.logs.get(&hash).cloned() {
+                        if let Some(blocks) = state.reorg_after_log_success.take() {
+                            Self::apply_reorg(&mut state, &blocks);
+                        }
+                        let raw = serde_json::to_string(&logs).unwrap();
+                        alloy_json_rpc::ResponsePayload::Success(
+                            serde_json::value::RawValue::from_string(raw).unwrap(),
+                        )
+                    } else {
+                        alloy_json_rpc::ResponsePayload::internal_error_message(
+                            "block not found".into(),
+                        )
+                    }
+                }
+            }
+            other => panic!("MockChain: unexpected RPC method `{other}`"),
+        };
+        alloy_json_rpc::Response { id: req.id().clone(), payload }
+    }
+}
+
+#[derive(Clone)]
+struct MockChainTransport {
+    chain: MockChain,
+}
+
+impl tower::Service<alloy_json_rpc::RequestPacket> for MockChainTransport {
+    type Response = alloy_json_rpc::ResponsePacket;
+    type Error = TransportError;
+    type Future = TransportFut<'static>;
+
+    fn poll_ready(&mut self, _cx: &mut std::task::Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: alloy_json_rpc::RequestPacket) -> Self::Future {
+        let chain = self.chain.clone();
+        Box::pin(async move {
+            Ok(match req {
+                alloy_json_rpc::RequestPacket::Single(req) => {
+                    alloy_json_rpc::ResponsePacket::Single(chain.handle_request(&req))
+                }
+                alloy_json_rpc::RequestPacket::Batch(reqs) => {
+                    alloy_json_rpc::ResponsePacket::Batch(
+                        reqs.iter().map(|r| chain.handle_request(r)).collect(),
+                    )
+                }
+            })
+        })
+    }
+}
+
+pub(crate) fn block(number: u64, hash_last_byte: u8, parent_hash_last_byte: u8) -> Block {
+    let mut block: Block = Block::default();
+    block.header.inner.number = number;
+    block.header.hash = B256::with_last_byte(hash_last_byte);
+    block.header.inner.parent_hash = B256::with_last_byte(parent_hash_last_byte);
+    block
+}
+
+pub(crate) fn log(number: u64, hash_last_byte: u8, index: u64) -> Log {
+    Log {
+        block_hash: Some(B256::with_last_byte(hash_last_byte)),
+        block_number: Some(number),
+        log_index: Some(index),
+        ..Default::default()
+    }
+}
+
+pub(crate) fn assert_batch(
+    block_logs: &BlockLogs<alloy_network::Ethereum>,
+    number: u64,
+    hash_last_byte: u8,
+    removed: bool,
+    log_count: usize,
+) {
+    let block_hash = B256::with_last_byte(hash_last_byte);
+    assert_eq!(block_logs.block.header().number(), number);
+    assert_eq!(block_logs.block.header().hash(), block_hash);
+    assert_eq!(block_logs.logs.len(), log_count);
+
+    for log in &block_logs.logs {
+        assert_eq!(log.block_number, Some(number));
+        assert_eq!(log.block_hash, Some(block_hash));
+        assert_eq!(log.removed, removed);
+    }
+}


### PR DESCRIPTION
  - Adds Provider::watch_logs_from(start_block, filter) — streams per-block BlockLogs futures from a historical height to head, fetching block and one-block log range concurrently with fallback to a block-hash-pinned log query for fork-safe batches.
  - Adds Provider::watch_canonical_logs_from(...) — reorg-aware variant that emits CanonicalEvent::Added / Removed for BlockLogs, reusing retained logs for Removed events.
  
## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [] Breaking changes
