### PR TITLE
fix(pubsub): deduplicate subscriptions and track cleanup

### DIFF
--- a/crates/json-rpc/src/request.rs
+++ b/crates/json-rpc/src/request.rs
@@ -394,6 +394,31 @@ impl SerializedRequest {
         }
     }
 
+    /// Clone this request with a different JSON-RPC request ID.
+    ///
+    /// The serialized params are preserved verbatim, including the distinction between omitted
+    /// params, `null`, and an empty collection.
+    pub fn with_id(&self, id: Id) -> serde_json::Result<Self> {
+        #[derive(Serialize)]
+        struct RequestWithId<'a> {
+            method: &'a str,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            params: Option<&'a RawValue>,
+            id: &'a Id,
+            jsonrpc: &'static str,
+        }
+
+        let request = serde_json::value::to_raw_value(&RequestWithId {
+            method: self.method(),
+            params: self.params_with_presence(),
+            id: &id,
+            jsonrpc: "2.0",
+        })?;
+        let mut meta = self.meta.clone();
+        meta.id = id;
+        Ok(Self { meta, request })
+    }
+
     /// Mark the request as a non-standard subscription (i.e. not
     /// `eth_subscribe`)
     pub const fn set_is_subscription(&mut self) {
@@ -441,6 +466,40 @@ impl SerializedRequest {
         req.params
     }
 
+    /// Get the exact serialized params when the `params` field is present.
+    ///
+    /// Unlike [`Self::params`], this distinguishes an omitted `params` field from an explicitly
+    /// serialized `null` value.
+    pub fn params_with_presence(&self) -> Option<&RawValue> {
+        #[derive(Default)]
+        enum ParamsField<'a> {
+            #[default]
+            Missing,
+            Present(&'a RawValue),
+        }
+
+        impl<'de: 'a, 'a> Deserialize<'de> for ParamsField<'a> {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                <&'de RawValue>::deserialize(deserializer).map(Self::Present)
+            }
+        }
+
+        #[derive(Deserialize)]
+        struct Req<'a> {
+            #[serde(borrow, default)]
+            params: ParamsField<'a>,
+        }
+
+        let req: Req<'_> = serde_json::from_str(self.request.get()).unwrap();
+        match req.params {
+            ParamsField::Missing => None,
+            ParamsField::Present(params) => Some(params),
+        }
+    }
+
     /// Get the hash of the serialized request's params.
     ///
     /// This partially deserializes the request, and should be avoided if
@@ -478,5 +537,21 @@ mod test {
         test_inner(Request::<u64>::new("test", "hello".to_string().into(), 1));
         test_inner(Request::<String>::new("test", Id::None, "test".to_string()));
         test_inner(Request::<Vec<u64>>::new("test", u64::MAX.into(), vec![1, 2, 3]));
+    }
+
+    #[test]
+    fn with_id_preserves_exact_params_presence_and_value() {
+        let omitted = Request::new("test", Id::Number(1), ()).serialize().unwrap();
+        let null =
+            Request::new("test", Id::Number(1), serde_json::Value::Null).serialize().unwrap();
+        let empty = Request::new("test", Id::Number(1), Vec::<u8>::new()).serialize().unwrap();
+
+        let omitted = omitted.with_id(Id::String("next".into())).unwrap();
+        let null = null.with_id(Id::String("next".into())).unwrap();
+        let empty = empty.with_id(Id::String("next".into())).unwrap();
+
+        assert!(omitted.params_with_presence().is_none());
+        assert_eq!(null.params_with_presence().unwrap().get(), "null");
+        assert_eq!(empty.params_with_presence().unwrap().get(), "[]");
     }
 }

--- a/crates/provider/src/ext/admin.rs
+++ b/crates/provider/src/ext/admin.rs
@@ -76,7 +76,7 @@ where
     fn subscribe_peer_events(
         &self,
     ) -> GetSubscription<alloy_rpc_client::NoParams, alloy_rpc_types_admin::PeerEvent> {
-        self.subscribe_to("admin_peerEvents")
+        self.subscribe_to("admin_peerEvents").unsubscribe_method("admin_unsubscribe")
     }
 }
 

--- a/crates/provider/src/ext/reth.rs
+++ b/crates/provider/src/ext/reth.rs
@@ -70,6 +70,7 @@ where
         &self,
     ) -> GetSubscription<alloy_rpc_client::NoParams, serde_json::Value> {
         self.subscribe_to("reth_subscribeChainNotifications")
+            .unsubscribe_method("reth_unsubscribeChainNotifications")
     }
 
     #[cfg(feature = "pubsub")]
@@ -77,5 +78,6 @@ where
         &self,
     ) -> GetSubscription<alloy_rpc_client::NoParams, serde_json::Value> {
         self.subscribe_to("reth_subscribePersistedBlock")
+            .unsubscribe_method("reth_unsubscribePersistedBlock")
     }
 }

--- a/crates/provider/src/provider/root.rs
+++ b/crates/provider/src/provider/root.rs
@@ -75,10 +75,19 @@ impl<N: Network> RootProvider<N> {
         self.pubsub_frontend()?.get_subscription(id).await.map(Subscription::from)
     }
 
-    /// Unsubscribes from the subscription corresponding to the given RPC subscription ID.
+    /// Force-unsubscribes the subscription and closes all local receivers sharing its key.
     #[cfg(feature = "pubsub")]
     pub fn unsubscribe(&self, id: alloy_primitives::B256) -> alloy_transport::TransportResult<()> {
         self.pubsub_frontend()?.unsubscribe(id)
+    }
+
+    /// Unsubscribes and waits for the server-side cleanup to reach a terminal state.
+    #[cfg(feature = "pubsub")]
+    pub async fn unsubscribe_and_wait(
+        &self,
+        id: alloy_primitives::B256,
+    ) -> alloy_transport::TransportResult<alloy_pubsub::UnsubscribeOutcome> {
+        self.pubsub_frontend()?.unsubscribe_and_wait(id).await
     }
 
     #[cfg(feature = "pubsub")]

--- a/crates/provider/src/provider/subscription.rs
+++ b/crates/provider/src/provider/subscription.rs
@@ -3,6 +3,7 @@ use alloy_primitives::B256;
 use alloy_pubsub::Subscription;
 use alloy_rpc_client::{RpcCall, WeakClient};
 use alloy_transport::{TransportErrorKind, TransportResult};
+use std::borrow::Cow;
 
 /// A general-purpose subscription request builder
 ///
@@ -34,6 +35,12 @@ where
         self.channel_size = Some(size);
         self
     }
+
+    /// Set the RPC method used to remove the server-side subscription.
+    pub fn unsubscribe_method(mut self, method: impl Into<Cow<'static, str>>) -> Self {
+        self.call.set_unsubscribe_method(method);
+        self
+    }
 }
 
 impl<P, R> core::fmt::Debug for GetSubscription<P, R>
@@ -57,7 +64,7 @@ where
     type Output = TransportResult<alloy_pubsub::Subscription<R>>;
     type IntoFuture = futures_utils_wasm::BoxFuture<'static, Self::Output>;
 
