### PR TITLE
chore: group weekly dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: weekly
       day: monday
-      time: "07:00"
+      time: "09:00"
       timezone: UTC
     cooldown:
       default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,15 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
-      interval: "weekly"
+      interval: weekly
+      day: monday
+      time: 09:00
+      timezone: UTC
     cooldown:
       default-days: 7
+    groups:
+      ci-weekly:
+        patterns:
+          - '*'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: weekly
       day: monday
-      time: 09:00
+      time: "07:00"
       timezone: UTC
     cooldown:
       default-days: 7


### PR DESCRIPTION
## Summary
- run all Dependabot ecosystems on a weekly schedule
- group dependency updates with a catch-all pattern
- group GitHub Actions/CI updates as `ci-weekly`

## Testing
- validated `.github/dependabot.yml` parses as YAML and every update entry is weekly with a dependency group