### PR TITLE
feat(signer-trezor): implement EIP-712 typed data signing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -173,3 +173,6 @@ serial_test = "3.0"
 similar-asserts = "1.5"
 tempfile = "3.20"
 tower-http = "0.6.1"
+
+[patch.crates-io]
+trezor-client = { git = "https://github.com/infinitefield/trezor-firmware.git", branch = "main" }

--- a/crates/signer-trezor/Cargo.toml
+++ b/crates/signer-trezor/Cargo.toml
@@ -24,16 +24,18 @@ workspace = true
 
 [dependencies]
 alloy-consensus = { workspace = true, features = ["std"] }
+alloy-dyn-abi = { workspace = true, features = ["std", "eip712"] }
 alloy-network.workspace = true
 alloy-primitives.workspace = true
-alloy-signer.workspace = true
+alloy-signer = { workspace = true, features = ["eip712"] }
 
-trezor-client = { version = "=0.1.5", default-features = false, features = [
+trezor-client = { version = "=0.1.6", default-features = false, features = [
     "ethereum",
 ] }
 
 async-trait.workspace = true
 semver.workspace = true
+serde_json.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 

--- a/crates/signer-trezor/src/signer.rs
+++ b/crates/signer-trezor/src/signer.rs
@@ -1,5 +1,6 @@
 use super::types::{DerivationType, TrezorError};
 use alloy_consensus::SignableTransaction;
+use alloy_dyn_abi::TypedData;
 use alloy_primitives::{
     hex, normalize_v, Address, ChainId, Signature, SignatureError, TxKind, B256, U256,
 };
@@ -48,6 +49,16 @@ impl Signer for TrezorSigner {
     #[inline]
     async fn sign_message(&self, message: &[u8]) -> Result<Signature> {
         self.sign_message_inner(message).await.map_err(alloy_signer::Error::other)
+    }
+
+    #[inline]
+    async fn sign_dynamic_typed_data(
+        &self,
+        payload: &TypedData,
+    ) -> Result<Signature> {
+        self.sign_typed_data_inner(payload)
+            .await
+            .map_err(alloy_signer::Error::other)
     }
 
     #[inline]
@@ -205,6 +216,57 @@ impl TrezorSigner {
         let apath = Self::convert_path(&self.derivation);
         let signature = client.ethereum_sign_message(message.into(), apath)?;
         signature_from_trezor(signature)
+    }
+
+    async fn sign_typed_data_inner(
+        &self,
+        data: &TypedData,
+    ) -> Result<Signature, TrezorError> {
+        let mut types_json: serde_json::Map<String, serde_json::Value> =
+            serde_json::to_value(&data.resolver)
+                .map_err(TrezorError::Eip712)?
+                .as_object()
+                .cloned()
+                .unwrap_or_default();
+
+        let domain_json =
+            serde_json::to_value(&data.domain).map_err(TrezorError::Eip712)?;
+
+        if !types_json.contains_key("EIP712Domain") {
+            let mut domain_fields = Vec::new();
+            let domain = &data.domain;
+            if domain.name.is_some() {
+                domain_fields.push(serde_json::json!({"name": "name", "type": "string"}));
+            }
+            if domain.version.is_some() {
+                domain_fields.push(serde_json::json!({"name": "version", "type": "string"}));
+            }
+            if domain.chain_id.is_some() {
+                domain_fields.push(serde_json::json!({"name": "chainId", "type": "uint256"}));
+            }
+            if domain.verifying_contract.is_some() {
+                domain_fields.push(serde_json::json!({"name": "verifyingContract", "type": "address"}));
+            }
+            if domain.salt.is_some() {
+                domain_fields.push(serde_json::json!({"name": "salt", "type": "bytes32"}));
+            }
+            types_json.insert(
+                "EIP712Domain".to_string(),
+                serde_json::Value::Array(domain_fields),
+            );
+        }
+
+        let mut client = self.get_client()?;
+        let path = Self::convert_path(&self.derivation);
+
+        let sig = client.ethereum_sign_typed_data(
+            path,
+            &data.primary_type,
+            &types_json,
+            &domain_json,
+            &data.message,
+        )?;
+        signature_from_trezor(sig)
     }
 
     // helper which converts a derivation path to [u32]

--- a/crates/signer-trezor/src/types.rs
+++ b/crates/signer-trezor/src/types.rs
@@ -54,6 +54,9 @@ pub enum TrezorError {
         "Trezor transaction signing only supports legacy and EIP-1559 transactions; got transaction type 0x{0:02x}"
     )]
     UnsupportedTransactionType(u8),
+    /// EIP-712 serialization error.
+    #[error(transparent)]
+    Eip712(serde_json::Error),
     /// Could not retrieve device features.
     #[error("could not retrieve device features")]
     Features,


### PR DESCRIPTION
Closes #4043

## Summary

- Override `sign_dynamic_typed_data` in `TrezorSigner` to use the Trezor's native EIP-712 streaming protocol (`EthereumSignTypedData`, message type 464)
- The device computes the EIP-712 hash on-device and displays struct fields for user verification
- Inject `EIP712Domain` into the types map since alloy's `Resolver` omits it, but the Trezor device needs it to compute the domain separator hash
- Add `Eip712` error variant to `TrezorError` for serialization errors
- Add `alloy-dyn-abi` (with `eip712` feature) and `serde_json` as dependencies

## Dependencies

This depends on `trezor-client` 0.1.6 gaining `ethereum_sign_typed_data()`, proposed in trezor/trezor-firmware#7038. The workspace `[patch.crates-io]` currently points to a fork with this method; it should be updated once `trezor-client` 0.1.6 is published.

## Test plan

- Tested with a Trezor Model T signing EIP-712 multisig payloads (Hyperliquid L1)
- Verified struct fields display correctly on device screen during signing
- Confirmed signature recovery matches the expected signer address