### PR TITLE
fix(provider): serialize eth_getBlockReceipts block hash as plain string

### DIFF
--- a/crates/provider/src/fillers/mod.rs
+++ b/crates/provider/src/fillers/mod.rs
@@ -49,10 +49,10 @@ use tracing::error;
 #[cfg(feature = "pubsub")]
 use crate::GetSubscription;
 use crate::{
-    provider::SendableTx, EthCall, EthCallMany, EthGetBlock, FilterPollerBuilder, Identity,
-    PendingTransaction, PendingTransactionBuilder, PendingTransactionConfig,
-    PendingTransactionError, Provider, ProviderCall, ProviderLayer, RootProvider, RpcWithBlock,
-    SendableTxErr,
+    provider::SendableTx, BlockReceiptsParams, EthCall, EthCallMany, EthGetBlock,
+    FilterPollerBuilder, Identity, PendingTransaction, PendingTransactionBuilder,
+    PendingTransactionConfig, PendingTransactionError, Provider, ProviderCall, ProviderLayer,
+    RootProvider, RpcWithBlock, SendableTxErr,
 };
 use alloy_json_rpc::RpcError;
 use alloy_network::{AnyNetwork, Ethereum, Network};
@@ -536,7 +536,7 @@ where
     fn get_block_receipts(
         &self,
         block: BlockId,
-    ) -> ProviderCall<(BlockId,), Option<Vec<N::ReceiptResponse>>> {
+    ) -> ProviderCall<(BlockReceiptsParams,), Option<Vec<N::ReceiptResponse>>> {
         self.inner.get_block_receipts(block)
     }
 

--- a/crates/provider/src/layers/cache.rs
+++ b/crates/provider/src/layers/cache.rs
@@ -1,5 +1,6 @@
 use crate::{
-    utils, ParamsWithBlock, Provider, ProviderCall, ProviderLayer, RootProvider, RpcWithBlock,
+    utils, BlockReceiptsParams, ParamsWithBlock, Provider, ProviderCall, ProviderLayer,
+    RootProvider, RpcWithBlock,
 };
 use alloy_eips::BlockId;
 use alloy_json_rpc::{RpcError, RpcSend};
