### PR TITLE
feat(provider): allow timeout for sendRawTransactionSync

### DIFF
--- a/crates/provider/src/ext/anvil.rs
+++ b/crates/provider/src/ext/anvil.rs
@@ -7,6 +7,7 @@ use alloy_primitives::{Address, Bytes, TxHash, B256, U128, U256, U64};
 use alloy_rpc_types_anvil::{Forking, Metadata, MineOptions, NodeInfo, ReorgOptions};
 use alloy_transport::{TransportError, TransportResult};
 use futures::try_join;
+use std::time::Duration;
 
 /// Anvil namespace rpc interface that gives access to several non-standard RPC methods.
 #[cfg_attr(target_family = "wasm", async_trait::async_trait(?Send))]
@@ -194,6 +195,14 @@ pub trait AnvilApi<N: Network>: Send + Sync {
     async fn eth_send_raw_transaction_sync(
         &self,
         request: Bytes,
+    ) -> TransportResult<N::ReceiptResponse>;
+
+    /// Sends a raw transaction and waits for it to be mined, returning the receipt or timing out
+    /// after the requested server-side timeout.
+    async fn eth_send_raw_transaction_sync_with_timeout(
+        &self,
+        request: Bytes,
+        timeout: Duration,
     ) -> TransportResult<N::ReceiptResponse>;
 
     /// Sets impersonated transaction
@@ -422,6 +431,16 @@ where
         self.client().request("eth_sendRawTransactionSync", (request,)).await
     }
 
+    async fn eth_send_raw_transaction_sync_with_timeout(
+        &self,
+        request: Bytes,
+        timeout: Duration,
+    ) -> TransportResult<N::ReceiptResponse> {
+        self.client()
+            .request("eth_sendRawTransactionSync", (request, duration_millis(timeout)))
+            .await
+    }
+
     async fn anvil_send_impersonated_transaction(
         &self,
         request: N::TransactionRequest,
@@ -480,6 +499,10 @@ where
         let pending = PendingTransactionBuilder::new(self.root().clone(), tx_hash?);
         Ok(pending)
     }
+}
+
+fn duration_millis(timeout: Duration) -> u64 {
+    u64::try_from(timeout.as_millis()).unwrap_or(u64::MAX)
 }
 
 /// Configuration for impersonated transactions, including optional funding and whether to stop

--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -38,7 +38,7 @@ use alloy_rpc_types_eth::{
 };
 use alloy_transport::TransportResult;
 use serde_json::value::RawValue;
-use std::borrow::Cow;
+use std::{borrow::Cow, time::Duration};
 
 /// A task that polls the provider with `eth_getFilterChanges`, returning a list of `R`.
 ///
@@ -1323,6 +1323,24 @@ pub trait Provider<N: Network = Ethereum>: Send + Sync {
         self.client().request("eth_sendRawTransactionSync", (rlp_hex,)).await
     }
 
+    /// Broadcasts a raw transaction RLP bytes to the network and returns the transaction receipt
+    /// after it has been mined or the server-side timeout elapses.
+    ///
+    /// The timeout is sent as the optional second `eth_sendRawTransactionSync` parameter in
+    /// milliseconds, as defined in [EIP-7966].
+    ///
+    /// [EIP-7966]: https://github.com/ethereum/EIPs/pull/9151
+    async fn send_raw_transaction_sync_with_timeout(
+        &self,
+        encoded_tx: &[u8],
+        timeout: Duration,
+    ) -> TransportResult<N::ReceiptResponse> {
+        let rlp_hex = hex::encode_prefixed(encoded_tx);
+        self.client()
+            .request("eth_sendRawTransactionSync", (rlp_hex, duration_millis(timeout)))
+            .await
+    }
+
     /// Broadcasts a raw transaction RLP bytes with a conditional [`TransactionConditional`] to the
     /// network.
     ///
@@ -1827,6 +1845,10 @@ pub trait Provider<N: Network = Ethereum>: Send + Sync {
     fn transaction_request(&self) -> N::TransactionRequest {
         Default::default()
     }
+}
+
+fn duration_millis(timeout: Duration) -> u64 {
+    u64::try_from(timeout.as_millis()).unwrap_or(u64::MAX)
 }
 
 #[cfg_attr(target_family = "wasm", async_trait::async_trait(?Send))]

