### PR TITLE
fix(consensus): reject string withdrawals in block RLP

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ alloy-json-abi = { version = "1.6.0", default-features = false }
 alloy-primitives = { version = "1.6.0", default-features = false }
 alloy-sol-types = { version = "1.6.0", default-features = false }
 
-alloy-rlp = { version = "0.3.9", default-features = false }
+alloy-rlp = { version = "0.3.14", default-features = false }
 alloy-trie = { version = "0.9.2", default-features = false }
 
 alloy-chains = { version = "0.2", default-features = false }

--- a/crates/consensus/src/block/mod.rs
+++ b/crates/consensus/src/block/mod.rs
@@ -444,7 +444,7 @@ where
 mod tests {
     use super::*;
     use crate::{Signed, TxEnvelope, TxLegacy};
-    use alloy_rlp::Encodable;
+    use alloy_rlp::{Decodable, Encodable};
 
     #[test]
     fn can_convert_block() {
@@ -518,6 +518,52 @@ mod tests {
         assert_eq!(sealed.header.number, 42);
         assert_eq!(sealed.body.transactions.len(), 1);
         assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn block_body_rejects_present_string_withdrawals() {
+        let mut omitted: &[u8] = &[0xc2, 0xc0, 0xc0];
+        let body = BlockBody::<TxEnvelope>::decode(&mut omitted).unwrap();
+        assert!(body.withdrawals.is_none());
+        assert!(omitted.is_empty());
+
+        let mut present_empty: &[u8] = &[0xc3, 0xc0, 0xc0, 0xc0];
+        let body = BlockBody::<TxEnvelope>::decode(&mut present_empty).unwrap();
+        assert!(body.withdrawals.as_ref().is_some_and(|w| w.is_empty()));
+        assert!(present_empty.is_empty());
+
+        let mut present_string: &[u8] = &[0xc3, 0xc0, 0xc0, 0x80];
+        assert!(BlockBody::<TxEnvelope>::decode(&mut present_string).is_err());
+    }
+
+    #[test]
+    fn block_decoders_reject_present_string_withdrawals() {
+        fn block_rlp_with_body_fields(body_fields: &[u8]) -> Vec<u8> {
+            let mut header = Vec::new();
+            Header::default().encode(&mut header);
+
+            let block_header = alloy_rlp::Header {
+                list: true,
+                payload_length: header.len() + body_fields.len(),
+            };
+            let mut out = Vec::with_capacity(block_header.length_with_payload());
+            block_header.encode(&mut out);
+            out.extend_from_slice(&header);
+            out.extend_from_slice(body_fields);
+            out
+        }
+
+        let omitted = block_rlp_with_body_fields(&[0xc0, 0xc0]);
+        assert!(Block::<TxEnvelope>::decode(&mut omitted.as_slice()).is_ok());
+        assert!(Block::<TxEnvelope>::decode_sealed(&mut omitted.as_slice()).is_ok());
+
+        let present_empty = block_rlp_with_body_fields(&[0xc0, 0xc0, 0xc0]);
+        assert!(Block::<TxEnvelope>::decode(&mut present_empty.as_slice()).is_ok());
+        assert!(Block::<TxEnvelope>::decode_sealed(&mut present_empty.as_slice()).is_ok());
+
+        let present_string = block_rlp_with_body_fields(&[0xc0, 0xc0, 0x80]);
+        assert!(Block::<TxEnvelope>::decode(&mut present_string.as_slice()).is_err());
+        assert!(Block::<TxEnvelope>::decode_sealed(&mut present_string.as_slice()).is_err());
     }
 }
 

--- a/crates/consensus/src/block/mod.rs
+++ b/crates/consensus/src/block/mod.rs
@@ -230,7 +230,7 @@ where
 #[derive(Debug, Clone, PartialEq, Eq, RlpEncodable, RlpDecodable)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "borsh", derive(borsh::BorshSerialize, borsh::BorshDeserialize))]
-#[rlp(trailing)]
+#[rlp(trailing(no_gaps))]
 pub struct BlockBody<T, H = Header> {
     /// Transactions in this block.
     pub transactions: Vec<T>,
@@ -336,7 +336,7 @@ mod block_rlp {
     use super::*;
 
     #[derive(RlpDecodable)]
-    #[rlp(trailing)]
+    #[rlp(trailing(no_gaps))]
     struct Helper<T, H> {
         header: H,
         transactions: Vec<T>,
@@ -345,7 +345,7 @@ mod block_rlp {
     }
 
     #[derive(RlpEncodable)]
-    #[rlp(trailing)]
+    #[rlp(trailing(no_gaps))]
     pub(crate) struct HelperRef<'a, T, H> {
         pub(crate) header: &'a H,
         pub(crate) transactions: &'a Vec<T>,

--- a/crates/consensus/src/block/mod.rs
+++ b/crates/consensus/src/block/mod.rs
@@ -542,10 +542,8 @@ mod tests {
             let mut header = Vec::new();
             Header::default().encode(&mut header);
 
-            let block_header = alloy_rlp::Header {
-                list: true,
-                payload_length: header.len() + body_fields.len(),
-            };
+            let block_header =
+                alloy_rlp::Header { list: true, payload_length: header.len() + body_fields.len() };
             let mut out = Vec::with_capacity(block_header.length_with_payload());
             block_header.encode(&mut out);
             out.extend_from_slice(&header);


### PR DESCRIPTION
## Motivation

`BlockBody` and the internal block RLP helper accepted an explicitly present RLP
string as the optional trailing withdrawals field. That allowed non-canonical
bytes such as `c3 c0 c0 80` to decode as the same body as the canonical omitted
withdrawals form.

## Solution

- Add regressions for omitted withdrawals, present empty-list withdrawals, and
  present string withdrawals.
- Use `#[rlp(trailing(no_gaps))]` for `BlockBody` and the block RLP helper types
  so a present withdrawals field must decode as a withdrawals list.

## Tests

- `cargo test -p alloy-consensus block_body_rejects_present_string_withdrawals --lib`
- `cargo test -p alloy-consensus block_decoders_reject_present_string_withdrawals --lib`

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
