### PR TITLE
feat: generic `CanonicalStore` for WatchCanonicalLogsFrom 

### DIFF
--- a/crates/provider/src/provider/mod.rs
+++ b/crates/provider/src/provider/mod.rs
@@ -8,8 +8,8 @@ pub use get_block::{EthGetBlock, EthGetBlockParams, WatchBlocks, WatchHeaders};
 
 mod watch_canonical_blocks_from;
 pub use watch_canonical_blocks_from::{
-    CanonicalEvent, CanonicalStore, InMemoryStore, InMemoryStoreError, WatchCanonicalBlocksFrom,
-    WatchCanonicalBlocksFromStream,
+    CanonicalEvent, CanonicalStore, InMemoryCanonicalStore, InMemoryCanonicalStoreError,
+    WatchCanonicalBlocksFrom, WatchCanonicalBlocksFromStream,
 };
 
 mod watch_canonical_logs_from;

--- a/crates/provider/src/provider/mod.rs
+++ b/crates/provider/src/provider/mod.rs
@@ -8,8 +8,8 @@ pub use get_block::{EthGetBlock, EthGetBlockParams, WatchBlocks, WatchHeaders};
 
 mod watch_canonical_blocks_from;
 pub use watch_canonical_blocks_from::{
-    CanonicalBlockStore, CanonicalEvent, InMemoryStore, InMemoryStoreInsertError,
-    WatchCanonicalBlocksFrom, WatchCanonicalBlocksFromStream,
+    CanonicalEvent, CanonicalStore, InMemoryStore, InMemoryStoreError, WatchCanonicalBlocksFrom,
+    WatchCanonicalBlocksFromStream,
 };
 
 mod watch_canonical_logs_from;

--- a/crates/provider/src/provider/mod.rs
+++ b/crates/provider/src/provider/mod.rs
@@ -8,8 +8,8 @@ pub use get_block::{EthGetBlock, EthGetBlockParams, WatchBlocks, WatchHeaders};
 
 mod watch_canonical_blocks_from;
 pub use watch_canonical_blocks_from::{
-    CanonicalBlockStore, CanonicalEvent, InMemoryStore, WatchCanonicalBlocksFrom,
-    WatchCanonicalBlocksFromStream,
+    CanonicalBlockStore, CanonicalEvent, InMemoryStore, InMemoryStoreInsertError,
+    WatchCanonicalBlocksFrom, WatchCanonicalBlocksFromStream,
 };
 
 mod watch_canonical_logs_from;

--- a/crates/provider/src/provider/mod.rs
+++ b/crates/provider/src/provider/mod.rs
@@ -8,7 +8,8 @@ pub use get_block::{EthGetBlock, EthGetBlockParams, WatchBlocks, WatchHeaders};
 
 mod watch_canonical_blocks_from;
 pub use watch_canonical_blocks_from::{
-    CanonicalEvent, WatchCanonicalBlocksFrom, WatchCanonicalBlocksFromStream,
+    CanonicalBlockStore, CanonicalEvent, InMemoryStore, WatchCanonicalBlocksFrom,
+    WatchCanonicalBlocksFromStream,
 };
 
 mod watch_canonical_logs_from;

