### PR TITLE
feat(network-primitives): add header num_hash helper

### DIFF
--- a/crates/network-primitives/src/traits.rs
+++ b/crates/network-primitives/src/traits.rs
@@ -164,6 +164,11 @@ pub trait TransactionResponse: Transaction {
 pub trait HeaderResponse: BlockHeader {
     /// Block hash
     fn hash(&self) -> BlockHash;
+
+    /// Returns the [`BlockNumHash`] of this header.
+    fn num_hash(&self) -> BlockNumHash {
+        BlockNumHash::new(self.number(), self.hash())
+    }
 }
 
 /// Block JSON-RPC response.

--- a/crates/rpc-types-eth/src/block.rs
+++ b/crates/rpc-types-eth/src/block.rs
@@ -854,6 +854,19 @@ mod tests {
     }
 
     #[test]
+    fn header_response_num_hash() {
+        let number = 42;
+        let hash = B256::with_last_byte(1);
+        let header = Header {
+            hash,
+            inner: alloy_consensus::Header { number, ..Default::default() },
+            ..Default::default()
+        };
+
+        assert_eq!(header.num_hash(), BlockNumHash::new(number, hash));
+    }
+
+    #[test]
     #[cfg(feature = "serde")]
     fn serde_json_header() {
         #[derive(serde::Deserialize)]


### PR DESCRIPTION
## Summary

Adds a default `HeaderResponse::num_hash()` helper that returns `BlockNumHash::new(self.number(), self.hash())`.

Adds a focused `rpc-types-eth` regression test against `Header`.

## Impact

RPC header consumers can retrieve a header number/hash pair without manually pairing `number()` and `hash()`, matching the existing transaction and receipt block num-hash helpers.