@@ -159,8 +160,9 @@ where
     fn get_block_receipts(
         &self,
         block: BlockId,
-    ) -> ProviderCall<(BlockId,), Option<Vec<N::ReceiptResponse>>> {
-        let req = RequestType::new("eth_getBlockReceipts", (block,)).with_block_id(block);
+    ) -> ProviderCall<(BlockReceiptsParams,), Option<Vec<N::ReceiptResponse>>> {
+        let req = RequestType::new("eth_getBlockReceipts", (BlockReceiptsParams::from(block),))
+            .with_block_id(block);
 
         let redirect = req.has_block_tag();
 

--- a/crates/provider/src/provider/block_receipts.rs
+++ b/crates/provider/src/provider/block_receipts.rs
@@ -1,0 +1,73 @@
+use alloy_eips::{BlockId, RpcBlockHash};
+use serde::{Serialize, Serializer};
+
+/// The block parameter for an `eth_getBlockReceipts` request.
+///
+/// Many `eth_getBlockReceipts` implementations expect a bare block-hash string
+/// (`"0x.."`) and reject the EIP-1898 object form (`{"blockHash":".."}`) that
+/// [`BlockId`] serializes a hash to. This wrapper serializes a
+/// [`BlockId::Hash`] as a plain hash string when `require_canonical` is not set,
+/// and otherwise (a block number/tag, or a hash that carries `require_canonical`)
+/// falls back to the standard [`BlockId`] serialization.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct BlockReceiptsParams(pub BlockId);
+
+impl From<BlockId> for BlockReceiptsParams {
+    fn from(block: BlockId) -> Self {
+        Self(block)
+    }
+}
+
+impl Serialize for BlockReceiptsParams {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self.0 {
+            BlockId::Hash(RpcBlockHash { block_hash, require_canonical: None }) => {
+                block_hash.serialize(serializer)
+            }
+            other => other.serialize(serializer),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::{b256, B256};
+
+    const HASH: B256 = b256!("0xa4c3c1414373ed64c1b80d007d8edab0335193d87788ebfddc59c79a5feb1ec2");
+
+    #[test]
+    fn hash_serializes_as_plain_string() {
+        let params = BlockReceiptsParams::from(BlockId::from(HASH));
+        let json = serde_json::to_value(params).unwrap();
+        assert_eq!(
+            json,
+            serde_json::json!("0xa4c3c1414373ed64c1b80d007d8edab0335193d87788ebfddc59c79a5feb1ec2")
+        );
+    }
+
+    #[test]
+    fn hash_with_require_canonical_keeps_object_form() {
+        let block = BlockId::Hash(RpcBlockHash::from_hash(HASH, Some(true)));
+        let json = serde_json::to_value(BlockReceiptsParams(block)).unwrap();
+        assert!(json.is_object());
+        assert_eq!(
+            json["blockHash"],
+            serde_json::json!("0xa4c3c1414373ed64c1b80d007d8edab0335193d87788ebfddc59c79a5feb1ec2")
+        );
+        assert_eq!(json["requireCanonical"], serde_json::json!(true));
+    }
+
+    #[test]
+    fn number_serializes_as_quantity_string() {
+        let json =
+            serde_json::to_value(BlockReceiptsParams::from(BlockId::number(0x12f7f81))).unwrap();
+        assert_eq!(json, serde_json::json!("0x12f7f81"));
+    }
+
+    #[test]
+    fn tag_serializes_as_string() {
+        let json = serde_json::to_value(BlockReceiptsParams::from(BlockId::latest())).unwrap();
+        assert_eq!(json, serde_json::json!("latest"));
+    }
+}

--- a/crates/provider/src/provider/erased.rs
+++ b/crates/provider/src/provider/erased.rs
@@ -7,8 +7,8 @@ use crate::GetSubscription;
 use crate::{
     heart::PendingTransactionError,
     utils::{Eip1559Estimation, Eip1559Estimator},
-    EthCall, PendingTransaction, PendingTransactionBuilder, PendingTransactionConfig, Provider,
-    ProviderCall, RootProvider, RpcWithBlock, SendableTx,
+    BlockReceiptsParams, EthCall, PendingTransaction, PendingTransactionBuilder,
+    PendingTransactionConfig, Provider, ProviderCall, RootProvider, RpcWithBlock, SendableTx,
 };
 use alloy_json_rpc::RpcRecv;
 use alloy_network::{Ethereum, Network};
@@ -184,7 +184,7 @@ impl<N: Network> Provider<N> for DynProvider<N> {
     fn get_block_receipts(
         &self,
         block: BlockId,
-    ) -> ProviderCall<(BlockId,), Option<Vec<N::ReceiptResponse>>> {
+    ) -> ProviderCall<(BlockReceiptsParams,), Option<Vec<N::ReceiptResponse>>> {
         self.0.get_block_receipts(block)
     }
 

--- a/crates/provider/src/provider/mod.rs
+++ b/crates/provider/src/provider/mod.rs
@@ -1,3 +1,6 @@
+mod block_receipts;
+pub use block_receipts::BlockReceiptsParams;
+
 mod eth_call;
 pub use eth_call::{Caller, EthCall, EthCallMany, EthCallManyParams, EthCallParams};
 

--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -5,8 +5,8 @@
 #[cfg(feature = "pubsub")]
 use super::get_block::SubFullBlocks;
 use super::{
-    DynProvider, Empty, EthCallMany, MulticallBuilder, WatchBlocks, WatchBlocksFrom,
-    WatchCanonicalBlocksFrom, WatchCanonicalLogsFrom, WatchHeaders, WatchLogsFrom,
+    BlockReceiptsParams, DynProvider, Empty, EthCallMany, MulticallBuilder, WatchBlocks,
+    WatchBlocksFrom, WatchCanonicalBlocksFrom, WatchCanonicalLogsFrom, WatchHeaders, WatchLogsFrom,
 };
 #[cfg(feature = "pubsub")]
 use crate::GetSubscription;
@@ -465,8 +465,8 @@ pub trait Provider<N: Network = Ethereum>: Send + Sync {
     fn get_block_receipts(
         &self,
         block: BlockId,
-    ) -> ProviderCall<(BlockId,), Option<Vec<N::ReceiptResponse>>> {
-        self.client().request("eth_getBlockReceipts", (block,)).into()
+    ) -> ProviderCall<(BlockReceiptsParams,), Option<Vec<N::ReceiptResponse>>> {
+        self.client().request("eth_getBlockReceipts", (BlockReceiptsParams::from(block),)).into()
     }
 
     /// Gets the EIP-7928 block access list by [`BlockId`].


### PR DESCRIPTION
Closes #4049.

## Motivation

`Provider::get_block_receipts(BlockId)` serializes a `BlockId::Hash` to the
EIP-1898 object form `{"blockHash":"0x.."}`. Some clients (e.g. taraxa-node)
implement `eth_getBlockReceipts` to accept **only** the plain hash string
`"0x.."` and reject the object with `INVALID_PARAMS`. The plain-string form is
accepted by every Geth-family client tested.

This can't be fixed by changing `BlockId`'s `Serialize`: for genuine EIP-1898
methods (`eth_call`, `eth_getProof`) a bare block-hash string is *invalid* and
the `{blockHash}` object is required. The fix has to be local to
`eth_getBlockReceipts`.

## Solution

Introduce `BlockReceiptsParams`, a thin wrapper over `BlockId` used only as the
`eth_getBlockReceipts` parameter. It serializes:

- `BlockId::Hash` with `require_canonical == None` → plain hash string `"0x.."`
- `BlockId::Hash` with `require_canonical == Some(_)` → standard `{blockHash, requireCanonical}` object (so the flag is preserved)
- `BlockId::Number` (number/tag) → unchanged (already a string)

All four `get_block_receipts` impls (trait default, `CacheLayer`, `Filler`,
`ErasedProvider`) route through it. The cache layer still tracks the raw
`BlockId` via `with_block_id` for tag detection, so caching behaviour is
unchanged.

## API note

This changes the parameter type in the public return signature from
`ProviderCall<(BlockId,), _>` to `ProviderCall<(BlockReceiptsParams,), _>`. The
method signature (`block: BlockId`) and the awaited result are unchanged, so
typical callers are unaffected, but it is technically a breaking change to that
generic. Happy to reshape this however you prefer — e.g. a different type name,
location (`alloy-eips`), or approach — if you'd rather take it another way.

## Tests

- New unit tests for `BlockReceiptsParams` serialization (hash → string,
  hash + `requireCanonical` → object, number → quantity, tag → string).
- Existing `gets_block_receipts` and cache `test_block_receipts` tests pass
  unchanged.

Downstream context: graphprotocol/graph-node#5835.