--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -975,6 +975,67 @@ pub trait Provider<N: Network = Ethereum>: Send + Sync {
     /// # Ok(())
     /// # }
     /// ```
+    ///
+    /// Use a custom [`CanonicalStore`](crate::provider::CanonicalStore) to retain more canonical
+    /// log history than the default in-memory store.
+    ///
+    /// ```no_run
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # use alloy_consensus::BlockHeader;
+    /// # use alloy_eips::BlockNumberOrTag;
+    /// # use alloy_network::{BlockResponse, Ethereum};
+    /// # use alloy_primitives::address;
+    /// # use alloy_provider::{
+    /// #     BlockLogs, CanonicalEvent, CanonicalStore, Provider, ProviderBuilder,
+    /// # };
+    /// # use alloy_rpc_types_eth::Filter;
+    /// # use futures::StreamExt;
+    /// # use std::{collections::BTreeMap, convert::Infallible, future};
+    /// #[derive(Debug, Default)]
+    /// struct LogHistoryStore {
+    ///     logs_by_number: BTreeMap<u64, BlockLogs<Ethereum>>,
+    /// }
+    ///
+    /// impl CanonicalStore<BlockLogs<Ethereum>> for LogHistoryStore {
+    ///     type Error = Infallible;
+    ///     type PushFuture = future::Ready<Result<(), Self::Error>>;
+    ///     type GetFuture = future::Ready<Result<Option<BlockLogs<Ethereum>>, Self::Error>>;
+    ///     type PopFuture = future::Ready<Result<Option<BlockLogs<Ethereum>>, Self::Error>>;
+    ///
+    ///     fn push(&mut self, block_logs: BlockLogs<Ethereum>) -> Self::PushFuture {
+    ///         self.logs_by_number.insert(block_logs.header().number(), block_logs);
+    ///         future::ready(Ok(()))
+    ///     }
+    ///
+    ///     fn get(&mut self, block_number: u64) -> Self::GetFuture {
+    ///         future::ready(Ok(self.logs_by_number.get(&block_number).cloned()))
+    ///     }
+    ///
+    ///     fn pop(&mut self) -> Self::PopFuture {
+    ///         let block_number = self.logs_by_number.keys().next_back().copied();
+    ///         future::ready(Ok(block_number.and_then(|n| self.logs_by_number.remove(&n))))
+    ///     }
+    /// }
+    ///
+    /// let provider = ProviderBuilder::new().connect_http("http://localhost:8545".parse()?);
+    /// let filter = Filter::new().address(address!("0x0000000000aE079eB8a274cD51c0f44a9E4d67d4"));
+    ///
+    /// let mut stream = provider
+    ///     .watch_canonical_logs_from(20_000_000, &filter)
+    ///     .block_tag(BlockNumberOrTag::Finalized)
+    ///     .block_store(LogHistoryStore::default())
+    ///     .into_stream();
+    ///
+    /// while let Some(event) = stream.next().await {
+    ///     match event? {
+    ///         CanonicalEvent::Added(block_logs) | CanonicalEvent::Removed(block_logs) => {
+    ///             let _ = block_logs;
+    ///         }
+    ///     }
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
     fn watch_canonical_logs_from(
         &self,
         start_block: u64,

--- a/crates/provider/src/provider/watch_blocks_from.rs
+++ b/crates/provider/src/provider/watch_blocks_from.rs
@@ -327,7 +327,7 @@ impl<N: Network> WatchBlocksFrom<N> {
 
     /// Converts this builder into a canonical-stream builder that emits
     /// [`crate::CanonicalEvent`] deltas on reorgs.
-    pub const fn canonical(self) -> WatchCanonicalBlocksFrom<N> {
+    pub fn canonical(self) -> WatchCanonicalBlocksFrom<N> {
         WatchCanonicalBlocksFrom::new(self)
     }
 

--- a/crates/provider/src/provider/watch_canonical_blocks_from.rs
+++ b/crates/provider/src/provider/watch_canonical_blocks_from.rs
@@ -8,6 +8,7 @@ use futures::{stream::Buffered, Stream, StreamExt as _};
 use pin_project::pin_project;
 use std::{
     collections::VecDeque,
+    fmt,
     future::Future,
     pin::Pin,
     task::{Context, Poll},
@@ -24,10 +25,14 @@ const MAX_REORG_DEPTH_DEFAULT: usize = 64;
 /// followed by [`CanonicalEvent::Added`] for the new canonical chain segment.
 #[derive(Debug)]
 #[must_use = "this builder does nothing unless you call `.into_stream`"]
-pub struct WatchCanonicalBlocksFrom<N: Network> {
+pub struct WatchCanonicalBlocksFrom<N, S = InMemoryStore<<N as Network>::BlockResponse>>
+where
+    N: Network,
+    S: CanonicalBlockStore<N>,
+{
     watch_blocks_from: WatchBlocksFrom<N>,
     rpc_concurrency: usize,
-    max_reorg_depth: usize,
+    block_store: S,
 }
 
 /// An item emitted by the canonical block stream.
@@ -40,14 +45,20 @@ pub enum CanonicalEvent<T> {
 }
 
 impl<N: Network> WatchCanonicalBlocksFrom<N> {
-    pub(crate) const fn new(watch_blocks_from: WatchBlocksFrom<N>) -> Self {
+    pub(crate) fn new(watch_blocks_from: WatchBlocksFrom<N>) -> Self {
         Self {
             watch_blocks_from,
             rpc_concurrency: RPC_CONCURRENCY_DEFAULT,
-            max_reorg_depth: MAX_REORG_DEPTH_DEFAULT,
+            block_store: InMemoryStore::new(MAX_REORG_DEPTH_DEFAULT),
         }
     }
+}
 
+impl<N, S> WatchCanonicalBlocksFrom<N, S>
+where
+    N: Network,
+    S: CanonicalBlockStore<N>,
+{
     /// Streams canonical blocks with full transaction bodies.
     pub fn full(mut self) -> Self {
         self.watch_blocks_from = self.watch_blocks_from.full();
@@ -78,28 +89,46 @@ impl<N: Network> WatchCanonicalBlocksFrom<N> {
         self
     }
 
-    /// Sets the maximum number of canonical blocks retained for reorg detection.
-    pub const fn max_reorg_depth(mut self, max_reorg_depth: usize) -> Self {
-        self.max_reorg_depth = if max_reorg_depth == 0 { 1 } else { max_reorg_depth };
-        self
+    /// Sets the store used to fetch previously emitted canonical blocks during reorg handling.
+    pub fn block_store<S2>(self, block_store: S2) -> WatchCanonicalBlocksFrom<N, S2>
+    where
+        S2: CanonicalBlockStore<N>,
+    {
+        WatchCanonicalBlocksFrom {
+            watch_blocks_from: self.watch_blocks_from,
+            rpc_concurrency: self.rpc_concurrency,
+            block_store,
+        }
     }
 
     /// Converts the builder into a stream of canonical block events.
-    pub fn into_stream(self) -> WatchCanonicalBlocksFromStream<N> {
-        let Self { watch_blocks_from, rpc_concurrency, max_reorg_depth } = self;
+    pub fn into_stream(self) -> WatchCanonicalBlocksFromStream<N, S> {
+        let Self { watch_blocks_from, rpc_concurrency, block_store } = self;
         let stream = watch_blocks_from.clone().into_stream().buffered(rpc_concurrency.max(1));
 
         WatchCanonicalBlocksFromStream {
             watch_blocks_from,
             stream,
-            buffer: FixedBuf::new(max_reorg_depth),
+            block_store,
+            canonical_tip: None,
             state: WatchCanonicalBlocksFromState::PollNext,
         }
     }
 }
 
-#[derive(Debug)]
-enum WatchCanonicalBlocksFromState<N: Network> {
+impl<N: Network> WatchCanonicalBlocksFrom<N, InMemoryStore<N::BlockResponse>> {
+    /// Sets the maximum number of canonical blocks retained by the default in-memory store.
+    pub fn max_reorg_depth(mut self, max_reorg_depth: usize) -> Self {
+        self.block_store = InMemoryStore::new(max_reorg_depth);
+        self
+    }
+}
+
+enum WatchCanonicalBlocksFromState<N, S>
+where
+    N: Network,
+    S: CanonicalBlockStore<N>,
+{
     /// Polling the next block from `watch_blocks_from(...).buffered(...)`.
     PollNext,
     /// Reconciling `next` with the canonical buffer by walking parents.
@@ -110,26 +139,99 @@ enum WatchCanonicalBlocksFromState<N: Network> {
         pending: VecDeque<N::BlockResponse>,
         fut: super::BlockFut<N::BlockResponse>,
     },
+    /// Polling an in-flight fetch for the rolled-back canonical block.
+    FetchingRemoved {
+        next: N::BlockResponse,
+        pending: VecDeque<N::BlockResponse>,
+        block_number: u64,
+        fut: Pin<Box<S::GetBlockFuture>>,
+    },
+    /// Polling an in-flight fetch for the new canonical tip after one rollback.
+    FetchingTipAfterRemoved {
+        next: N::BlockResponse,
+        pending: VecDeque<N::BlockResponse>,
+        removed: N::BlockResponse,
+        fut: Pin<Box<S::GetBlockFuture>>,
+    },
     /// Emitting `Added` events for `pending`, then `next`.
     EmitPending { pending: VecDeque<N::BlockResponse>, next: Option<N::BlockResponse> },
+    /// Polling an in-flight store insert before emitting an `Added` event.
+    StoringAdded {
+        pending: VecDeque<N::BlockResponse>,
+        next: Option<N::BlockResponse>,
+        block: N::BlockResponse,
+        fut: Pin<Box<S::InsertBlockFuture>>,
+    },
     /// Yield one terminal error item and then end the stream.
     EmitError { err: TransportError },
     /// Stream terminated.
     Done,
 }
 
+impl<N, S> fmt::Debug for WatchCanonicalBlocksFromState<N, S>
+where
+    N: Network,
+    S: CanonicalBlockStore<N>,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::PollNext => f.write_str("PollNext"),
+            Self::Reconcile { next, pending } => {
+                f.debug_struct("Reconcile").field("next", next).field("pending", pending).finish()
+            }
+            Self::FetchingParent { next, pending, .. } => f
+                .debug_struct("FetchingParent")
+                .field("next", next)
+                .field("pending", pending)
+                .finish_non_exhaustive(),
+            Self::FetchingRemoved { next, pending, block_number, .. } => f
+                .debug_struct("FetchingRemoved")
+                .field("next", next)
+                .field("pending", pending)
+                .field("block_number", block_number)
+                .finish_non_exhaustive(),
+            Self::FetchingTipAfterRemoved { next, pending, removed, .. } => f
+                .debug_struct("FetchingTipAfterRemoved")
+                .field("next", next)
+                .field("pending", pending)
+                .field("removed", removed)
+                .finish_non_exhaustive(),
+            Self::EmitPending { pending, next } => {
+                f.debug_struct("EmitPending").field("pending", pending).field("next", next).finish()
+            }
+            Self::StoringAdded { pending, next, block, .. } => f
+                .debug_struct("StoringAdded")
+                .field("pending", pending)
+                .field("next", next)
+                .field("block", block)
+                .finish_non_exhaustive(),
+            Self::EmitError { err } => f.debug_struct("EmitError").field("err", err).finish(),
+            Self::Done => f.write_str("Done"),
+        }
+    }
+}
+
 /// A stream of canonical block events produced by [`WatchCanonicalBlocksFrom`].
 #[derive(Debug)]
 #[pin_project]
-pub struct WatchCanonicalBlocksFromStream<N: Network> {
+pub struct WatchCanonicalBlocksFromStream<N, S = InMemoryStore<<N as Network>::BlockResponse>>
+where
+    N: Network,
+    S: CanonicalBlockStore<N>,
+{
     watch_blocks_from: WatchBlocksFrom<N>,
     #[pin]
     stream: Buffered<WatchBlocksFromStream<N>>,
-    buffer: FixedBuf<N::BlockResponse>,
-    state: WatchCanonicalBlocksFromState<N>,
+    block_store: S,
+    canonical_tip: Option<N::BlockResponse>,
+    state: WatchCanonicalBlocksFromState<N, S>,
 }
 
-impl<N: Network> Stream for WatchCanonicalBlocksFromStream<N> {
+impl<N, S> Stream for WatchCanonicalBlocksFromStream<N, S>
+where
+    N: Network,
+    S: CanonicalBlockStore<N>,
+{
     type Item = TransportResult<CanonicalEvent<N::BlockResponse>>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
@@ -159,7 +261,7 @@ impl<N: Network> Stream for WatchCanonicalBlocksFromStream<N> {
                 },
                 WatchCanonicalBlocksFromState::Reconcile { next, pending } => {
                     let front = pending.front().unwrap_or(&next);
-                    let Some(canonical_tip) = this.buffer.last() else {
+                    let Some(canonical_tip) = this.canonical_tip.as_ref() else {
                         *this.state = WatchCanonicalBlocksFromState::EmitPending {
                             pending,
                             next: Some(next),
@@ -182,21 +284,14 @@ impl<N: Network> Stream for WatchCanonicalBlocksFromStream<N> {
                     let height = front.header().number();
                     let canonical_height = canonical_tip.header().number();
                     if canonical_height + 1 == height {
-                        let removed = this
-                            .buffer
-                            .pop()
-                            .expect("position is always < canonical buffer length");
-                        if this.buffer.len() == 0 {
-                            *this.state = WatchCanonicalBlocksFromState::EmitError {
-                                err: TransportErrorKind::custom_str(
-                                    "Deep reorg detected; no canonical history retained.",
-                                ),
-                            };
-                        } else {
-                            *this.state =
-                                WatchCanonicalBlocksFromState::Reconcile { next, pending };
-                        }
-                        return Poll::Ready(Some(Ok(CanonicalEvent::Removed(removed))));
+                        let fut = Box::pin(this.block_store.get_block(canonical_height));
+                        *this.state = WatchCanonicalBlocksFromState::FetchingRemoved {
+                            next,
+                            pending,
+                            block_number: canonical_height,
+                            fut,
+                        };
+                        continue;
                     }
 
                     let Some(parent_height) = height.checked_sub(1) else {
@@ -241,20 +336,124 @@ impl<N: Network> Stream for WatchCanonicalBlocksFromStream<N> {
                         }
                     }
                 }
+                WatchCanonicalBlocksFromState::FetchingRemoved {
+                    next,
+                    pending,
+                    block_number,
+                    mut fut,
+                } => match fut.as_mut().poll(cx) {
+                    Poll::Pending => {
+                        *this.state = WatchCanonicalBlocksFromState::FetchingRemoved {
+                            next,
+                            pending,
+                            block_number,
+                            fut,
+                        };
+                        return Poll::Pending;
+                    }
+                    Poll::Ready(Err(err)) => {
+                        *this.state = WatchCanonicalBlocksFromState::EmitError { err };
+                    }
+                    Poll::Ready(Ok(None)) => {
+                        *this.state = WatchCanonicalBlocksFromState::EmitError {
+                            err: TransportErrorKind::custom_str(
+                                "Canonical block history is missing an expected block.",
+                            ),
+                        };
+                    }
+                    Poll::Ready(Ok(Some(removed))) => {
+                        let Some(parent_number) = block_number.checked_sub(1) else {
+                            *this.canonical_tip = None;
+                            *this.state = WatchCanonicalBlocksFromState::EmitError {
+                                err: deep_reorg_block_error(),
+                            };
+                            return Poll::Ready(Some(Ok(CanonicalEvent::Removed(removed))));
+                        };
+                        let fut = Box::pin(this.block_store.get_block(parent_number));
+                        *this.state = WatchCanonicalBlocksFromState::FetchingTipAfterRemoved {
+                            next,
+                            pending,
+                            removed,
+                            fut,
+                        };
+                    }
+                },
+                WatchCanonicalBlocksFromState::FetchingTipAfterRemoved {
+                    next,
+                    pending,
+                    removed,
+                    mut fut,
+                } => match fut.as_mut().poll(cx) {
+                    Poll::Pending => {
+                        *this.state = WatchCanonicalBlocksFromState::FetchingTipAfterRemoved {
+                            next,
+                            pending,
+                            removed,
+                            fut,
+                        };
+                        return Poll::Pending;
+                    }
+                    Poll::Ready(Err(err)) => {
+                        *this.state = WatchCanonicalBlocksFromState::EmitError { err };
+                    }
+                    Poll::Ready(Ok(previous_tip)) => {
+                        *this.canonical_tip = previous_tip;
+                        *this.state = if this.canonical_tip.is_some() {
+                            WatchCanonicalBlocksFromState::Reconcile { next, pending }
+                        } else {
+                            WatchCanonicalBlocksFromState::EmitError {
+                                err: deep_reorg_block_error(),
+                            }
+                        };
+                        return Poll::Ready(Some(Ok(CanonicalEvent::Removed(removed))));
+                    }
+                },
                 WatchCanonicalBlocksFromState::EmitPending { mut pending, mut next } => {
                     if let Some(block) = pending.pop_front() {
-                        this.buffer.push(block.clone());
-                        *this.state = WatchCanonicalBlocksFromState::EmitPending { pending, next };
-                        return Poll::Ready(Some(Ok(CanonicalEvent::Added(block))));
+                        let fut = Box::pin(this.block_store.insert_block(block.clone()));
+                        *this.state = WatchCanonicalBlocksFromState::StoringAdded {
+                            pending,
+                            next,
+                            block,
+                            fut,
+                        };
+                        continue;
                     }
 
                     if let Some(next) = next.take() {
-                        this.buffer.push(next.clone());
-                        *this.state = WatchCanonicalBlocksFromState::PollNext;
-                        return Poll::Ready(Some(Ok(CanonicalEvent::Added(next))));
+                        let fut = Box::pin(this.block_store.insert_block(next.clone()));
+                        *this.state = WatchCanonicalBlocksFromState::StoringAdded {
+                            pending,
+                            next: None,
+                            block: next,
+                            fut,
+                        };
+                        continue;
                     }
 
                     *this.state = WatchCanonicalBlocksFromState::PollNext;
+                }
+                WatchCanonicalBlocksFromState::StoringAdded { pending, next, block, mut fut } => {
+                    match fut.as_mut().poll(cx) {
+                        Poll::Pending => {
+                            *this.state = WatchCanonicalBlocksFromState::StoringAdded {
+                                pending,
+                                next,
+                                block,
+                                fut,
+                            };
+                            return Poll::Pending;
+                        }
+                        Poll::Ready(Err(err)) => {
+                            *this.state = WatchCanonicalBlocksFromState::EmitError { err };
+                        }
+                        Poll::Ready(Ok(())) => {
+                            *this.canonical_tip = Some(block.clone());
+                            *this.state =
+                                WatchCanonicalBlocksFromState::EmitPending { pending, next };
+                            return Poll::Ready(Some(Ok(CanonicalEvent::Added(block))));
+                        }
+                    }
                 }
                 WatchCanonicalBlocksFromState::EmitError { err } => {
                     *this.state = WatchCanonicalBlocksFromState::Done;
@@ -267,6 +466,84 @@ impl<N: Network> Stream for WatchCanonicalBlocksFromStream<N> {
             }
         }
     }
+}
+
+/// A store of previously emitted canonical blocks used to produce removed events on reorgs.
+pub trait CanonicalBlockStore<N: Network>: std::fmt::Debug + Send + Sync + 'static {
+    /// Future returned by [`insert_block`](Self::insert_block).
+    #[cfg(not(target_family = "wasm"))]
+    type InsertBlockFuture: Future<Output = TransportResult<()>> + Send + 'static;
+
+    /// Future returned by [`insert_block`](Self::insert_block).
+    #[cfg(target_family = "wasm")]
+    type InsertBlockFuture: Future<Output = TransportResult<()>> + 'static;
+
+    /// Future returned by [`get_block`](Self::get_block).
+    #[cfg(not(target_family = "wasm"))]
+    type GetBlockFuture: Future<Output = TransportResult<Option<N::BlockResponse>>> + Send + 'static;
+
+    /// Future returned by [`get_block`](Self::get_block).
+    #[cfg(target_family = "wasm")]
+    type GetBlockFuture: Future<Output = TransportResult<Option<N::BlockResponse>>> + 'static;
+
+    /// Records a newly emitted canonical block.
+    fn insert_block(&mut self, block: N::BlockResponse) -> Self::InsertBlockFuture;
+
+    /// Fetches a previously emitted canonical block by block number.
+    fn get_block(&mut self, block_number: u64) -> Self::GetBlockFuture;
+}
+
+/// In-memory canonical history store used by default by canonical watchers.
+#[derive(Debug)]
+pub struct InMemoryStore<T> {
+    inner: FixedBuf<(u64, T)>,
+}
+
+impl<T> InMemoryStore<T> {
+    /// Creates an in-memory store retaining up to `max_reorg_depth` canonical items.
+    pub fn new(max_reorg_depth: usize) -> Self {
+        Self { inner: FixedBuf::new(max_reorg_depth) }
+    }
+}
+
+impl<T> InMemoryStore<T>
+where
+    T: Clone,
+{
+    fn insert(&mut self, block_number: u64, item: T) -> TransportResult<()> {
+        self.inner.push((block_number, item));
+        Ok(())
+    }
+
+    fn get(&self, block_number: u64) -> TransportResult<Option<T>> {
+        Ok(self
+            .inner
+            .iter()
+            .rev()
+            .find(|(stored_number, _)| *stored_number == block_number)
+            .map(|(_, item)| item.clone()))
+    }
+}
+
+impl<N> CanonicalBlockStore<N> for InMemoryStore<N::BlockResponse>
+where
+    N: Network,
+{
+    type InsertBlockFuture = std::future::Ready<TransportResult<()>>;
+    type GetBlockFuture = std::future::Ready<TransportResult<Option<N::BlockResponse>>>;
+
+    fn insert_block(&mut self, block: N::BlockResponse) -> Self::InsertBlockFuture {
+        let block_number = block.header().number();
+        std::future::ready(self.insert(block_number, block))
+    }
+
+    fn get_block(&mut self, block_number: u64) -> Self::GetBlockFuture {
+        std::future::ready(self.get(block_number))
+    }
+}
+
+fn deep_reorg_block_error() -> TransportError {
+    TransportErrorKind::custom_str("Deep reorg detected; no canonical history retained.")
 }
 
 #[derive(Debug)]
@@ -299,6 +576,10 @@ impl<T> FixedBuf<T> {
     pub(super) fn len(&self) -> usize {
         self.buf.len()
     }
+
+    pub(super) fn iter(&self) -> std::collections::vec_deque::Iter<'_, T> {
+        self.buf.iter()
+    }
 }
 
 #[cfg(test)]
@@ -309,7 +590,7 @@ mod tests {
     use alloy_primitives::{B256, U64};
     use alloy_rpc_client::RpcClient;
     use alloy_rpc_types_eth::Block;
-    use alloy_transport::{TransportError, TransportFut};
+    use alloy_transport::{TransportError, TransportFut, TransportResult};
     use futures::StreamExt;
     use std::{
         collections::HashMap,
@@ -444,6 +725,31 @@ mod tests {
         block
     }
 
+    #[derive(Debug, Default)]
+    struct FullHistoryBlockStore {
+        blocks: HashMap<u64, Block>,
+    }
+
+    impl FullHistoryBlockStore {
+        fn new() -> Self {
+            Self::default()
+        }
+    }
+
+    impl CanonicalBlockStore<alloy_network::Ethereum> for FullHistoryBlockStore {
+        type InsertBlockFuture = std::future::Ready<TransportResult<()>>;
+        type GetBlockFuture = std::future::Ready<TransportResult<Option<Block>>>;
+
+        fn insert_block(&mut self, block: Block) -> Self::InsertBlockFuture {
+            self.blocks.insert(block.header.number, block);
+            std::future::ready(Ok(()))
+        }
+
+        fn get_block(&mut self, block_number: u64) -> Self::GetBlockFuture {
+            std::future::ready(Ok(self.blocks.get(&block_number).cloned()))
+        }
+    }
+
     #[tokio::test]
     async fn emits_removed_then_added_on_reorg_within_buffer() {
         let chain = MockChain::new();
@@ -501,6 +807,57 @@ mod tests {
                 assert_eq!(block.header.hash, B256::with_last_byte(44));
             }
             other => panic!("expected Added(4), got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn custom_block_store_can_recover_reorg_beyond_default_memory_depth() {
+        let chain = MockChain::new();
+        chain.extend(&[block(1, 1, 0), block(2, 2, 1), block(3, 3, 2), block(4, 4, 3)]);
+
+        let provider = chain.provider();
+        let mut stream = provider
+            .watch_blocks_from(1)
+            .block_tag(BlockNumberOrTag::Latest)
+            .poll_interval(Duration::from_millis(1))
+            .canonical()
+            .rpc_concurrency(1)
+            .block_store(FullHistoryBlockStore::new())
+            .into_stream();
+
+        for expected in [1_u64, 2, 3, 4] {
+            let item =
+                timeout(Duration::from_secs(1), stream.next()).await.unwrap().unwrap().unwrap();
+            match item {
+                CanonicalEvent::Added(block) => assert_eq!(block.header.number, expected),
+                other => panic!("expected Added({expected}), got {other:?}"),
+            }
+        }
+
+        chain.reorg(&[block(2, 22, 1), block(3, 33, 22), block(4, 44, 33), block(5, 55, 44)]);
+
+        for expected in [(4, 4), (3, 3), (2, 2)] {
+            let item =
+                timeout(Duration::from_secs(1), stream.next()).await.unwrap().unwrap().unwrap();
+            match item {
+                CanonicalEvent::Removed(block) => {
+                    assert_eq!(block.header.number, expected.0);
+                    assert_eq!(block.header.hash, B256::with_last_byte(expected.1));
+                }
+                other => panic!("expected Removed({}), got {other:?}", expected.0),
+            }
+        }
+
+        for expected in [(2, 22), (3, 33), (4, 44), (5, 55)] {
+            let item =
+                timeout(Duration::from_secs(1), stream.next()).await.unwrap().unwrap().unwrap();
+            match item {
+                CanonicalEvent::Added(block) => {
+                    assert_eq!(block.header.number, expected.0);
+                    assert_eq!(block.header.hash, B256::with_last_byte(expected.1));
+                }
+                other => panic!("expected Added({}), got {other:?}", expected.0),
+            }
         }
     }
 

--- a/crates/provider/src/provider/watch_canonical_blocks_from.rs
+++ b/crates/provider/src/provider/watch_canonical_blocks_from.rs
@@ -25,7 +25,7 @@ const MAX_REORG_DEPTH_DEFAULT: usize = 64;
 /// followed by [`CanonicalEvent::Added`] for the new canonical chain segment.
 #[derive(Debug)]
 #[must_use = "this builder does nothing unless you call `.into_stream`"]
-pub struct WatchCanonicalBlocksFrom<N, S = InMemoryStore<<N as Network>::BlockResponse>>
+pub struct WatchCanonicalBlocksFrom<N, S = InMemoryCanonicalStore<<N as Network>::BlockResponse>>
 where
     N: Network,
     S: CanonicalStore<N::BlockResponse>,
@@ -49,7 +49,7 @@ impl<N: Network> WatchCanonicalBlocksFrom<N> {
         Self {
             watch_blocks_from,
             rpc_concurrency: RPC_CONCURRENCY_DEFAULT,
-            block_store: InMemoryStore::<N::BlockResponse>::new(MAX_REORG_DEPTH_DEFAULT),
+            block_store: InMemoryCanonicalStore::<N::BlockResponse>::new(MAX_REORG_DEPTH_DEFAULT),
         }
     }
 }
@@ -116,10 +116,10 @@ where
     }
 }
 
-impl<N: Network> WatchCanonicalBlocksFrom<N, InMemoryStore<N::BlockResponse>> {
+impl<N: Network> WatchCanonicalBlocksFrom<N, InMemoryCanonicalStore<N::BlockResponse>> {
     /// Sets the maximum number of canonical blocks retained by the default in-memory store.
     pub fn max_reorg_depth(mut self, max_reorg_depth: usize) -> Self {
-        self.block_store = InMemoryStore::<N::BlockResponse>::new(max_reorg_depth);
+        self.block_store = InMemoryCanonicalStore::<N::BlockResponse>::new(max_reorg_depth);
         self
     }
 }
@@ -222,8 +222,10 @@ where
 /// A stream of canonical block events produced by [`WatchCanonicalBlocksFrom`].
 #[derive(Debug)]
 #[pin_project]
-pub struct WatchCanonicalBlocksFromStream<N, S = InMemoryStore<<N as Network>::BlockResponse>>
-where
+pub struct WatchCanonicalBlocksFromStream<
+    N,
+    S = InMemoryCanonicalStore<<N as Network>::BlockResponse>,
+> where
     N: Network,
     S: CanonicalStore<N::BlockResponse>,
 {
@@ -548,11 +550,11 @@ pub trait CanonicalStore<T>: std::fmt::Debug + Send + Sync + 'static {
 ///
 /// Stores the most recent `max_reorg_depth` items as a strictly sequential, contiguous chain.
 #[derive(Debug)]
-pub struct InMemoryStore<T> {
+pub struct InMemoryCanonicalStore<T> {
     inner: FixedBuf<T>,
 }
 
-impl<T> InMemoryStore<T>
+impl<T> InMemoryCanonicalStore<T>
 where
     T: BlockResponse,
     T::Header: BlockHeader,
@@ -563,9 +565,9 @@ where
     }
 }
 
-/// Error returned by [`InMemoryStore`] operations.
+/// Error returned by [`InMemoryCanonicalStore`] operations.
 #[derive(Debug, thiserror::Error)]
-pub enum InMemoryStoreError {
+pub enum InMemoryCanonicalStoreError {
     /// Pushed item's height leaves a gap relative to the most recent retained item.
     #[error("pushed item #{got} is out of order; expected sequential extension at #{expected}")]
     OutOfOrder {
@@ -576,12 +578,12 @@ pub enum InMemoryStoreError {
     },
 }
 
-impl<T> CanonicalStore<T> for InMemoryStore<T>
+impl<T> CanonicalStore<T> for InMemoryCanonicalStore<T>
 where
     T: BlockResponse + Clone + std::fmt::Debug + Send + Sync + 'static,
     T::Header: BlockHeader,
 {
-    type Error = InMemoryStoreError;
+    type Error = InMemoryCanonicalStoreError;
     type PushFuture = std::future::Ready<Result<(), Self::Error>>;
     type GetFuture = std::future::Ready<Result<Option<T>, Self::Error>>;
     type PopFuture = std::future::Ready<Result<Option<T>, Self::Error>>;
@@ -591,7 +593,7 @@ where
         if let Some(last) = self.inner.last() {
             let expected = last.header().number() + 1;
             if expected != block_number {
-                return std::future::ready(Err(InMemoryStoreError::OutOfOrder {
+                return std::future::ready(Err(InMemoryCanonicalStoreError::OutOfOrder {
                     expected,
                     got: block_number,
                 }));
@@ -835,7 +837,7 @@ mod tests {
 
     #[tokio::test]
     async fn in_memory_store_supports_block_logs() {
-        let mut store = InMemoryStore::<BlockLogs<alloy_network::Ethereum>>::new(2);
+        let mut store = InMemoryCanonicalStore::<BlockLogs<alloy_network::Ethereum>>::new(2);
         let block_logs = BlockLogs { block: block(1, 1, 0), logs: Vec::new() };
 
         store.push(block_logs.clone()).await.unwrap();

--- a/crates/provider/src/provider/watch_canonical_blocks_from.rs
+++ b/crates/provider/src/provider/watch_canonical_blocks_from.rs
@@ -124,6 +124,10 @@ impl<N: Network> WatchCanonicalBlocksFrom<N, InMemoryStore<N::BlockResponse>> {
     }
 }
 
+#[pin_project(
+    project = WatchCanonicalBlocksFromStateProj,
+    project_replace = WatchCanonicalBlocksFromStateProjOwn,
+)]
 enum WatchCanonicalBlocksFromState<N, S>
 where
     N: Network,
@@ -137,6 +141,7 @@ where
     FetchingParent {
         next: N::BlockResponse,
         pending: VecDeque<N::BlockResponse>,
+        #[pin]
         fut: super::BlockFut<N::BlockResponse>,
     },
     /// Polling an in-flight fetch for the rolled-back canonical block.
@@ -144,14 +149,16 @@ where
         next: N::BlockResponse,
         pending: VecDeque<N::BlockResponse>,
         block_number: u64,
-        fut: Pin<Box<S::GetBlockFuture>>,
+        #[pin]
+        fut: S::GetBlockFuture,
     },
     /// Polling an in-flight fetch for the new canonical tip after one rollback.
     FetchingTipAfterRemoved {
         next: N::BlockResponse,
         pending: VecDeque<N::BlockResponse>,
         removed: N::BlockResponse,
-        fut: Pin<Box<S::GetBlockFuture>>,
+        #[pin]
+        fut: S::GetBlockFuture,
     },
     /// Emitting `Added` events for `pending`, then `next`.
     EmitPending { pending: VecDeque<N::BlockResponse>, next: Option<N::BlockResponse> },
@@ -160,7 +167,8 @@ where
         pending: VecDeque<N::BlockResponse>,
         next: Option<N::BlockResponse>,
         block: N::BlockResponse,
-        fut: Pin<Box<S::InsertBlockFuture>>,
+        #[pin]
+        fut: S::InsertBlockFuture,
     },
     /// Yield one terminal error item and then end the stream.
     EmitError { err: TransportError },
@@ -224,6 +232,7 @@ where
     stream: Buffered<WatchBlocksFromStream<N>>,
     block_store: S,
     canonical_tip: Option<N::BlockResponse>,
+    #[pin]
     state: WatchCanonicalBlocksFromState<N, S>,
 }
 
@@ -238,43 +247,49 @@ where
         let mut this = self.project();
 
         loop {
-            let state = std::mem::replace(this.state, WatchCanonicalBlocksFromState::Done);
-            match state {
-                WatchCanonicalBlocksFromState::PollNext => match this.stream.as_mut().poll_next(cx)
-                {
-                    Poll::Pending => {
-                        *this.state = WatchCanonicalBlocksFromState::PollNext;
-                        return Poll::Pending;
+            match this.state.as_mut().project() {
+                WatchCanonicalBlocksFromStateProj::Done => return Poll::Ready(None),
+                WatchCanonicalBlocksFromStateProj::PollNext => {
+                    match this.stream.as_mut().poll_next(cx) {
+                        Poll::Pending => return Poll::Pending,
+                        Poll::Ready(None) => {
+                            this.state.set(WatchCanonicalBlocksFromState::Done);
+                        }
+                        Poll::Ready(Some(Ok(next))) => {
+                            this.state.set(WatchCanonicalBlocksFromState::Reconcile {
+                                next,
+                                pending: VecDeque::new(),
+                            });
+                        }
+                        Poll::Ready(Some(Err(err))) => {
+                            this.state.set(WatchCanonicalBlocksFromState::EmitError { err });
+                        }
                     }
-                    Poll::Ready(None) => {
-                        *this.state = WatchCanonicalBlocksFromState::Done;
-                    }
-                    Poll::Ready(Some(Ok(next))) => {
-                        *this.state = WatchCanonicalBlocksFromState::Reconcile {
-                            next,
-                            pending: VecDeque::new(),
-                        };
-                    }
-                    Poll::Ready(Some(Err(err))) => {
-                        *this.state = WatchCanonicalBlocksFromState::EmitError { err };
-                    }
-                },
-                WatchCanonicalBlocksFromState::Reconcile { next, pending } => {
+                }
+                WatchCanonicalBlocksFromStateProj::Reconcile { .. } => {
+                    let WatchCanonicalBlocksFromStateProjOwn::Reconcile { next, pending } = this
+                        .state
+                        .as_mut()
+                        .project_replace(WatchCanonicalBlocksFromState::Done)
+                    else {
+                        unreachable!()
+                    };
+
                     let front = pending.front().unwrap_or(&next);
                     let Some(canonical_tip) = this.canonical_tip.as_ref() else {
-                        *this.state = WatchCanonicalBlocksFromState::EmitPending {
+                        this.state.set(WatchCanonicalBlocksFromState::EmitPending {
                             pending,
                             next: Some(next),
-                        };
+                        });
                         continue;
                     };
 
                     let parent_hash = front.header().parent_hash();
                     if parent_hash == canonical_tip.header().hash() {
-                        *this.state = WatchCanonicalBlocksFromState::EmitPending {
+                        this.state.set(WatchCanonicalBlocksFromState::EmitPending {
                             pending,
                             next: Some(next),
-                        };
+                        });
                         continue;
                     }
 
@@ -284,184 +299,195 @@ where
                     let height = front.header().number();
                     let canonical_height = canonical_tip.header().number();
                     if canonical_height + 1 == height {
-                        let fut = Box::pin(this.block_store.get_block(canonical_height));
-                        *this.state = WatchCanonicalBlocksFromState::FetchingRemoved {
+                        let fut = this.block_store.get_block(canonical_height);
+                        this.state.set(WatchCanonicalBlocksFromState::FetchingRemoved {
                             next,
                             pending,
                             block_number: canonical_height,
                             fut,
-                        };
+                        });
                         continue;
                     }
 
                     let Some(parent_height) = height.checked_sub(1) else {
-                        *this.state = WatchCanonicalBlocksFromState::EmitError {
+                        this.state.set(WatchCanonicalBlocksFromState::EmitError {
                             err: TransportErrorKind::custom_str(
                                 "Cannot backfill parent for genesis block during canonical reconciliation.",
                             ),
-                        };
+                        });
                         continue;
                     };
 
                     let watch_blocks_from = this.watch_blocks_from.clone();
                     let fut = watch_blocks_from.get_block(parent_height);
-                    *this.state =
-                        WatchCanonicalBlocksFromState::FetchingParent { next, pending, fut };
+                    this.state.set(WatchCanonicalBlocksFromState::FetchingParent {
+                        next,
+                        pending,
+                        fut,
+                    });
                 }
-                WatchCanonicalBlocksFromState::FetchingParent { next, mut pending, mut fut } => {
-                    match Pin::new(&mut fut).poll(cx) {
-                        Poll::Pending => {
-                            *this.state = WatchCanonicalBlocksFromState::FetchingParent {
-                                next,
-                                pending,
-                                fut,
-                            };
-                            return Poll::Pending;
-                        }
+                WatchCanonicalBlocksFromStateProj::FetchingParent { fut, .. } => {
+                    let parent = match fut.poll(cx) {
+                        Poll::Pending => return Poll::Pending,
                         Poll::Ready(Err(err)) => {
-                            *this.state = WatchCanonicalBlocksFromState::EmitError { err };
+                            this.state.set(WatchCanonicalBlocksFromState::EmitError { err });
+                            continue;
                         }
-                        Poll::Ready(Ok(parent)) => {
-                            let front = pending.front().unwrap_or(&next);
-                            if parent.header().hash() != front.header().parent_hash() {
-                                // Parent no longer matches: a second reorg happened while
-                                // reconciling. Abandon this item and continue with next blocks.
-                                *this.state = WatchCanonicalBlocksFromState::PollNext;
-                                continue;
-                            }
-
-                            pending.push_front(parent);
-                            *this.state =
-                                WatchCanonicalBlocksFromState::Reconcile { next, pending };
-                        }
+                        Poll::Ready(Ok(parent)) => parent,
+                    };
+                    let WatchCanonicalBlocksFromStateProjOwn::FetchingParent {
+                        next,
+                        mut pending,
+                        ..
+                    } = this.state.as_mut().project_replace(WatchCanonicalBlocksFromState::Done)
+                    else {
+                        unreachable!()
+                    };
+                    let front = pending.front().unwrap_or(&next);
+                    if parent.header().hash() != front.header().parent_hash() {
+                        // Parent no longer matches: a second reorg happened while
+                        // reconciling. Abandon this item and continue with next blocks.
+                        this.state.set(WatchCanonicalBlocksFromState::PollNext);
+                        continue;
                     }
+                    pending.push_front(parent);
+                    this.state.set(WatchCanonicalBlocksFromState::Reconcile { next, pending });
                 }
-                WatchCanonicalBlocksFromState::FetchingRemoved {
-                    next,
-                    pending,
-                    block_number,
-                    mut fut,
-                } => match fut.as_mut().poll(cx) {
-                    Poll::Pending => {
-                        *this.state = WatchCanonicalBlocksFromState::FetchingRemoved {
-                            next,
-                            pending,
-                            block_number,
-                            fut,
-                        };
-                        return Poll::Pending;
-                    }
-                    Poll::Ready(Err(err)) => {
-                        *this.state = WatchCanonicalBlocksFromState::EmitError { err };
-                    }
-                    Poll::Ready(Ok(None)) => {
-                        *this.state = WatchCanonicalBlocksFromState::EmitError {
-                            err: TransportErrorKind::custom_str(
-                                "Canonical block history is missing an expected block.",
-                            ),
-                        };
-                    }
-                    Poll::Ready(Ok(Some(removed))) => {
-                        let Some(parent_number) = block_number.checked_sub(1) else {
-                            *this.canonical_tip = None;
-                            *this.state = WatchCanonicalBlocksFromState::EmitError {
-                                err: deep_reorg_block_error(),
-                            };
-                            return Poll::Ready(Some(Ok(CanonicalEvent::Removed(removed))));
-                        };
-                        let fut = Box::pin(this.block_store.get_block(parent_number));
-                        *this.state = WatchCanonicalBlocksFromState::FetchingTipAfterRemoved {
-                            next,
-                            pending,
-                            removed,
-                            fut,
-                        };
-                    }
-                },
-                WatchCanonicalBlocksFromState::FetchingTipAfterRemoved {
-                    next,
-                    pending,
-                    removed,
-                    mut fut,
-                } => match fut.as_mut().poll(cx) {
-                    Poll::Pending => {
-                        *this.state = WatchCanonicalBlocksFromState::FetchingTipAfterRemoved {
-                            next,
-                            pending,
-                            removed,
-                            fut,
-                        };
-                        return Poll::Pending;
-                    }
-                    Poll::Ready(Err(err)) => {
-                        *this.state = WatchCanonicalBlocksFromState::EmitError { err };
-                    }
-                    Poll::Ready(Ok(previous_tip)) => {
-                        *this.canonical_tip = previous_tip;
-                        *this.state = if this.canonical_tip.is_some() {
-                            WatchCanonicalBlocksFromState::Reconcile { next, pending }
-                        } else {
-                            WatchCanonicalBlocksFromState::EmitError {
-                                err: deep_reorg_block_error(),
-                            }
-                        };
+                WatchCanonicalBlocksFromStateProj::FetchingRemoved { fut, .. } => {
+                    let removed = match fut.poll(cx) {
+                        Poll::Pending => return Poll::Pending,
+                        Poll::Ready(Err(err)) => {
+                            this.state.set(WatchCanonicalBlocksFromState::EmitError { err });
+                            continue;
+                        }
+                        Poll::Ready(Ok(None)) => {
+                            this.state.set(WatchCanonicalBlocksFromState::EmitError {
+                                err: TransportErrorKind::custom_str(
+                                    "Canonical block history is missing an expected block.",
+                                ),
+                            });
+                            continue;
+                        }
+                        Poll::Ready(Ok(Some(removed))) => removed,
+                    };
+                    let WatchCanonicalBlocksFromStateProjOwn::FetchingRemoved {
+                        next,
+                        pending,
+                        block_number,
+                        ..
+                    } = this.state.as_mut().project_replace(WatchCanonicalBlocksFromState::Done)
+                    else {
+                        unreachable!()
+                    };
+                    let Some(parent_number) = block_number.checked_sub(1) else {
+                        *this.canonical_tip = None;
+                        this.state.set(WatchCanonicalBlocksFromState::EmitError {
+                            err: deep_reorg_block_error(),
+                        });
                         return Poll::Ready(Some(Ok(CanonicalEvent::Removed(removed))));
+                    };
+                    let fut = this.block_store.get_block(parent_number);
+                    this.state.set(WatchCanonicalBlocksFromState::FetchingTipAfterRemoved {
+                        next,
+                        pending,
+                        removed,
+                        fut,
+                    });
+                }
+                WatchCanonicalBlocksFromStateProj::FetchingTipAfterRemoved { fut, .. } => {
+                    let previous_tip = match fut.poll(cx) {
+                        Poll::Pending => return Poll::Pending,
+                        Poll::Ready(Err(err)) => {
+                            this.state.set(WatchCanonicalBlocksFromState::EmitError { err });
+                            continue;
+                        }
+                        Poll::Ready(Ok(previous_tip)) => previous_tip,
+                    };
+                    let WatchCanonicalBlocksFromStateProjOwn::FetchingTipAfterRemoved {
+                        next,
+                        pending,
+                        removed,
+                        ..
+                    } = this.state.as_mut().project_replace(WatchCanonicalBlocksFromState::Done)
+                    else {
+                        unreachable!()
+                    };
+                    *this.canonical_tip = previous_tip;
+                    if this.canonical_tip.is_some() {
+                        this.state
+                            .set(WatchCanonicalBlocksFromState::Reconcile { next, pending });
+                    } else {
+                        this.state.set(WatchCanonicalBlocksFromState::EmitError {
+                            err: deep_reorg_block_error(),
+                        });
                     }
-                },
-                WatchCanonicalBlocksFromState::EmitPending { mut pending, mut next } => {
+                    return Poll::Ready(Some(Ok(CanonicalEvent::Removed(removed))));
+                }
+                WatchCanonicalBlocksFromStateProj::EmitPending { .. } => {
+                    let WatchCanonicalBlocksFromStateProjOwn::EmitPending {
+                        mut pending,
+                        mut next,
+                    } = this.state.as_mut().project_replace(WatchCanonicalBlocksFromState::Done)
+                    else {
+                        unreachable!()
+                    };
+
                     if let Some(block) = pending.pop_front() {
-                        let fut = Box::pin(this.block_store.insert_block(block.clone()));
-                        *this.state = WatchCanonicalBlocksFromState::StoringAdded {
+                        let fut = this.block_store.insert_block(block.clone());
+                        this.state.set(WatchCanonicalBlocksFromState::StoringAdded {
                             pending,
                             next,
                             block,
                             fut,
-                        };
+                        });
                         continue;
                     }
 
-                    if let Some(next) = next.take() {
-                        let fut = Box::pin(this.block_store.insert_block(next.clone()));
-                        *this.state = WatchCanonicalBlocksFromState::StoringAdded {
+                    if let Some(block) = next.take() {
+                        let fut = this.block_store.insert_block(block.clone());
+                        this.state.set(WatchCanonicalBlocksFromState::StoringAdded {
                             pending,
                             next: None,
-                            block: next,
+                            block,
                             fut,
-                        };
+                        });
                         continue;
                     }
 
-                    *this.state = WatchCanonicalBlocksFromState::PollNext;
+                    this.state.set(WatchCanonicalBlocksFromState::PollNext);
                 }
-                WatchCanonicalBlocksFromState::StoringAdded { pending, next, block, mut fut } => {
-                    match fut.as_mut().poll(cx) {
-                        Poll::Pending => {
-                            *this.state = WatchCanonicalBlocksFromState::StoringAdded {
-                                pending,
-                                next,
-                                block,
-                                fut,
-                            };
-                            return Poll::Pending;
-                        }
+                WatchCanonicalBlocksFromStateProj::StoringAdded { fut, .. } => {
+                    match fut.poll(cx) {
+                        Poll::Pending => return Poll::Pending,
                         Poll::Ready(Err(err)) => {
-                            *this.state = WatchCanonicalBlocksFromState::EmitError { err };
+                            this.state.set(WatchCanonicalBlocksFromState::EmitError { err });
+                            continue;
                         }
-                        Poll::Ready(Ok(())) => {
-                            *this.canonical_tip = Some(block.clone());
-                            *this.state =
-                                WatchCanonicalBlocksFromState::EmitPending { pending, next };
-                            return Poll::Ready(Some(Ok(CanonicalEvent::Added(block))));
-                        }
+                        Poll::Ready(Ok(())) => {}
                     }
+                    let WatchCanonicalBlocksFromStateProjOwn::StoringAdded {
+                        pending,
+                        next,
+                        block,
+                        ..
+                    } = this.state.as_mut().project_replace(WatchCanonicalBlocksFromState::Done)
+                    else {
+                        unreachable!()
+                    };
+                    *this.canonical_tip = Some(block.clone());
+                    this.state
+                        .set(WatchCanonicalBlocksFromState::EmitPending { pending, next });
+                    return Poll::Ready(Some(Ok(CanonicalEvent::Added(block))));
                 }
-                WatchCanonicalBlocksFromState::EmitError { err } => {
-                    *this.state = WatchCanonicalBlocksFromState::Done;
+                WatchCanonicalBlocksFromStateProj::EmitError { .. } => {
+                    let WatchCanonicalBlocksFromStateProjOwn::EmitError { err } = this
+                        .state
+                        .as_mut()
+                        .project_replace(WatchCanonicalBlocksFromState::Done)
+                    else {
+                        unreachable!()
+                    };
                     return Poll::Ready(Some(Err(err)));
-                }
-                WatchCanonicalBlocksFromState::Done => {
-                    *this.state = WatchCanonicalBlocksFromState::Done;
-                    return Poll::Ready(None);
                 }
             }
         }

--- a/crates/provider/src/provider/watch_canonical_blocks_from.rs
+++ b/crates/provider/src/provider/watch_canonical_blocks_from.rs
@@ -231,7 +231,7 @@ where
     #[pin]
     stream: Buffered<WatchBlocksFromStream<N>>,
     block_store: S,
-    canonical_tip: Option<N::BlockResponse>,
+    canonical_tip: Option<N::HeaderResponse>,
     #[pin]
     state: WatchCanonicalBlocksFromState<N, S>,
 }
@@ -283,7 +283,7 @@ where
                     };
 
                     let parent_hash = front.header().parent_hash();
-                    if parent_hash == canonical_tip.header().hash() {
+                    if parent_hash == canonical_tip.hash() {
                         this.state.set(WatchCanonicalBlocksFromState::EmitPending {
                             pending,
                             next: Some(next),
@@ -295,9 +295,9 @@ where
                     // Because WatchBlocksFrom emits strictly sequential heights, we can
                     // remove the tip when heights are adjacent.
                     let height = front.header().number();
-                    let canonical_height = canonical_tip.header().number();
+                    let canonical_height = canonical_tip.number();
                     if canonical_height + 1 == height {
-                        let fut = this.block_store.pop(canonical_height);
+                        let fut = this.block_store.pop();
                         this.state.set(WatchCanonicalBlocksFromState::FetchingRemoved {
                             next,
                             pending,
@@ -414,7 +414,7 @@ where
                     else {
                         unreachable!()
                     };
-                    *this.canonical_tip = previous_tip;
+                    *this.canonical_tip = previous_tip.as_ref().map(|block| block.header().clone());
                     if this.canonical_tip.is_some() {
                         this.state.set(WatchCanonicalBlocksFromState::Reconcile { next, pending });
                     } else {
@@ -475,7 +475,7 @@ where
                     else {
                         unreachable!()
                     };
-                    *this.canonical_tip = Some(block.clone());
+                    *this.canonical_tip = Some(block.header().clone());
                     this.state.set(WatchCanonicalBlocksFromState::EmitPending { pending, next });
                     return Poll::Ready(Some(Ok(CanonicalEvent::Added(block))));
                 }
@@ -535,13 +535,13 @@ pub trait CanonicalStore<T>: std::fmt::Debug + Send + Sync + 'static {
     /// and terminates after emitting any already-popped removed item.
     fn get(&mut self, block_number: u64) -> Self::GetFuture;
 
-    /// Removes and returns a previously emitted canonical item by block number.
+    /// Removes and returns the most recently pushed canonical item.
     ///
-    /// The stream calls this before emitting [`CanonicalEvent::Removed`]. If this returns an error,
-    /// the stream yields that error and then terminates before emitting the removed event.
-    /// Returning `Ok(None)` means the removed block is no longer available; the stream reports
-    /// missing canonical history and terminates.
-    fn pop(&mut self, block_number: u64) -> Self::PopFuture;
+    /// The stream calls this before emitting [`CanonicalEvent::Removed`] to roll back the current
+    /// canonical tip. If this returns an error, the stream yields that error and then terminates
+    /// before emitting the removed event. Returning `Ok(None)` means the removed block is no longer
+    /// available; the stream reports missing canonical history and terminates.
+    fn pop(&mut self) -> Self::PopFuture;
 }
 
 /// In-memory canonical history store used by default by canonical watchers.
@@ -612,13 +612,8 @@ where
         std::future::ready(Ok(item))
     }
 
-    fn pop(&mut self, block_number: u64) -> Self::PopFuture {
-        let item = if self.inner.last().is_some_and(|last| last.header().number() == block_number) {
-            self.inner.pop()
-        } else {
-            None
-        };
-        std::future::ready(Ok(item))
+    fn pop(&mut self) -> Self::PopFuture {
+        std::future::ready(Ok(self.inner.pop()))
     }
 }
 
@@ -832,8 +827,9 @@ mod tests {
             std::future::ready(Ok(self.blocks.get(&block_number).cloned()))
         }
 
-        fn pop(&mut self, block_number: u64) -> Self::PopFuture {
-            std::future::ready(Ok(self.blocks.remove(&block_number)))
+        fn pop(&mut self) -> Self::PopFuture {
+            let item = self.blocks.keys().max().copied().and_then(|n| self.blocks.remove(&n));
+            std::future::ready(Ok(item))
         }
     }
 
@@ -848,7 +844,7 @@ mod tests {
         assert_eq!(stored.block.header.number, 1);
         assert_eq!(stored.block.header.hash, B256::with_last_byte(1));
 
-        let removed = store.pop(1).await.unwrap().unwrap();
+        let removed = store.pop().await.unwrap().unwrap();
         assert_eq!(removed.block.header.number, 1);
         assert!(store.get(1).await.unwrap().is_none());
     }

--- a/crates/provider/src/provider/watch_canonical_blocks_from.rs
+++ b/crates/provider/src/provider/watch_canonical_blocks_from.rs
@@ -1,7 +1,7 @@
 use crate::{transport::TransportErrorKind, WatchBlocksFrom, WatchBlocksFromStream};
 use alloy_consensus::BlockHeader;
 use alloy_eips::BlockNumberOrTag;
-use alloy_network::{BlockResponse as _, Network};
+use alloy_network::{BlockResponse, Network};
 use alloy_network_primitives::HeaderResponse;
 use alloy_transport::{TransportError, TransportResult};
 use futures::{stream::Buffered, Stream, StreamExt as _};
@@ -357,7 +357,9 @@ where
                     let removed = match fut.poll(cx) {
                         Poll::Pending => return Poll::Pending,
                         Poll::Ready(Err(err)) => {
-                            this.state.set(WatchCanonicalBlocksFromState::EmitError { err });
+                            this.state.set(WatchCanonicalBlocksFromState::EmitError {
+                                err: TransportErrorKind::custom(err),
+                            });
                             continue;
                         }
                         Poll::Ready(Ok(None)) => {
@@ -398,7 +400,9 @@ where
                     let previous_tip = match fut.poll(cx) {
                         Poll::Pending => return Poll::Pending,
                         Poll::Ready(Err(err)) => {
-                            this.state.set(WatchCanonicalBlocksFromState::EmitError { err });
+                            this.state.set(WatchCanonicalBlocksFromState::EmitError {
+                                err: TransportErrorKind::custom(err),
+                            });
                             continue;
                         }
                         Poll::Ready(Ok(previous_tip)) => previous_tip,
@@ -460,7 +464,9 @@ where
                     match fut.poll(cx) {
                         Poll::Pending => return Poll::Pending,
                         Poll::Ready(Err(err)) => {
-                            this.state.set(WatchCanonicalBlocksFromState::EmitError { err });
+                            this.state.set(WatchCanonicalBlocksFromState::EmitError {
+                                err: TransportErrorKind::custom(err),
+                            });
                             continue;
                         }
                         Poll::Ready(Ok(())) => {}
@@ -496,21 +502,40 @@ where
 
 /// A store of previously emitted canonical blocks used to produce removed events on reorgs.
 pub trait CanonicalBlockStore<N: Network>: std::fmt::Debug + Send + Sync + 'static {
+    /// Error returned by [`insert_block`](Self::insert_block).
+    #[cfg(not(target_family = "wasm"))]
+    type InsertError: std::error::Error + Send + Sync + 'static;
+
+    /// Error returned by [`insert_block`](Self::insert_block).
+    #[cfg(target_family = "wasm")]
+    type InsertError: std::error::Error + 'static;
+
+    /// Error returned by [`get_block`](Self::get_block).
+    #[cfg(not(target_family = "wasm"))]
+    type GetError: std::error::Error + Send + Sync + 'static;
+
+    /// Error returned by [`get_block`](Self::get_block).
+    #[cfg(target_family = "wasm")]
+    type GetError: std::error::Error + 'static;
+
     /// Future returned by [`insert_block`](Self::insert_block).
     #[cfg(not(target_family = "wasm"))]
-    type InsertBlockFuture: Future<Output = TransportResult<()>> + Send + 'static;
+    type InsertBlockFuture: Future<Output = Result<(), Self::InsertError>> + Send + 'static;
 
     /// Future returned by [`insert_block`](Self::insert_block).
     #[cfg(target_family = "wasm")]
-    type InsertBlockFuture: Future<Output = TransportResult<()>> + 'static;
+    type InsertBlockFuture: Future<Output = Result<(), Self::InsertError>> + 'static;
 
     /// Future returned by [`get_block`](Self::get_block).
     #[cfg(not(target_family = "wasm"))]
-    type GetBlockFuture: Future<Output = TransportResult<Option<N::BlockResponse>>> + Send + 'static;
+    type GetBlockFuture: Future<Output = Result<Option<N::BlockResponse>, Self::GetError>>
+        + Send
+        + 'static;
 
     /// Future returned by [`get_block`](Self::get_block).
     #[cfg(target_family = "wasm")]
-    type GetBlockFuture: Future<Output = TransportResult<Option<N::BlockResponse>>> + 'static;
+    type GetBlockFuture: Future<Output = Result<Option<N::BlockResponse>, Self::GetError>>
+        + 'static;
 
     /// Records a newly emitted canonical block.
     fn insert_block(&mut self, block: N::BlockResponse) -> Self::InsertBlockFuture;
@@ -520,51 +545,80 @@ pub trait CanonicalBlockStore<N: Network>: std::fmt::Debug + Send + Sync + 'stat
 }
 
 /// In-memory canonical history store used by default by canonical watchers.
+///
+/// Stores the most recent `max_reorg_depth` blocks as a strictly sequential, contiguous chain.
+/// On insert, any retained block at a height `>=` the new block's height is dropped so the
+/// buffer continues to represent a single canonical chain after a reorg.
 #[derive(Debug)]
 pub struct InMemoryStore<T> {
-    inner: FixedBuf<(u64, T)>,
+    inner: FixedBuf<T>,
 }
 
 impl<T> InMemoryStore<T> {
     /// Creates an in-memory store retaining up to `max_reorg_depth` canonical items.
-    pub fn new(max_reorg_depth: usize) -> Self {
+    pub(crate) fn new(max_reorg_depth: usize) -> Self {
         Self { inner: FixedBuf::new(max_reorg_depth) }
     }
 }
 
 impl<T> InMemoryStore<T>
 where
-    T: Clone,
+    T: BlockResponse + Clone,
+    T::Header: BlockHeader,
 {
-    fn insert(&mut self, block_number: u64, item: T) -> TransportResult<()> {
-        self.inner.push((block_number, item));
+    fn insert(&mut self, block: T) -> Result<(), InMemoryStoreInsertError> {
+        let block_number = block.header().number();
+        while self.inner.last().is_some_and(|last| last.header().number() >= block_number) {
+            self.inner.pop();
+        }
+        if let Some(last) = self.inner.last() {
+            let expected = last.header().number() + 1;
+            if expected != block_number {
+                return Err(InMemoryStoreInsertError::OutOfOrder { expected, got: block_number });
+            }
+        }
+        self.inner.push(block);
         Ok(())
     }
 
-    fn get(&self, block_number: u64) -> TransportResult<Option<T>> {
-        Ok(self
-            .inner
-            .iter()
-            .rev()
-            .find(|(stored_number, _)| *stored_number == block_number)
-            .map(|(_, item)| item.clone()))
+    fn get(&self, block_number: u64) -> Option<T> {
+        let last_number = self.inner.last()?.header().number();
+        let offset = usize::try_from(last_number.checked_sub(block_number)?).ok()?;
+        let index = self.inner.len().checked_sub(1)?.checked_sub(offset)?;
+        self.inner.get(index).cloned()
     }
+}
+
+/// Error returned by [`InMemoryStore::insert_block`].
+#[derive(Debug, thiserror::Error)]
+pub enum InMemoryStoreInsertError {
+    /// Inserted block's height leaves a gap relative to the most recent retained block.
+    #[error(
+        "inserted block #{got} is out of order; expected sequential extension at #{expected}"
+    )]
+    OutOfOrder {
+        /// The block height that was expected next.
+        expected: u64,
+        /// The block height that was actually provided.
+        got: u64,
+    },
 }
 
 impl<N> CanonicalBlockStore<N> for InMemoryStore<N::BlockResponse>
 where
     N: Network,
 {
-    type InsertBlockFuture = std::future::Ready<TransportResult<()>>;
-    type GetBlockFuture = std::future::Ready<TransportResult<Option<N::BlockResponse>>>;
+    type InsertError = InMemoryStoreInsertError;
+    type GetError = std::convert::Infallible;
+    type InsertBlockFuture = std::future::Ready<Result<(), Self::InsertError>>;
+    type GetBlockFuture = std::future::Ready<Result<Option<N::BlockResponse>, Self::GetError>>;
 
     fn insert_block(&mut self, block: N::BlockResponse) -> Self::InsertBlockFuture {
-        let block_number = block.header().number();
-        std::future::ready(self.insert(block_number, block))
+        std::future::ready(self.insert(block))
     }
 
     fn get_block(&mut self, block_number: u64) -> Self::GetBlockFuture {
-        std::future::ready(self.get(block_number))
+        std::future::ready(Ok(self.get(block_number)))
     }
 }
 
@@ -599,12 +653,12 @@ impl<T> FixedBuf<T> {
         self.buf.back()
     }
 
-    pub(super) fn len(&self) -> usize {
-        self.buf.len()
+    pub(super) fn get(&self, index: usize) -> Option<&T> {
+        self.buf.get(index)
     }
 
-    pub(super) fn iter(&self) -> std::collections::vec_deque::Iter<'_, T> {
-        self.buf.iter()
+    pub(super) fn len(&self) -> usize {
+        self.buf.len()
     }
 }
 
@@ -763,8 +817,10 @@ mod tests {
     }
 
     impl CanonicalBlockStore<alloy_network::Ethereum> for FullHistoryBlockStore {
-        type InsertBlockFuture = std::future::Ready<TransportResult<()>>;
-        type GetBlockFuture = std::future::Ready<TransportResult<Option<Block>>>;
+        type InsertError = std::convert::Infallible;
+        type GetError = std::convert::Infallible;
+        type InsertBlockFuture = std::future::Ready<Result<(), Self::InsertError>>;
+        type GetBlockFuture = std::future::Ready<Result<Option<Block>, Self::GetError>>;
 
         fn insert_block(&mut self, block: Block) -> Self::InsertBlockFuture {
             self.blocks.insert(block.header.number, block);

--- a/crates/provider/src/provider/watch_canonical_blocks_from.rs
+++ b/crates/provider/src/provider/watch_canonical_blocks_from.rs
@@ -28,7 +28,7 @@ const MAX_REORG_DEPTH_DEFAULT: usize = 64;
 pub struct WatchCanonicalBlocksFrom<N, S = InMemoryStore<<N as Network>::BlockResponse>>
 where
     N: Network,
-    S: CanonicalBlockStore<N>,
+    S: CanonicalStore<N::BlockResponse>,
 {
     watch_blocks_from: WatchBlocksFrom<N>,
     rpc_concurrency: usize,
@@ -49,7 +49,7 @@ impl<N: Network> WatchCanonicalBlocksFrom<N> {
         Self {
             watch_blocks_from,
             rpc_concurrency: RPC_CONCURRENCY_DEFAULT,
-            block_store: InMemoryStore::new(MAX_REORG_DEPTH_DEFAULT),
+            block_store: InMemoryStore::<N::BlockResponse>::new(MAX_REORG_DEPTH_DEFAULT),
         }
     }
 }
@@ -57,7 +57,7 @@ impl<N: Network> WatchCanonicalBlocksFrom<N> {
 impl<N, S> WatchCanonicalBlocksFrom<N, S>
 where
     N: Network,
-    S: CanonicalBlockStore<N>,
+    S: CanonicalStore<N::BlockResponse>,
 {
     /// Streams canonical blocks with full transaction bodies.
     pub fn full(mut self) -> Self {
@@ -92,7 +92,7 @@ where
     /// Sets the store used to fetch previously emitted canonical blocks during reorg handling.
     pub fn block_store<S2>(self, block_store: S2) -> WatchCanonicalBlocksFrom<N, S2>
     where
-        S2: CanonicalBlockStore<N>,
+        S2: CanonicalStore<N::BlockResponse>,
     {
         WatchCanonicalBlocksFrom {
             watch_blocks_from: self.watch_blocks_from,
@@ -119,7 +119,7 @@ where
 impl<N: Network> WatchCanonicalBlocksFrom<N, InMemoryStore<N::BlockResponse>> {
     /// Sets the maximum number of canonical blocks retained by the default in-memory store.
     pub fn max_reorg_depth(mut self, max_reorg_depth: usize) -> Self {
-        self.block_store = InMemoryStore::new(max_reorg_depth);
+        self.block_store = InMemoryStore::<N::BlockResponse>::new(max_reorg_depth);
         self
     }
 }
@@ -131,7 +131,7 @@ impl<N: Network> WatchCanonicalBlocksFrom<N, InMemoryStore<N::BlockResponse>> {
 enum WatchCanonicalBlocksFromState<N, S>
 where
     N: Network,
-    S: CanonicalBlockStore<N>,
+    S: CanonicalStore<N::BlockResponse>,
 {
     /// Polling the next block from `watch_blocks_from(...).buffered(...)`.
     PollNext,
@@ -150,7 +150,7 @@ where
         pending: VecDeque<N::BlockResponse>,
         block_number: u64,
         #[pin]
-        fut: S::GetBlockFuture,
+        fut: S::PopFuture,
     },
     /// Polling an in-flight fetch for the new canonical tip after one rollback.
     FetchingTipAfterRemoved {
@@ -158,7 +158,7 @@ where
         pending: VecDeque<N::BlockResponse>,
         removed: N::BlockResponse,
         #[pin]
-        fut: S::GetBlockFuture,
+        fut: S::GetFuture,
     },
     /// Emitting `Added` events for `pending`, then `next`.
     EmitPending { pending: VecDeque<N::BlockResponse>, next: Option<N::BlockResponse> },
@@ -168,7 +168,7 @@ where
         next: Option<N::BlockResponse>,
         block: N::BlockResponse,
         #[pin]
-        fut: S::InsertBlockFuture,
+        fut: S::PushFuture,
     },
     /// Yield one terminal error item and then end the stream.
     EmitError { err: TransportError },
@@ -179,7 +179,7 @@ where
 impl<N, S> fmt::Debug for WatchCanonicalBlocksFromState<N, S>
 where
     N: Network,
-    S: CanonicalBlockStore<N>,
+    S: CanonicalStore<N::BlockResponse>,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -225,7 +225,7 @@ where
 pub struct WatchCanonicalBlocksFromStream<N, S = InMemoryStore<<N as Network>::BlockResponse>>
 where
     N: Network,
-    S: CanonicalBlockStore<N>,
+    S: CanonicalStore<N::BlockResponse>,
 {
     watch_blocks_from: WatchBlocksFrom<N>,
     #[pin]
@@ -239,7 +239,7 @@ where
 impl<N, S> Stream for WatchCanonicalBlocksFromStream<N, S>
 where
     N: Network,
-    S: CanonicalBlockStore<N>,
+    S: CanonicalStore<N::BlockResponse>,
 {
     type Item = TransportResult<CanonicalEvent<N::BlockResponse>>;
 
@@ -297,7 +297,7 @@ where
                     let height = front.header().number();
                     let canonical_height = canonical_tip.header().number();
                     if canonical_height + 1 == height {
-                        let fut = this.block_store.get_block(canonical_height);
+                        let fut = this.block_store.pop(canonical_height);
                         this.state.set(WatchCanonicalBlocksFromState::FetchingRemoved {
                             next,
                             pending,
@@ -386,7 +386,7 @@ where
                         });
                         return Poll::Ready(Some(Ok(CanonicalEvent::Removed(removed))));
                     };
-                    let fut = this.block_store.get_block(parent_number);
+                    let fut = this.block_store.get(parent_number);
                     this.state.set(WatchCanonicalBlocksFromState::FetchingTipAfterRemoved {
                         next,
                         pending,
@@ -432,7 +432,7 @@ where
                     };
 
                     if let Some(block) = pending.pop_front() {
-                        let fut = this.block_store.insert_block(block.clone());
+                        let fut = this.block_store.push(block.clone());
                         this.state.set(WatchCanonicalBlocksFromState::StoringAdded {
                             pending,
                             next,
@@ -443,7 +443,7 @@ where
                     }
 
                     if let Some(block) = next.take() {
-                        let fut = this.block_store.insert_block(block.clone());
+                        let fut = this.block_store.push(block.clone());
                         this.state.set(WatchCanonicalBlocksFromState::StoringAdded {
                             pending,
                             next: None,
@@ -492,99 +492,82 @@ where
     }
 }
 
-/// A store of previously emitted canonical blocks used to produce removed events on reorgs.
-pub trait CanonicalBlockStore<N: Network>: std::fmt::Debug + Send + Sync + 'static {
-    /// Error returned by [`insert_block`](Self::insert_block).
+/// A store of previously emitted canonical items used to produce removed events on reorgs.
+pub trait CanonicalStore<T>: std::fmt::Debug + Send + Sync + 'static {
+    /// Error returned by store operations.
+    type Error: std::error::Error + Send + Sync + 'static;
+
+    /// Future returned by [`push`](Self::push).
     #[cfg(not(target_family = "wasm"))]
-    type InsertError: std::error::Error + Send + Sync + 'static;
+    type PushFuture: Future<Output = Result<(), Self::Error>> + Send + 'static;
 
-    /// Error returned by [`insert_block`](Self::insert_block).
+    /// Future returned by [`push`](Self::push).
     #[cfg(target_family = "wasm")]
-    type InsertError: std::error::Error + 'static;
+    type PushFuture: Future<Output = Result<(), Self::Error>> + 'static;
 
-    /// Error returned by [`get_block`](Self::get_block).
+    /// Future returned by [`get`](Self::get).
     #[cfg(not(target_family = "wasm"))]
-    type GetError: std::error::Error + Send + Sync + 'static;
+    type GetFuture: Future<Output = Result<Option<T>, Self::Error>> + Send + 'static;
 
-    /// Error returned by [`get_block`](Self::get_block).
+    /// Future returned by [`get`](Self::get).
     #[cfg(target_family = "wasm")]
-    type GetError: std::error::Error + 'static;
+    type GetFuture: Future<Output = Result<Option<T>, Self::Error>> + 'static;
 
-    /// Future returned by [`insert_block`](Self::insert_block).
+    /// Future returned by [`pop`](Self::pop).
     #[cfg(not(target_family = "wasm"))]
-    type InsertBlockFuture: Future<Output = Result<(), Self::InsertError>> + Send + 'static;
+    type PopFuture: Future<Output = Result<Option<T>, Self::Error>> + Send + 'static;
 
-    /// Future returned by [`insert_block`](Self::insert_block).
+    /// Future returned by [`pop`](Self::pop).
     #[cfg(target_family = "wasm")]
-    type InsertBlockFuture: Future<Output = Result<(), Self::InsertError>> + 'static;
+    type PopFuture: Future<Output = Result<Option<T>, Self::Error>> + 'static;
 
-    /// Future returned by [`get_block`](Self::get_block).
-    #[cfg(not(target_family = "wasm"))]
-    type GetBlockFuture: Future<Output = Result<Option<N::BlockResponse>, Self::GetError>>
-        + Send
-        + 'static;
+    /// Records a newly emitted canonical item.
+    ///
+    /// Only consecutive items are pushed. If this returns an error, the canonical stream yields
+    /// that error and then terminates before emitting the corresponding [`CanonicalEvent::Added`].
+    fn push(&mut self, item: T) -> Self::PushFuture;
 
-    /// Future returned by [`get_block`](Self::get_block).
-    #[cfg(target_family = "wasm")]
-    type GetBlockFuture: Future<Output = Result<Option<N::BlockResponse>, Self::GetError>> + 'static;
+    /// Fetches a previously emitted canonical item by block number.
+    ///
+    /// The stream calls this after a rollback to find the new retained tip. If this returns an
+    /// error, the stream yields that error and then terminates. Returning `Ok(None)` means the
+    /// retained history is missing the requested ancestor; the stream treats that as a deep reorg
+    /// and terminates after emitting any already-popped removed item.
+    fn get(&mut self, block_number: u64) -> Self::GetFuture;
 
-    /// Records a newly emitted canonical block.
-    fn insert_block(&mut self, block: N::BlockResponse) -> Self::InsertBlockFuture;
-
-    /// Fetches a previously emitted canonical block by block number.
-    fn get_block(&mut self, block_number: u64) -> Self::GetBlockFuture;
+    /// Removes and returns a previously emitted canonical item by block number.
+    ///
+    /// The stream calls this before emitting [`CanonicalEvent::Removed`]. If this returns an error,
+    /// the stream yields that error and then terminates before emitting the removed event.
+    /// Returning `Ok(None)` means the removed block is no longer available; the stream reports
+    /// missing canonical history and terminates.
+    fn pop(&mut self, block_number: u64) -> Self::PopFuture;
 }
 
 /// In-memory canonical history store used by default by canonical watchers.
 ///
-/// Stores the most recent `max_reorg_depth` blocks as a strictly sequential, contiguous chain.
-/// On insert, any retained block at a height `>=` the new block's height is dropped so the
-/// buffer continues to represent a single canonical chain after a reorg.
+/// Stores the most recent `max_reorg_depth` items as a strictly sequential, contiguous chain.
 #[derive(Debug)]
 pub struct InMemoryStore<T> {
     inner: FixedBuf<T>,
 }
 
-impl<T> InMemoryStore<T> {
+impl<T> InMemoryStore<T>
+where
+    T: BlockResponse,
+    T::Header: BlockHeader,
+{
     /// Creates an in-memory store retaining up to `max_reorg_depth` canonical items.
-    pub(crate) fn new(max_reorg_depth: usize) -> Self {
+    pub fn new(max_reorg_depth: usize) -> Self {
         Self { inner: FixedBuf::new(max_reorg_depth) }
     }
 }
 
-impl<T> InMemoryStore<T>
-where
-    T: BlockResponse + Clone,
-    T::Header: BlockHeader,
-{
-    fn insert(&mut self, block: T) -> Result<(), InMemoryStoreInsertError> {
-        let block_number = block.header().number();
-        while self.inner.last().is_some_and(|last| last.header().number() >= block_number) {
-            self.inner.pop();
-        }
-        if let Some(last) = self.inner.last() {
-            let expected = last.header().number() + 1;
-            if expected != block_number {
-                return Err(InMemoryStoreInsertError::OutOfOrder { expected, got: block_number });
-            }
-        }
-        self.inner.push(block);
-        Ok(())
-    }
-
-    fn get(&self, block_number: u64) -> Option<T> {
-        let last_number = self.inner.last()?.header().number();
-        let offset = usize::try_from(last_number.checked_sub(block_number)?).ok()?;
-        let index = self.inner.len().checked_sub(1)?.checked_sub(offset)?;
-        self.inner.get(index).cloned()
-    }
-}
-
-/// Error returned by [`InMemoryStore::insert_block`].
+/// Error returned by [`InMemoryStore`] operations.
 #[derive(Debug, thiserror::Error)]
-pub enum InMemoryStoreInsertError {
-    /// Inserted block's height leaves a gap relative to the most recent retained block.
-    #[error("inserted block #{got} is out of order; expected sequential extension at #{expected}")]
+pub enum InMemoryStoreError {
+    /// Pushed item's height leaves a gap relative to the most recent retained item.
+    #[error("pushed item #{got} is out of order; expected sequential extension at #{expected}")]
     OutOfOrder {
         /// The block height that was expected next.
         expected: u64,
@@ -593,21 +576,49 @@ pub enum InMemoryStoreInsertError {
     },
 }
 
-impl<N> CanonicalBlockStore<N> for InMemoryStore<N::BlockResponse>
+impl<T> CanonicalStore<T> for InMemoryStore<T>
 where
-    N: Network,
+    T: BlockResponse + Clone + std::fmt::Debug + Send + Sync + 'static,
+    T::Header: BlockHeader,
 {
-    type InsertError = InMemoryStoreInsertError;
-    type GetError = std::convert::Infallible;
-    type InsertBlockFuture = std::future::Ready<Result<(), Self::InsertError>>;
-    type GetBlockFuture = std::future::Ready<Result<Option<N::BlockResponse>, Self::GetError>>;
+    type Error = InMemoryStoreError;
+    type PushFuture = std::future::Ready<Result<(), Self::Error>>;
+    type GetFuture = std::future::Ready<Result<Option<T>, Self::Error>>;
+    type PopFuture = std::future::Ready<Result<Option<T>, Self::Error>>;
 
-    fn insert_block(&mut self, block: N::BlockResponse) -> Self::InsertBlockFuture {
-        std::future::ready(self.insert(block))
+    fn push(&mut self, item: T) -> Self::PushFuture {
+        let block_number = item.header().number();
+        if let Some(last) = self.inner.last() {
+            let expected = last.header().number() + 1;
+            if expected != block_number {
+                return std::future::ready(Err(InMemoryStoreError::OutOfOrder {
+                    expected,
+                    got: block_number,
+                }));
+            }
+        }
+        self.inner.push(item);
+        std::future::ready(Ok(()))
     }
 
-    fn get_block(&mut self, block_number: u64) -> Self::GetBlockFuture {
-        std::future::ready(Ok(self.get(block_number)))
+    fn get(&mut self, block_number: u64) -> Self::GetFuture {
+        let item = self.inner.last().and_then(|last| {
+            let offset = usize::try_from(last.header().number().checked_sub(block_number)?).ok()?;
+            let index = self.inner.len().checked_sub(1)?.checked_sub(offset)?;
+            self.inner.get(index).and_then(|stored| {
+                (stored.header().number() == block_number).then(|| stored.clone())
+            })
+        });
+        std::future::ready(Ok(item))
+    }
+
+    fn pop(&mut self, block_number: u64) -> Self::PopFuture {
+        let item = if self.inner.last().is_some_and(|last| last.header().number() == block_number) {
+            self.inner.pop()
+        } else {
+            None
+        };
+        std::future::ready(Ok(item))
     }
 }
 
@@ -654,7 +665,7 @@ impl<T> FixedBuf<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Provider, ProviderBuilder};
+    use crate::{BlockLogs, Provider, ProviderBuilder};
     use alloy_eips::BlockNumberOrTag;
     use alloy_primitives::{B256, U64};
     use alloy_rpc_client::RpcClient;
@@ -805,20 +816,41 @@ mod tests {
         }
     }
 
-    impl CanonicalBlockStore<alloy_network::Ethereum> for FullHistoryBlockStore {
-        type InsertError = std::convert::Infallible;
-        type GetError = std::convert::Infallible;
-        type InsertBlockFuture = std::future::Ready<Result<(), Self::InsertError>>;
-        type GetBlockFuture = std::future::Ready<Result<Option<Block>, Self::GetError>>;
+    impl CanonicalStore<Block> for FullHistoryBlockStore {
+        type Error = std::convert::Infallible;
+        type PushFuture = std::future::Ready<Result<(), Self::Error>>;
+        type GetFuture = std::future::Ready<Result<Option<Block>, Self::Error>>;
+        type PopFuture = std::future::Ready<Result<Option<Block>, Self::Error>>;
 
-        fn insert_block(&mut self, block: Block) -> Self::InsertBlockFuture {
-            self.blocks.insert(block.header.number, block);
+        fn push(&mut self, block: Block) -> Self::PushFuture {
+            let block_number = block.header().number();
+            self.blocks.insert(block_number, block);
             std::future::ready(Ok(()))
         }
 
-        fn get_block(&mut self, block_number: u64) -> Self::GetBlockFuture {
+        fn get(&mut self, block_number: u64) -> Self::GetFuture {
             std::future::ready(Ok(self.blocks.get(&block_number).cloned()))
         }
+
+        fn pop(&mut self, block_number: u64) -> Self::PopFuture {
+            std::future::ready(Ok(self.blocks.remove(&block_number)))
+        }
+    }
+
+    #[tokio::test]
+    async fn in_memory_store_supports_block_logs() {
+        let mut store = InMemoryStore::<BlockLogs<alloy_network::Ethereum>>::new(2);
+        let block_logs = BlockLogs { block: block(1, 1, 0), logs: Vec::new() };
+
+        store.push(block_logs.clone()).await.unwrap();
+
+        let stored = store.get(1).await.unwrap().unwrap();
+        assert_eq!(stored.block.header.number, 1);
+        assert_eq!(stored.block.header.hash, B256::with_last_byte(1));
+
+        let removed = store.pop(1).await.unwrap().unwrap();
+        assert_eq!(removed.block.header.number, 1);
+        assert!(store.get(1).await.unwrap().is_none());
     }
 
     #[tokio::test]

--- a/crates/provider/src/provider/watch_canonical_blocks_from.rs
+++ b/crates/provider/src/provider/watch_canonical_blocks_from.rs
@@ -267,10 +267,8 @@ where
                     }
                 }
                 WatchCanonicalBlocksFromStateProj::Reconcile { .. } => {
-                    let WatchCanonicalBlocksFromStateProjOwn::Reconcile { next, pending } = this
-                        .state
-                        .as_mut()
-                        .project_replace(WatchCanonicalBlocksFromState::Done)
+                    let WatchCanonicalBlocksFromStateProjOwn::Reconcile { next, pending } =
+                        this.state.as_mut().project_replace(WatchCanonicalBlocksFromState::Done)
                     else {
                         unreachable!()
                     };
@@ -418,8 +416,7 @@ where
                     };
                     *this.canonical_tip = previous_tip;
                     if this.canonical_tip.is_some() {
-                        this.state
-                            .set(WatchCanonicalBlocksFromState::Reconcile { next, pending });
+                        this.state.set(WatchCanonicalBlocksFromState::Reconcile { next, pending });
                     } else {
                         this.state.set(WatchCanonicalBlocksFromState::EmitError {
                             err: deep_reorg_block_error(),
@@ -428,10 +425,8 @@ where
                     return Poll::Ready(Some(Ok(CanonicalEvent::Removed(removed))));
                 }
                 WatchCanonicalBlocksFromStateProj::EmitPending { .. } => {
-                    let WatchCanonicalBlocksFromStateProjOwn::EmitPending {
-                        mut pending,
-                        mut next,
-                    } = this.state.as_mut().project_replace(WatchCanonicalBlocksFromState::Done)
+                    let WatchCanonicalBlocksFromStateProjOwn::EmitPending { mut pending, mut next } =
+                        this.state.as_mut().project_replace(WatchCanonicalBlocksFromState::Done)
                     else {
                         unreachable!()
                     };
@@ -481,15 +476,12 @@ where
                         unreachable!()
                     };
                     *this.canonical_tip = Some(block.clone());
-                    this.state
-                        .set(WatchCanonicalBlocksFromState::EmitPending { pending, next });
+                    this.state.set(WatchCanonicalBlocksFromState::EmitPending { pending, next });
                     return Poll::Ready(Some(Ok(CanonicalEvent::Added(block))));
                 }
                 WatchCanonicalBlocksFromStateProj::EmitError { .. } => {
-                    let WatchCanonicalBlocksFromStateProjOwn::EmitError { err } = this
-                        .state
-                        .as_mut()
-                        .project_replace(WatchCanonicalBlocksFromState::Done)
+                    let WatchCanonicalBlocksFromStateProjOwn::EmitError { err } =
+                        this.state.as_mut().project_replace(WatchCanonicalBlocksFromState::Done)
                     else {
                         unreachable!()
                     };
@@ -534,8 +526,7 @@ pub trait CanonicalBlockStore<N: Network>: std::fmt::Debug + Send + Sync + 'stat
 
     /// Future returned by [`get_block`](Self::get_block).
     #[cfg(target_family = "wasm")]
-    type GetBlockFuture: Future<Output = Result<Option<N::BlockResponse>, Self::GetError>>
-        + 'static;
+    type GetBlockFuture: Future<Output = Result<Option<N::BlockResponse>, Self::GetError>> + 'static;
 
     /// Records a newly emitted canonical block.
     fn insert_block(&mut self, block: N::BlockResponse) -> Self::InsertBlockFuture;
@@ -593,9 +584,7 @@ where
 #[derive(Debug, thiserror::Error)]
 pub enum InMemoryStoreInsertError {
     /// Inserted block's height leaves a gap relative to the most recent retained block.
-    #[error(
-        "inserted block #{got} is out of order; expected sequential extension at #{expected}"
-    )]
+    #[error("inserted block #{got} is out of order; expected sequential extension at #{expected}")]
     OutOfOrder {
         /// The block height that was expected next.
         expected: u64,
@@ -670,7 +659,7 @@ mod tests {
     use alloy_primitives::{B256, U64};
     use alloy_rpc_client::RpcClient;
     use alloy_rpc_types_eth::Block;
-    use alloy_transport::{TransportError, TransportFut, TransportResult};
+    use alloy_transport::{TransportError, TransportFut};
     use futures::StreamExt;
     use std::{
         collections::HashMap,

--- a/crates/provider/src/provider/watch_canonical_logs_from.rs
+++ b/crates/provider/src/provider/watch_canonical_logs_from.rs
@@ -1,5 +1,5 @@
 use super::{
-    BlockLogs, BlockLogsFut, CanonicalEvent, CanonicalStore, InMemoryStore, WatchLogsFrom,
+    BlockLogs, BlockLogsFut, CanonicalEvent, CanonicalStore, InMemoryCanonicalStore, WatchLogsFrom,
     WatchLogsFromStream,
 };
 use crate::transport::TransportErrorKind;
@@ -45,7 +45,7 @@ const MAX_REORG_DEPTH_DEFAULT: usize = 64;
 /// transport-level retry behavior.
 #[derive(Debug)]
 #[must_use = "this builder does nothing unless you call `.into_stream`"]
-pub struct WatchCanonicalLogsFrom<N, S = InMemoryStore<BlockLogs<N>>>
+pub struct WatchCanonicalLogsFrom<N, S = InMemoryCanonicalStore<BlockLogs<N>>>
 where
     N: Network,
     S: CanonicalStore<BlockLogs<N>>,
@@ -60,7 +60,7 @@ impl<N: Network> WatchCanonicalLogsFrom<N> {
         Self {
             watch_logs_from,
             rpc_concurrency: RPC_CONCURRENCY_DEFAULT,
-            block_store: InMemoryStore::<BlockLogs<N>>::new(MAX_REORG_DEPTH_DEFAULT),
+            block_store: InMemoryCanonicalStore::<BlockLogs<N>>::new(MAX_REORG_DEPTH_DEFAULT),
         }
     }
 }
@@ -137,11 +137,11 @@ where
     }
 }
 
-impl<N: Network> WatchCanonicalLogsFrom<N, InMemoryStore<BlockLogs<N>>> {
+impl<N: Network> WatchCanonicalLogsFrom<N, InMemoryCanonicalStore<BlockLogs<N>>> {
     /// Sets the maximum number of canonical blocks and their logs retained by the default
     /// in-memory store.
     pub fn max_reorg_depth(mut self, max_reorg_depth: usize) -> Self {
-        self.block_store = InMemoryStore::<BlockLogs<N>>::new(max_reorg_depth);
+        self.block_store = InMemoryCanonicalStore::<BlockLogs<N>>::new(max_reorg_depth);
         self
     }
 }
@@ -248,7 +248,7 @@ where
 /// does not need to query logs for rolled-back blocks after a reorg.
 #[derive(Debug)]
 #[pin_project]
-pub struct WatchCanonicalLogsFromStream<N, S = InMemoryStore<BlockLogs<N>>>
+pub struct WatchCanonicalLogsFromStream<N, S = InMemoryCanonicalStore<BlockLogs<N>>>
 where
     N: Network,
     S: CanonicalStore<BlockLogs<N>>,
@@ -544,7 +544,7 @@ mod tests {
     };
     use crate::{CanonicalStore, Provider};
     use alloy_eips::BlockNumberOrTag;
-    use alloy_network::{BlockResponse as _, Ethereum};
+    use alloy_network::Ethereum;
     use alloy_rpc_types_eth::Filter;
     use futures::StreamExt;
     use std::{collections::HashMap, time::Duration};
@@ -577,7 +577,8 @@ mod tests {
         }
 
         fn pop(&mut self) -> Self::PopFuture {
-            let item = self.block_logs.keys().max().copied().and_then(|n| self.block_logs.remove(&n));
+            let item =
+                self.block_logs.keys().max().copied().and_then(|n| self.block_logs.remove(&n));
             std::future::ready(Ok(item))
         }
     }

--- a/crates/provider/src/provider/watch_canonical_logs_from.rs
+++ b/crates/provider/src/provider/watch_canonical_logs_from.rs
@@ -1,5 +1,5 @@
 use super::{
-    watch_canonical_blocks_from::FixedBuf, BlockLogs, BlockLogsFut, CanonicalEvent, WatchLogsFrom,
+    BlockLogs, BlockLogsFut, CanonicalEvent, CanonicalStore, InMemoryStore, WatchLogsFrom,
     WatchLogsFromStream,
 };
 use crate::transport::TransportErrorKind;
@@ -12,6 +12,7 @@ use futures::{stream::Buffered, Stream, StreamExt as _};
 use pin_project::pin_project;
 use std::{
     collections::VecDeque,
+    fmt,
     future::Future,
     pin::Pin,
     task::{Context, Poll},
@@ -44,21 +45,31 @@ const MAX_REORG_DEPTH_DEFAULT: usize = 64;
 /// transport-level retry behavior.
 #[derive(Debug)]
 #[must_use = "this builder does nothing unless you call `.into_stream`"]
-pub struct WatchCanonicalLogsFrom<N: Network> {
+pub struct WatchCanonicalLogsFrom<N, S = InMemoryStore<BlockLogs<N>>>
+where
+    N: Network,
+    S: CanonicalStore<BlockLogs<N>>,
+{
     watch_logs_from: WatchLogsFrom<N>,
     rpc_concurrency: usize,
-    max_reorg_depth: usize,
+    block_store: S,
 }
 
 impl<N: Network> WatchCanonicalLogsFrom<N> {
-    pub(crate) const fn new(watch_logs_from: WatchLogsFrom<N>) -> Self {
+    pub(crate) fn new(watch_logs_from: WatchLogsFrom<N>) -> Self {
         Self {
             watch_logs_from,
             rpc_concurrency: RPC_CONCURRENCY_DEFAULT,
-            max_reorg_depth: MAX_REORG_DEPTH_DEFAULT,
+            block_store: InMemoryStore::<BlockLogs<N>>::new(MAX_REORG_DEPTH_DEFAULT),
         }
     }
+}
 
+impl<N, S> WatchCanonicalLogsFrom<N, S>
+where
+    N: Network,
+    S: CanonicalStore<BlockLogs<N>>,
+{
     /// Streams block log batches with full transaction bodies in the block response.
     pub fn full(mut self) -> Self {
         self.watch_logs_from = self.watch_logs_from.full();
@@ -94,13 +105,17 @@ impl<N: Network> WatchCanonicalLogsFrom<N> {
         self
     }
 
-    /// Sets the maximum number of canonical blocks and their logs retained for reorg detection.
-    ///
-    /// Removed events can only be emitted for blocks still retained in this buffer. A reorg deeper
-    /// than the retained history yields a terminal error. A value of `0` is clamped to `1`.
-    pub const fn max_reorg_depth(mut self, max_reorg_depth: usize) -> Self {
-        self.max_reorg_depth = if max_reorg_depth == 0 { 1 } else { max_reorg_depth };
-        self
+    /// Sets the store used to fetch previously emitted canonical block log batches during reorg
+    /// handling.
+    pub fn block_store<S2>(self, block_store: S2) -> WatchCanonicalLogsFrom<N, S2>
+    where
+        S2: CanonicalStore<BlockLogs<N>>,
+    {
+        WatchCanonicalLogsFrom {
+            watch_logs_from: self.watch_logs_from,
+            rpc_concurrency: self.rpc_concurrency,
+            block_store,
+        }
     }
 
     /// Converts the builder into a stream of canonical block log events.
@@ -108,33 +123,122 @@ impl<N: Network> WatchCanonicalLogsFrom<N> {
     /// The returned stream emits [`CanonicalEvent`] values containing [`BlockLogs`].
     /// Added events contain logs with `removed = false`; removed events contain retained logs with
     /// `removed = true`.
-    pub fn into_stream(self) -> WatchCanonicalLogsFromStream<N> {
-        let Self { watch_logs_from, rpc_concurrency, max_reorg_depth } = self;
+    pub fn into_stream(self) -> WatchCanonicalLogsFromStream<N, S> {
+        let Self { watch_logs_from, rpc_concurrency, block_store } = self;
         let stream = watch_logs_from.clone().into_stream().buffered(rpc_concurrency.max(1));
 
         WatchCanonicalLogsFromStream {
             watch_logs_from,
             stream,
-            buffer: FixedBuf::new(max_reorg_depth),
+            block_store,
+            canonical_tip: None,
             state: WatchCanonicalLogsFromState::PollNext,
         }
     }
 }
 
-#[derive(Debug)]
-enum WatchCanonicalLogsFromState<N: Network> {
+impl<N: Network> WatchCanonicalLogsFrom<N, InMemoryStore<BlockLogs<N>>> {
+    /// Sets the maximum number of canonical blocks and their logs retained by the default
+    /// in-memory store.
+    pub fn max_reorg_depth(mut self, max_reorg_depth: usize) -> Self {
+        self.block_store = InMemoryStore::<BlockLogs<N>>::new(max_reorg_depth);
+        self
+    }
+}
+
+#[pin_project(
+    project = WatchCanonicalLogsFromStateProj,
+    project_replace = WatchCanonicalLogsFromStateProjOwn,
+)]
+enum WatchCanonicalLogsFromState<N, S>
+where
+    N: Network,
+    S: CanonicalStore<BlockLogs<N>>,
+{
     /// Polling the next block/log pair from `WatchLogsFromStream`.
     PollNext,
     /// Reconciling `next` with the canonical buffer by walking parents.
     Reconcile { next: BlockLogs<N>, pending: VecDeque<BlockLogs<N>> },
     /// Polling an in-flight parent block/log fetch.
-    FetchingParent { next: BlockLogs<N>, pending: VecDeque<BlockLogs<N>>, fut: BlockLogsFut<N> },
+    FetchingParent {
+        next: BlockLogs<N>,
+        pending: VecDeque<BlockLogs<N>>,
+        #[pin]
+        fut: BlockLogsFut<N>,
+    },
+    /// Polling an in-flight fetch for the rolled-back canonical block logs.
+    FetchingRemoved {
+        next: BlockLogs<N>,
+        pending: VecDeque<BlockLogs<N>>,
+        block_number: u64,
+        #[pin]
+        fut: S::PopFuture,
+    },
+    /// Polling an in-flight fetch for the new canonical tip after one rollback.
+    FetchingTipAfterRemoved {
+        next: BlockLogs<N>,
+        pending: VecDeque<BlockLogs<N>>,
+        removed: BlockLogs<N>,
+        #[pin]
+        fut: S::GetFuture,
+    },
     /// Emitting block log batches for `pending`, then `next`.
     EmitPending { pending: VecDeque<BlockLogs<N>>, next: Option<BlockLogs<N>> },
+    /// Polling an in-flight store insert before emitting an `Added` event.
+    StoringAdded {
+        pending: VecDeque<BlockLogs<N>>,
+        next: Option<BlockLogs<N>>,
+        block_logs: BlockLogs<N>,
+        #[pin]
+        fut: S::PushFuture,
+    },
     /// Yield one terminal error item and then end the stream.
     EmitError { err: TransportError },
     /// Stream terminated.
     Done,
+}
+
+impl<N, S> fmt::Debug for WatchCanonicalLogsFromState<N, S>
+where
+    N: Network,
+    S: CanonicalStore<BlockLogs<N>>,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::PollNext => f.write_str("PollNext"),
+            Self::Reconcile { next, pending } => {
+                f.debug_struct("Reconcile").field("next", next).field("pending", pending).finish()
+            }
+            Self::FetchingParent { next, pending, .. } => f
+                .debug_struct("FetchingParent")
+                .field("next", next)
+                .field("pending", pending)
+                .finish_non_exhaustive(),
+            Self::FetchingRemoved { next, pending, block_number, .. } => f
+                .debug_struct("FetchingRemoved")
+                .field("next", next)
+                .field("pending", pending)
+                .field("block_number", block_number)
+                .finish_non_exhaustive(),
+            Self::FetchingTipAfterRemoved { next, pending, removed, .. } => f
+                .debug_struct("FetchingTipAfterRemoved")
+                .field("next", next)
+                .field("pending", pending)
+                .field("removed", removed)
+                .finish_non_exhaustive(),
+            Self::EmitPending { pending, next } => {
+                f.debug_struct("EmitPending").field("pending", pending).field("next", next).finish()
+            }
+            Self::StoringAdded { pending, next, block_logs, .. } => f
+                .debug_struct("StoringAdded")
+                .field("pending", pending)
+                .field("next", next)
+                .field("block_logs", block_logs)
+                .finish_non_exhaustive(),
+            Self::EmitError { err } => f.debug_struct("EmitError").field("err", err).finish(),
+            Self::Done => f.write_str("Done"),
+        }
+    }
 }
 
 /// A stream of canonical log batches produced by [`WatchCanonicalLogsFrom`].
@@ -144,153 +248,290 @@ enum WatchCanonicalLogsFromState<N: Network> {
 /// does not need to query logs for rolled-back blocks after a reorg.
 #[derive(Debug)]
 #[pin_project]
-pub struct WatchCanonicalLogsFromStream<N: Network> {
+pub struct WatchCanonicalLogsFromStream<N, S = InMemoryStore<BlockLogs<N>>>
+where
+    N: Network,
+    S: CanonicalStore<BlockLogs<N>>,
+{
     watch_logs_from: WatchLogsFrom<N>,
     #[pin]
     stream: Buffered<WatchLogsFromStream<N>>,
-    buffer: FixedBuf<BlockLogs<N>>,
-    state: WatchCanonicalLogsFromState<N>,
+    block_store: S,
+    canonical_tip: Option<N::HeaderResponse>,
+    #[pin]
+    state: WatchCanonicalLogsFromState<N, S>,
 }
 
-impl<N: Network> Stream for WatchCanonicalLogsFromStream<N> {
+impl<N, S> Stream for WatchCanonicalLogsFromStream<N, S>
+where
+    N: Network,
+    S: CanonicalStore<BlockLogs<N>>,
+{
     type Item = TransportResult<CanonicalEvent<BlockLogs<N>>>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let mut this = self.project();
 
         loop {
-            let state = std::mem::replace(this.state, WatchCanonicalLogsFromState::Done);
-            match state {
-                WatchCanonicalLogsFromState::PollNext => match this.stream.as_mut().poll_next(cx) {
-                    Poll::Pending => {
-                        *this.state = WatchCanonicalLogsFromState::PollNext;
-                        return Poll::Pending;
+            match this.state.as_mut().project() {
+                WatchCanonicalLogsFromStateProj::Done => return Poll::Ready(None),
+                WatchCanonicalLogsFromStateProj::PollNext => {
+                    match this.stream.as_mut().poll_next(cx) {
+                        Poll::Pending => return Poll::Pending,
+                        Poll::Ready(None) => {
+                            this.state.set(WatchCanonicalLogsFromState::Done);
+                        }
+                        Poll::Ready(Some(Ok(next))) => {
+                            this.state.set(WatchCanonicalLogsFromState::Reconcile {
+                                next,
+                                pending: VecDeque::new(),
+                            });
+                        }
+                        Poll::Ready(Some(Err(err))) => {
+                            this.state.set(WatchCanonicalLogsFromState::EmitError { err });
+                        }
                     }
-                    Poll::Ready(None) => {
-                        *this.state = WatchCanonicalLogsFromState::Done;
-                    }
-                    Poll::Ready(Some(Ok(next))) => {
-                        *this.state = WatchCanonicalLogsFromState::Reconcile {
-                            next,
-                            pending: VecDeque::new(),
-                        };
-                    }
-                    Poll::Ready(Some(Err(err))) => {
-                        *this.state = WatchCanonicalLogsFromState::EmitError { err };
-                    }
-                },
-                WatchCanonicalLogsFromState::Reconcile { next, pending } => {
+                }
+                WatchCanonicalLogsFromStateProj::Reconcile { .. } => {
+                    let WatchCanonicalLogsFromStateProjOwn::Reconcile { next, pending } =
+                        this.state.as_mut().project_replace(WatchCanonicalLogsFromState::Done)
+                    else {
+                        unreachable!()
+                    };
+
                     let front = pending.front().unwrap_or(&next);
-                    let Some(canonical_tip) = this.buffer.last() else {
-                        *this.state =
-                            WatchCanonicalLogsFromState::EmitPending { pending, next: Some(next) };
+                    let Some(canonical_tip) = this.canonical_tip.as_ref() else {
+                        this.state.set(WatchCanonicalLogsFromState::EmitPending {
+                            pending,
+                            next: Some(next),
+                        });
                         continue;
                     };
 
-                    let parent_hash = front.block.header().parent_hash();
-                    if parent_hash == canonical_tip.block.header().hash() {
-                        *this.state =
-                            WatchCanonicalLogsFromState::EmitPending { pending, next: Some(next) };
+                    let parent_hash = front.header().parent_hash();
+                    if parent_hash == canonical_tip.hash() {
+                        this.state.set(WatchCanonicalLogsFromState::EmitPending {
+                            pending,
+                            next: Some(next),
+                        });
                         continue;
                     }
 
-                    let height = front.block.header().number();
-                    let canonical_height = canonical_tip.block.header().number();
+                    let height = front.header().number();
+                    let canonical_height = canonical_tip.number();
                     if canonical_height + 1 == height {
-                        let removed = this
-                            .buffer
-                            .pop()
-                            .expect("position is always < canonical buffer length");
-                        let after = if this.buffer.len() == 0 {
-                            WatchCanonicalLogsFromState::EmitError {
-                                err: TransportErrorKind::custom_str(
-                                    "Deep reorg detected; no canonical log history retained.",
-                                ),
-                            }
-                        } else {
-                            WatchCanonicalLogsFromState::Reconcile { next, pending }
-                        };
-                        *this.state = after;
-                        return Poll::Ready(Some(Ok(block_log_event(removed, true))));
+                        let fut = this.block_store.pop();
+                        this.state.set(WatchCanonicalLogsFromState::FetchingRemoved {
+                            next,
+                            pending,
+                            block_number: canonical_height,
+                            fut,
+                        });
+                        continue;
                     }
 
                     let Some(parent_height) = height.checked_sub(1) else {
-                        *this.state = WatchCanonicalLogsFromState::EmitError {
+                        this.state.set(WatchCanonicalLogsFromState::EmitError {
                             err: TransportErrorKind::custom_str(
                                 "Cannot backfill parent for genesis block during canonical log reconciliation.",
                             ),
-                        };
+                        });
                         continue;
                     };
 
                     let watch_logs_from = this.watch_logs_from.clone();
                     let fut = watch_logs_from.get_block_logs(parent_height);
-                    *this.state =
-                        WatchCanonicalLogsFromState::FetchingParent { next, pending, fut };
+                    this.state.set(WatchCanonicalLogsFromState::FetchingParent {
+                        next,
+                        pending,
+                        fut,
+                    });
                 }
-                WatchCanonicalLogsFromState::FetchingParent { next, mut pending, mut fut } => {
-                    match Pin::new(&mut fut).poll(cx) {
-                        Poll::Pending => {
-                            *this.state =
-                                WatchCanonicalLogsFromState::FetchingParent { next, pending, fut };
-                            return Poll::Pending;
-                        }
+                WatchCanonicalLogsFromStateProj::FetchingParent { fut, .. } => {
+                    let parent = match fut.poll(cx) {
+                        Poll::Pending => return Poll::Pending,
                         Poll::Ready(Err(err)) => {
-                            *this.state = WatchCanonicalLogsFromState::EmitError { err };
+                            this.state.set(WatchCanonicalLogsFromState::EmitError { err });
+                            continue;
                         }
-                        Poll::Ready(Ok(parent)) => {
-                            let front = pending.front().unwrap_or(&next);
-                            if parent.block.header().hash() != front.block.header().parent_hash() {
-                                // Parent no longer matches: a second reorg happened while
-                                // reconciling. Abandon this item and continue with next blocks.
-                                *this.state = WatchCanonicalLogsFromState::PollNext;
-                                continue;
-                            }
-
-                            pending.push_front(parent);
-                            *this.state = WatchCanonicalLogsFromState::Reconcile { next, pending };
-                        }
+                        Poll::Ready(Ok(parent)) => parent,
+                    };
+                    let WatchCanonicalLogsFromStateProjOwn::FetchingParent {
+                        next,
+                        mut pending,
+                        ..
+                    } = this.state.as_mut().project_replace(WatchCanonicalLogsFromState::Done)
+                    else {
+                        unreachable!()
+                    };
+                    let front = pending.front().unwrap_or(&next);
+                    if parent.header().hash() != front.header().parent_hash() {
+                        // Parent no longer matches: a second reorg happened while
+                        // reconciling. Abandon this item and continue with next blocks.
+                        this.state.set(WatchCanonicalLogsFromState::PollNext);
+                        continue;
                     }
+
+                    pending.push_front(parent);
+                    this.state.set(WatchCanonicalLogsFromState::Reconcile { next, pending });
                 }
-                WatchCanonicalLogsFromState::EmitPending { mut pending, mut next } => {
+                WatchCanonicalLogsFromStateProj::FetchingRemoved { fut, .. } => {
+                    let removed = match fut.poll(cx) {
+                        Poll::Pending => return Poll::Pending,
+                        Poll::Ready(Err(err)) => {
+                            this.state.set(WatchCanonicalLogsFromState::EmitError {
+                                err: TransportErrorKind::custom(err),
+                            });
+                            continue;
+                        }
+                        Poll::Ready(Ok(None)) => {
+                            this.state.set(WatchCanonicalLogsFromState::EmitError {
+                                err: TransportErrorKind::custom_str(
+                                    "Canonical log history is missing an expected block.",
+                                ),
+                            });
+                            continue;
+                        }
+                        Poll::Ready(Ok(Some(removed))) => removed,
+                    };
+                    let WatchCanonicalLogsFromStateProjOwn::FetchingRemoved {
+                        next,
+                        pending,
+                        block_number,
+                        ..
+                    } = this.state.as_mut().project_replace(WatchCanonicalLogsFromState::Done)
+                    else {
+                        unreachable!()
+                    };
+                    let Some(parent_number) = block_number.checked_sub(1) else {
+                        *this.canonical_tip = None;
+                        this.state.set(WatchCanonicalLogsFromState::EmitError {
+                            err: deep_reorg_log_error(),
+                        });
+                        return Poll::Ready(Some(Ok(block_log_event(removed, true))));
+                    };
+                    let fut = this.block_store.get(parent_number);
+                    this.state.set(WatchCanonicalLogsFromState::FetchingTipAfterRemoved {
+                        next,
+                        pending,
+                        removed,
+                        fut,
+                    });
+                }
+                WatchCanonicalLogsFromStateProj::FetchingTipAfterRemoved { fut, .. } => {
+                    let previous_tip = match fut.poll(cx) {
+                        Poll::Pending => return Poll::Pending,
+                        Poll::Ready(Err(err)) => {
+                            this.state.set(WatchCanonicalLogsFromState::EmitError {
+                                err: TransportErrorKind::custom(err),
+                            });
+                            continue;
+                        }
+                        Poll::Ready(Ok(previous_tip)) => previous_tip,
+                    };
+                    let WatchCanonicalLogsFromStateProjOwn::FetchingTipAfterRemoved {
+                        next,
+                        pending,
+                        removed,
+                        ..
+                    } = this.state.as_mut().project_replace(WatchCanonicalLogsFromState::Done)
+                    else {
+                        unreachable!()
+                    };
+                    *this.canonical_tip =
+                        previous_tip.as_ref().map(|block_logs| block_logs.header().clone());
+                    if this.canonical_tip.is_some() {
+                        this.state.set(WatchCanonicalLogsFromState::Reconcile { next, pending });
+                    } else {
+                        this.state.set(WatchCanonicalLogsFromState::EmitError {
+                            err: deep_reorg_log_error(),
+                        });
+                    }
+                    return Poll::Ready(Some(Ok(block_log_event(removed, true))));
+                }
+                WatchCanonicalLogsFromStateProj::EmitPending { .. } => {
+                    let WatchCanonicalLogsFromStateProjOwn::EmitPending { mut pending, mut next } =
+                        this.state.as_mut().project_replace(WatchCanonicalLogsFromState::Done)
+                    else {
+                        unreachable!()
+                    };
+
                     if let Some(block_logs) = pending.pop_front() {
-                        this.buffer.push(block_logs.clone());
-                        *this.state = WatchCanonicalLogsFromState::EmitPending { pending, next };
-                        return Poll::Ready(Some(Ok(block_log_event(block_logs, false))));
+                        let fut = this.block_store.push(block_logs.clone());
+                        this.state.set(WatchCanonicalLogsFromState::StoringAdded {
+                            pending,
+                            next,
+                            block_logs,
+                            fut,
+                        });
+                        continue;
                     }
 
                     if let Some(block_logs) = next.take() {
-                        this.buffer.push(block_logs.clone());
-                        *this.state = WatchCanonicalLogsFromState::PollNext;
-                        return Poll::Ready(Some(Ok(block_log_event(block_logs, false))));
+                        let fut = this.block_store.push(block_logs.clone());
+                        this.state.set(WatchCanonicalLogsFromState::StoringAdded {
+                            pending,
+                            next: None,
+                            block_logs,
+                            fut,
+                        });
+                        continue;
                     }
 
-                    *this.state = WatchCanonicalLogsFromState::PollNext;
+                    this.state.set(WatchCanonicalLogsFromState::PollNext);
                 }
-                WatchCanonicalLogsFromState::EmitError { err } => {
-                    *this.state = WatchCanonicalLogsFromState::Done;
+                WatchCanonicalLogsFromStateProj::StoringAdded { fut, .. } => {
+                    match fut.poll(cx) {
+                        Poll::Pending => return Poll::Pending,
+                        Poll::Ready(Err(err)) => {
+                            this.state.set(WatchCanonicalLogsFromState::EmitError {
+                                err: TransportErrorKind::custom(err),
+                            });
+                            continue;
+                        }
+                        Poll::Ready(Ok(())) => {}
+                    }
+                    let WatchCanonicalLogsFromStateProjOwn::StoringAdded {
+                        pending,
+                        next,
+                        block_logs,
+                        ..
+                    } = this.state.as_mut().project_replace(WatchCanonicalLogsFromState::Done)
+                    else {
+                        unreachable!()
+                    };
+                    *this.canonical_tip = Some(block_logs.header().clone());
+                    this.state.set(WatchCanonicalLogsFromState::EmitPending { pending, next });
+                    return Poll::Ready(Some(Ok(block_log_event(block_logs, false))));
+                }
+                WatchCanonicalLogsFromStateProj::EmitError { .. } => {
+                    let WatchCanonicalLogsFromStateProjOwn::EmitError { err } =
+                        this.state.as_mut().project_replace(WatchCanonicalLogsFromState::Done)
+                    else {
+                        unreachable!()
+                    };
                     return Poll::Ready(Some(Err(err)));
-                }
-                WatchCanonicalLogsFromState::Done => {
-                    *this.state = WatchCanonicalLogsFromState::Done;
-                    return Poll::Ready(None);
                 }
             }
         }
     }
 }
 
+fn deep_reorg_log_error() -> TransportError {
+    TransportErrorKind::custom_str("Deep reorg detected; no canonical log history retained.")
+}
+
 fn block_log_event<N: Network>(
     mut block_logs: BlockLogs<N>,
     removed: bool,
 ) -> CanonicalEvent<BlockLogs<N>> {
-    for log in &mut block_logs.logs {
-        log.removed = removed;
-    }
-
     if removed {
+        for log in &mut block_logs.logs {
+            log.removed = true;
+        }
         CanonicalEvent::Removed(block_logs)
     } else {
+        // Logs from fresh fetches already have `removed = false`, so no mutation is needed.
         CanonicalEvent::Added(block_logs)
     }
 }
@@ -301,16 +542,53 @@ mod tests {
         super::watch_logs_test_utils::{assert_batch, block, log, MockChain},
         *,
     };
-    use crate::Provider;
+    use crate::{CanonicalStore, Provider};
     use alloy_eips::BlockNumberOrTag;
+    use alloy_network::{BlockResponse as _, Ethereum};
     use alloy_rpc_types_eth::Filter;
     use futures::StreamExt;
-    use std::time::Duration;
+    use std::{collections::HashMap, time::Duration};
     use tokio::time::timeout;
 
-    async fn next_event(
-        stream: &mut WatchCanonicalLogsFromStream<alloy_network::Ethereum>,
-    ) -> CanonicalEvent<BlockLogs<alloy_network::Ethereum>> {
+    #[derive(Debug, Default)]
+    struct FullHistoryLogStore {
+        block_logs: HashMap<u64, BlockLogs<Ethereum>>,
+    }
+
+    impl FullHistoryLogStore {
+        fn new() -> Self {
+            Self::default()
+        }
+    }
+
+    impl CanonicalStore<BlockLogs<Ethereum>> for FullHistoryLogStore {
+        type Error = std::convert::Infallible;
+        type PushFuture = std::future::Ready<Result<(), Self::Error>>;
+        type GetFuture = std::future::Ready<Result<Option<BlockLogs<Ethereum>>, Self::Error>>;
+        type PopFuture = std::future::Ready<Result<Option<BlockLogs<Ethereum>>, Self::Error>>;
+
+        fn push(&mut self, block_logs: BlockLogs<Ethereum>) -> Self::PushFuture {
+            self.block_logs.insert(block_logs.header().number(), block_logs);
+            std::future::ready(Ok(()))
+        }
+
+        fn get(&mut self, block_number: u64) -> Self::GetFuture {
+            std::future::ready(Ok(self.block_logs.get(&block_number).cloned()))
+        }
+
+        fn pop(&mut self) -> Self::PopFuture {
+            let item = self.block_logs.keys().max().copied().and_then(|n| self.block_logs.remove(&n));
+            std::future::ready(Ok(item))
+        }
+    }
+
+    async fn next_event<S>(
+        stream: &mut WatchCanonicalLogsFromStream<Ethereum, S>,
+    ) -> CanonicalEvent<BlockLogs<Ethereum>>
+    where
+        S: CanonicalStore<BlockLogs<Ethereum>>,
+        WatchCanonicalLogsFromStream<Ethereum, S>: Unpin,
+    {
         timeout(Duration::from_secs(1), stream.next()).await.unwrap().unwrap().unwrap()
     }
 
@@ -340,6 +618,46 @@ mod tests {
             }
             other => panic!("expected Removed({number}), got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn custom_block_store_can_recover_log_reorg() {
+        let chain = MockChain::new();
+        chain.extend(&[
+            (block(1, 1, 0), vec![log(1, 1, 0)]),
+            (block(2, 2, 1), vec![log(2, 2, 0)]),
+            (block(3, 3, 2), vec![log(3, 3, 0)]),
+            (block(4, 4, 3), vec![log(4, 4, 0)]),
+        ]);
+
+        let provider = chain.provider();
+        let mut stream = provider
+            .watch_canonical_logs_from(1, &Filter::new())
+            .block_tag(BlockNumberOrTag::Latest)
+            .poll_interval(Duration::from_millis(1))
+            .rpc_concurrency(1)
+            .block_store(FullHistoryLogStore::new())
+            .into_stream();
+
+        assert_added(next_event(&mut stream).await, 1, 1, 1);
+        assert_added(next_event(&mut stream).await, 2, 2, 1);
+        assert_added(next_event(&mut stream).await, 3, 3, 1);
+        assert_added(next_event(&mut stream).await, 4, 4, 1);
+
+        chain.reorg(&[
+            (block(2, 22, 1), vec![log(2, 22, 0)]),
+            (block(3, 33, 22), vec![log(3, 33, 0)]),
+            (block(4, 44, 33), vec![log(4, 44, 0)]),
+            (block(5, 55, 44), vec![log(5, 55, 0)]),
+        ]);
+
+        assert_removed(next_event(&mut stream).await, 4, 4, 1);
+        assert_removed(next_event(&mut stream).await, 3, 3, 1);
+        assert_removed(next_event(&mut stream).await, 2, 2, 1);
+        assert_added(next_event(&mut stream).await, 2, 22, 1);
+        assert_added(next_event(&mut stream).await, 3, 33, 1);
+        assert_added(next_event(&mut stream).await, 4, 44, 1);
+        assert_added(next_event(&mut stream).await, 5, 55, 1);
     }
 
     #[tokio::test]

--- a/crates/provider/src/provider/watch_logs_from.rs
+++ b/crates/provider/src/provider/watch_logs_from.rs
@@ -36,13 +36,6 @@ pub struct BlockLogs<N: Network> {
     pub logs: Vec<Log>,
 }
 
-impl<N: Network> BlockLogs<N> {
-    /// Returns the header for the block these logs belong to.
-    pub fn header(&self) -> &N::HeaderResponse {
-        self.block.header()
-    }
-}
-
 impl<N: Network> BlockResponse for BlockLogs<N> {
     type Header = N::HeaderResponse;
     type Transaction = N::TransactionResponse;
@@ -152,7 +145,7 @@ impl<N: Network> WatchLogsFrom<N> {
 
     /// Converts this builder into a canonical-stream builder that emits
     /// [`CanonicalEvent`](crate::CanonicalEvent) deltas on reorgs.
-    pub const fn canonical(self) -> WatchCanonicalLogsFrom<N> {
+    pub fn canonical(self) -> WatchCanonicalLogsFrom<N> {
         WatchCanonicalLogsFrom::new(self)
     }
 

--- a/crates/provider/src/provider/watch_logs_from.rs
+++ b/crates/provider/src/provider/watch_logs_from.rs
@@ -6,8 +6,8 @@ use crate::transport::TransportErrorKind;
 use alloy_consensus::BlockHeader;
 use alloy_eips::BlockNumberOrTag;
 use alloy_json_rpc::RpcError;
-use alloy_network::{BlockResponse as _, Network};
-use alloy_network_primitives::{BlockTransactionsKind, HeaderResponse};
+use alloy_network::{BlockResponse, Network};
+use alloy_network_primitives::{BlockTransactions, BlockTransactionsKind, HeaderResponse};
 use alloy_primitives::B256;
 use alloy_rpc_client::{RpcCall, RpcClientInner, WeakClient};
 use alloy_rpc_types_eth::{Filter, Log};
@@ -40,6 +40,23 @@ impl<N: Network> BlockLogs<N> {
     /// Returns the header for the block these logs belong to.
     pub fn header(&self) -> &N::HeaderResponse {
         self.block.header()
+    }
+}
+
+impl<N: Network> BlockResponse for BlockLogs<N> {
+    type Header = N::HeaderResponse;
+    type Transaction = N::TransactionResponse;
+
+    fn header(&self) -> &Self::Header {
+        self.block.header()
+    }
+
+    fn transactions(&self) -> &BlockTransactions<Self::Transaction> {
+        self.block.transactions()
+    }
+
+    fn transactions_mut(&mut self) -> &mut BlockTransactions<Self::Transaction> {
+        self.block.transactions_mut()
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Currently we are using an in memory store to monitor for reorgs in `watch_canonical_logs_from`. This is useful, but a user may want to use their own asynchronous database as their source of truth and not store blocks/logs in memory.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Create a `CanonicalStore` trait which allows users to use their asynchronous database as the source of truth for reconciling reorgs. No breaking changes with the current release.

```rust
#[derive(Debug, Default)]                                                                  
struct LogHistoryStore {                                                                   
    logs_by_number: BTreeMap<u64, BlockLogs<Ethereum>>,                                    
}                                                                                          
                                                                                           
impl CanonicalStore<BlockLogs<Ethereum>> for LogHistoryStore {                             
    type Error = Infallible;                                                               
    type PushFuture = future::Ready<Result<(), Self::Error>>;                              
    type GetFuture = future::Ready<Result<Option<BlockLogs<Ethereum>>, Self::Error>>;      
    type PopFuture = future::Ready<Result<Option<BlockLogs<Ethereum>>, Self::Error>>;      
                                                                                           
    fn push(&mut self, block_logs: BlockLogs<Ethereum>) -> Self::PushFuture {              
        self.logs_by_number.insert(block_logs.header().number(), block_logs);              
        future::ready(Ok(()))                                                              
    }                                                                                      
                                                                                           
    fn get(&mut self, block_number: u64) -> Self::GetFuture {                              
        future::ready(Ok(self.logs_by_number.get(&block_number).cloned()))                 
    }                                                                                      
                                                                                           
    fn pop(&mut self) -> Self::PopFuture {                                                 
        let block_number = self.logs_by_number.keys().next_back().copied();                
        future::ready(Ok(block_number.and_then(|n| self.logs_by_number.remove(&n))))       
    }                                                                                      
}                                                                                          
                                                                                           
let provider = ProviderBuilder::new().connect_http("http://localhost:8545".parse()?);      
let filter = Filter::new().address(address!("0x0000000000aE079eB8a274cD51c0f44a9E4d67d4"));
                                                                                           
let mut stream = provider                                                                  
    .watch_canonical_logs_from(20_000_000, &filter)                                        
    .block_tag(BlockNumberOrTag::Finalized)                                                
    .block_store(LogHistoryStore::default())                                               
    .into_stream();                                                                        
                                                                                           
while let Some(event) = stream.next().await {                                              
    match event? {                                                                         
        CanonicalEvent::Added(block_logs) | CanonicalEvent::Removed(block_logs) => {       
            let _ = block_logs;                                                            
        }                                                                                  
    }                                                                                      
}                                                                                          
```

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [x] Breaking changes
