### PR TITLE
fix(eips): forward eip7928 borsh feature

### DIFF
--- a/crates/eips/Cargo.toml
+++ b/crates/eips/Cargo.toml
@@ -129,4 +129,5 @@ borsh = [
 	"alloy-primitives/borsh",
 	"alloy-eip2930/borsh",
 	"alloy-eip7702/borsh",
+	"alloy-eip7928/borsh",
 ]

--- a/crates/eips/src/eip7928.rs
+++ b/crates/eips/src/eip7928.rs
@@ -6,3 +6,15 @@
 //! [`alloy-eip7928`]: https://crates.io/crates/alloy-eip7928
 
 pub use alloy_eip7928::*;
+
+#[cfg(all(test, feature = "borsh"))]
+mod tests {
+    use super::bal::Bal;
+
+    fn assert_borsh<T: borsh::BorshSerialize + borsh::BorshDeserialize>() {}
+
+    #[test]
+    fn bal_has_borsh_when_feature_enabled() {
+        assert_borsh::<Bal>();
+    }
+}


### PR DESCRIPTION
## Motivation

`alloy-eip7928` exposes a `borsh` feature, but the aggregate `alloy-eips` crate did not forward it from its own `borsh` feature. This meant EIP-7928 types re-exported through `alloy-eips` did not get borsh impls when users enabled `alloy-eips/borsh`.

## Solution

Forward `alloy-eip7928/borsh` from the aggregate `borsh` feature and add a compile assertion covering `Bal`.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
