### PR TITLE
revert: rustdoc no_inline workaround

### DIFF
--- a/crates/alloy/src/lib.rs
+++ b/crates/alloy/src/lib.rs
@@ -16,21 +16,19 @@
 pub use alloy_core as core;
 
 /// Low-level primitives for Ethereum.
-// Avoid nightly rustdoc ICEs when inlining external crate docs:
-// https://github.com/paradigmxyz/solar/pull/912
-#[doc(no_inline)]
+#[doc(inline)]
 pub use self::core::primitives;
 #[doc(no_inline)]
 pub use primitives::{hex, uint};
 
 /// Dynamic Solidity type encoder.
 #[cfg(feature = "dyn-abi")]
-#[doc(no_inline)]
+#[doc(inline)]
 pub use self::core::dyn_abi;
 
 /// Full Ethereum [JSON-ABI](https://docs.soliditylang.org/en/latest/abi-spec.html) implementation.
 #[cfg(feature = "json-abi")]
-#[doc(no_inline)]
+#[doc(inline)]
 pub use self::core::json_abi;
 
 /// Solidity type modeling and [ABI] and [EIP-712] codec implementation.
@@ -38,7 +36,7 @@ pub use self::core::json_abi;
 /// [ABI]: https://docs.soliditylang.org/en/latest/abi-spec.html
 /// [EIP-712]: https://eips.ethereum.org/EIPS/eip-712
 #[cfg(feature = "sol-types")]
-#[doc(no_inline)]
+#[doc(inline)]
 pub use self::core::sol_types;
 
 // Show this re-export in docs instead of the wrapper below.
@@ -50,7 +48,7 @@ pub use sol_types::sol;
 ///
 /// [rlp]: https://ethereum.org/en/developers/docs/data-structures-and-encoding/rlp
 #[cfg(feature = "rlp")]
-#[doc(no_inline)]
+#[doc(inline)]
 pub use self::core::rlp;
 
 /// [`sol!`](sol_types::sol!) `macro_rules!` wrapper to set import attributes.

--- a/crates/signer-aws/src/lib.rs
+++ b/crates/signer-aws/src/lib.rs
@@ -12,9 +12,5 @@ extern crate tracing;
 mod signer;
 pub use signer::{AwsSigner, AwsSignerError};
 
-// Avoid nightly rustdoc ICEs when inlining external crate docs:
-// https://github.com/paradigmxyz/solar/pull/912
-#[doc(no_inline)]
 pub use aws_config;
-#[doc(no_inline)]
 pub use aws_sdk_kms;

--- a/crates/signer-gcp/src/lib.rs
+++ b/crates/signer-gcp/src/lib.rs
@@ -12,7 +12,4 @@ extern crate tracing;
 mod signer;
 pub use signer::{GcpKeyRingRef, GcpSigner, GcpSignerError, KeySpecifier};
 
-// Avoid nightly rustdoc ICEs when inlining external crate docs:
-// https://github.com/paradigmxyz/solar/pull/912
-#[doc(no_inline)]
 pub use gcloud_sdk;

--- a/crates/signer-ledger/src/lib.rs
+++ b/crates/signer-ledger/src/lib.rs
@@ -16,7 +16,4 @@ pub use signer::LedgerSigner;
 mod types;
 pub use types::{DerivationType as HDPath, LedgerError};
 
-// Avoid nightly rustdoc ICEs when inlining external crate docs:
-// https://github.com/paradigmxyz/solar/pull/912
-#[doc(no_inline)]
 pub use coins_ledger;

--- a/crates/signer-local/src/lib.rs
+++ b/crates/signer-local/src/lib.rs
@@ -30,14 +30,10 @@ mod secp256k1;
 #[cfg(feature = "yubihsm")]
 mod yubi;
 
-// Avoid nightly rustdoc ICEs when inlining external crate docs:
-// https://github.com/paradigmxyz/solar/pull/912
 #[cfg(feature = "yubihsm")]
-#[doc(no_inline)]
 pub use yubihsm;
 
 #[cfg(feature = "mnemonic")]
-#[doc(no_inline)]
 pub use coins_bip39;
 
 #[cfg(feature = "secp256k1")]

--- a/crates/signer-turnkey/src/lib.rs
+++ b/crates/signer-turnkey/src/lib.rs
@@ -9,9 +9,6 @@
 mod signer;
 pub use signer::{TurnkeySigner, TurnkeySignerError};
 
-// Avoid nightly rustdoc ICEs when inlining external crate docs:
-// https://github.com/paradigmxyz/solar/pull/912
-#[doc(no_inline)]
 pub use turnkey_client::{self, TurnkeyClientError, TurnkeyP256ApiKey};
 
 /// Alias for the Turnkey SDK client using the P256 API key stamper.

--- a/crates/signer/src/lib.rs
+++ b/crates/signer/src/lib.rs
@@ -15,9 +15,6 @@ pub use signer::{Either, Signer, SignerSync};
 pub mod utils;
 
 pub use alloy_primitives::Signature;
-// Avoid nightly rustdoc ICEs when inlining external crate docs:
-// https://github.com/paradigmxyz/solar/pull/912
-#[doc(no_inline)]
 pub use k256;
 
 /// Utility to get and set the chain ID on a transaction and the resulting signature within a

--- a/crates/transport-http/src/lib.rs
+++ b/crates/transport-http/src/lib.rs
@@ -6,10 +6,7 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
-// Avoid nightly rustdoc ICEs when inlining external crate docs:
-// https://github.com/paradigmxyz/solar/pull/912
 #[cfg(all(feature = "reqwest", not(all(target_os = "wasi", target_env = "p1"))))]
-#[doc(no_inline)]
 pub use reqwest;
 #[cfg(all(feature = "reqwest", not(all(target_os = "wasi", target_env = "p1"))))]
 mod reqwest_transport;
@@ -19,10 +16,8 @@ mod reqwest_transport;
 pub use reqwest_transport::*;
 
 #[cfg(all(not(target_family = "wasm"), feature = "hyper"))]
-#[doc(no_inline)]
 pub use hyper;
 #[cfg(all(not(target_family = "wasm"), feature = "hyper"))]
-#[doc(no_inline)]
 pub use hyper_util;
 
 mod layers;


### PR DESCRIPTION
Reverts the temporary rustdoc ICE workaround now that the upstream rustdoc panic has been fixed.

Prompted by: @DaniPopes