### PR TITLE
feat(provider): mixed tuple and dynamic multicall

### DIFF
--- a/crates/contract/src/multicall.rs
+++ b/crates/contract/src/multicall.rs
@@ -330,6 +330,136 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_nested_dynamic_in_tuple() {
+        let weth = address!("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2");
+        let usdc = address!("A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48");
+        let provider = ProviderBuilder::new().connect_anvil_with_config(|a| a.fork(FORK_URL));
+
+        let weth_erc20 = ERC20::new(weth, &provider);
+        let usdc_erc20 = ERC20::new(usdc, &provider);
+
+        // Two dynamic multicalls nested inside a single tuple multicall, executed in one request.
+        let supplies_inner = provider
+            .multicall()
+            .dynamic()
+            .extend(vec![weth_erc20.totalSupply(), usdc_erc20.totalSupply()]);
+        let balances_inner = provider.multicall().dynamic().extend(vec![
+            weth_erc20.balanceOf(address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045")),
+            usdc_erc20.balanceOf(address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045")),
+        ]);
+
+        let (supplies, balances) = provider
+            .multicall()
+            .add_nested(supplies_inner)
+            .add_nested(balances_inner)
+            .aggregate()
+            .await
+            .unwrap();
+
+        assert_eq!(supplies.len(), 2);
+        assert_eq!(balances.len(), 2);
+
+        // Cross-check against the equivalent separate dynamic multicalls.
+        let supplies_ref = provider
+            .multicall()
+            .dynamic()
+            .extend(vec![weth_erc20.totalSupply(), usdc_erc20.totalSupply()])
+            .aggregate()
+            .await
+            .unwrap();
+        assert_eq!(supplies, supplies_ref);
+    }
+
+    #[tokio::test]
+    async fn test_nested_tuple_in_dynamic() {
+        let weth = address!("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2");
+        let usdc = address!("A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48");
+        let provider = ProviderBuilder::new().connect_anvil_with_config(|a| a.fork(FORK_URL));
+
+        let weth_erc20 = ERC20::new(weth, &provider);
+        let usdc_erc20 = ERC20::new(usdc, &provider);
+
+        // A tuple multicall nested inside a dynamic multicall: one (totalSupply, balanceOf) tuple
+        // per token, all fetched in a single request.
+        let owner = address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045");
+        let weth_tuple =
+            provider.multicall().add(weth_erc20.totalSupply()).add(weth_erc20.balanceOf(owner));
+        let usdc_tuple =
+            provider.multicall().add(usdc_erc20.totalSupply()).add(usdc_erc20.balanceOf(owner));
+
+        let results = provider
+            .multicall()
+            .dynamic_nested()
+            .extend_nested_dynamic(vec![weth_tuple, usdc_tuple])
+            .aggregate()
+            .await
+            .unwrap();
+
+        assert_eq!(results.len(), 2);
+        // Each entry is the inner tuple's success returns: (totalSupplyReturn, balanceReturn).
+        let (weth_supply, weth_balance) = &results[0];
+        let (usdc_supply, usdc_balance) = &results[1];
+
+        // Cross-check the first tuple against a standalone tuple multicall.
+        let (weth_supply_ref, weth_balance_ref) = provider
+            .multicall()
+            .add(weth_erc20.totalSupply())
+            .add(weth_erc20.balanceOf(owner))
+            .aggregate()
+            .await
+            .unwrap();
+        assert_eq!(weth_supply, &weth_supply_ref);
+        assert_eq!(weth_balance, &weth_balance_ref);
+        let _ = (usdc_supply, usdc_balance);
+    }
+
+    #[tokio::test]
+    async fn test_nested_allow_failure_inner_index() {
+        let weth = address!("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2");
+        let provider = ProviderBuilder::new()
+            .connect_anvil_with_wallet_and_config(|a| a.fork(FORK_URL))
+            .unwrap();
+
+        let dummy = deploy_dummy(provider.clone()).await;
+        let erc20 = ERC20::new(weth, &provider);
+
+        // Inner tuple multicall with a failing-but-allowed call at inner index 1.
+        let inner =
+            provider.multicall().add(erc20.totalSupply()).add_call(dummy.fail().into_call(true));
+
+        // Outer tuple multicall, nested, fallible aggregation.
+        let (nested_res,) = provider.multicall().add_nested(inner).aggregate3().await.unwrap();
+
+        // The nested call itself succeeded (inner aggregate3 did not revert), so we get the inner
+        // results, with the failure indexed relative to the inner builder.
+        let (ts, fail) = nested_res.unwrap();
+        assert!(ts.is_ok());
+        assert!(matches!(fail.unwrap_err(), Failure { idx: 1, return_data: _ }));
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "nested multicall builders do not support payable/value calls")]
+    async fn test_nested_rejects_value() {
+        let provider = ProviderBuilder::new().connect_anvil();
+
+        let inner_with_value = provider.multicall().add_call(
+            CallItem::<ERC20::transferCall>::new(
+                address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045"),
+                ERC20::transferCall {
+                    to: address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045"),
+                    value: U256::ZERO,
+                }
+                .abi_encode()
+                .into(),
+            )
+            .value(U256::from(1)),
+        );
+
+        // Should panic: nested builders cannot carry value.
+        let _ = provider.multicall().add_nested(inner_with_value);
+    }
+
+    #[tokio::test]
     async fn test_extend_dynamic() {
         let weth = address!("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2");
         let provider = ProviderBuilder::new().connect_anvil_with_config(|a| a.fork(FORK_URL));

--- a/crates/provider/src/provider/multicall/inner_types.rs
+++ b/crates/provider/src/provider/multicall/inner_types.rs
@@ -1,8 +1,8 @@
 use std::{fmt::Debug, marker::PhantomData};
 
 use super::{
-    bindings::IMulticall3::{Call, Call3, Call3Value},
-    CallTuple,
+    bindings::IMulticall3::{aggregate3Call, Call, Call3, Call3Value, Result as MulticallResult},
+    CallDecoder, CallTuple,
 };
 use alloy_primitives::{Address, Bytes, U256};
 use alloy_sol_types::SolCall;
@@ -149,43 +149,82 @@ where
     }
 }
 
