### PR TITLE
chore(eips): address nightly clippy lint

### DIFF
--- a/crates/eips/src/eip4844/engine.rs
+++ b/crates/eips/src/eip4844/engine.rs
@@ -229,11 +229,11 @@ mod tests {
         );
         assert_eq!(&encoded[..BYTES_PER_BLOB], blob_and_proof.blob.as_slice());
 
-        let mut proof_chunks = encoded[expected_offset..].chunks_exact(48);
-        for (proof, chunk) in blob_and_proof.proofs.iter().zip(&mut proof_chunks) {
+        let (proof_chunks, remainder) = encoded[expected_offset..].as_chunks::<48>();
+        for (proof, chunk) in blob_and_proof.proofs.iter().zip(proof_chunks) {
             assert_eq!(chunk, proof.as_slice());
         }
-        assert!(proof_chunks.remainder().is_empty());
+        assert!(remainder.is_empty());
 
         let decoded = <BlobAndProofV2 as ssz::Decode>::from_ssz_bytes(&encoded).unwrap();
         assert_eq!(decoded, blob_and_proof);

--- a/crates/eips/src/eip7594/sidecar.rs
+++ b/crates/eips/src/eip7594/sidecar.rs
@@ -1168,8 +1168,8 @@ impl BlobCellMask {
         self,
         cells: &[crate::eip7594::Cell],
     ) -> Option<Vec<crate::eip7594::Cell>> {
-        let chunks = cells.chunks_exact(CELLS_PER_EXT_BLOB);
-        if !chunks.remainder().is_empty() {
+        let (chunks, remainder) = cells.as_chunks::<CELLS_PER_EXT_BLOB>();
+        if !remainder.is_empty() {
             return None;
         }
 
@@ -1424,7 +1424,9 @@ mod tests {
         let matching_cells =
             sidecar.compute_matching_cells_with_settings(cell_mask, settings).unwrap();
         let expected_matching_cells = cells
-            .chunks_exact(CELLS_PER_EXT_BLOB)
+            .as_chunks::<CELLS_PER_EXT_BLOB>()
+            .0
+            .iter()
             .flat_map(|blob_cells| [blob_cells[0], blob_cells[7]])
             .collect::<Vec<_>>();
         assert_eq!(


### PR DESCRIPTION
## Summary

- replace constant-sized `chunks_exact` calls with `as_chunks` in EIP-4844 and EIP-7594 code and tests
- satisfy the new nightly `chunks_exact_to_as_chunks` lint while preserving remainder handling
