### PR TITLE
feat(consensus): add block gas limit validation

### DIFF
--- a/crates/consensus/src/block/header.rs
+++ b/crates/consensus/src/block/header.rs
@@ -5,7 +5,10 @@ use crate::{
 };
 use alloc::vec::Vec;
 use alloy_eips::{
-    eip1559::{calc_next_block_base_fee, BaseFeeParams},
+    eip1559::{
+        calc_next_block_base_fee, calculate_block_gas_limit_with_bound_divisor, BaseFeeParams,
+        GAS_LIMIT_BOUND_DIVISOR,
+    },
     eip1898::BlockWithParent,
     eip7840::BlobParams,
     merge::ALLOWED_FUTURE_BLOCK_TIME_SECONDS,
@@ -572,6 +575,17 @@ impl<'a> arbitrary::Arbitrary<'a> for Header {
     }
 }
 
+/// Error returned when a block's gas limit is not the closest possible value to the desired gas
+/// limit.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, thiserror::Error)]
+#[error("gas limit mismatch: got {got}, expected {expected}")]
+pub struct GasLimitMismatch {
+    /// The gas limit from the block header.
+    pub got: u64,
+    /// The closest valid gas limit to the desired gas limit.
+    pub expected: u64,
+}
+
 /// Trait for extracting specific Ethereum block data from a header
 #[auto_impl::auto_impl(&, Arc)]
 pub trait BlockHeader {
@@ -730,6 +744,51 @@ pub trait BlockHeader {
             self.base_fee_per_gas()?,
             base_fee_params,
         ))
+    }
+
+    /// Validates that a child block's gas limit is the closest possible value to the desired gas
+    /// limit, using the default [`GAS_LIMIT_BOUND_DIVISOR`].
+    ///
+    /// `self` is the parent block header and `gas_limit` is the child block's gas limit.
+    ///
+    /// Ref: <https://github.com/flashbots/builder/blob/a742641e24df68bc2fc476199b012b0abce40ffe/core/blockchain.go#L2474-L2477>
+    fn validate_gas_limit(
+        &self,
+        desired_gas_limit: u64,
+        gas_limit: u64,
+    ) -> Result<(), GasLimitMismatch> {
+        self.validate_gas_limit_with_bound_divisor(
+            desired_gas_limit,
+            gas_limit,
+            GAS_LIMIT_BOUND_DIVISOR,
+        )
+    }
+
+    /// Validates that a child block's gas limit is the closest possible value to the desired gas
+    /// limit, using the provided gas limit bound divisor.
+    ///
+    /// `self` is the parent block header and `gas_limit` is the child block's gas limit.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `gas_limit_bound_divisor` is zero.
+    fn validate_gas_limit_with_bound_divisor(
+        &self,
+        desired_gas_limit: u64,
+        gas_limit: u64,
+        gas_limit_bound_divisor: u64,
+    ) -> Result<(), GasLimitMismatch> {
+        let expected = calculate_block_gas_limit_with_bound_divisor(
+            self.gas_limit(),
+            desired_gas_limit,
+            gas_limit_bound_divisor,
+        );
+
+        if gas_limit != expected {
+            return Err(GasLimitMismatch { got: gas_limit, expected });
+        }
+
+        Ok(())
     }
 
     /// Returns the parent block's number and hash
