### PR TITLE
fix(provider): recover receipts missed by heartbeat

### DIFF
--- a/crates/provider/src/ext/anvil.rs
+++ b/crates/provider/src/ext/anvil.rs
@@ -529,16 +529,19 @@ mod tests {
     use super::*;
     use crate::{
         fillers::{ChainIdFiller, GasFiller},
-        ProviderBuilder,
+        ProviderBuilder, WalletProvider,
     };
     use alloy_consensus::{BlockHeader, SidecarBuilder, SimpleCoder};
     use alloy_eips::BlockNumberOrTag;
     use alloy_network::{AnyNetwork, TransactionBuilder, TransactionBuilder4844};
     use alloy_network_primitives::BlockResponse as _;
+    use alloy_node_bindings::Anvil;
     use alloy_primitives::{address, B256};
+    use alloy_rpc_client::RpcClient;
     use alloy_rpc_types_eth::TransactionRequest;
     use alloy_sol_types::{sol, SolCall};
     use alloy_transport::mock::Asserter;
+    use std::time::Duration;
 
     const FORK_URL: &str = "https://ethereum.reth.rs/rpc";
 
@@ -700,6 +703,45 @@ mod tests {
         let num = provider.get_block_number().await.unwrap();
 
         assert_eq!(num, start_num + 10);
+    }
+
+    #[tokio::test]
+    async fn get_receipt_recovers_when_heartbeat_misses_confirmed_transaction() {
+        let anvil = Anvil::new().spawn();
+        let wallet = anvil.wallet().unwrap();
+        let client = RpcClient::builder()
+            .http(anvil.endpoint_url())
+            .with_poll_interval(Duration::from_millis(10));
+        let provider = ProviderBuilder::new().wallet(wallet).connect_client(client);
+        provider.anvil_set_auto_mine(false).await.unwrap();
+
+        for attempt in 1..=20 {
+            let tx = TransactionRequest::default()
+                .with_to(provider.default_signer_address())
+                .with_value(U256::from(1));
+            let pending = provider.send_transaction(tx).await.unwrap();
+            let tx_hash = *pending.tx_hash();
+
+            let watcher = tokio::spawn(async move {
+                pending
+                    .with_required_confirmations(3)
+                    .with_timeout(Some(Duration::from_millis(150)))
+                    .get_receipt()
+                    .await
+            });
+
+            // Let the heartbeat register the transaction, then mine enough blocks to satisfy the
+            // confirmation target. If the block stream initializes after mining, it only looks
+            // back one block and misses the transaction in the first of these three blocks.
+            tokio::task::yield_now().await;
+            provider.anvil_mine(Some(3), None).await.unwrap();
+
+            let receipt = watcher
+                .await
+                .unwrap()
+                .unwrap_or_else(|err| panic!("attempt {attempt} failed: {err}"));
+            assert_eq!(receipt.transaction_hash, tx_hash);
+        }
     }
 
     #[tokio::test]

--- a/crates/provider/src/heart.rs
+++ b/crates/provider/src/heart.rs
@@ -3,13 +3,13 @@
 use crate::{blocks::Paused, Provider, RootProvider};
 use alloy_consensus::BlockHeader;
 use alloy_json_rpc::RpcError;
-use alloy_network::{BlockResponse, Network};
+use alloy_network::{BlockResponse, Network, ReceiptResponse};
 use alloy_primitives::{
     map::{B256HashMap, B256HashSet},
     TxHash, B256,
 };
 use alloy_transport::{utils::Spawnable, TransportError};
-use futures::{future::pending, stream::StreamExt, FutureExt, Stream};
+use futures::{stream::StreamExt, FutureExt, Stream};
 use std::{
     collections::{BTreeMap, VecDeque},
     fmt,
@@ -226,30 +226,13 @@ impl<N: Network> PendingTransactionBuilder<N> {
         let hash = self.config.tx_hash;
         let required_confirmations = self.config.required_confirmations;
         let mut pending_tx = self.provider.watch_pending_transaction(self.config).await?;
-
-        // FIXME: this is a hotfix to prevent a race condition where the heartbeat would miss the
-        // block the tx was mined in. Only apply this for single confirmation to respect the
-        // confirmation setting.
-        let mut interval = if required_confirmations > 1 {
-            None
-        } else {
-            Some(interval(self.provider.client().poll_interval()))
-        };
+        let mut interval = interval(self.provider.client().poll_interval());
 
         loop {
             let mut confirmed = false;
 
-            // If more than 1 block confirmations is specified then we can rely on the regular
-            // watch_pending_transaction and dont need this workaround for the above mentioned race
-            // condition
-            let tick_fut = if let Some(interval) = interval.as_mut() {
-                interval.tick().map(|_| ()).left_future()
-            } else {
-                pending::<()>().right_future()
-            };
-
             select! {
-                _ = tick_fut => {},
+                _ = interval.tick() => {},
                 res = &mut pending_tx => {
                     let _ = res?;
                     confirmed = true;
@@ -259,7 +242,18 @@ impl<N: Network> PendingTransactionBuilder<N> {
             // try to fetch the receipt
             let receipt = self.provider.get_transaction_receipt(hash).await?;
             if let Some(receipt) = receipt {
-                return Ok(receipt);
+                if confirmed || required_confirmations <= 1 {
+                    return Ok(receipt);
+                }
+
+                if let Some(receipt_block) = receipt.block_number() {
+                    let current_block = self.provider.get_block_number().await?;
+                    let confirmed_at =
+                        receipt_block.saturating_add(required_confirmations.saturating_sub(1));
+                    if current_block >= confirmed_at {
+                        return Ok(receipt);
+                    }
+                }
             }
 
             if confirmed {


### PR DESCRIPTION
## Motivation

`PendingTransactionBuilder::get_receipt()` can time out when multiple confirmations are requested, even if the receipt already exists and the required confirmation height has been reached.

This happens when the heartbeat resumes after several blocks are mined at once and misses the block containing the transaction.

Closes #3916.

## Solution

Poll for the transaction receipt for all confirmation counts instead of relying exclusively on the heartbeat when more than one confirmation is requested.

When a receipt is found, compare its block number and the current chain height against the requested confirmation count before returning it. This preserves confirmation semantics while providing a fallback when the heartbeat misses the transaction block.

A regression test repeatedly mines three blocks at once and verifies that `get_receipt()` returns the confirmed receipt instead of timing out.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes