### PR TITLE
fix(tx-macros): preserve fallback decode cursor

### DIFF
--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -1462,6 +1462,17 @@ mod tests {
         assert_eq!(tx.encode_2718_len(), hex_data.len());
     }
 
+    #[test]
+    fn decode_2718_exact_rejects_fallback_suffix_reproducer() {
+        let raw = hex!("c23b2d0c818686d22d04457979803200c0018686c2790500ff05");
+
+        assert!(TxEnvelope::decode_2718_exact(&raw).is_err());
+
+        let mut buf = raw.as_slice();
+        assert!(TxEnvelope::decode_2718(&mut buf).is_err());
+        assert_eq!(buf, raw.as_slice());
+    }
+
     #[cfg(feature = "serde")]
     fn test_serde_roundtrip<T: SignableTransaction<Signature>>(tx: T)
     where

--- a/crates/tx-macros/src/expand.rs
+++ b/crates/tx-macros/src/expand.rs
@@ -564,7 +564,9 @@ impl Expander {
         let fallback_decode_arms = self.variants.all.iter().map(|v| {
             let name = &v.name;
             quote! {
-                if let Ok(tx) = #alloy_eips::Decodable2718::fallback_decode(buf) {
+                let mut candidate = *buf;
+                if let Ok(tx) = #alloy_eips::Decodable2718::fallback_decode(&mut candidate) {
+                    *buf = candidate;
                     return Ok(Self::#name(tx))
                 }
             }


### PR DESCRIPTION
## Motivation

The `TransactionEnvelope` derive macro retried fallback-capable variants against
the same mutable input cursor. If one variant advanced the cursor before failing,
the next variant decoded from the shifted suffix instead of the original
transaction boundary.

## Solution

- Add a regression for the malformed fallback suffix reproducer from fuzzing.
- Decode each fallback variant against a candidate cursor and commit the cursor
  back to the caller only when that variant succeeds.

## Tests

- `cargo test -p alloy-consensus decode_2718_exact_rejects_fallback_suffix_reproducer --lib`

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