-/// Marker for Dynamic Calls i.e where in SolCall type is locked to one specific type and multicall
-/// returns a Vec of the corresponding return type instead of a tuple.
+/// Marker for dynamic calls: the entry type is fixed, so the multicall returns a `Vec` instead of a
+/// tuple.
+///
+/// `D` may be a plain [`SolCall`] (`Vec` of its return value) or a [`Nested`] multicall (`Vec` of
+/// the inner results).
 #[derive(Debug)]
-pub struct Dynamic<D: SolCall>(PhantomData<fn(D) -> D>);
+pub struct Dynamic<D: CallDecoder>(PhantomData<fn(D) -> D>);
 
-impl<D: SolCall> CallTuple for Dynamic<D> {
-    type Returns = Vec<Result<D::Return, Failure>>;
-    type SuccessReturns = Vec<D::Return>;
+impl<D: CallDecoder> CallTuple for Dynamic<D> {
+    type Returns = Vec<D::ResultReturn>;
+    type SuccessReturns = Vec<D::SuccessReturn>;
 
     fn decode_returns(data: &[Bytes]) -> Result<Self::SuccessReturns> {
-        data.iter().map(|d| D::abi_decode_returns(d).map_err(MulticallError::DecodeError)).collect()
+        data.iter().map(|d| D::abi_decode_success(d)).collect()
     }
 
-    fn decode_return_results(
-        results: &[super::bindings::IMulticall3::Result],
-    ) -> Result<Self::Returns> {
-        let mut ret = vec![];
-        for (idx, res) in results.iter().enumerate() {
-            if res.success {
-                ret.push(
-                    D::abi_decode_returns(&res.returnData)
-                        .map_err(|_| Failure { idx, return_data: res.returnData.clone() }),
-                )
-            } else {
-                ret.push(Err(Failure { idx, return_data: res.returnData.clone() }));
-            }
-        }
-
-        Ok(ret)
+    fn decode_return_results(results: &[MulticallResult]) -> Result<Self::Returns> {
+        Ok(results.iter().enumerate().map(|(idx, res)| D::abi_decode_result(idx, res)).collect())
     }
 
     fn try_into_success(results: Self::Returns) -> Result<Self::SuccessReturns> {
-        let mut ret = vec![];
-        for res in results {
-            ret.push(res.map_err(|e| MulticallError::CallFailed(e.return_data))?);
+        results.into_iter().map(D::try_into_success).collect()
+    }
+}
+
+/// Marker for a multicall nested inside another multicall.
+///
+/// `Inner` is the [`CallTuple`] of the inner [`MulticallBuilder`](crate::MulticallBuilder). Its
+/// calls are encoded as one `aggregate3` call, so a whole batch decodes as a single outer entry:
+///
+/// - Inside a tuple multicall, it becomes one tuple element (e.g. `(Vec<A>, Vec<B>)`).
+/// - Inside a dynamic multicall (`Dynamic<Nested<Inner>>`), the result is
+///   `Vec<Inner::SuccessReturns>` (e.g. `Vec<(A, B)>`).
+///
+/// Nested payable calls are not supported; entries are always encoded with zero value.
+///
+/// ## Failure indices
+///
+/// On the fallible path (`aggregate3`/`try_aggregate`) an entry decodes to
+/// `Result<Inner::Returns, Failure>`: the outer `Err(Failure)` uses the **outer** index (the whole
+/// nested call failed), while any [`Failure`] inside `Inner::Returns` uses the **inner** index.
+#[derive(Debug)]
+pub struct Nested<Inner: CallTuple>(PhantomData<fn(Inner) -> Inner>);
+
+impl<Inner: CallTuple> CallDecoder for Nested<Inner> {
+    type SuccessReturn = Inner::SuccessReturns;
+    type ResultReturn = core::result::Result<Inner::Returns, Failure>;
+
+    fn abi_decode_success(data: &Bytes) -> Result<Self::SuccessReturn> {
+        let results =
+            aggregate3Call::abi_decode_returns(data).map_err(MulticallError::DecodeError)?;
+        // Success path: reject any failed inner call, then decode via the inner success path so a
+        // malformed return still surfaces as `DecodeError`.
+        let mut return_data = Vec::with_capacity(results.len());
+        for result in results {
+            if !result.success {
+                return Err(MulticallError::CallFailed(result.returnData));
+            }
+            return_data.push(result.returnData);
         }
-        Ok(ret)
+        Inner::decode_returns(&return_data)
+    }
+
+    fn abi_decode_result(idx: usize, result: &MulticallResult) -> Self::ResultReturn {
+        if !result.success {
+            return Err(Failure { idx, return_data: result.returnData.clone() });
+        }
+        let results = aggregate3Call::abi_decode_returns(&result.returnData)
+            .map_err(|_| Failure { idx, return_data: result.returnData.clone() })?;
+        Inner::decode_return_results(&results)
+            .map_err(|_| Failure { idx, return_data: result.returnData.clone() })
+    }
+
+    fn try_into_success(result: Self::ResultReturn) -> Result<Self::SuccessReturn> {
+        let returns = result.map_err(|f| MulticallError::CallFailed(f.return_data))?;
+        Inner::try_into_success(returns)
     }
 }
 

--- a/crates/provider/src/provider/multicall/mod.rs
+++ b/crates/provider/src/provider/multicall/mod.rs
@@ -22,12 +22,12 @@ use crate::provider::multicall::bindings::IMulticall3::{
 mod inner_types;
 pub use inner_types::{
     CallInfoTrait, CallItem, CallItemBuilder, Dynamic, Failure, MulticallError, MulticallItem,
-    Result,
+    Nested, Result,
 };
 
 mod tuple;
 use tuple::TuplePush;
-pub use tuple::{CallTuple, Empty};
+pub use tuple::{CallDecoder, CallTuple, Empty};
 
 /// Default address for the Multicall3 contract on most chains. See: <https://github.com/mds1/multicall>
 pub const MULTICALL3_ADDRESS: Address = address!("0xcA11bde05977b3631167028862bE2a173976CA11");
@@ -135,6 +135,40 @@ where
             _pd: Default::default(),
         }
     }
+
+    /// Converts an empty [`MulticallBuilder`] into a dynamic nested one.
+    ///
+    /// This is the "tuple nested inside a dynamic multicall" shape: each entry added via
+    /// [`add_nested_dynamic`](MulticallBuilder::add_nested_dynamic) is an inner builder sharing the
+    /// same [`CallTuple`] `Inner`, and [`aggregate`](MulticallBuilder::aggregate) returns a
+    /// `Vec<Inner::SuccessReturns>` (e.g. `Vec<(A, B)>`).
+    ///
+    /// ```ignore
+    /// let results: Vec<(totalSupplyReturn, balanceOfReturn)> = provider
+    ///     .multicall()
+    ///     .dynamic_nested()
+    ///     .extend_nested_dynamic(tokens.iter().map(|t| {
+    ///         provider.multicall().add(t.totalSupply()).add(t.balanceOf(owner))
+    ///     }))
+    ///     .aggregate()
+    ///     .await?;
+    /// ```
+    ///
+    /// For the inverse shape (`(Vec<A>, Vec<B>)`), use
+    /// [`add_nested`](MulticallBuilder::add_nested).
+    pub fn dynamic_nested<Inner: CallTuple + 'static>(
+        self,
+    ) -> MulticallBuilder<Dynamic<Nested<Inner>>, P, N> {
+        MulticallBuilder {
+            calls: self.calls,
+            provider: self.provider,
+            block: self.block,
+            state_override: self.state_override,
+            address: self.address,
+            input_kind: self.input_kind,
+            _pd: Default::default(),
+        }
+    }
 }
 
 impl<D: SolCall + 'static, P, N> MulticallBuilder<Dynamic<D>, P, N>