-    fn into_future(self) -> Self::IntoFuture {
+    fn into_future(mut self) -> Self::IntoFuture {
         Box::pin(async move {
             let client = self
                 .client
@@ -65,9 +72,13 @@ where
                 .ok_or_else(|| TransportErrorKind::custom_str("client dropped"))?;
             let pubsub = client.pubsub_frontend().ok_or(TransportErrorKind::PubsubUnavailable)?;
 
-            // Set config channel size if any
             if let Some(size) = self.channel_size {
-                pubsub.set_channel_size(size);
+                if size == 0 {
+                    return Err(alloy_json_rpc::RpcError::local_usage_str(
+                        "subscription channel size must be non-zero",
+                    ));
+                }
+                self.call.set_subscription_channel_size(size);
             }
 
             let id = self.call.await?;

--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -1700,7 +1700,9 @@ pub trait Provider<N: Network = Ethereum>: Send + Sync {
     ///
     /// This is a helper method for creating subscriptions to methods that are not
     /// "eth_subscribe" and don't require parameters. It automatically marks the
-    /// request as a subscription.
+    /// request as a subscription. Because custom protocols do not share a universal cleanup
+    /// naming convention, configure [`GetSubscription::unsubscribe_method`] when the server
+    /// exposes one. Without it, the subscription can only be reclaimed when the connection closes.
     ///
     /// # Examples
     ///
@@ -1728,10 +1730,19 @@ pub trait Provider<N: Network = Ethereum>: Send + Sync {
         GetSubscription::new(self.weak_client(), rpc_call)
     }
 
-    /// Cancels a subscription given the subscription ID.
+    /// Force-cancels a subscription and closes all local receivers sharing its key.
     #[cfg(feature = "pubsub")]
     async fn unsubscribe(&self, id: B256) -> TransportResult<()> {
         self.root().unsubscribe(id)
+    }
+
+    /// Cancels a subscription and waits for server confirmation or connection-level cleanup.
+    #[cfg(feature = "pubsub")]
+    async fn unsubscribe_and_wait(
+        &self,
+        id: B256,
+    ) -> TransportResult<alloy_pubsub::UnsubscribeOutcome> {
+        self.root().unsubscribe_and_wait(id).await
     }
 
     /// Gets syncing info.

--- a/crates/pubsub/Cargo.toml
+++ b/crates/pubsub/Cargo.toml
@@ -28,7 +28,6 @@ alloy-primitives.workspace = true
 alloy-transport.workspace = true
 
 auto_impl.workspace = true
-bimap.workspace = true
 futures.workspace = true
 parking_lot.workspace = true
 serde.workspace = true

--- a/crates/pubsub/README.md
+++ b/crates/pubsub/README.md
@@ -63,7 +63,7 @@ For a normal request, the user sends a request to the **frontend**, and
 later receives a response via a tokio oneshot channel. This is straightforward
 and easy to reason about. Subscriptions, however, are side-effects of other
 requests, and are long-lived. They are managed by the **service** and
-identified by a `U256` id. The **service** uses this id to manage the
+identified by a local `B256` id. The **service** uses this id to manage the
 subscription lifecycle, and to dispatch notifications to the correct
 subscribers.
 
@@ -72,7 +72,7 @@ subscribers.
 When a user issues a subscription request, the **frontend** sends a
 subscription request to the **service**. The **service** dispatches it to the
 RPC server via the **backend**. The **service** then intercepts the RPC server
-response containing the serve id, and assigns a `local_id` to the subscription.
+response containing the server id, and assigns a `local_id` to the subscription.
 This `local_id` is used to identify the subscription in the **service** and in
 tasks consuming the subscription, while the `server_id` is used to identify the
 subscription to the RPC server, and to associate notifications with specific
@@ -82,6 +82,10 @@ This allows us to use long-lived `local_id` values to manage subscriptions over
 multiple reconnections, without having to notify frontend users of the ID change
 when the server connection is lost. It also prevents race conditions when
 unsubscribing during or immediately after a reconnection.
+
+The local ID is derived from the complete subscription method and exact serialized params. Calls
+with the same method and params share one server subscription and receive independent local
+broadcast receivers. Calls with different methods never alias merely because their params match.
 
 ### What is a subscription request?
 
@@ -93,9 +97,22 @@ on unknown methods, the `Request`, `SerializedRequest` and `RpcCall` expose
 `set_is_subscription()`, which can be used to mark any given request as a
 subscription.
 
-When marking a request as a subscription, the **service** will intercept the
-RPC response, which MUST be a `U256` value. Subscription requests that return
-anything other than a `U256` value will not function.
+When marking a request as a subscription, also configure the matching cleanup RPC with
+`RpcCall::set_unsubscribe_method()` when the protocol provides one. Custom subscription protocols
+do not share a universal naming convention, so the service does not guess or fall back to
+`eth_unsubscribe`. A custom subscription without a configured cleanup method can only be reclaimed
+when its connection closes.
+
+The **service** intercepts the RPC response, which must contain a numeric or string subscription
+ID. Other response types will not function as subscriptions.
+
+The service reserves string request IDs beginning with `alloy-pubsub:` for resubscribe and cleanup
+traffic. Manually constructed requests must not use that prefix.
+
+`PubSubFrontend::unsubscribe()` retains its enqueue-only behavior. Use
+`PubSubFrontend::unsubscribe_and_wait()` when the caller needs to observe server confirmation,
+server-reported absence, an RPC error, or connection-level cleanup. Both methods are force
+operations: they close all local receivers sharing the same method and params.
 
 ### Subscription Lifecycle
 
@@ -116,16 +133,16 @@ Subscription Request Lifecycle:
 1. The user issues a subscription request to the **frontend**.
 1. The **frontend** sends the request to the **service**, with a oneshot channel
    to receive the response.
-1. The **service** stores the oneshot channel in its `RequestManager`.
-1. The **service** sends the request to the **backend**.
+1. The **service** joins the request to an existing matching single-flight, or creates one and sends
+   a single request to the **backend**.
 1. The **backend** sends the request to the RPC server.
-1. The RPC server responds with a `U256` value (the `server_id`).
+1. The RPC server responds with a numeric or string `server_id`.
 1. The **backend** sends the response to the **service**.
 1. The **service** assigns a `local_id` to the subscription, creates a
    subscription broadcast channel, and stores the relevant information in its
    `SubscriptionManager`.
 1. The **service** overwrites the JSON RPC response with the `local_id`.
-1. The **service** sends the response to the waiting task via the oneshot.
+1. The **service** sends a response with each waiter's original JSON-RPC request ID via its oneshot.
 
 Subscription Notification Lifecycle
 

--- a/crates/pubsub/src/frontend.rs
+++ b/crates/pubsub/src/frontend.rs
@@ -1,4 +1,4 @@
-use crate::{ix::PubSubInstruction, managers::InFlight, RawSubscription};
+use crate::{ix::PubSubInstruction, managers::InFlight, RawSubscription, UnsubscribeOutcome};
 use alloy_json_rpc::{RequestPacket, Response, ResponsePacket, SerializedRequest};
 use alloy_primitives::B256;
 use alloy_transport::{TransportError, TransportErrorKind, TransportFut, TransportResult};
@@ -49,11 +49,26 @@ impl PubSubFrontend {
         }
     }
 
-    /// Unsubscribe from a subscription.
+    /// Force-unsubscribe a subscription, closing all local receivers sharing its key.
     pub fn unsubscribe(&self, id: B256) -> TransportResult<()> {
         self.tx
             .send(PubSubInstruction::Unsubscribe(id))
             .map_err(|_| TransportErrorKind::backend_gone())
+    }
+
+    /// Unsubscribe and wait until the server confirms cleanup or the owning connection closes.
+    pub fn unsubscribe_and_wait(
+        &self,
+        id: B256,
+    ) -> impl Future<Output = TransportResult<UnsubscribeOutcome>> + Send + 'static {
+        let backend_tx = self.tx.clone();
+        async move {
+            let (tx, rx) = oneshot::channel();
+            backend_tx
+                .send(PubSubInstruction::UnsubscribeAndWait(id, tx))
+                .map_err(|_| TransportErrorKind::backend_gone())?;
+            rx.await.map_err(|_| TransportErrorKind::backend_gone())?
+        }
     }
 
     /// Send a request.
@@ -104,9 +119,9 @@ impl PubSubFrontend {
     /// Set the channel size. This is the number of items to buffer in new
     /// subscription channels. Defaults to 16. See
     /// [`tokio::sync::broadcast`] for a description of relevant
-    /// behavior.
+    /// behavior. A zero capacity is rejected as a local usage error when a
+    /// subscription request is sent.
     pub fn set_channel_size(&self, channel_size: usize) {
-        debug_assert_ne!(channel_size, 0, "channel size must be non-zero");
         self.channel_size.store(channel_size, Ordering::Relaxed);
     }
 }

--- a/crates/pubsub/src/ix.rs
+++ b/crates/pubsub/src/ix.rs
@@ -1,5 +1,6 @@
-use crate::{managers::InFlight, RawSubscription};
+use crate::{managers::InFlight, RawSubscription, UnsubscribeOutcome};
 use alloy_primitives::B256;
+use alloy_transport::TransportResult;
 use std::fmt;
 use tokio::sync::oneshot;
 
@@ -11,6 +12,8 @@ pub enum PubSubInstruction {
     GetSub(B256, oneshot::Sender<Option<RawSubscription>>),
     /// Unsubscribe from a subscription.
     Unsubscribe(B256),
+    /// Unsubscribe and wait for the server-side cleanup to reach a terminal state.
+    UnsubscribeAndWait(B256, oneshot::Sender<TransportResult<UnsubscribeOutcome>>),
 }
 
 impl fmt::Debug for PubSubInstruction {
@@ -19,6 +22,9 @@ impl fmt::Debug for PubSubInstruction {
             Self::Request(arg0) => f.debug_tuple("Request").field(arg0).finish(),
             Self::GetSub(arg0, _) => f.debug_tuple("GetSub").field(arg0).finish(),
             Self::Unsubscribe(arg0) => f.debug_tuple("Unsubscribe").field(arg0).finish(),
+            Self::UnsubscribeAndWait(arg0, _) => {
+                f.debug_tuple("UnsubscribeAndWait").field(arg0).finish()
+            }
         }
     }
 }

--- a/crates/pubsub/src/lib.rs
+++ b/crates/pubsub/src/lib.rs
@@ -15,6 +15,9 @@ pub use connect::PubSubConnect;
 mod frontend;
 pub use frontend::PubSubFrontend;
 
+mod options;
+pub use options::{SubscriptionOptions, UnsubscribeOutcome};
+
 mod ix;
 pub use ix::PubSubInstruction;
 

--- a/crates/pubsub/src/managers/active_sub.rs
+++ b/crates/pubsub/src/managers/active_sub.rs
@@ -3,17 +3,21 @@ use alloy_json_rpc::SerializedRequest;
 use alloy_primitives::B256;
 use parking_lot::Mutex;
 use serde_json::value::RawValue;
-use std::{fmt, hash::Hash, ops::DerefMut};
+use std::{borrow::Cow, fmt, ops::DerefMut};
 use tokio::sync::broadcast;
 
 /// An active subscription.
 pub(crate) struct ActiveSubscription {
-    /// Cached hash of the request, used for sorting and equality.
+    /// Subscription identity and public alias.
     pub(crate) local_id: B256,
     /// The serialized subscription request.
     pub(crate) request: SerializedRequest,
     /// The channel via which notifications are broadcast.
     pub(crate) tx: broadcast::Sender<Box<RawValue>>,
+    /// The configured channel capacity.
+    pub(crate) channel_size: usize,
+    /// The server-side cleanup method.
+    pub(crate) unsubscribe_method: Option<Cow<'static, str>>,
     /// The initial channel via which notifications are received.
     ///
     /// This is stored so that we don't drop any notifications between initializing
@@ -24,39 +28,13 @@ pub(crate) struct ActiveSubscription {
     pub(crate) rx: Mutex<Option<broadcast::Receiver<Box<RawValue>>>>,
 }
 
-// NB: We implement this to prevent any incorrect future implementations.
-// See: https://doc.rust-lang.org/std/hash/trait.Hash.html#hash-and-eq
-impl Hash for ActiveSubscription {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.local_id.hash(state);
-    }
-}
-
-impl PartialEq for ActiveSubscription {
-    fn eq(&self, other: &Self) -> bool {
-        self.local_id == other.local_id
-    }
-}
-
-impl Eq for ActiveSubscription {}
-
-impl PartialOrd for ActiveSubscription {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for ActiveSubscription {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.local_id.cmp(&other.local_id)
-    }
-}
-
 impl fmt::Debug for ActiveSubscription {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ActiveSubscription")
             .field("local_id", &self.local_id)
             .field("request", &self.request)
+            .field("channel_size", &self.channel_size)
+            .field("unsubscribe_method", &self.unsubscribe_method)
             .field("subscribers", &self.tx.receiver_count())
             .finish()
     }
@@ -64,10 +42,14 @@ impl fmt::Debug for ActiveSubscription {
 
 impl ActiveSubscription {
     /// Create a new active subscription.
-    pub(crate) fn new(request: SerializedRequest, channel_size: usize) -> Self {
-        let local_id = request.params_hash();
+    pub(crate) fn new(
+        local_id: B256,
+        request: SerializedRequest,
+        channel_size: usize,
+        unsubscribe_method: Option<Cow<'static, str>>,
+    ) -> Self {
         let (tx, rx) = broadcast::channel(channel_size);
-        Self { request, local_id, tx, rx: Mutex::new(Some(rx)) }
+        Self { request, local_id, tx, channel_size, unsubscribe_method, rx: Mutex::new(Some(rx)) }
     }
 
     /// Serialize the request as a boxed [`RawValue`].

--- a/crates/pubsub/src/managers/in_flight.rs
+++ b/crates/pubsub/src/managers/in_flight.rs
@@ -1,6 +1,7 @@
+use crate::SubscriptionOptions;
 use alloy_json_rpc::{Response, ResponsePayload, SerializedRequest, SubId};
 use alloy_transport::{TransportError, TransportResult};
-use std::fmt;
+use std::{borrow::Cow, fmt};
 use tokio::sync::oneshot;
 
 /// An in-flight JSON-RPC request.
@@ -14,6 +15,9 @@ pub struct InFlight {
     /// The number of items to buffer in the subscription channel.
     pub channel_size: usize,
 
+    /// The method used to remove the server-side subscription.
+    pub(crate) unsubscribe_method: Option<Cow<'static, str>>,
+
     /// The channel to send the response on.
     pub tx: oneshot::Sender<TransportResult<Response>>,
 }
@@ -23,6 +27,7 @@ impl fmt::Debug for InFlight {
         f.debug_struct("InFlight")
             .field("request", &self.request)
             .field("channel_size", &self.channel_size)
+            .field("unsubscribe_method", &self.unsubscribe_method)
             .field("tx_is_closed", &self.tx.is_closed())
             .finish()
     }
@@ -32,11 +37,15 @@ impl InFlight {
     /// Create a new in-flight request.
     pub fn new(
         request: SerializedRequest,
-        channel_size: usize,
+        default_channel_size: usize,
     ) -> (Self, oneshot::Receiver<TransportResult<Response>>) {
         let (tx, rx) = oneshot::channel();
+        let options = request.meta().extensions().get::<SubscriptionOptions>();
+        let channel_size =
+            options.and_then(SubscriptionOptions::channel_size).unwrap_or(default_channel_size);
+        let unsubscribe_method = options.and_then(SubscriptionOptions::unsubscribe_method_owned);
 
-        (Self { request, channel_size, tx }, rx)
+        (Self { request, channel_size, unsubscribe_method, tx }, rx)
     }
 
     /// Check if the request is a subscription.

--- a/crates/pubsub/src/managers/sub.rs
+++ b/crates/pubsub/src/managers/sub.rs
@@ -1,87 +1,76 @@
 use crate::{managers::ActiveSubscription, RawSubscription};
 use alloy_json_rpc::{EthNotification, SerializedRequest, SubId};
 use alloy_primitives::B256;
-use bimap::BiBTreeMap;
+use std::{borrow::Cow, collections::BTreeMap};
 
 #[derive(Debug, Default)]
 pub(crate) struct SubscriptionManager {
-    /// The subscriptions.
-    local_to_sub: BiBTreeMap<B256, ActiveSubscription>,
-    /// Tracks the CURRENT server id for a subscription.
-    local_to_server: BiBTreeMap<B256, SubId>,
+    /// Active subscriptions keyed by their local ID.
+    subscriptions: BTreeMap<B256, ActiveSubscription>,
+    /// Current server IDs to local IDs.
+    servers: BTreeMap<SubId, B256>,
 }
 
 impl SubscriptionManager {
     /// Get an iterator over the subscriptions.
     pub(crate) fn iter(&self) -> impl Iterator<Item = (&B256, &ActiveSubscription)> {
-        self.local_to_sub.iter()
+        self.subscriptions.iter()
     }
 
     /// Get the number of subscriptions.
     pub(crate) fn len(&self) -> usize {
-        self.local_to_sub.len()
+        self.subscriptions.len()
     }
 
     /// Insert a subscription.
-    fn insert(
+    pub(crate) fn insert(
         &mut self,
+        local_id: B256,
         request: SerializedRequest,
         server_id: SubId,
         channel_size: usize,
-    ) -> RawSubscription {
-        let active = ActiveSubscription::new(request, channel_size);
-        let sub = active.subscribe();
-
-        let local_id = active.local_id;
-        self.local_to_server.insert(local_id, server_id);
-        self.local_to_sub.insert(local_id, active);
-
-        sub
+        unsubscribe_method: Option<Cow<'static, str>>,
+    ) {
+        let active = ActiveSubscription::new(local_id, request, channel_size, unsubscribe_method);
+        let previous_server = self.servers.insert(server_id, local_id);
+        debug_assert!(previous_server.is_none(), "server subscription id must not be overwritten");
+        let previous = self.subscriptions.insert(local_id, active);
+        debug_assert!(previous.is_none(), "active subscription must not be overwritten");
     }
 
-    /// Insert or update the server_id for a subscription.
-    pub(crate) fn upsert(
-        &mut self,
-        request: SerializedRequest,
-        server_id: SubId,
-        channel_size: usize,
-    ) -> RawSubscription {
-        let local_id = request.params_hash();
-
-        // If we already know a subscription with the exact params,
-        // we can just update the server_id and get a new listener.
-        if self.local_to_sub.contains_left(&local_id) {
-            self.change_server_id(local_id, server_id);
-            self.get_subscription(local_id).expect("checked existence")
-        } else {
-            self.insert(request, server_id, channel_size)
-        }
-    }
-
-    /// De-alias an alias, getting the original ID.
+    /// Get the local ID associated with a server ID.
     pub(crate) fn local_id_for(&self, server_id: &SubId) -> Option<B256> {
-        self.local_to_server.get_by_right(server_id).copied()
-    }
-
-    /// De-alias an alias, getting the original ID.
-    pub(crate) fn server_id_for(&self, local_id: &B256) -> Option<&SubId> {
-        self.local_to_server.get_by_left(local_id)
+        self.servers.get(server_id).copied()
     }
 
     /// Drop all server_ids.
     pub(crate) fn drop_server_ids(&mut self) {
-        self.local_to_server.clear();
+        self.servers.clear();
     }
 
-    /// Change the server_id of a subscription.
-    fn change_server_id(&mut self, local_id: B256, server_id: SubId) {
-        self.local_to_server.insert(local_id, server_id);
+    /// Associate a new server id with an existing subscription without overwriting another id.
+    pub(crate) fn set_server_id(&mut self, local_id: &B256, server_id: SubId) -> bool {
+        if !self.subscriptions.contains_key(local_id)
+            || self.server_id_for_local_id(local_id).is_some()
+            || self.servers.contains_key(&server_id)
+        {
+            return false;
+        }
+        self.servers.insert(server_id, *local_id);
+        true
     }
 
     /// Remove a subscription by its local_id.
-    pub(crate) fn remove_sub(&mut self, local_id: B256) {
-        let _ = self.local_to_sub.remove_by_left(&local_id);
-        let _ = self.local_to_server.remove_by_left(&local_id);
+    pub(crate) fn remove_sub(
+        &mut self,
+        local_id: B256,
+    ) -> Option<(ActiveSubscription, Option<SubId>)> {
+        let subscription = self.subscriptions.remove(&local_id)?;
+        let server_id = self.server_id_for_local_id(&local_id).cloned();
+        if let Some(server_id) = &server_id {
+            self.servers.remove(server_id);
+        }
+        Some((subscription, server_id))
     }
 
     /// Notify the subscription channel of a new value, if the sub is known,
@@ -89,7 +78,7 @@ impl SubscriptionManager {
     /// exists, the notification is dropped.
     pub(crate) fn notify(&mut self, notification: EthNotification) {
         if let Some(local_id) = self.local_id_for(&notification.subscription) {
-            if let Some(sub) = self.local_to_sub.get_by_left(&local_id) {
+            if let Some(sub) = self.get(&local_id) {
                 sub.notify(notification.result);
             }
         }
@@ -97,6 +86,20 @@ impl SubscriptionManager {
 
     /// Get a receiver for a subscription.
     pub(crate) fn get_subscription(&self, local_id: B256) -> Option<RawSubscription> {
-        self.local_to_sub.get_by_left(&local_id).map(ActiveSubscription::subscribe)
+        self.get(&local_id).map(ActiveSubscription::subscribe)
+    }
+
+    pub(crate) fn get(&self, local_id: &B256) -> Option<&ActiveSubscription> {
+        self.subscriptions.get(local_id)
+    }
+
+    pub(crate) fn contains_server_id(&self, server_id: &SubId) -> bool {
+        self.servers.contains_key(server_id)
+    }
+
+    pub(crate) fn server_id_for_local_id(&self, local_id: &B256) -> Option<&SubId> {
+        self.servers
+            .iter()
+            .find_map(|(server_id, candidate)| (candidate == local_id).then_some(server_id))
     }
 }

--- a/crates/pubsub/src/options.rs
+++ b/crates/pubsub/src/options.rs
@@ -1,0 +1,56 @@
+use std::borrow::Cow;
+
+/// Per-request configuration for a pubsub subscription.
+///
+/// This value is carried in the JSON-RPC request extensions and consumed by the pubsub service.
+/// It is never serialized onto the wire.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct SubscriptionOptions {
+    /// The requested local broadcast channel capacity.
+    channel_size: Option<usize>,
+    /// The RPC method used to clean up the server-side subscription.
+    unsubscribe_method: Option<Cow<'static, str>>,
+}
+
+impl SubscriptionOptions {
+    /// Returns the requested local broadcast channel capacity.
+    pub const fn channel_size(&self) -> Option<usize> {
+        self.channel_size
+    }
+
+    /// Sets the requested local broadcast channel capacity.
+    ///
+    /// A zero capacity is invalid and is rejected before wire dispatch.
+    pub const fn set_channel_size(&mut self, channel_size: usize) {
+        self.channel_size = Some(channel_size);
+    }
+
+    /// Returns the configured server-side unsubscribe method.
+    ///
+    /// `None` means the protocol provides no known cleanup RPC and the subscription can only be
+    /// reclaimed when its connection closes.
+    pub fn unsubscribe_method(&self) -> Option<&str> {
+        self.unsubscribe_method.as_deref()
+    }
+
+    /// Sets the server-side unsubscribe method.
+    pub fn set_unsubscribe_method(&mut self, method: impl Into<Cow<'static, str>>) {
+        self.unsubscribe_method = Some(method.into());
+    }
+
+    pub(crate) fn unsubscribe_method_owned(&self) -> Option<Cow<'static, str>> {
+        self.unsubscribe_method.clone()
+    }
+}
+
+/// The terminal result of a tracked server-side unsubscribe request.
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum UnsubscribeOutcome {
+    /// The server confirmed that the subscription was removed.
+    ServerConfirmed,
+    /// The server or local service reported that the subscription was already absent.
+    AlreadyAbsent,
+    /// The connection closed, which releases all subscriptions owned by that connection.
+    TransportClosed,
+}

--- a/crates/pubsub/src/service.rs
+++ b/crates/pubsub/src/service.rs
@@ -2,16 +2,18 @@ use crate::{
     handle::ConnectionHandle,
     ix::PubSubInstruction,
     managers::{InFlight, RequestManager, SubscriptionManager},
-    PubSubConnect, PubSubFrontend, RawSubscription,
+    PubSubConnect, PubSubFrontend, RawSubscription, UnsubscribeOutcome,
 };
-use alloy_json_rpc::{Id, PubSubItem, Request, Response, ResponsePayload, RpcError, SubId};
-use alloy_primitives::B256;
+use alloy_json_rpc::{
+    Id, PubSubItem, Request, Response, ResponsePayload, RpcError, SerializedRequest, SubId,
+};
+use alloy_primitives::{Keccak256, B256};
 use alloy_transport::{
     utils::{to_json_raw_value, Spawnable},
     TransportErrorKind, TransportResult,
 };
 use serde_json::value::RawValue;
-use std::time::Duration;
+use std::{borrow::Cow, collections::BTreeMap, time::Duration};
 use tokio::sync::{mpsc, oneshot};
 
 #[cfg(all(target_family = "wasm", target_os = "unknown"))]
@@ -21,6 +23,49 @@ use wasmtimer::tokio::sleep;
 use tokio::time::sleep;
 
 const MAX_RECONNECT_RETRY_INTERVAL: Duration = Duration::from_secs(30);
+
+type CleanupWaiter = oneshot::Sender<TransportResult<UnsubscribeOutcome>>;
+
+fn subscription_local_id(request: &SerializedRequest) -> B256 {
+    let method = request.method().as_bytes();
+    let mut hasher = Keccak256::new();
+    hasher.update((method.len() as u64).to_be_bytes());
+    hasher.update(method);
+    match request.params_with_presence() {
+        Some(params) => {
+            hasher.update([1]);
+            hasher.update((params.get().len() as u64).to_be_bytes());
+            hasher.update(params.get().as_bytes());
+        }
+        None => hasher.update([0]),
+    }
+    hasher.finalize()
+}
+
+#[derive(Debug)]
+struct StartingSubscription {
+    request: SerializedRequest,
+    wire_request_id: Id,
+    waiters: Vec<InFlight>,
+    channel_size: usize,
+    unsubscribe_method: Option<Cow<'static, str>>,
+}
+
+#[derive(Debug)]
+struct SubscribeRoute {
+    local_id: B256,
+    unsubscribe_method: Option<Cow<'static, str>>,
+    connection_epoch: u64,
+    cleanup_waiters: Vec<CleanupWaiter>,
+}
+
+#[derive(Debug)]
+struct PendingCleanup {
+    server_id: SubId,
+    unsubscribe_method: Cow<'static, str>,
+    connection_epoch: u64,
+    waiters: Vec<CleanupWaiter>,
+}
 
 /// The service contains the backend handle, a subscription manager, and the
 /// configuration details required to reconnect.
@@ -40,21 +85,58 @@ pub(crate) struct PubSubService<T> {
 
     /// The request manager.
     pub(crate) in_flights: RequestManager,
+
+    /// Subscription requests that have been dispatched but are not active yet.
+    starting: BTreeMap<B256, StartingSubscription>,
+
+    /// Every subscribe request ID remains routed until its connection closes so duplicate or late
+    /// successful responses can be compensated with an unsubscribe.
+    subscribe_routes: BTreeMap<Id, SubscribeRoute>,
+
+    /// Active keys currently awaiting a resubscribe response.
+    reconnecting: BTreeMap<B256, Id>,
+
+    /// Tracked server-side unsubscribe requests.
+    pending_cleanups: BTreeMap<Id, PendingCleanup>,
+
+    /// Monotonically increasing connection generation.
+    connection_epoch: u64,
+
+    /// Monotonically increasing sequence for service-owned request IDs.
+    request_sequence: u64,
+
+    /// Waiters for subscriptions whose protocol provides no cleanup method.
+    connection_cleanup_waiters: BTreeMap<u64, Vec<CleanupWaiter>>,
 }
 
 impl<T: PubSubConnect> PubSubService<T> {
-    /// Create a new service from a connector.
-    pub(crate) async fn connect(connector: T) -> TransportResult<PubSubFrontend> {
-        let handle = connector.connect().await?;
-
-        let (tx, reqs) = mpsc::unbounded_channel();
-        let this = Self {
+    fn new(
+        handle: ConnectionHandle,
+        connector: T,
+        reqs: mpsc::UnboundedReceiver<PubSubInstruction>,
+    ) -> Self {
+        Self {
             handle,
             connector,
             reqs,
             subs: SubscriptionManager::default(),
             in_flights: Default::default(),
-        };
+            starting: BTreeMap::new(),
+            subscribe_routes: BTreeMap::new(),
+            reconnecting: BTreeMap::new(),
+            pending_cleanups: BTreeMap::new(),
+            connection_epoch: 0,
+            request_sequence: 0,
+            connection_cleanup_waiters: BTreeMap::new(),
+        }
+    }
+
+    /// Create a new service from a connector.
+    pub(crate) async fn connect(connector: T) -> TransportResult<PubSubFrontend> {
+        let handle = connector.connect().await?;
+
+        let (tx, reqs) = mpsc::unbounded_channel();
+        let this = Self::new(handle, connector, reqs);
         this.spawn();
         Ok(PubSubFrontend::new(tx))
     }
@@ -71,6 +153,7 @@ impl<T: PubSubConnect> PubSubService<T> {
     async fn reconnect(&mut self) -> TransportResult<()> {
         debug!("Reconnecting pubsub service backend");
 
+        let old_epoch = self.connection_epoch;
         let mut old_handle = self.get_new_backend().await?;
 
         debug!("Draining old backend to_handle");
@@ -81,12 +164,45 @@ impl<T: PubSubConnect> PubSubService<T> {
         }
 
         old_handle.shutdown();
+        self.finish_connection_epoch(old_epoch);
+        self.connection_epoch =
+            self.connection_epoch.checked_add(1).expect("connection epoch exhausted");
 
         // Re-issue pending requests.
         debug!(count = self.in_flights.len(), "Reissuing pending requests");
-        for (_, in_flight) in self.in_flights.iter() {
-            let msg = in_flight.request.serialized().to_owned();
+        let pending_requests = self
+            .in_flights
+            .iter()
+            .map(|(_, in_flight)| in_flight.request.serialized().to_owned())
+            .collect::<Vec<_>>();
+        for msg in pending_requests {
             self.dispatch_request(msg)?;
+        }
+
+        // Re-issue live single-flight subscriptions. Fully cancelled requests are discarded: the
+        // old connection closing has already reclaimed any server-side resource they created.
+        let starting_local_ids = self.starting.keys().copied().collect::<Vec<_>>();
+        for local_id in starting_local_ids {
+            let has_live_waiter = self.starting.get_mut(&local_id).is_some_and(|starting| {
+                starting.waiters.retain(|waiter| !waiter.tx.is_closed());
+                !starting.waiters.is_empty()
+            });
+            if !has_live_waiter {
+                self.starting.remove(&local_id);
+                continue;
+            }
+
+            let wire_request_id = self.next_service_id();
+            let (request, unsubscribe_method) = {
+                let starting = self.starting.get_mut(&local_id).expect("checked above");
+                starting.wire_request_id = wire_request_id.clone();
+                (
+                    starting.request.with_id(wire_request_id.clone()).map_err(RpcError::ser_err)?,
+                    starting.unsubscribe_method.clone(),
+                )
+            };
+            self.insert_subscribe_route(wire_request_id, local_id, unsubscribe_method);
+            self.dispatch_request(request.into_serialized())?;
         }
 
         // Re-subscribe to all active subscriptions
@@ -94,15 +210,22 @@ impl<T: PubSubConnect> PubSubService<T> {
 
         // Drop all server IDs. We'll re-insert them as we get responses.
         self.subs.drop_server_ids();
+        self.reconnecting.clear();
 
         // Dispatch all subscription requests.
-        for (_, sub) in self.subs.iter() {
-            let req = sub.request().to_owned();
-            let (in_flight, _) = InFlight::new(req.clone(), sub.tx.receiver_count());
-            self.in_flights.insert(in_flight);
-
-            let msg = req.into_serialized();
-            self.dispatch_request(msg)?;
+        let active = self
+            .subs
+            .iter()
+            .map(|(&local_id, sub)| {
+                (local_id, sub.request().clone(), sub.unsubscribe_method.clone())
+            })
+            .collect::<Vec<_>>();
+        for (local_id, request, unsubscribe_method) in active {
+            let wire_request_id = self.next_service_id();
+            let request = request.with_id(wire_request_id.clone()).map_err(RpcError::ser_err)?;
+            self.reconnecting.insert(local_id, wire_request_id.clone());
+            self.insert_subscribe_route(wire_request_id, local_id, unsubscribe_method);
+            self.dispatch_request(request.into_serialized())?;
         }
 
         Ok(())
@@ -113,12 +236,175 @@ impl<T: PubSubConnect> PubSubService<T> {
         self.handle.to_socket.send(brv).map(drop).map_err(|_| TransportErrorKind::backend_gone())
     }
 
+    fn next_service_id(&mut self) -> Id {
+        let sequence = self.request_sequence;
+        self.request_sequence =
+            self.request_sequence.checked_add(1).expect("service request ID sequence exhausted");
+        Id::String(format!("alloy-pubsub:{}:{sequence}", self.connection_epoch))
+    }
+
+    fn insert_subscribe_route(
+        &mut self,
+        request_id: Id,
+        local_id: B256,
+        unsubscribe_method: Option<Cow<'static, str>>,
+    ) {
+        let route = SubscribeRoute {
+            local_id,
+            unsubscribe_method,
+            connection_epoch: self.connection_epoch,
+            cleanup_waiters: Vec::new(),
+        };
+        let previous = self.subscribe_routes.insert(request_id, route);
+        debug_assert!(previous.is_none(), "service request IDs must never be reused");
+    }
+
+    fn finish_connection_epoch(&mut self, epoch: u64) {
+        let cleanup_ids = self
+            .pending_cleanups
+            .iter()
+            .filter(|(_, cleanup)| cleanup.connection_epoch == epoch)
+            .map(|(id, _)| id.clone())
+            .collect::<Vec<_>>();
+        for id in cleanup_ids {
+            if let Some(cleanup) = self.pending_cleanups.remove(&id) {
+                debug!(?cleanup.server_id, method=%cleanup.unsubscribe_method, "cleanup completed by transport close");
+                Self::complete_cleanup_waiters(
+                    cleanup.waiters,
+                    UnsubscribeOutcome::TransportClosed,
+                );
+            }
+        }
+
+        let route_ids = self
+            .subscribe_routes
+            .iter()
+            .filter(|(_, route)| route.connection_epoch == epoch)
+            .map(|(id, _)| id.clone())
+            .collect::<Vec<_>>();
+        for id in route_ids {
+            if let Some(route) = self.subscribe_routes.remove(&id) {
+                Self::complete_cleanup_waiters(
+                    route.cleanup_waiters,
+                    UnsubscribeOutcome::TransportClosed,
+                );
+            }
+        }
+        if let Some(waiters) = self.connection_cleanup_waiters.remove(&epoch) {
+            Self::complete_cleanup_waiters(waiters, UnsubscribeOutcome::TransportClosed);
+        }
+    }
+
     /// Service a request.
     fn service_request(&mut self, in_flight: InFlight) -> TransportResult<()> {
-        let brv = in_flight.request();
+        if !in_flight.is_subscription() {
+            let brv = in_flight.request();
 
-        self.dispatch_request(brv.serialized().to_owned())?;
-        self.in_flights.insert(in_flight);
+            self.dispatch_request(brv.serialized().to_owned())?;
+            self.in_flights.insert(in_flight);
+            return Ok(());
+        }
+
+        if in_flight.tx.is_closed() {
+            return Ok(());
+        }
+
+        if in_flight.channel_size == 0 {
+            let _ = in_flight
+                .tx
+                .send(Err(RpcError::local_usage_str("subscription channel size must be non-zero")));
+            return Ok(());
+        }
+
+        let local_id = subscription_local_id(in_flight.request());
+        let unsubscribe_method = Self::unsubscribe_method(&in_flight);
+
+        if let Some(starting) = self.starting.get_mut(&local_id) {
+            Self::warn_config_conflict(
+                local_id,
+                starting.channel_size,
+                starting.unsubscribe_method.as_deref(),
+                in_flight.channel_size,
+                unsubscribe_method.as_deref(),
+            );
+            starting.waiters.push(in_flight);
+            return Ok(());
+        }
+
+        if let Some(active) = self.subs.get(&local_id) {
+            Self::warn_config_conflict(
+                local_id,
+                active.channel_size,
+                active.unsubscribe_method.as_deref(),
+                in_flight.channel_size,
+                unsubscribe_method.as_deref(),
+            );
+            return Self::send_subscription_alias(in_flight, active.local_id);
+        }
+
+        let wire_request_id = in_flight.request.id().clone();
+        let request = in_flight.request.clone();
+        let message = request.serialized().to_owned();
+        let channel_size = in_flight.channel_size;
+        self.starting.insert(
+            local_id,
+            StartingSubscription {
+                request,
+                wire_request_id: wire_request_id.clone(),
+                waiters: vec![in_flight],
+                channel_size,
+                unsubscribe_method: unsubscribe_method.clone(),
+            },
+        );
+        self.insert_subscribe_route(wire_request_id, local_id, unsubscribe_method);
+        self.dispatch_request(message)?;
+
+        Ok(())
+    }
+
+    fn unsubscribe_method(in_flight: &InFlight) -> Option<Cow<'static, str>> {
+        if let Some(method) = &in_flight.unsubscribe_method {
+            return Some(method.clone());
+        }
+        if in_flight.request.method() == "eth_subscribe" {
+            return Some(Cow::Borrowed("eth_unsubscribe"));
+        }
+        warn!(
+            method = in_flight.request.method(),
+            "custom subscription has no cleanup method; it can only be reclaimed by closing the connection"
+        );
+        None
+    }
+
+    fn warn_config_conflict(
+        local_id: B256,
+        existing_channel_size: usize,
+        existing_unsubscribe_method: Option<&str>,
+        requested_channel_size: usize,
+        requested_unsubscribe_method: Option<&str>,
+    ) {
+        if existing_channel_size != requested_channel_size {
+            warn!(
+                ?local_id,
+                existing_channel_size,
+                requested_channel_size,
+                "subscription already exists; keeping its channel size"
+            );
+        }
+        if existing_unsubscribe_method != requested_unsubscribe_method {
+            warn!(
+                ?local_id,
+                existing_unsubscribe_method,
+                requested_unsubscribe_method,
+                "subscription already exists; keeping its unsubscribe method"
+            );
+        }
+    }
+
+    fn send_subscription_alias(in_flight: InFlight, local_id: B256) -> TransportResult<()> {
+        let id = in_flight.request.id().clone();
+        let alias = to_json_raw_value(&local_id)?;
+        let _ = in_flight.tx.send(Ok(Response { id, payload: ResponsePayload::Success(alias) }));
 
         Ok(())
     }
@@ -132,15 +418,46 @@ impl<T: PubSubConnect> PubSubService<T> {
     }
 
     /// Service an unsubscribe instruction.
-    fn service_unsubscribe(&mut self, local_id: B256) -> TransportResult<()> {
-        if let Some(server_id) = self.subs.server_id_for(&local_id) {
-            // TODO: ideally we can send this with an unused id
-            let req = Request::new("eth_unsubscribe", Id::Number(1), [server_id]);
-            let brv = req.serialize().expect("no ser error").take_request();
+    fn service_unsubscribe(
+        &mut self,
+        local_id: B256,
+        waiter: Option<CleanupWaiter>,
+    ) -> TransportResult<()> {
+        let mut waiters = waiter.into_iter().collect::<Vec<_>>();
+        if let Some((subscription, server_id)) = self.subs.remove_sub(local_id) {
+            if let Some(server_id) = server_id {
+                if let Some(unsubscribe_method) = subscription.unsubscribe_method {
+                    return self.start_cleanup(server_id, unsubscribe_method, waiters);
+                }
+                warn!(?server_id, "subscription has no cleanup method; deferring reclamation until connection close");
+                self.defer_cleanup_until_connection_close(waiters);
+                return Ok(());
+            }
 
-            self.dispatch_request(brv)?;
+            if let Some(route_id) = self.reconnecting.remove(&subscription.local_id) {
+                if let Some(route) = self.subscribe_routes.get_mut(&route_id) {
+                    route.cleanup_waiters.append(&mut waiters);
+                    return Ok(());
+                }
+            }
+
+            Self::complete_cleanup_waiters(waiters, UnsubscribeOutcome::TransportClosed);
+            return Ok(());
         }
-        self.subs.remove_sub(local_id);
+
+        if let Some(starting) = self.starting.remove(&local_id) {
+            for in_flight in starting.waiters {
+                let _ = in_flight.tx.send(Err(RpcError::local_usage_str(
+                    "subscription was unsubscribed before activation",
+                )));
+            }
+            if let Some(route) = self.subscribe_routes.get_mut(&starting.wire_request_id) {
+                route.cleanup_waiters.append(&mut waiters);
+                return Ok(());
+            }
+        }
+
+        Self::complete_cleanup_waiters(waiters, UnsubscribeOutcome::AlreadyAbsent);
         Ok(())
     }
 
@@ -153,17 +470,26 @@ impl<T: PubSubConnect> PubSubService<T> {
                 self.service_get_sub(alias, tx);
                 Ok(())
             }
-            PubSubInstruction::Unsubscribe(alias) => self.service_unsubscribe(alias),
+            PubSubInstruction::Unsubscribe(alias) => self.service_unsubscribe(alias, None),
+            PubSubInstruction::UnsubscribeAndWait(alias, tx) => {
+                self.service_unsubscribe(alias, Some(tx))
+            }
         }
     }
 
     /// Handle an item from the backend.
     fn handle_item(&mut self, item: PubSubItem) -> TransportResult<()> {
         match item {
-            PubSubItem::Response(resp) => match self.in_flights.handle_response(resp) {
-                Some((server_id, in_flight)) => self.handle_sub_response(in_flight, server_id),
-                None => Ok(()),
-            },
+            PubSubItem::Response(resp) => {
+                if self.pending_cleanups.contains_key(&resp.id) {
+                    self.handle_cleanup_response(resp)
+                } else if self.subscribe_routes.contains_key(&resp.id) {
+                    self.handle_sub_response(resp)
+                } else {
+                    let _ = self.in_flights.handle_response(resp);
+                    Ok(())
+                }
+            }
             PubSubItem::Notification(notification) => {
                 self.subs.notify(notification);
                 Ok(())
@@ -171,26 +497,288 @@ impl<T: PubSubConnect> PubSubService<T> {
         }
     }
 
-    /// Rewrite the subscription id and insert into the subscriptions manager
-    fn handle_sub_response(
+    /// Route a subscribe or resubscribe response without ever overwriting an active server ID.
+    fn handle_sub_response(&mut self, response: Response) -> TransportResult<()> {
+        let route = self.subscribe_routes.get(&response.id).expect("checked by caller");
+        let local_id = route.local_id;
+        let unsubscribe_method = route.unsubscribe_method.clone();
+
+        match response.payload {
+            ResponsePayload::Success(value) => match serde_json::from_str::<SubId>(value.get()) {
+                Ok(server_id) => {
+                    self.handle_sub_success(response.id, local_id, unsubscribe_method, server_id)
+                }
+                Err(error) => {
+                    self.handle_invalid_sub_response(response.id, local_id, value.get(), error);
+                    Ok(())
+                }
+            },
+            ResponsePayload::Failure(error) => {
+                self.handle_sub_failure(response.id, local_id, error);
+                Ok(())
+            }
+        }
+    }
+
+    fn handle_sub_success(
         &mut self,
-        in_flight: InFlight,
+        response_id: Id,
+        local_id: B256,
+        unsubscribe_method: Option<Cow<'static, str>>,
         server_id: SubId,
     ) -> TransportResult<()> {
-        let request = in_flight.request;
-        let id = request.id().clone();
+        let is_expected_start = self
+            .starting
+            .get(&local_id)
+            .is_some_and(|starting| starting.wire_request_id == response_id);
+        if is_expected_start {
+            let mut starting = self.starting.remove(&local_id).expect("checked above");
+            starting.waiters.retain(|waiter| !waiter.tx.is_closed());
+            if starting.waiters.is_empty() || self.subs.get(&local_id).is_some() {
+                return self.compensate_subscription(response_id, server_id, unsubscribe_method);
+            }
+            if self.subs.contains_server_id(&server_id) {
+                warn!(?server_id, ?local_id, "subscription response reused a live server id");
+                for in_flight in starting.waiters {
+                    let _ = in_flight.tx.send(Err(RpcError::local_usage_str(
+                        "subscription response reused a live server id",
+                    )));
+                }
+                return Ok(());
+            }
 
-        let sub = self.subs.upsert(request, server_id, in_flight.channel_size);
+            self.subs.insert(
+                local_id,
+                starting.request,
+                server_id.clone(),
+                starting.channel_size,
+                starting.unsubscribe_method,
+            );
+            let mut delivered = false;
+            for in_flight in starting.waiters {
+                let id = in_flight.request.id().clone();
+                let alias = to_json_raw_value(&local_id)?;
+                delivered |= in_flight
+                    .tx
+                    .send(Ok(Response { id, payload: ResponsePayload::Success(alias) }))
+                    .is_ok();
+            }
+            if !delivered {
+                if let Some((subscription, _)) = self.subs.remove_sub(local_id) {
+                    if let Some(unsubscribe_method) = subscription.unsubscribe_method {
+                        self.start_cleanup(server_id, unsubscribe_method, Vec::new())?;
+                    } else {
+                        warn!(?server_id, "abandoned subscription has no cleanup method; it will remain until connection close");
+                    }
+                }
+            }
+            return Ok(());
+        }
 
-        // Serialized B256 is always a valid serialized U256 too.
-        let ser_alias = to_json_raw_value(sub.local_id())?;
+        let is_expected_reconnect =
+            self.reconnecting.get(&local_id).is_some_and(|request_id| request_id == &response_id);
+        if is_expected_reconnect {
+            self.reconnecting.remove(&local_id);
+            if self.subs.set_server_id(&local_id, server_id.clone()) {
+                return Ok(());
+            }
+            self.subs.remove_sub(local_id);
+        }
 
-        // We send back a success response with the new subscription ID.
-        // We don't care if the channel is dead.
-        let _ =
-            in_flight.tx.send(Ok(Response { id, payload: ResponsePayload::Success(ser_alias) }));
+        self.compensate_subscription(response_id, server_id, unsubscribe_method)
+    }
 
+    fn handle_invalid_sub_response(
+        &mut self,
+        response_id: Id,
+        local_id: B256,
+        value: &str,
+        error: serde_json::Error,
+    ) {
+        warn!(?local_id, %error, "invalid subscription response");
+        let is_expected_start = self
+            .starting
+            .get(&local_id)
+            .is_some_and(|starting| starting.wire_request_id == response_id);
+        if is_expected_start {
+            if let Some(starting) = self.starting.remove(&local_id) {
+                for in_flight in starting.waiters {
+                    let error = serde_json::from_str::<SubId>(value).unwrap_err();
+                    let _ = in_flight
+                        .tx
+                        .send(Err(alloy_transport::TransportError::deser_err(error, value)));
+                }
+            }
+        } else if self
+            .reconnecting
+            .get(&local_id)
+            .is_some_and(|request_id| request_id == &response_id)
+        {
+            self.reconnecting.remove(&local_id);
+            self.subs.remove_sub(local_id);
+        }
+
+        if let Some(route) = self.subscribe_routes.get_mut(&response_id) {
+            for waiter in std::mem::take(&mut route.cleanup_waiters) {
+                let error = serde_json::from_str::<SubId>(value).unwrap_err();
+                let _ = waiter.send(Err(alloy_transport::TransportError::deser_err(error, value)));
+            }
+        }
+    }
+
+    fn handle_sub_failure(
+        &mut self,
+        response_id: Id,
+        local_id: B256,
+        error: alloy_json_rpc::ErrorPayload,
+    ) {
+        let is_expected_start = self
+            .starting
+            .get(&local_id)
+            .is_some_and(|starting| starting.wire_request_id == response_id);
+        if is_expected_start {
+            if let Some(starting) = self.starting.remove(&local_id) {
+                for in_flight in starting.waiters {
+                    let id = in_flight.request.id().clone();
+                    let _ = in_flight.tx.send(Ok(Response {
+                        id,
+                        payload: ResponsePayload::Failure(error.clone()),
+                    }));
+                }
+            }
+        } else if self
+            .reconnecting
+            .get(&local_id)
+            .is_some_and(|request_id| request_id == &response_id)
+        {
+            self.reconnecting.remove(&local_id);
+            self.subs.remove_sub(local_id);
+            warn!(?local_id, %error, "failed to restore subscription after reconnect");
+        }
+
+        if let Some(route) = self.subscribe_routes.get_mut(&response_id) {
+            Self::complete_cleanup_waiters(
+                std::mem::take(&mut route.cleanup_waiters),
+                UnsubscribeOutcome::AlreadyAbsent,
+            );
+        }
+    }
+
+    fn compensate_subscription(
+        &mut self,
+        response_id: Id,
+        server_id: SubId,
+        unsubscribe_method: Option<Cow<'static, str>>,
+    ) -> TransportResult<()> {
+        if self.subs.contains_server_id(&server_id) {
+            let waiters = self
+                .subscribe_routes
+                .get_mut(&response_id)
+                .map(|route| std::mem::take(&mut route.cleanup_waiters))
+                .unwrap_or_default();
+            warn!(?server_id, "refusing to clean up a server id held by a live subscription");
+            for waiter in waiters {
+                let _ = waiter.send(Err(RpcError::local_usage_str(
+                    "stale cleanup targeted a live subscription",
+                )));
+            }
+            return Ok(());
+        }
+        let Some(unsubscribe_method) = unsubscribe_method else {
+            warn!(?server_id, "unclaimed subscription has no cleanup method; it will remain until connection close");
+            return Ok(());
+        };
+        let waiters = self
+            .subscribe_routes
+            .get_mut(&response_id)
+            .map(|route| std::mem::take(&mut route.cleanup_waiters))
+            .unwrap_or_default();
+        warn!(?server_id, "cleaning up an unclaimed subscription response");
+        self.start_cleanup(server_id, unsubscribe_method, waiters)
+    }
+
+    fn defer_cleanup_until_connection_close(&mut self, waiters: Vec<CleanupWaiter>) {
+        if !waiters.is_empty() {
+            self.connection_cleanup_waiters
+                .entry(self.connection_epoch)
+                .or_default()
+                .extend(waiters);
+        }
+    }
+
+    fn start_cleanup(
+        &mut self,
+        server_id: SubId,
+        unsubscribe_method: Cow<'static, str>,
+        waiters: Vec<CleanupWaiter>,
+    ) -> TransportResult<()> {
+        if let Some((_, cleanup)) =
+            self.pending_cleanups.iter_mut().find(|(_, cleanup)| cleanup.server_id == server_id)
+        {
+            cleanup.waiters.extend(waiters);
+            return Ok(());
+        }
+
+        let request_id = self.next_service_id();
+        let request =
+            Request::new(unsubscribe_method.clone(), request_id.clone(), [server_id.clone()])
+                .serialize()
+                .map_err(RpcError::ser_err)?;
+        self.pending_cleanups.insert(
+            request_id,
+            PendingCleanup {
+                server_id,
+                unsubscribe_method,
+                connection_epoch: self.connection_epoch,
+                waiters,
+            },
+        );
+        self.dispatch_request(request.into_serialized())
+    }
+
+    fn handle_cleanup_response(&mut self, response: Response) -> TransportResult<()> {
+        let cleanup = self.pending_cleanups.remove(&response.id).expect("checked by caller");
+        match response.payload {
+            ResponsePayload::Success(value) => match serde_json::from_str::<bool>(value.get()) {
+                Ok(true) => {
+                    trace!(?cleanup.server_id, method=%cleanup.unsubscribe_method, "subscription cleanup confirmed");
+                    Self::complete_cleanup_waiters(
+                        cleanup.waiters,
+                        UnsubscribeOutcome::ServerConfirmed,
+                    );
+                }
+                Ok(false) => {
+                    info!(?cleanup.server_id, method=%cleanup.unsubscribe_method, "subscription was already absent");
+                    Self::complete_cleanup_waiters(
+                        cleanup.waiters,
+                        UnsubscribeOutcome::AlreadyAbsent,
+                    );
+                }
+                Err(error) => {
+                    warn!(?cleanup.server_id, method=%cleanup.unsubscribe_method, %error, "invalid subscription cleanup response");
+                    for waiter in cleanup.waiters {
+                        let error = serde_json::from_str::<bool>(value.get()).unwrap_err();
+                        let _ = waiter.send(Err(alloy_transport::TransportError::deser_err(
+                            error,
+                            value.get(),
+                        )));
+                    }
+                }
+            },
+            ResponsePayload::Failure(error) => {
+                warn!(?cleanup.server_id, method=%cleanup.unsubscribe_method, %error, "subscription cleanup failed");
+                for waiter in cleanup.waiters {
+                    let _ = waiter.send(Err(RpcError::ErrorResp(error.clone())));
+                }
+            }
+        }
         Ok(())
+    }
+
+    fn complete_cleanup_waiters(waiters: Vec<CleanupWaiter>, outcome: UnsubscribeOutcome) {
+        for waiter in waiters {
+            let _ = waiter.send(Ok(outcome));
+        }
     }
 
     /// Attempt to reconnect with retries.
@@ -298,6 +886,8 @@ impl<T: PubSubConnect> PubSubService<T> {
                 }
             };
 
+            let epoch = self.connection_epoch;
+            self.finish_connection_epoch(epoch);
             if let Err(err) = result {
                 error!(%err, "pubsub service reconnection error");
             }
@@ -322,8 +912,8 @@ fn reconnect_retry_interval(base_interval: Duration, retry_count: u32) -> Durati
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ConnectionInterface;
-    use alloy_json_rpc::Request;
+    use crate::{ConnectionInterface, SubscriptionOptions};
+    use alloy_json_rpc::{Request, SerializedRequest};
     use std::{
         sync::{
             atomic::{AtomicUsize, Ordering},
@@ -352,6 +942,615 @@ mod tests {
                 .take()
                 .ok_or_else(|| TransportErrorKind::custom_str("missing mock connection handle"))
         }
+    }
+
+    fn test_service() -> (PubSubService<MockConnect>, ConnectionInterface) {
+        let (handle, interface) = ConnectionHandle::new();
+        let (_tx, reqs) = mpsc::unbounded_channel();
+        (PubSubService::new(handle, MockConnect::default(), reqs), interface)
+    }
+
+    fn eth_subscription(id: u64, topic: &'static str) -> SerializedRequest {
+        Request::new("eth_subscribe", Id::Number(id), (topic,)).serialize().unwrap()
+    }
+
+    fn custom_subscription(
+        id: u64,
+        method: &'static str,
+        unsubscribe_method: Option<&'static str>,
+    ) -> SerializedRequest {
+        let mut request = Request::new(method, Id::Number(id), ());
+        request.set_is_subscription();
+        if let Some(unsubscribe_method) = unsubscribe_method {
+            request
+                .meta
+                .extensions_mut()
+                .get_or_insert_default::<SubscriptionOptions>()
+                .set_unsubscribe_method(unsubscribe_method);
+        }
+        request.serialize().unwrap()
+    }
+
+    fn with_channel_size(mut request: SerializedRequest, channel_size: usize) -> SerializedRequest {
+        request
+            .meta_mut()
+            .extensions_mut()
+            .get_or_insert_default::<SubscriptionOptions>()
+            .set_channel_size(channel_size);
+        request
+    }
+
+    fn subscription_response(id: Id, server_id: &str) -> Response {
+        Response {
+            id,
+            payload: ResponsePayload::Success(
+                to_json_raw_value(&SubId::String(server_id.to_owned())).unwrap(),
+            ),
+        }
+    }
+
+    fn bool_response(id: Id, value: bool) -> Response {
+        Response { id, payload: ResponsePayload::Success(to_json_raw_value(&value).unwrap()) }
+    }
+
+    fn take_wire(interface: &mut ConnectionInterface) -> serde_json::Value {
+        let request = interface.from_frontend.try_recv().expect("expected outbound request");
+        serde_json::from_str(request.get()).unwrap()
+    }
+
+    fn assert_no_wire(interface: &mut ConnectionInterface) {
+        assert!(matches!(
+            interface.from_frontend.try_recv(),
+            Err(mpsc::error::TryRecvError::Empty)
+        ));
+    }
+
+    fn alias_from_response(response: Response, expected_id: Id) -> B256 {
+        assert_eq!(response.id, expected_id);
+        match response.payload {
+            ResponsePayload::Success(value) => serde_json::from_str(value.get()).unwrap(),
+            ResponsePayload::Failure(error) => panic!("unexpected error response: {error}"),
+        }
+    }
+
+    fn activate(
+        service: &mut PubSubService<MockConnect>,
+        interface: &mut ConnectionInterface,
+        request: SerializedRequest,
+        server_id: &str,
+    ) -> B256 {
+        let request_id = request.id().clone();
+        let (in_flight, mut rx) = InFlight::new(request, 16);
+        service.service_request(in_flight).unwrap();
+        let _ = take_wire(interface);
+        service.handle_item(subscription_response(request_id.clone(), server_id).into()).unwrap();
+        let response = rx.try_recv().unwrap().unwrap();
+        alias_from_response(response, request_id)
+    }
+
+    #[test]
+    fn subscription_local_id_includes_the_method() {
+        let admin = Request::new("admin_peerEvents", Id::Number(1), ()).serialize().unwrap();
+        let reth = Request::new("reth_subscribeChainNotifications", Id::Number(2), ())
+            .serialize()
+            .unwrap();
+
+        assert_ne!(subscription_local_id(&admin), subscription_local_id(&reth));
+    }
+
+    #[test]
+    fn subscription_local_id_distinguishes_params_presence_and_value() {
+        let omitted = Request::new("custom_subscribe", Id::Number(1), ()).serialize().unwrap();
+        let null = Request::new("custom_subscribe", Id::Number(2), serde_json::Value::Null)
+            .serialize()
+            .unwrap();
+        let empty =
+            Request::new("custom_subscribe", Id::Number(3), Vec::<u8>::new()).serialize().unwrap();
+
+        let omitted = subscription_local_id(&omitted);
+        let null = subscription_local_id(&null);
+        let empty = subscription_local_id(&empty);
+        assert_ne!(omitted, null);
+        assert_ne!(omitted, empty);
+        assert_ne!(null, empty);
+    }
+
+    #[test]
+    fn identical_subscriptions_share_one_wire_request_and_preserve_waiter_ids() {
+        let (mut service, mut interface) = test_service();
+        let (first, mut first_rx) = InFlight::new(eth_subscription(1, "newHeads"), 16);
+        let (second, mut second_rx) = InFlight::new(eth_subscription(2, "newHeads"), 16);
+
+        service.service_request(first).unwrap();
+        let wire = take_wire(&mut interface);
+        assert_eq!(wire["id"], 1);
+        service.service_request(second).unwrap();
+        assert_no_wire(&mut interface);
+
+        service.handle_item(subscription_response(Id::Number(1), "server-1").into()).unwrap();
+        let first_alias = alias_from_response(first_rx.try_recv().unwrap().unwrap(), Id::Number(1));
+        let second_alias =
+            alias_from_response(second_rx.try_recv().unwrap().unwrap(), Id::Number(2));
+        assert_eq!(first_alias, second_alias);
+        assert_eq!(service.subs.len(), 1);
+
+        let first_local = service.subs.get_subscription(first_alias).unwrap();
+        let second_local = service.subs.get_subscription(second_alias).unwrap();
+        assert_eq!(first_local.local_id, second_local.local_id);
+
+        let (third, mut third_rx) = InFlight::new(eth_subscription(3, "newHeads"), 16);
+        service.service_request(third).unwrap();
+        assert_no_wire(&mut interface);
+        assert_eq!(
+            alias_from_response(third_rx.try_recv().unwrap().unwrap(), Id::Number(3)),
+            first_alias
+        );
+    }
+
+    #[test]
+    fn different_methods_with_omitted_params_do_not_collide() {
+        let (mut service, mut interface) = test_service();
+        let (admin, _admin_rx) =
+            InFlight::new(custom_subscription(1, "admin_peerEvents", None), 16);
+        let (reth, _reth_rx) =
+            InFlight::new(custom_subscription(2, "reth_subscribeChainNotifications", None), 16);
+
+        service.service_request(admin).unwrap();
+        service.service_request(reth).unwrap();
+        assert_eq!(take_wire(&mut interface)["method"], "admin_peerEvents");
+        assert_eq!(take_wire(&mut interface)["method"], "reth_subscribeChainNotifications");
+        assert_eq!(service.starting.len(), 2);
+    }
+
+    #[test]
+    fn cancelled_single_flight_is_compensated_after_success() {
+        let (mut service, mut interface) = test_service();
+        let (in_flight, rx) = InFlight::new(eth_subscription(1, "logs"), 16);
+        service.service_request(in_flight).unwrap();
+        let _ = take_wire(&mut interface);
+        drop(rx);
+
+        service.handle_item(subscription_response(Id::Number(1), "abandoned").into()).unwrap();
+        assert_eq!(service.subs.len(), 0);
+        let cleanup = take_wire(&mut interface);
+        assert_eq!(cleanup["method"], "eth_unsubscribe");
+        assert_eq!(cleanup["params"], serde_json::json!(["abandoned"]));
+    }
+
+    #[test]
+    fn cancelling_first_waiter_does_not_cancel_other_waiters() {
+        let (mut service, mut interface) = test_service();
+        let (first, first_rx) = InFlight::new(eth_subscription(1, "logs"), 16);
+        let (second, mut second_rx) = InFlight::new(eth_subscription(2, "logs"), 16);
+        service.service_request(first).unwrap();
+        let _ = take_wire(&mut interface);
+        service.service_request(second).unwrap();
+        drop(first_rx);
+
+        service.handle_item(subscription_response(Id::Number(1), "shared").into()).unwrap();
+        let _ = alias_from_response(second_rx.try_recv().unwrap().unwrap(), Id::Number(2));
+        assert_eq!(service.subs.len(), 1);
+        assert_no_wire(&mut interface);
+    }
+
+    #[test]
+    fn new_waiter_joins_existing_single_flight_after_earlier_waiters_cancel() {
+        let (mut service, mut interface) = test_service();
+        let (first, first_rx) = InFlight::new(eth_subscription(1, "logs"), 16);
+        service.service_request(first).unwrap();
+        let _ = take_wire(&mut interface);
+        drop(first_rx);
+
+        let (second, mut second_rx) = InFlight::new(eth_subscription(2, "logs"), 16);
+        service.service_request(second).unwrap();
+        assert_no_wire(&mut interface);
+
+        service.handle_item(subscription_response(Id::Number(1), "shared").into()).unwrap();
+        let _ = alias_from_response(second_rx.try_recv().unwrap().unwrap(), Id::Number(2));
+        assert_eq!(service.subs.len(), 1);
+        assert_no_wire(&mut interface);
+    }
+
+    #[test]
+    fn cancelled_before_service_dispatch_has_no_side_effect() {
+        let (mut service, mut interface) = test_service();
+        let (in_flight, rx) = InFlight::new(eth_subscription(1, "logs"), 16);
+        drop(rx);
+
+        service.service_request(in_flight).unwrap();
+        assert!(service.starting.is_empty());
+        assert_no_wire(&mut interface);
+    }
+
+    #[test]
+    fn subscription_error_is_fanned_out_with_each_waiter_id() {
+        let (mut service, mut interface) = test_service();
+        let (first, mut first_rx) = InFlight::new(eth_subscription(1, "logs"), 16);
+        let (second, mut second_rx) = InFlight::new(eth_subscription(2, "logs"), 16);
+        service.service_request(first).unwrap();
+        let _ = take_wire(&mut interface);
+        service.service_request(second).unwrap();
+
+        service.handle_item(Response::internal_error(Id::Number(1)).into()).unwrap();
+        let first = first_rx.try_recv().unwrap().unwrap();
+        let second = second_rx.try_recv().unwrap().unwrap();
+        assert_eq!(first.id, Id::Number(1));
+        assert_eq!(second.id, Id::Number(2));
+        assert!(first.is_error());
+        assert!(second.is_error());
+        assert!(service.starting.is_empty());
+        assert_eq!(service.subs.len(), 0);
+    }
+
+    #[test]
+    fn different_params_create_independent_upstream_subscriptions() {
+        let (mut service, mut interface) = test_service();
+        let (heads, _heads_rx) = InFlight::new(eth_subscription(1, "newHeads"), 16);
+        let (logs, _logs_rx) = InFlight::new(eth_subscription(2, "logs"), 16);
+
+        service.service_request(heads).unwrap();
+        service.service_request(logs).unwrap();
+
+        assert_eq!(take_wire(&mut interface)["params"], serde_json::json!(["newHeads"]));
+        assert_eq!(take_wire(&mut interface)["params"], serde_json::json!(["logs"]));
+        assert_eq!(service.starting.len(), 2);
+    }
+
+    #[test]
+    fn duplicate_server_response_is_cleaned_without_overwriting_active_id() {
+        let (mut service, mut interface) = test_service();
+        let alias =
+            activate(&mut service, &mut interface, eth_subscription(1, "newHeads"), "active");
+
+        service.handle_item(subscription_response(Id::Number(1), "duplicate").into()).unwrap();
+        let cleanup = take_wire(&mut interface);
+        assert_eq!(cleanup["params"], serde_json::json!(["duplicate"]));
+        assert_eq!(
+            service.subs.server_id_for_local_id(&alias),
+            Some(&SubId::String("active".into()))
+        );
+
+        service.handle_item(subscription_response(Id::Number(1), "active").into()).unwrap();
+        assert_no_wire(&mut interface);
+    }
+
+    #[test]
+    fn per_request_channel_size_is_first_creator_wins_and_zero_is_rejected() {
+        let (mut service, mut interface) = test_service();
+        let first_request = with_channel_size(eth_subscription(1, "newHeads"), 7);
+        let second_request = with_channel_size(eth_subscription(2, "newHeads"), 11);
+        let local_id = subscription_local_id(&first_request);
+        let (first, mut first_rx) = InFlight::new(first_request, 16);
+        let (second, mut second_rx) = InFlight::new(second_request, 16);
+        service.service_request(first).unwrap();
+        let _ = take_wire(&mut interface);
+        service.service_request(second).unwrap();
+        assert_no_wire(&mut interface);
+        service.handle_item(subscription_response(Id::Number(1), "sized").into()).unwrap();
+        first_rx.try_recv().unwrap().unwrap();
+        second_rx.try_recv().unwrap().unwrap();
+        assert_eq!(service.subs.get(&local_id).unwrap().channel_size, 7);
+
+        let active_request = with_channel_size(eth_subscription(3, "newHeads"), 19);
+        let (active, mut active_rx) = InFlight::new(active_request, 16);
+        service.service_request(active).unwrap();
+        assert_no_wire(&mut interface);
+        active_rx.try_recv().unwrap().unwrap();
+        assert_eq!(service.subs.get(&local_id).unwrap().channel_size, 7);
+
+        let independent_request = with_channel_size(eth_subscription(4, "logs"), 13);
+        let independent_local_id = subscription_local_id(&independent_request);
+        let _ = activate(&mut service, &mut interface, independent_request, "independent");
+        assert_eq!(service.subs.get(&independent_local_id).unwrap().channel_size, 13);
+        assert_eq!(service.subs.get(&local_id).unwrap().channel_size, 7);
+
+        let zero = with_channel_size(eth_subscription(5, "newPendingTransactions"), 0);
+        let (zero, mut zero_rx) = InFlight::new(zero, 16);
+        service.service_request(zero).unwrap();
+        assert!(zero_rx.try_recv().unwrap().unwrap_err().is_local_usage_error());
+        assert_no_wire(&mut interface);
+    }
+
+    #[test]
+    fn tracked_cleanup_uses_reserved_id_and_waits_for_ack() {
+        let (mut service, mut interface) = test_service();
+        let alias =
+            activate(&mut service, &mut interface, eth_subscription(1, "newHeads"), "active");
+        let (tx, mut rx) = oneshot::channel();
+        service.service_unsubscribe(alias, Some(tx)).unwrap();
+        let cleanup = take_wire(&mut interface);
+        assert_eq!(cleanup["method"], "eth_unsubscribe");
+        let cleanup_id = cleanup["id"].as_str().unwrap().to_owned();
+        assert!(cleanup_id.starts_with("alloy-pubsub:0:"));
+        assert!(matches!(rx.try_recv(), Err(oneshot::error::TryRecvError::Empty)));
+
+        service.handle_item(bool_response(Id::String(cleanup_id.clone()), true).into()).unwrap();
+        assert_eq!(rx.try_recv().unwrap().unwrap(), UnsubscribeOutcome::ServerConfirmed);
+
+        let live = activate(&mut service, &mut interface, eth_subscription(2, "logs"), "live");
+        service.handle_item(bool_response(Id::String(cleanup_id), true).into()).unwrap();
+        assert!(service.subs.get(&live).is_some());
+        assert_no_wire(&mut interface);
+    }
+
+    #[test]
+    fn concurrent_cleanups_use_distinct_service_request_ids() {
+        let (mut service, mut interface) = test_service();
+        let first =
+            activate(&mut service, &mut interface, eth_subscription(1, "newHeads"), "first");
+        let second = activate(&mut service, &mut interface, eth_subscription(2, "logs"), "second");
+
+        service.service_unsubscribe(first, None).unwrap();
+        service.service_unsubscribe(second, None).unwrap();
+        let first_cleanup = take_wire(&mut interface);
+        let second_cleanup = take_wire(&mut interface);
+
+        assert_ne!(first_cleanup["id"], second_cleanup["id"]);
+        assert!(first_cleanup["id"].as_str().unwrap().starts_with("alloy-pubsub:0:"));
+        assert!(second_cleanup["id"].as_str().unwrap().starts_with("alloy-pubsub:0:"));
+    }
+
+    #[test]
+    fn cleanup_response_cannot_hijack_numeric_in_flight_request() {
+        let (mut service, mut interface) = test_service();
+        let normal = Request::new("eth_blockNumber", Id::Number(1), ()).serialize().unwrap();
+        let (normal, mut normal_rx) = InFlight::new(normal, 16);
+        service.service_request(normal).unwrap();
+        let _ = take_wire(&mut interface);
+
+        let alias =
+            activate(&mut service, &mut interface, eth_subscription(2, "newHeads"), "active");
+        let (tx, mut cleanup_rx) = oneshot::channel();
+        service.service_unsubscribe(alias, Some(tx)).unwrap();
+        let cleanup = take_wire(&mut interface);
+        let cleanup_id = Id::String(cleanup["id"].as_str().unwrap().to_owned());
+        service.handle_item(bool_response(cleanup_id, true).into()).unwrap();
+        assert_eq!(cleanup_rx.try_recv().unwrap().unwrap(), UnsubscribeOutcome::ServerConfirmed);
+        assert!(matches!(normal_rx.try_recv(), Err(oneshot::error::TryRecvError::Empty)));
+
+        let normal_response = Response {
+            id: Id::Number(1),
+            payload: ResponsePayload::Success(to_json_raw_value(&"0x1").unwrap()),
+        };
+        service.handle_item(normal_response.into()).unwrap();
+        assert_eq!(normal_rx.try_recv().unwrap().unwrap().id, Id::Number(1));
+    }
+
+    #[test]
+    fn tracked_cleanup_reports_false_and_rpc_error_without_retry() {
+        let (mut service, mut interface) = test_service();
+        let alias =
+            activate(&mut service, &mut interface, eth_subscription(1, "newHeads"), "first");
+        let (tx, mut rx) = oneshot::channel();
+        service.service_unsubscribe(alias, Some(tx)).unwrap();
+        let cleanup = take_wire(&mut interface);
+        let cleanup_id = Id::String(cleanup["id"].as_str().unwrap().to_owned());
+        service.handle_item(bool_response(cleanup_id, false).into()).unwrap();
+        assert_eq!(rx.try_recv().unwrap().unwrap(), UnsubscribeOutcome::AlreadyAbsent);
+
+        let alias = activate(&mut service, &mut interface, eth_subscription(2, "logs"), "second");
+        let (tx, mut rx) = oneshot::channel();
+        service.service_unsubscribe(alias, Some(tx)).unwrap();
+        let cleanup = take_wire(&mut interface);
+        let cleanup_id = Id::String(cleanup["id"].as_str().unwrap().to_owned());
+        service.handle_item(Response::internal_error(cleanup_id).into()).unwrap();
+        assert!(rx.try_recv().unwrap().unwrap_err().is_error_resp());
+        assert_no_wire(&mut interface);
+    }
+
+    #[tokio::test]
+    async fn pending_cleanup_completes_on_close_and_is_not_replayed() {
+        let (old_handle, mut old_interface) = ConnectionHandle::new();
+        let (new_handle, mut new_interface) = ConnectionHandle::new();
+        let connector = MockConnect(Arc::new(Mutex::new(Some(new_handle))));
+        let (_tx, reqs) = mpsc::unbounded_channel();
+        let mut service = PubSubService::new(old_handle, connector, reqs);
+        let alias =
+            activate(&mut service, &mut old_interface, eth_subscription(1, "newHeads"), "active");
+        let (tx, mut rx) = oneshot::channel();
+        service.service_unsubscribe(alias, Some(tx)).unwrap();
+        let _ = take_wire(&mut old_interface);
+
+        service.reconnect().await.unwrap();
+        assert_eq!(rx.try_recv().unwrap().unwrap(), UnsubscribeOutcome::TransportClosed);
+        assert_no_wire(&mut new_interface);
+    }
+
+    #[test]
+    fn force_unsubscribe_closes_all_local_receivers() {
+        let (mut service, mut interface) = test_service();
+        let alias =
+            activate(&mut service, &mut interface, eth_subscription(1, "newHeads"), "active");
+        let mut first = service.subs.get_subscription(alias).unwrap();
+        let mut second = service.subs.get_subscription(alias).unwrap();
+
+        service.service_unsubscribe(alias, None).unwrap();
+        let _ = take_wire(&mut interface);
+        assert!(matches!(
+            first.rx.try_recv(),
+            Err(tokio::sync::broadcast::error::TryRecvError::Closed)
+        ));
+        assert!(matches!(
+            second.rx.try_recv(),
+            Err(tokio::sync::broadcast::error::TryRecvError::Closed)
+        ));
+    }
+
+    #[test]
+    fn force_unsubscribe_while_starting_compensates_the_late_server_id() {
+        let (mut service, mut interface) = test_service();
+        let request = eth_subscription(1, "newHeads");
+        let alias = subscription_local_id(&request);
+        let (in_flight, mut response_rx) = InFlight::new(request, 16);
+        service.service_request(in_flight).unwrap();
+        let _ = take_wire(&mut interface);
+
+        let (tx, mut cleanup_rx) = oneshot::channel();
+        service.service_unsubscribe(alias, Some(tx)).unwrap();
+        assert!(response_rx.try_recv().unwrap().unwrap_err().is_local_usage_error());
+        assert_no_wire(&mut interface);
+
+        service.handle_item(subscription_response(Id::Number(1), "late").into()).unwrap();
+        let cleanup = take_wire(&mut interface);
+        assert_eq!(cleanup["params"], serde_json::json!(["late"]));
+        let cleanup_id = Id::String(cleanup["id"].as_str().unwrap().to_owned());
+        service.handle_item(bool_response(cleanup_id, true).into()).unwrap();
+        assert_eq!(cleanup_rx.try_recv().unwrap().unwrap(), UnsubscribeOutcome::ServerConfirmed);
+        assert_eq!(service.subs.len(), 0);
+    }
+
+    #[test]
+    fn force_unsubscribe_while_starting_reports_an_invalid_subscribe_response() {
+        let (mut service, mut interface) = test_service();
+        let request = eth_subscription(1, "newHeads");
+        let alias = subscription_local_id(&request);
+        let (in_flight, _response_rx) = InFlight::new(request, 16);
+        service.service_request(in_flight).unwrap();
+        let _ = take_wire(&mut interface);
+
+        let (tx, mut cleanup_rx) = oneshot::channel();
+        service.service_unsubscribe(alias, Some(tx)).unwrap();
+        let invalid = Response {
+            id: Id::Number(1),
+            payload: ResponsePayload::Success(to_json_raw_value(&true).unwrap()),
+        };
+        service.handle_item(invalid.into()).unwrap();
+
+        assert!(cleanup_rx.try_recv().unwrap().unwrap_err().is_deser_error());
+        assert_no_wire(&mut interface);
+        assert_eq!(service.subs.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn force_unsubscribe_during_reconnect_tracks_late_server_id() {
+        let (old_handle, mut old_interface) = ConnectionHandle::new();
+        let (new_handle, mut new_interface) = ConnectionHandle::new();
+        let connector = MockConnect(Arc::new(Mutex::new(Some(new_handle))));
+        let (_tx, reqs) = mpsc::unbounded_channel();
+        let mut service = PubSubService::new(old_handle, connector, reqs);
+        let alias = activate(
+            &mut service,
+            &mut old_interface,
+            eth_subscription(1, "newHeads"),
+            "old-server",
+        );
+
+        service.reconnect().await.unwrap();
+        let replay = take_wire(&mut new_interface);
+        let replay_id = Id::String(replay["id"].as_str().unwrap().to_owned());
+        let (tx, mut rx) = oneshot::channel();
+        service.service_unsubscribe(alias, Some(tx)).unwrap();
+        assert_no_wire(&mut new_interface);
+
+        service.handle_item(subscription_response(replay_id, "late-server").into()).unwrap();
+        let cleanup = take_wire(&mut new_interface);
+        assert_eq!(cleanup["params"], serde_json::json!(["late-server"]));
+        let cleanup_id = Id::String(cleanup["id"].as_str().unwrap().to_owned());
+        service.handle_item(bool_response(cleanup_id, true).into()).unwrap();
+        assert_eq!(rx.try_recv().unwrap().unwrap(), UnsubscribeOutcome::ServerConfirmed);
+    }
+
+    #[test]
+    fn verified_custom_cleanup_methods_are_used_exactly() {
+        let cases = [
+            ("admin_peerEvents", "admin_unsubscribe"),
+            ("reth_subscribeChainNotifications", "reth_unsubscribeChainNotifications"),
+            ("reth_subscribePersistedBlock", "reth_unsubscribePersistedBlock"),
+        ];
+
+        for (index, (subscribe, unsubscribe)) in cases.into_iter().enumerate() {
+            let (mut service, mut interface) = test_service();
+            let alias = activate(
+                &mut service,
+                &mut interface,
+                custom_subscription(index as u64 + 1, subscribe, Some(unsubscribe)),
+                &format!("server-{index}"),
+            );
+            service.service_unsubscribe(alias, None).unwrap();
+            assert_eq!(take_wire(&mut interface)["method"], unsubscribe);
+        }
+    }
+
+    #[test]
+    fn conflicting_custom_cleanup_method_keeps_first_creator_value() {
+        let (mut service, mut interface) = test_service();
+        let (first, mut first_rx) =
+            InFlight::new(custom_subscription(1, "custom_events", Some("custom_unsubscribeA")), 16);
+        let (second, mut second_rx) =
+            InFlight::new(custom_subscription(2, "custom_events", Some("custom_unsubscribeB")), 16);
+        service.service_request(first).unwrap();
+        let _ = take_wire(&mut interface);
+        service.service_request(second).unwrap();
+        service.handle_item(subscription_response(Id::Number(1), "custom").into()).unwrap();
+        let alias = alias_from_response(first_rx.try_recv().unwrap().unwrap(), Id::Number(1));
+        let second_alias =
+            alias_from_response(second_rx.try_recv().unwrap().unwrap(), Id::Number(2));
+        assert_eq!(alias, second_alias);
+
+        service.service_unsubscribe(alias, None).unwrap();
+        assert_eq!(take_wire(&mut interface)["method"], "custom_unsubscribeA");
+    }
+
+    #[test]
+    fn custom_subscription_without_cleanup_method_waits_for_connection_close() {
+        let (mut service, mut interface) = test_service();
+        let alias = activate(
+            &mut service,
+            &mut interface,
+            custom_subscription(1, "custom_events", None),
+            "custom",
+        );
+        let (tx, mut rx) = oneshot::channel();
+        service.service_unsubscribe(alias, Some(tx)).unwrap();
+        assert_no_wire(&mut interface);
+        assert!(matches!(rx.try_recv(), Err(oneshot::error::TryRecvError::Empty)));
+
+        service.finish_connection_epoch(0);
+        assert_eq!(rx.try_recv().unwrap().unwrap(), UnsubscribeOutcome::TransportClosed);
+    }
+
+    #[tokio::test]
+    async fn reconnect_uses_unique_route_and_preserves_channel_capacity() {
+        let (old_handle, mut old_interface) = ConnectionHandle::new();
+        let (new_handle, mut new_interface) = ConnectionHandle::new();
+        let connector = MockConnect(Arc::new(Mutex::new(Some(new_handle))));
+        let (_tx, reqs) = mpsc::unbounded_channel();
+        let mut service = PubSubService::new(old_handle, connector, reqs);
+        let request = with_channel_size(eth_subscription(1, "newHeads"), 23);
+        let local_id = subscription_local_id(&request);
+        let _ = activate(&mut service, &mut old_interface, request, "old-server");
+
+        service.reconnect().await.unwrap();
+        let replay = take_wire(&mut new_interface);
+        assert_eq!(replay["method"], "eth_subscribe");
+        let replay_id = replay["id"].as_str().unwrap().to_owned();
+        assert!(replay_id.starts_with("alloy-pubsub:1:"));
+        assert_eq!(service.subs.get(&local_id).unwrap().channel_size, 23);
+
+        service
+            .handle_item(subscription_response(Id::String(replay_id), "new-server").into())
+            .unwrap();
+        assert_eq!(
+            service.subs.server_id_for_local_id(&local_id),
+            Some(&SubId::String("new-server".into()))
+        );
+    }
+
+    #[tokio::test]
+    async fn reconnect_does_not_reissue_fully_cancelled_starting_request() {
+        let (old_handle, mut old_interface) = ConnectionHandle::new();
+        let (new_handle, mut new_interface) = ConnectionHandle::new();
+        let connector = MockConnect(Arc::new(Mutex::new(Some(new_handle))));
+        let (_tx, reqs) = mpsc::unbounded_channel();
+        let mut service = PubSubService::new(old_handle, connector, reqs);
+        let (in_flight, rx) = InFlight::new(eth_subscription(1, "newHeads"), 16);
+        service.service_request(in_flight).unwrap();
+        let _ = take_wire(&mut old_interface);
+        drop(rx);
+
+        service.reconnect().await.unwrap();
+        assert!(service.starting.is_empty());
+        assert_no_wire(&mut new_interface);
     }
 
     /// Mock connector that counts every `try_reconnect` invocation and
@@ -445,13 +1644,7 @@ mod tests {
         let (reconnected_handle, mut reconnected_interface) = ConnectionHandle::new();
         let connector = MockConnect(Arc::new(Mutex::new(Some(reconnected_handle))));
         let (tx, reqs) = mpsc::unbounded_channel();
-        let service = PubSubService {
-            handle: dead_handle,
-            connector,
-            reqs,
-            subs: SubscriptionManager::default(),
-            in_flights: RequestManager::default(),
-        };
+        let service = PubSubService::new(dead_handle, connector, reqs);
         service.spawn();
 
         let first = Request::new("eth_blockNumber", Id::Number(1), ()).serialize().unwrap();
@@ -486,13 +1679,7 @@ mod tests {
         let connector = NonRetryableConnect::default();
         let counter = connector.0.clone();
         let (tx, reqs) = mpsc::unbounded_channel();
-        let service = PubSubService {
-            handle: dead_handle,
-            connector,
-            reqs,
-            subs: SubscriptionManager::default(),
-            in_flights: RequestManager::default(),
-        };
+        let service = PubSubService::new(dead_handle, connector, reqs);
         service.spawn();
 
         let req = Request::new("eth_blockNumber", Id::Number(1), ()).serialize().unwrap();
@@ -523,13 +1710,7 @@ mod tests {
         let calls = connector.calls.clone();
 
         let (_tx, reqs) = mpsc::unbounded_channel();
-        let service = PubSubService {
-            handle: live_handle,
-            connector,
-            reqs,
-            subs: SubscriptionManager::default(),
-            in_flights: RequestManager::default(),
-        };
+        let service = PubSubService::new(live_handle, connector, reqs);
         service.spawn();
 
         // Backend signals a deterministic, non-retryable failure.
@@ -558,13 +1739,7 @@ mod tests {
         let calls = connector.calls.clone();
 
         let (tx, reqs) = mpsc::unbounded_channel();
-        let service = PubSubService {
-            handle: live_handle,
-            connector,
-            reqs,
-            subs: SubscriptionManager::default(),
-            in_flights: RequestManager::default(),
-        };
+        let service = PubSubService::new(live_handle, connector, reqs);
         service.spawn();
 
         // Trigger the legacy close path.

--- a/crates/rpc-client/src/call.rs
+++ b/crates/rpc-client/src/call.rs
@@ -216,6 +216,9 @@ where
     /// Set the request to be a non-standard subscription (i.e. not
     /// "eth_subscribe").
     ///
+    /// Call [`Self::set_unsubscribe_method`] as well when the custom protocol exposes a cleanup
+    /// RPC. Otherwise the subscription can only be reclaimed when its connection closes.
+    ///
     /// # Panics
     ///
     /// Panics if called after the request has been sent.
@@ -226,6 +229,30 @@ where
     /// Set the subscription status of the request.
     pub fn set_subscription_status(&mut self, status: bool) {
         self.request_mut().meta.set_subscription_status(status);
+    }
+
+    /// Set the server-side method used to unsubscribe a non-standard subscription.
+    ///
+    /// This configuration is consumed by pubsub transports and is not serialized onto the wire.
+    #[cfg(feature = "pubsub")]
+    pub fn set_unsubscribe_method(&mut self, method: impl Into<std::borrow::Cow<'static, str>>) {
+        self.request_mut()
+            .meta
+            .extensions_mut()
+            .get_or_insert_default::<alloy_pubsub::SubscriptionOptions>()
+            .set_unsubscribe_method(method);
+    }
+
+    /// Set the local broadcast channel capacity for this subscription request.
+    ///
+    /// This configuration is consumed by pubsub transports and is not serialized onto the wire.
+    #[cfg(feature = "pubsub")]
+    pub fn set_subscription_channel_size(&mut self, channel_size: usize) {
+        self.request_mut()
+            .meta
+            .extensions_mut()
+            .get_or_insert_default::<alloy_pubsub::SubscriptionOptions>()
+            .set_channel_size(channel_size);
     }
 
     /// Get a mutable reference to the params of the request.


### PR DESCRIPTION
## Summary

- derive subscription local IDs from the full RPC method plus exact serialized params and single-flight matching requests before wire dispatch
- preserve every caller's JSON-RPC response ID while sharing one upstream subscription, and compensate cancelled or duplicate successful responses without overwriting a live server ID
- track unsubscribe requests with reserved, unique IDs and add `unsubscribe_and_wait` without changing the existing enqueue-only `unsubscribe` behavior
- carry channel capacity and custom cleanup method as per-request metadata, preserving first-creator-wins semantics for matching local IDs
- make reconnect routing epoch-aware, retain effective channel capacity, avoid replaying fully cancelled starts, and settle old cleanup requests on connection close

## Motivation

The previous `SubscriptionManager::upsert` deduplicated only after every subscribe request had already reached the server. Matching sequential or concurrent requests therefore created unreachable server-side subscriptions. Subscription identity also omitted the RPC method, and the fixed numeric unsubscribe request ID could hijack an unrelated in-flight response.

This change fixes those deterministic lifecycle bugs without changing receiver-Drop retention semantics; that behavior remains deferred to PR B pending the decision in #4082.

## Identity and route retention

The service computes one fixed-size `B256` local ID from an unambiguous encoding of the RPC method, params presence, and exact serialized params. Service maps and response routes store only that local ID; large params remain only in the serialized request retained for replay.

Subscribe response routes remain until their connection closes so a duplicate or late successful response can still be associated with its cleanup method and compensated. This trades a small amount of connection-lifetime route state for stronger orphan protection; Active reuse does not create additional routes.

## Custom cleanup metadata

The existing helpers now carry the protocol methods verified against their implementations:

- `admin_peerEvents` -> `admin_unsubscribe` (geth's namespace unsubscribe routing)
- `reth_subscribeChainNotifications` -> `reth_unsubscribeChainNotifications`
- `reth_subscribePersistedBlock` -> `reth_unsubscribePersistedBlock`

Generic custom subscriptions do not guess a cleanup method and do not fall back to `eth_unsubscribe`. If none is configured, the entry is marked as connection-owned and cleanup completes only when that connection closes.

References:

- https://github.com/ethereum/go-ethereum/blob/06b23b4293950d8c08b624b90f310d1e918048e8/rpc/json.go
- https://github.com/ethereum/go-ethereum/blob/06b23b4293950d8c08b624b90f310d1e918048e8/rpc/handler.go
- https://github.com/paradigmxyz/reth/blob/4ed6acaffdf0823cfef0f512fc7319b332710c3d/crates/rpc/rpc-api/src/reth.rs

## Compatibility

- `unsubscribe` remains enqueue-only; `unsubscribe_and_wait` is additive.
- Receiver-Drop retention and automatic cleanup are intentionally unchanged.
- Local aliases now hash the method plus exact params, so aliases produced by the old params-only scheme change.
- Unknown custom namespaces require an explicit cleanup method; there is no unsafe naming fallback.

## Validation

- `cargo +1.94.1 test -p alloy-json-rpc -p alloy-pubsub`
- `cargo +1.94.1 test -p alloy-rpc-client --features pubsub,ws`
- `cargo +1.94.1 test -p alloy-provider --features pubsub,ws --lib -- --skip provider::r#trait::tests::test_fill_transaction`
- `cargo +1.94.1 test -p alloy-provider --features pubsub,ws --test it`
- `cargo +1.94.1 test -p alloy-provider --all-features --doc`
- `cargo +1.94.1 clippy -p alloy-pubsub -p alloy-rpc-client -p alloy-provider --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo +1.94.1 doc -p alloy-pubsub -p alloy-rpc-client -p alloy-provider --all-features --no-deps`

The one skipped provider unit test uses a local test node that returns JSON-RPC `-32601 Method not found` for its transaction method; the remaining provider run passed 130 tests (4 ignored), and all 5 WS integration tests passed.

Ref #4082
