### PR TITLE
feat(provider): add anvil_dump_state_with_history to AnvilApi

### DIFF
--- a/crates/provider/src/ext/anvil.rs
+++ b/crates/provider/src/ext/anvil.rs
@@ -98,6 +98,15 @@ pub trait AnvilApi<N: Network>: Send + Sync {
     /// process by calling `anvil_loadState`
     async fn anvil_dump_state(&self) -> TransportResult<Bytes>;
 
+    /// Like [`anvil_dump_state`](Self::anvil_dump_state) but also includes historical states of
+    /// accounts and storage at particular block hashes, allowing a reloaded node to serve RPC
+    /// calls for blocks prior to the one at which state was dumped.
+    ///
+    /// Equivalent to running anvil with `--preserve-historical-states` at startup.
+    ///
+    /// The returned buffer can be passed to [`anvil_load_state`](Self::anvil_load_state).
+    async fn anvil_dump_state_with_history(&self) -> TransportResult<Bytes>;
+
     /// Append chain state buffer to current chain. Will overwrite any conflicting addresses or
     /// storage.
     async fn anvil_load_state(&self, buf: Bytes) -> TransportResult<bool>;
@@ -307,6 +316,10 @@ where
 
     async fn anvil_dump_state(&self) -> TransportResult<Bytes> {
         self.client().request_noparams("anvil_dumpState").await
+    }
+
+    async fn anvil_dump_state_with_history(&self) -> TransportResult<Bytes> {
+        self.client().request("anvil_dumpState", (true,)).await
     }
 
     async fn anvil_load_state(&self, buf: Bytes) -> TransportResult<bool> {
@@ -890,6 +903,19 @@ mod tests {
         let provider = ProviderBuilder::new().connect_anvil();
 
         let state = provider.anvil_dump_state().await.unwrap();
+
+        assert!(!state.is_empty());
+
+        let res = provider.anvil_load_state(state).await.unwrap();
+
+        assert!(res);
+    }
+
+    #[tokio::test]
+    async fn test_anvil_dump_state_with_history() {
+        let provider = ProviderBuilder::new().connect_anvil();
+
+        let state = provider.anvil_dump_state_with_history().await.unwrap();
 
         assert!(!state.is_empty());
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

`anvil_dumpState` accepts an optional `preserve_historical_states: bool` parameter (added in foundry-rs/foundry), but `AnvilApi::anvil_dump_state` always calls the RPC without any parameter, which makes the server default to `false` — silently omitting historical states from the dump even when the node was started with `--preserve-historical-states`.

There is no way to get a full state dump (including historical account and storage states at each block hash) through the typed provider API.


<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Adds `anvil_dump_state_with_history` as a non-breaking addition to `AnvilApi`. It calls `anvil_dumpState` with `true`, including historical states in the returned buffer. A reloaded node can then serve RPC calls for blocks prior to the one at which state was dumped.

The existing `anvil_dump_state` is unchanged to avoid breaking changes.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