@@ -1143,6 +1202,29 @@ pub(crate) mod serde_bincode_compat {
 mod tests {
     use super::*;
     use alloy_primitives::{b256, hex};
+
+    #[test]
+    fn validate_gas_limit() {
+        let parent = Header { gas_limit: 30_000_000, ..Default::default() };
+
+        assert_eq!(parent.validate_gas_limit(30_000_000, 30_000_000), Ok(()));
+        assert_eq!(parent.validate_gas_limit(20_000_000, 29_970_705), Ok(()));
+
+        let err = parent.validate_gas_limit(40_000_000, 30_000_000).unwrap_err();
+        assert_eq!(err, GasLimitMismatch { got: 30_000_000, expected: 30_029_295 });
+        assert_eq!(err.to_string(), "gas limit mismatch: got 30000000, expected 30029295");
+    }
+
+    #[test]
+    fn validate_gas_limit_with_custom_bound_divisor() {
+        let parent = Header { gas_limit: 1_000, ..Default::default() };
+
+        assert_eq!(parent.validate_gas_limit_with_bound_divisor(2_000, 1_099, 10), Ok(()));
+        assert_eq!(
+            parent.validate_gas_limit_with_bound_divisor(2_000, 1_098, 10),
+            Err(GasLimitMismatch { got: 1_098, expected: 1_099 })
+        );
+    }
 
     #[test]
     fn decode_header_rlp() {

--- a/crates/consensus/src/block/mod.rs
+++ b/crates/consensus/src/block/mod.rs
@@ -1,7 +1,7 @@
 //! Block-related consensus types.
 
 mod header;
-pub use header::{BlockHeader, Header};
+pub use header::{BlockHeader, GasLimitMismatch, Header};
 
 mod traits;
 pub use traits::EthBlock;

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -21,7 +21,9 @@ pub use alloy_trie::TrieAccount;
 pub type Account = TrieAccount;
 
 mod block;
-pub use block::{Block, BlockBody, BlockHeader, EthBlock, Header, HeaderInfo, HeaderRoots};
+pub use block::{
+    Block, BlockBody, BlockHeader, EthBlock, GasLimitMismatch, Header, HeaderInfo, HeaderRoots,
+};
 
 mod indexed;
 pub use indexed::Indexed;

--- a/crates/eips/src/eip1559/helpers.rs
+++ b/crates/eips/src/eip1559/helpers.rs
@@ -146,9 +146,29 @@ pub fn calc_next_block_base_fee(
 /// Calculate the gas limit for the next block based on parent and desired gas limits.
 /// Ref: <https://github.com/ethereum/go-ethereum/blob/88cbfab332c96edfbe99d161d9df6a40721bd786/core/block_validator.go#L166>
 pub fn calculate_block_gas_limit(parent_gas_limit: u64, desired_gas_limit: u64) -> u64 {
-    let delta = (parent_gas_limit / GAS_LIMIT_BOUND_DIVISOR).saturating_sub(1);
-    let min_gas_limit = parent_gas_limit - delta;
-    let max_gas_limit = parent_gas_limit + delta;
+    calculate_block_gas_limit_with_bound_divisor(
+        parent_gas_limit,
+        desired_gas_limit,
+        GAS_LIMIT_BOUND_DIVISOR,
+    )
+}
+
+/// Calculate the gas limit for the next block based on parent and desired gas limits and a custom
+/// gas limit bound divisor.
+///
+/// # Panics
+///
+/// Panics if `gas_limit_bound_divisor` is zero.
+pub fn calculate_block_gas_limit_with_bound_divisor(
+    parent_gas_limit: u64,
+    desired_gas_limit: u64,
+    gas_limit_bound_divisor: u64,
+) -> u64 {
+    assert!(gas_limit_bound_divisor != 0, "gas limit bound divisor must be non-zero");
+
+    let delta = (parent_gas_limit / gas_limit_bound_divisor).saturating_sub(1);
+    let min_gas_limit = parent_gas_limit.saturating_sub(delta);
+    let max_gas_limit = parent_gas_limit.saturating_add(delta);
     desired_gas_limit.clamp(min_gas_limit, max_gas_limit)
 }
 
@@ -160,6 +180,28 @@ mod tests {
     #[test]
     fn min_protocol_sanity() {
         assert_eq!(MIN_PROTOCOL_BASE_FEE_U256.to::<u64>(), MIN_PROTOCOL_BASE_FEE);
+    }
+
+    #[test]
+    fn calculate_block_gas_limit_bounds_desired_limit() {
+        let parent_gas_limit = 30_000_000;
+        let min_gas_limit = 29_970_705;
+        let max_gas_limit = 30_029_295;
+
+        assert_eq!(calculate_block_gas_limit(parent_gas_limit, 20_000_000), min_gas_limit);
+        assert_eq!(calculate_block_gas_limit(parent_gas_limit, 30_000_000), 30_000_000);
+        assert_eq!(calculate_block_gas_limit(parent_gas_limit, 40_000_000), max_gas_limit);
+    }
+
+    #[test]
+    fn calculate_block_gas_limit_uses_custom_bound_divisor() {
+        assert_eq!(calculate_block_gas_limit_with_bound_divisor(1_000, 2_000, 10), 1_099);
+    }
+
+    #[test]
+    #[should_panic(expected = "gas limit bound divisor must be non-zero")]
+    fn calculate_block_gas_limit_rejects_zero_bound_divisor() {
+        calculate_block_gas_limit_with_bound_divisor(1_000, 2_000, 0);
     }
 
     #[test]

--- a/crates/eips/src/eip1559/mod.rs
+++ b/crates/eips/src/eip1559/mod.rs
@@ -11,5 +11,5 @@ pub use constants::*;
 mod helpers;
 pub use helpers::{
     calc_effective_gas_price, calc_next_block_base_fee, calculate_block_gas_limit,
-    Eip1559Estimation,
+    calculate_block_gas_limit_with_bound_divisor, Eip1559Estimation,
 };


### PR DESCRIPTION
## Summary

- add reusable `BlockHeader` gas-limit validation for validator-registered limits
- support both Ethereum's default gas-limit bound divisor and custom divisors
- return a dedicated `GasLimitMismatch` carrying the actual and expected limits
- expose the custom-divisor EIP-1559 gas-limit calculator

## Motivation

Reth currently implements this validator gas-limit check locally. Keeping the bound calculation and validation in Alloy makes the behavior reusable across consumers and keeps it alongside the shared header and EIP-1559 primitives.