@@ -232,6 +266,51 @@ where
     }
 }
 
+impl<Inner, P, N> MulticallBuilder<Dynamic<Nested<Inner>>, P, N>
+where
+    Inner: CallTuple + 'static,
+    P: Provider<N>,
+    N: Network,
+{
+    /// Add a nested multicall to the dynamic builder.
+    ///
+    /// The `inner` builder's calls are encoded as one `aggregate3` call targeting its `address`
+    /// (which must be a Multicall3-compatible contract). All entries must share the same `Inner`
+    /// tuple. The `inner` builder's `block` and `state_override` are ignored.
+    ///
+    /// # Panics
+    ///
+    /// Panics if any of the `inner` builder's calls carry a non-zero `value` (nested payable calls
+    /// are not supported).
+    pub fn add_nested_dynamic<IP: Provider<N>>(
+        mut self,
+        inner: MulticallBuilder<Inner, IP, N>,
+    ) -> Self {
+        assert!(
+            inner.calls.iter().all(|c| c.value.is_zero()),
+            "nested multicall builders do not support payable/value calls"
+        );
+        self.calls.push(Call3Value {
+            target: inner.address,
+            allowFailure: false,
+            value: U256::ZERO,
+            callData: inner.to_aggregate3_call().abi_encode().into(),
+        });
+        self
+    }
+
+    /// Extend the dynamic builder with a sequence of nested multicalls.
+    pub fn extend_nested_dynamic<IP: Provider<N>>(
+        mut self,
+        inners: impl IntoIterator<Item = MulticallBuilder<Inner, IP, N>>,
+    ) -> Self {
+        for inner in inners {
+            self = self.add_nested_dynamic(inner);
+        }
+        self
+    }
+}
+
 impl<T, P, N> MulticallBuilder<T, &P, N>
 where
     T: CallTuple,
@@ -302,6 +381,51 @@ where
         <T as TuplePush<D>>::Pushed: CallTuple,
     {
         self.calls.push(call.to_call3_value());
+        MulticallBuilder {
+            calls: self.calls,
+            provider: self.provider,
+            block: self.block,
+            state_override: self.state_override,
+            address: self.address,
+            input_kind: self.input_kind,
+            _pd: Default::default(),
+        }
+    }
+
+    /// Appends a nested multicall to the stack.
+    ///
+    /// The `inner` builder's calls are encoded as one `aggregate3` call, so the nested result
+    /// becomes one entry of the outer tuple (e.g. nesting two dynamic multicalls yields
+    /// `(Vec<A>, Vec<B>)`). The nested call is not allowed to fail: if an inner call reverts, the
+    /// inner `aggregate3` reverts and propagates to the outer call.
+    ///
+    /// The `inner` builder's `block` and `state_override` are ignored; its `address` is used as the
+    /// nested call target and must be a Multicall3-compatible contract.
+    ///
+    /// # Panics
+    ///
+    /// Panics if any of the `inner` builder's calls carry a non-zero `value` (nested payable calls
+    /// are not supported).
+    pub fn add_nested<InnerT, IP>(
+        mut self,
+        inner: MulticallBuilder<InnerT, IP, N>,
+    ) -> MulticallBuilder<T::Pushed, P, N>
+    where
+        InnerT: CallTuple + 'static,
+        IP: Provider<N>,
+        T: TuplePush<Nested<InnerT>>,
+        <T as TuplePush<Nested<InnerT>>>::Pushed: CallTuple,
+    {
+        assert!(
+            inner.calls.iter().all(|c| c.value.is_zero()),
+            "nested multicall builders do not support payable/value calls"
+        );
+        self.calls.push(Call3Value {
+            target: inner.address,
+            allowFailure: false,
+            value: U256::ZERO,
+            callData: inner.to_aggregate3_call().abi_encode().into(),
+        });
         MulticallBuilder {
             calls: self.calls,
             provider: self.provider,

--- a/crates/provider/src/provider/multicall/tuple.rs
+++ b/crates/provider/src/provider/multicall/tuple.rs
@@ -20,6 +20,50 @@ pub trait TuplePush<T> {
     type Pushed;
 }
 
+/// Decodes the return data of a single multicall entry.
+///
+/// Implemented for every [`SolCall`] (a plain call) and for [`Nested`](crate::Nested) (a whole
+/// nested multicall), so an entry can be either without changing the return types of plain calls.
+#[doc(hidden)]
+pub trait CallDecoder {
+    /// The decoded return value on the success path (used by `aggregate`).
+    type SuccessReturn;
+
+    /// The decoded return value on the fallible path (used by `aggregate3`/`tryAggregate`).
+    type ResultReturn;
+
+    /// Decode the raw return bytes of this entry, assuming the call succeeded.
+    fn abi_decode_success(data: &Bytes) -> Result<Self::SuccessReturn>;
+
+    /// Decode a [`MulticallResult`] for this entry, preserving per-call failures.
+    fn abi_decode_result(idx: usize, result: &MulticallResult) -> Self::ResultReturn;
+
+    /// Convert a [`Self::ResultReturn`] into a [`Self::SuccessReturn`], failing if the call failed.
+    fn try_into_success(result: Self::ResultReturn) -> Result<Self::SuccessReturn>;
+}
+
+impl<D: SolCall> CallDecoder for D {
+    type SuccessReturn = D::Return;
+    type ResultReturn = core::result::Result<D::Return, Failure>;
+
+    fn abi_decode_success(data: &Bytes) -> Result<Self::SuccessReturn> {
+        D::abi_decode_returns(data).map_err(MulticallError::DecodeError)
+    }
+
+    fn abi_decode_result(idx: usize, result: &MulticallResult) -> Self::ResultReturn {
+        if result.success {
+            D::abi_decode_returns(&result.returnData)
+                .map_err(|_| Failure { idx, return_data: result.returnData.clone() })
+        } else {
+            Err(Failure { idx, return_data: result.returnData.clone() })
+        }
+    }
+
+    fn try_into_success(result: Self::ResultReturn) -> Result<Self::SuccessReturn> {
+        result.map_err(|f| MulticallError::CallFailed(f.return_data))
+    }
+}
+
 /// A trait for tuples of SolCalls that can be decoded
 #[doc(hidden)]
 pub trait CallTuple: Sealed {
@@ -92,7 +136,7 @@ pub struct Empty;
 
 impl Sealed for Empty {}
 
-impl<T: SolCall> TuplePush<T> for Empty {
+impl<T: CallDecoder> TuplePush<T> for Empty {
     type Pushed = (T,);
 }
 
@@ -110,24 +154,24 @@ impl CallTuple for Empty {
     }
 }
 
-impl<D: SolCall> Sealed for Dynamic<D> {}
+impl<D: CallDecoder> Sealed for Dynamic<D> {}
 
 // Macro to implement for tuples of different sizes
 macro_rules! impl_tuple {
     ($($idx:tt => $ty:ident),+) => {
-        impl<$($ty: SolCall,)+> Sealed for ($($ty,)+) {}
+        impl<$($ty: CallDecoder,)+> Sealed for ($($ty,)+) {}
 
         // Implement pushing a new type onto the tuple
-        impl<T: SolCall, $($ty: SolCall,)+> TuplePush<T> for ($($ty,)+) {
+        impl<T: CallDecoder, $($ty: CallDecoder,)+> TuplePush<T> for ($($ty,)+) {
             type Pushed = ($($ty,)+ T,);
         }
 
         // Implement decoding for the tuple
-        impl<$($ty: SolCall,)+> CallTuple for ($($ty,)+) {
-            // The Returns associated type is a tuple of each SolCall's Return type
-            type Returns = ($(Result<$ty::Return, Failure>,)+);
+        impl<$($ty: CallDecoder,)+> CallTuple for ($($ty,)+) {
+            // The Returns associated type is a tuple of each entry's fallible return type
+            type Returns = ($(<$ty as CallDecoder>::ResultReturn,)+);
 
-            type SuccessReturns = ($($ty::Return,)+);
+            type SuccessReturns = ($(<$ty as CallDecoder>::SuccessReturn,)+);
 
             fn decode_returns(data: &[Bytes]) -> Result<Self::SuccessReturns> {
                 if data.len() != count!($($ty),+) {
@@ -135,7 +179,7 @@ macro_rules! impl_tuple {
                 }
 
                 // Decode each return value in order
-                Ok(($($ty::abi_decode_returns(&data[$idx]).map_err(MulticallError::DecodeError)?,)+))
+                Ok(($(<$ty as CallDecoder>::abi_decode_success(&data[$idx])?,)+))
             }
 
             fn decode_return_results(results: &[MulticallResult]) -> Result<Self::Returns> {
@@ -143,22 +187,11 @@ macro_rules! impl_tuple {
                     return Err(MulticallError::NoReturnData);
                 }
 
-                Ok(($(
-                    match &results[$idx].success {
-                        true => $ty::abi_decode_returns(&results[$idx].returnData)
-                            .or_else(|_| Err(Failure { idx: $idx, return_data: results[$idx].returnData.clone() })),
-                        false => Err(Failure { idx: $idx, return_data: results[$idx].returnData.clone() }),
-                    },
-                )+))
+                Ok(($(<$ty as CallDecoder>::abi_decode_result($idx, &results[$idx]),)+))
             }
 
             fn try_into_success(results: Self::Returns) -> Result<Self::SuccessReturns> {
-                Ok(($(
-                    match results.$idx {
-                        Ok(value) => value,
-                        Err(failure) => return Err(MulticallError::CallFailed(failure.return_data)),
-                    },
-                )+))
+                Ok(($(<$ty as CallDecoder>::try_into_success(results.$idx)?,)+))
             }
         }
     };


### PR DESCRIPTION
Adds nested Multicall3 support so tuple and dynamic multicalls can be mixed in one request.

- `add_nested` → dynamic-in-tuple: `(Vec<A>, Vec<B>)`
- `dynamic_nested` + `extend_nested_dynamic` → tuple-in-dynamic: `Vec<(A, B)>`

Non-breaking: internal `CallDecoder` trait keeps existing return types unchanged. Nested payable calls unsupported (panics). Includes fork tests for both shapes.


Closes #4054