### PR TITLE
ci: ignore proc-macro-error2 advisory

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -11,6 +11,9 @@ ignore = [
     "RUSTSEC-2026-0097",
     # https://rustsec.org/advisories/RUSTSEC-2025-0141 bincode is unmaintained, need to transition all deps to wincode first
     "RUSTSEC-2025-0141",
+    # https://rustsec.org/advisories/RUSTSEC-2026-0173 proc-macro-error2 is unmaintained
+    # and is pulled in transitively by upstream crates with no safe upgrade available.
+    "RUSTSEC-2026-0173",
 ]
 
 [bans]


### PR DESCRIPTION
Adds `RUSTSEC-2026-0173` to the ignored advisory list in `deny.toml`.

The deny job started failing because `proc-macro-error2` is now reported as unmaintained and is pulled in transitively through `alloy-sol-macro v1.6.0`. `cargo-deny` reports that no safe upgrade is available for this advisory, so this mirrors the upstream mitigation used in `tempoxyz/tempo` while keeping the ignore documented in the deny policy.

This should unblock PRs that fail only on the new unmaintained advisory without changing dependency resolution or package code.
