### PR TITLE
chore: bump MSRV to 1.94.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         rust:
           - "stable"
           - "nightly"
-          - "1.91" # MSRV
+          - "1.94.1" # MSRV
         flags:
           # No features
           - "--no-default-features -F reqwest-rustls-tls"
@@ -38,7 +38,7 @@ jobs:
           - "--all-features"
         exclude:
           # All features on MSRV
-          - rust: "1.91" # MSRV
+          - rust: "1.94.1" # MSRV
             flags: "--all-features"
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -59,16 +59,16 @@ jobs:
           cache-on-failure: true
       # Only run tests on latest stable and above
       - name: Install cargo-nextest
-        if: ${{ matrix.rust != '1.91' }} # MSRV
+        if: ${{ matrix.rust != '1.94.1' }} # MSRV
         uses: taiki-e/install-action@cca35edeb1d01366c2843b68fc3ca441446d73d3 # v2
         with:
           tool: nextest
       - name: build
-        if: ${{ matrix.rust == '1.91' }} # MSRV
+        if: ${{ matrix.rust == '1.94.1' }} # MSRV
         run: cargo build --workspace ${{ matrix.flags }}
       - name: test
         shell: bash
-        if: ${{ matrix.rust != '1.91' }} # MSRV
+        if: ${{ matrix.rust != '1.94.1' }} # MSRV
         run: cargo nextest run --workspace ${{ matrix.flags }}
 
   doctest:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.package]
 version = "2.1.1"
 edition = "2021"
-rust-version = "1.91"
+rust-version = "1.94.1"
 authors = ["Alloy Contributors"]
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/alloy-rs/alloy"

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ When updating this, also update:
 - .github/workflows/ci.yml
 -->
 
-The current MSRV (minimum supported rust version) is 1.91.
+The current MSRV (minimum supported rust version) is 1.94.1.
 
 Alloy will keep a rolling MSRV policy of **at least** two versions behind the
 latest stable release (so if the latest stable release is 1.58, we would


### PR DESCRIPTION
## Summary

- Bumps the workspace `rust-version` to 1.94.1.
- Updates the README MSRV text and CI MSRV matrix/conditions to match.

## Impact

Cargo metadata, project documentation, and CI now agree on the new minimum supported Rust version.