### PR TITLE
perf(json-rpc): skip re-parse when returning owned Box<RawValue>

### DIFF
--- a/crates/json-rpc/src/result.rs
+++ b/crates/json-rpc/src/result.rs
@@ -1,6 +1,6 @@
 use crate::{Response, ResponsePayload, RpcError, RpcRecv};
 use serde_json::value::RawValue;
-use std::borrow::Borrow;
+use std::{any::TypeId, borrow::Borrow};
 
 /// The result of a JSON-RPC request.
 ///
@@ -54,11 +54,24 @@ pub fn try_deserialize_ok<J, T, E, ErrResp>(
     result: RpcResult<J, E, ErrResp>,
 ) -> RpcResult<T, E, ErrResp>
 where
-    J: Borrow<RawValue>,
+    J: Borrow<RawValue> + 'static,
     T: RpcRecv,
     ErrResp: RpcRecv,
 {
     let json = result?;
+
+    // Fast path: the caller wants the already-owned `Box<RawValue>` back unchanged. Hand it
+    // over directly, skipping the byte copy and full JSON validation scan that
+    // `from_str::<Box<RawValue>>` would repeat over an already-validated value.
+    if TypeId::of::<J>() == TypeId::of::<Box<RawValue>>()
+        && TypeId::of::<T>() == TypeId::of::<Box<RawValue>>()
+    {
+        // SAFETY: `J` and `T` are both `Box<RawValue>`, so this is a no-op reinterpretation.
+        // `transmute_copy` stands in for the unstable `transmute_unchecked` (sizes are equal).
+        let json = std::mem::ManuallyDrop::new(json);
+        return Ok(unsafe { std::mem::transmute_copy::<J, T>(&json) });
+    }
+
     let _guard = debug_span!("deserialize_response", ty=%std::any::type_name::<T>()).entered();
     let json = json.borrow().get();
     trace!(%json, "deserializing");
@@ -66,4 +79,34 @@ where
         .inspect(|response| trace!(?response, "deserialized"))
         .inspect_err(|err| trace!(?err, "failed to deserialize"))
         .map_err(|err| RpcError::deser_err(err, json))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::value::to_raw_value;
+
+    #[test]
+    fn raw_value_success_returns_payload_without_reencoding() {
+        // Deliberately non-canonical spacing: a byte-identical result proves the payload
+        // was not re-parsed and re-encoded.
+        let src = "{  \"a\" :1,\"b\": [ 2 ,3 ] }";
+        let raw = RawValue::from_string(src.to_owned()).unwrap();
+        let ptr = raw.get().as_ptr();
+        let input: RpcResult<Box<RawValue>, (), Box<RawValue>> = Ok(raw);
+
+        let out = try_deserialize_ok::<_, Box<RawValue>, (), Box<RawValue>>(input).unwrap();
+
+        assert_eq!(out.get(), src);
+        // Same allocation: the owned payload was handed back, not rebuilt.
+        assert_eq!(out.get().as_ptr(), ptr);
+    }
+
+    #[test]
+    fn generic_deserialize_path_unchanged() {
+        let raw = to_raw_value(&42u64).unwrap();
+        let input: RpcResult<Box<RawValue>, (), Box<RawValue>> = Ok(raw);
+        let out = try_deserialize_ok::<_, u64, (), Box<RawValue>>(input).unwrap();
+        assert_eq!(out, 42);
+    }
 }


### PR DESCRIPTION
`try_deserialize_ok` calls `serde_json::from_str::<Box<RawValue>>` even when `J` is already `Box<RawValue>`, so the raw passthrough path (`Provider::raw_request`, `RpcClient::request`/batch with `Box<RawValue>`) copies and re-validates a payload it already owns on every response.

When `J` and `T` are both `Box<RawValue>`, return the owned payload directly behind a `TypeId` guard, matching the `transmute_copy` specialization in `IntoBoxTransport::into_box_transport`. The generic deserialize path is unchanged.

This adds a `'static` bound to the (public) `try_deserialize_ok`, needed for `TypeId`. Both in-tree callers pass `Box<RawValue>`; only external callers passing a borrowed `J` would be affected.
