### PR TITLE
docs: fix contributors guide link in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@ the requirements below.
 
 Bug fixes and new features should include tests.
 
-Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md
+Contributors guide: https://github.com/alloy-rs/alloy/blob/main/CONTRIBUTING.md
 
 The contributors guide includes instructions for running rustfmt and building the
 documentation.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

The pull request template currently links to the contributors guide in `alloy-rs/core`, but this repository is `alloy-rs/alloy`.



## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Update the contributors guide link in `.github/PULL_REQUEST_TEMPLATE.md` to point to this repository's `CONTRIBUTING.md`.


## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