--- a/crates/provider/tests/it/mock.rs
+++ b/crates/provider/tests/it/mock.rs
@@ -1,7 +1,17 @@
+use alloy_json_rpc::{RequestPacket, Response, ResponsePacket};
 use alloy_primitives::{bytes, Address, U256};
+#[cfg(feature = "anvil-api")]
+use alloy_provider::ext::AnvilApi;
 use alloy_provider::{Provider, ProviderBuilder};
+use alloy_rpc_client::RpcClient;
 use alloy_rpc_types_eth::TransactionRequest;
-use alloy_transport::mock::Asserter;
+use alloy_transport::{mock::Asserter, TransportError, TransportFut};
+use serde_json::{json, Value};
+use std::{
+    sync::{Arc, Mutex},
+    task::{Context, Poll},
+    time::Duration,
+};
 
 #[tokio::test]
 async fn mocked_default_provider() {
@@ -41,4 +51,93 @@ async fn mocked_default_provider() {
     asserter.push_success(&assert_bal);
     let response = provider.get_balance(Address::default()).await.unwrap();
     assert_eq!(response, assert_bal);
+}
+
+#[tokio::test]
+async fn mocked_send_raw_transaction_sync_timeout_params() {
+    let requests = Arc::new(Mutex::new(Vec::new()));
+    let provider = ProviderBuilder::new()
+        .connect_client(RpcClient::new(CaptureTransport::new(requests.clone()), true));
+
+    let _ = provider.send_raw_transaction_sync(&[0x12, 0x34]).await;
+    let _ = provider
+        .send_raw_transaction_sync_with_timeout(&[0x12, 0x34], Duration::from_millis(1_500))
+        .await;
+    #[cfg(feature = "anvil-api")]
+    {
+        let _ = provider.eth_send_raw_transaction_sync(bytes!("1234")).await;
+        let _ = provider
+            .eth_send_raw_transaction_sync_with_timeout(
+                bytes!("1234"),
+                Duration::from_millis(1_500),
+            )
+            .await;
+    }
+
+    let expected = vec![
+        json!({
+            "method": "eth_sendRawTransactionSync",
+            "params": ["0x1234"],
+        }),
+        json!({
+            "method": "eth_sendRawTransactionSync",
+            "params": ["0x1234", 1500],
+        }),
+    ];
+    #[cfg(feature = "anvil-api")]
+    let expected = {
+        let mut expected = expected;
+        expected.extend([
+            json!({
+                "method": "eth_sendRawTransactionSync",
+                "params": ["0x1234"],
+            }),
+            json!({
+                "method": "eth_sendRawTransactionSync",
+                "params": ["0x1234", 1500],
+            }),
+        ]);
+        expected
+    };
+    let requests = requests.lock().unwrap();
+    assert_eq!(requests.as_slice(), expected);
+}
+
+#[derive(Clone, Debug)]
+struct CaptureTransport {
+    requests: Arc<Mutex<Vec<Value>>>,
+}
+
+impl CaptureTransport {
+    fn new(requests: Arc<Mutex<Vec<Value>>>) -> Self {
+        Self { requests }
+    }
+}
+
+impl tower::Service<RequestPacket> for CaptureTransport {
+    type Response = ResponsePacket;
+    type Error = TransportError;
+    type Future = TransportFut<'static>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: RequestPacket) -> Self::Future {
+        let requests = self.requests.clone();
+        Box::pin(async move {
+            let req = req.as_single().expect("expected single request");
+            let params = req
+                .params()
+                .map(|params| serde_json::from_str(params.get()).unwrap())
+                .unwrap_or(Value::Null);
+
+            requests.lock().unwrap().push(json!({
+                "method": req.method(),
+                "params": params,
+            }));
+
+            Ok(ResponsePacket::Single(Response::internal_error(req.id().clone())))
+        })
+    }
 }


### PR DESCRIPTION
This adds timeout-aware variants for `eth_sendRawTransactionSync` on both `Provider` and `AnvilApi`.

The timeout is forwarded as the optional millisecond argument expected by the RPC method, and the mock transport tests now assert both the existing and timeout-bearing request shapes.
