### PR TITLE
docs: fix bug report template link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,10 +61,10 @@ PR that helps others avoid the problems that you encountered.
 ### Submitting a Bug Report
 
 When opening a new issue in the Alloy issue tracker, users will be presented
-with a [basic template][template] that should be filled in. If you believe that
-you have uncovered a bug, please fill out this form, following the template to
-the best of your ability. Do not worry if you cannot answer every detail, just
-fill in what you can.
+with a [bug report form][bug-template] that should be filled in. If you believe
+that you have uncovered a bug, please fill out this form, following the template
+to the best of your ability. Do not worry if you cannot answer every detail,
+just fill in what you can.
 
 The two most important pieces of information we need in order to properly
 evaluate the report is a description of the behavior you are seeing and a simple
@@ -77,7 +77,7 @@ cases should be limited, as much as possible, to using only Alloy APIs.
 See [How to create a Minimal, Complete, and Verifiable example][mcve].
 
 [mcve]: https://stackoverflow.com/help/mcve
-[template]: .github/PULL_REQUEST_TEMPLATE.md
+[bug-template]: .github/ISSUE_TEMPLATE/BUG-FORM.yml
 
 ### Triaging a Bug Report
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/alloy/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

The "Submitting a Bug Report" section in `CONTRIBUTING.md` referred readers to the pull request template, even though that section is about opening issues.


## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Update the section to point to the repository's bug report issue form at `.github/ISSUE_TEMPLATE/BUG-FORM.yml`, while leaving the pull request template reference for the PR section unchanged.

This is documentation-only and does not affect code behavior.


## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
