### PR TITLE
fix(pubsub): prevent subscription lifecycle leaks

### DIFF
--- a/crates/json-rpc/src/request.rs
+++ b/crates/json-rpc/src/request.rs
@@ -394,6 +394,31 @@ impl SerializedRequest {
         }
     }
 
+    /// Clone this request with a different JSON-RPC request ID.
+    ///
+    /// The serialized params are preserved verbatim, including the distinction between omitted
+    /// params, `null`, and an empty collection.
+    pub fn with_id(&self, id: Id) -> serde_json::Result<Self> {
+        #[derive(Serialize)]
+        struct RequestWithId<'a> {
+            method: &'a str,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            params: Option<&'a RawValue>,
+            id: &'a Id,
+            jsonrpc: &'static str,
+        }
+
+        let request = serde_json::value::to_raw_value(&RequestWithId {
+            method: self.method(),
+            params: self.params_with_presence(),
+            id: &id,
+            jsonrpc: "2.0",
+        })?;
+        let mut meta = self.meta.clone();
+        meta.id = id;
+        Ok(Self { meta, request })
+    }
+
     /// Mark the request as a non-standard subscription (i.e. not
     /// `eth_subscribe`)
     pub const fn set_is_subscription(&mut self) {
@@ -441,6 +466,40 @@ impl SerializedRequest {
         req.params
     }
 
+    /// Get the exact serialized params when the `params` field is present.
+    ///
+    /// Unlike [`Self::params`], this distinguishes an omitted `params` field from an explicitly
+    /// serialized `null` value.
+    pub fn params_with_presence(&self) -> Option<&RawValue> {
+        #[derive(Default)]
+        enum ParamsField<'a> {
+            #[default]
+            Missing,
+            Present(&'a RawValue),
+        }
+
+        impl<'de: 'a, 'a> Deserialize<'de> for ParamsField<'a> {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                <&'de RawValue>::deserialize(deserializer).map(Self::Present)
+            }
+        }
+
+        #[derive(Deserialize)]
+        struct Req<'a> {
+            #[serde(borrow, default)]
+            params: ParamsField<'a>,
+        }
+
+        let req: Req<'_> = serde_json::from_str(self.request.get()).unwrap();
+        match req.params {
+            ParamsField::Missing => None,
+            ParamsField::Present(params) => Some(params),
+        }
+    }
+
     /// Get the hash of the serialized request's params.
     ///
     /// This partially deserializes the request, and should be avoided if
@@ -478,5 +537,21 @@ mod test {
         test_inner(Request::<u64>::new("test", "hello".to_string().into(), 1));
         test_inner(Request::<String>::new("test", Id::None, "test".to_string()));
         test_inner(Request::<Vec<u64>>::new("test", u64::MAX.into(), vec![1, 2, 3]));
+    }
+
+    #[test]
+    fn with_id_preserves_exact_params_presence_and_value() {
+        let omitted = Request::new("test", Id::Number(1), ()).serialize().unwrap();
+        let null =
+            Request::new("test", Id::Number(1), serde_json::Value::Null).serialize().unwrap();
+        let empty = Request::new("test", Id::Number(1), Vec::<u8>::new()).serialize().unwrap();
+
+        let omitted = omitted.with_id(Id::String("next".into())).unwrap();
+        let null = null.with_id(Id::String("next".into())).unwrap();
+        let empty = empty.with_id(Id::String("next".into())).unwrap();
+
+        assert!(omitted.params_with_presence().is_none());
+        assert_eq!(null.params_with_presence().unwrap().get(), "null");
+        assert_eq!(empty.params_with_presence().unwrap().get(), "[]");
     }
 }

--- a/crates/json-rpc/src/request.rs
+++ b/crates/json-rpc/src/request.rs
@@ -403,6 +403,31 @@ impl SerializedRequest {
         }
     }
 
+    /// Clone this request with a different JSON-RPC request ID.
+    ///
+    /// The serialized params are preserved verbatim, including the distinction between omitted
+    /// params, `null`, and an empty collection.
+    pub fn with_id(&self, id: Id) -> serde_json::Result<Self> {
+        #[derive(Serialize)]
+        struct RequestWithId<'a> {
+            method: &'a str,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            params: Option<&'a RawValue>,
+            id: &'a Id,
+            jsonrpc: &'static str,
+        }
+
+        let request = serde_json::value::to_raw_value(&RequestWithId {
+            method: self.method(),
+            params: self.params_with_presence(),
+            id: &id,
+            jsonrpc: "2.0",
+        })?;
+        let mut meta = self.meta.clone();
+        meta.id = id;
+        Ok(Self { meta, request })
+    }
+
     /// Mark the request as a non-standard subscription (i.e. not
     /// `eth_subscribe`)
     pub const fn set_is_subscription(&mut self) {
@@ -450,6 +475,40 @@ impl SerializedRequest {
         req.params
     }
 
+    /// Get the exact serialized params when the `params` field is present.
+    ///
+    /// Unlike [`Self::params`], this distinguishes an omitted `params` field from an explicitly
+    /// serialized `null` value.
+    pub fn params_with_presence(&self) -> Option<&RawValue> {
+        #[derive(Default)]
+        enum ParamsField<'a> {
+            #[default]
+            Missing,
+            Present(&'a RawValue),
+        }
+
+        impl<'de: 'a, 'a> Deserialize<'de> for ParamsField<'a> {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                <&'de RawValue>::deserialize(deserializer).map(Self::Present)
+            }
+        }
+
+        #[derive(Deserialize)]
+        struct Req<'a> {
+            #[serde(borrow, default)]
+            params: ParamsField<'a>,
+        }
+
+        let req: Req<'_> = serde_json::from_str(self.request.get()).unwrap();
+        match req.params {
+            ParamsField::Missing => None,
+            ParamsField::Present(params) => Some(params),
+        }
+    }
+
     /// Get the hash of the serialized request's params.
     ///
     /// This partially deserializes the request, and should be avoided if
@@ -487,5 +546,21 @@ mod test {
         test_inner(Request::<u64>::new("test", "hello".to_string().into(), 1));
         test_inner(Request::<String>::new("test", Id::None, "test".to_string()));
         test_inner(Request::<Vec<u64>>::new("test", u64::MAX.into(), vec![1, 2, 3]));
+    }
+
+    #[test]
+    fn with_id_preserves_exact_params_presence_and_value() {
+        let omitted = Request::new("test", Id::Number(1), ()).serialize().unwrap();
+        let null =
+            Request::new("test", Id::Number(1), serde_json::Value::Null).serialize().unwrap();
+        let empty = Request::new("test", Id::Number(1), Vec::<u8>::new()).serialize().unwrap();
+
+        let omitted = omitted.with_id(Id::String("next".into())).unwrap();
+        let null = null.with_id(Id::String("next".into())).unwrap();
+        let empty = empty.with_id(Id::String("next".into())).unwrap();
+
+        assert!(omitted.params_with_presence().is_none());
+        assert_eq!(null.params_with_presence().unwrap().get(), "null");
+        assert_eq!(empty.params_with_presence().unwrap().get(), "[]");
     }
 }

--- a/crates/provider/src/ext/admin.rs
+++ b/crates/provider/src/ext/admin.rs
@@ -76,7 +76,7 @@ where
     fn subscribe_peer_events(
         &self,
     ) -> GetSubscription<alloy_rpc_client::NoParams, alloy_rpc_types_admin::PeerEvent> {
-        self.subscribe_to("admin_peerEvents")
+        self.subscribe_to("admin_peerEvents").unsubscribe_method("admin_unsubscribe")
     }
 }
 

--- a/crates/provider/src/ext/reth.rs
+++ b/crates/provider/src/ext/reth.rs
@@ -70,6 +70,7 @@ where
         &self,
     ) -> GetSubscription<alloy_rpc_client::NoParams, serde_json::Value> {
         self.subscribe_to("reth_subscribeChainNotifications")
+            .unsubscribe_method("reth_unsubscribeChainNotifications")
     }
 
     #[cfg(feature = "pubsub")]
@@ -77,5 +78,6 @@ where
         &self,
     ) -> GetSubscription<alloy_rpc_client::NoParams, serde_json::Value> {
         self.subscribe_to("reth_subscribePersistedBlock")
+            .unsubscribe_method("reth_unsubscribePersistedBlock")
     }
 }

--- a/crates/provider/src/provider/get_block.rs
+++ b/crates/provider/src/provider/get_block.rs
@@ -448,6 +448,12 @@ impl<N: alloy_network::Network> SubFullBlocks<N> {
         self
     }
 
+    /// Set when the server-side subscription is eligible for automatic cleanup.
+    pub fn retention_policy(mut self, policy: alloy_pubsub::SubscriptionRetentionPolicy) -> Self {
+        self.sub = self.sub.retention_policy(policy);
+        self
+    }
+
     /// Subscribe to the inner stream of headers and map them to block responses.
     pub async fn into_stream(
         self,

--- a/crates/provider/src/provider/root.rs
+++ b/crates/provider/src/provider/root.rs
@@ -75,10 +75,19 @@ impl<N: Network> RootProvider<N> {
         self.pubsub_frontend()?.get_subscription(id).await.map(Subscription::from)
     }
 
-    /// Unsubscribes from the subscription corresponding to the given RPC subscription ID.
+    /// Force-unsubscribes the subscription and closes all local receivers sharing its key.
     #[cfg(feature = "pubsub")]
     pub fn unsubscribe(&self, id: alloy_primitives::B256) -> alloy_transport::TransportResult<()> {
         self.pubsub_frontend()?.unsubscribe(id)
+    }
+
+    /// Unsubscribes and waits for the server-side cleanup to reach a terminal state.
+    #[cfg(feature = "pubsub")]
+    pub async fn unsubscribe_and_wait(
+        &self,
+        id: alloy_primitives::B256,
+    ) -> alloy_transport::TransportResult<alloy_pubsub::UnsubscribeOutcome> {
+        self.pubsub_frontend()?.unsubscribe_and_wait(id).await
     }
 
     #[cfg(feature = "pubsub")]

--- a/crates/provider/src/provider/root.rs
+++ b/crates/provider/src/provider/root.rs
@@ -66,7 +66,10 @@ impl<N: Network> RootProvider<N> {
 }
 
 impl<N: Network> RootProvider<N> {
-    /// Gets the subscription corresponding to the given RPC subscription ID.
+    /// Gets a legacy/manual receiver claim corresponding to the given local subscription ID.
+    ///
+    /// This does not upgrade the entry's retention policy. A receiver-only entry that has already
+    /// reached zero receivers is considered ended and returns `subscription not found`.
     #[cfg(feature = "pubsub")]
     pub async fn get_subscription<R: alloy_json_rpc::RpcRecv>(
         &self,

--- a/crates/provider/src/provider/root.rs
+++ b/crates/provider/src/provider/root.rs
@@ -83,10 +83,19 @@ impl<N: Network> RootProvider<N> {
         self.pubsub_frontend()?.get_subscription(id).await.map(Subscription::from)
     }
 
-    /// Unsubscribes from the subscription corresponding to the given RPC subscription ID.
+    /// Force-unsubscribes the subscription and closes all local receivers sharing its key.
     #[cfg(feature = "pubsub")]
     pub fn unsubscribe(&self, id: alloy_primitives::B256) -> alloy_transport::TransportResult<()> {
         self.pubsub_frontend()?.unsubscribe(id)
+    }
+
+    /// Unsubscribes and waits for the server-side cleanup to reach a terminal state.
+    #[cfg(feature = "pubsub")]
+    pub async fn unsubscribe_and_wait(
+        &self,
+        id: alloy_primitives::B256,
+    ) -> alloy_transport::TransportResult<alloy_pubsub::UnsubscribeOutcome> {
+        self.pubsub_frontend()?.unsubscribe_and_wait(id).await
     }
 
     #[cfg(feature = "pubsub")]

--- a/crates/provider/src/provider/root.rs
+++ b/crates/provider/src/provider/root.rs
@@ -74,7 +74,10 @@ impl<N: Network> RootProvider<N> {
 }
 
 impl<N: Network> RootProvider<N> {
-    /// Gets the subscription corresponding to the given RPC subscription ID.
+    /// Gets a legacy/manual receiver claim corresponding to the given local subscription ID.
+    ///
+    /// This does not upgrade the entry's retention policy. A receiver-only entry that has already
+    /// reached zero receivers is considered ended and returns `subscription not found`.
     #[cfg(feature = "pubsub")]
     pub async fn get_subscription<R: alloy_json_rpc::RpcRecv>(
         &self,

--- a/crates/provider/src/provider/subscription.rs
+++ b/crates/provider/src/provider/subscription.rs
@@ -3,6 +3,7 @@ use alloy_primitives::B256;
 use alloy_pubsub::Subscription;
 use alloy_rpc_client::{RpcCall, WeakClient};
 use alloy_transport::{TransportErrorKind, TransportResult};
+use std::borrow::Cow;
 
 /// A general-purpose subscription request builder
 ///
@@ -34,6 +35,12 @@ where
         self.channel_size = Some(size);
         self
     }
+
+    /// Set the RPC method used to remove the server-side subscription.
+    pub fn unsubscribe_method(mut self, method: impl Into<Cow<'static, str>>) -> Self {
+        self.call.set_unsubscribe_method(method);
+        self
+    }
 }
 
 impl<P, R> core::fmt::Debug for GetSubscription<P, R>
@@ -57,7 +64,7 @@ where
     type Output = TransportResult<alloy_pubsub::Subscription<R>>;
     type IntoFuture = futures_utils_wasm::BoxFuture<'static, Self::Output>;
 
-    fn into_future(self) -> Self::IntoFuture {
+    fn into_future(mut self) -> Self::IntoFuture {
         Box::pin(async move {
             let client = self
                 .client
@@ -65,9 +72,13 @@ where
                 .ok_or_else(|| TransportErrorKind::custom_str("client dropped"))?;
             let pubsub = client.pubsub_frontend().ok_or(TransportErrorKind::PubsubUnavailable)?;
 
-            // Set config channel size if any
             if let Some(size) = self.channel_size {
-                pubsub.set_channel_size(size);
+                if size == 0 {
+                    return Err(alloy_json_rpc::RpcError::local_usage_str(
+                        "subscription channel size must be non-zero",
+                    ));
+                }
+                self.call.set_subscription_channel_size(size);
             }
 
             let id = self.call.await?;

--- a/crates/provider/src/provider/subscription.rs
+++ b/crates/provider/src/provider/subscription.rs
@@ -1,14 +1,15 @@
 use alloy_json_rpc::{RpcRecv, RpcSend};
 use alloy_primitives::B256;
-use alloy_pubsub::Subscription;
+use alloy_pubsub::{Subscription, SubscriptionReceiverTicket, SubscriptionRetentionPolicy};
 use alloy_rpc_client::{RpcCall, WeakClient};
 use alloy_transport::{TransportErrorKind, TransportResult};
 use std::borrow::Cow;
 
 /// A general-purpose subscription request builder
 ///
-/// This struct allows configuring subscription parameters and channel size
-/// before initiating a request to subscribe to Ethereum events.
+/// This struct allows configuring subscription parameters, channel size, and retention before
+/// initiating a request to subscribe to Ethereum events. Typed subscriptions default to automatic
+/// cleanup after their final local receiver is dropped.
 pub struct GetSubscription<P, R>
 where
     P: RpcSend,
@@ -17,6 +18,7 @@ where
     client: WeakClient,
     call: RpcCall<P, B256>,
     channel_size: Option<usize>,
+    retention_policy: SubscriptionRetentionPolicy,
     _marker: std::marker::PhantomData<fn() -> R>,
 }
 
@@ -27,7 +29,13 @@ where
 {
     /// Creates a new [`GetSubscription`] instance
     pub fn new(client: WeakClient, call: RpcCall<P, B256>) -> Self {
-        Self { client, call, channel_size: None, _marker: std::marker::PhantomData }
+        Self {
+            client,
+            call,
+            channel_size: None,
+            retention_policy: SubscriptionRetentionPolicy::WhileReceivers,
+            _marker: std::marker::PhantomData,
+        }
     }
 
     /// Set the channel_size for the subscription stream.
@@ -41,6 +49,14 @@ where
         self.call.set_unsubscribe_method(method);
         self
     }
+
+    /// Set when the server-side subscription is eligible for automatic cleanup.
+    ///
+    /// Typed subscriptions default to [`SubscriptionRetentionPolicy::WhileReceivers`].
+    pub const fn retention_policy(mut self, policy: SubscriptionRetentionPolicy) -> Self {
+        self.retention_policy = policy;
+        self
+    }
 }
 
 impl<P, R> core::fmt::Debug for GetSubscription<P, R>
@@ -51,6 +67,7 @@ where
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("GetSubscription")
             .field("channel_size", &self.channel_size)
+            .field("retention_policy", &self.retention_policy)
             .field("call", &self.call)
             .finish()
     }
@@ -70,7 +87,7 @@ where
                 .client
                 .upgrade()
                 .ok_or_else(|| TransportErrorKind::custom_str("client dropped"))?;
-            let pubsub = client.pubsub_frontend().ok_or(TransportErrorKind::PubsubUnavailable)?;
+            client.pubsub_frontend().ok_or(TransportErrorKind::PubsubUnavailable)?;
 
             if let Some(size) = self.channel_size {
                 if size == 0 {
@@ -81,9 +98,14 @@ where
                 self.call.set_subscription_channel_size(size);
             }
 
-            let id = self.call.await?;
+            let (ticket, receiver) = SubscriptionReceiverTicket::channel();
+            self.call.set_subscription_receiver_ticket(ticket);
+            self.call.set_subscription_retention_policy(self.retention_policy);
 
-            pubsub.get_subscription(id).await.map(Subscription::from)
+            let id = self.call.await?;
+            let subscription = receiver.await.map_err(|_| TransportErrorKind::backend_gone())?;
+            debug_assert_eq!(&id, subscription.local_id());
+            Ok(Subscription::from(subscription))
         })
     }
 }

--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -1700,7 +1700,9 @@ pub trait Provider<N: Network = Ethereum>: Send + Sync {
     ///
     /// This is a helper method for creating subscriptions to methods that are not
     /// "eth_subscribe" and don't require parameters. It automatically marks the
-    /// request as a subscription.
+    /// request as a subscription. Because custom protocols do not share a universal cleanup
+    /// naming convention, configure [`GetSubscription::unsubscribe_method`] when the server
+    /// exposes one. Without it, the subscription can only be reclaimed when the connection closes.
     ///
     /// # Examples
     ///
@@ -1728,10 +1730,19 @@ pub trait Provider<N: Network = Ethereum>: Send + Sync {
         GetSubscription::new(self.weak_client(), rpc_call)
     }
 
-    /// Cancels a subscription given the subscription ID.
+    /// Force-cancels a subscription and closes all local receivers sharing its key.
     #[cfg(feature = "pubsub")]
     async fn unsubscribe(&self, id: B256) -> TransportResult<()> {
         self.root().unsubscribe(id)
+    }
+
+    /// Cancels a subscription and waits for server confirmation or connection-level cleanup.
+    #[cfg(feature = "pubsub")]
+    async fn unsubscribe_and_wait(
+        &self,
+        id: B256,
+    ) -> TransportResult<alloy_pubsub::UnsubscribeOutcome> {
+        self.root().unsubscribe_and_wait(id).await
     }
 
     /// Gets syncing info.

--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -1684,6 +1684,10 @@ pub trait Provider<N: Network = Ethereum>: Send + Sync {
     }
 
     /// Subscribe to an RPC event.
+    ///
+    /// The returned typed builder defaults to cleaning up the upstream subscription after its last
+    /// local receiver is dropped. Use [`GetSubscription::retention_policy`] to retain it until an
+    /// explicit force unsubscribe instead.
     #[cfg(feature = "pubsub")]
     #[auto_impl(keep_default_for(&, &mut, Rc, Arc, Box))]
     fn subscribe<P, R>(&self, params: P) -> GetSubscription<P, R>

--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -1701,7 +1701,9 @@ pub trait Provider<N: Network = Ethereum>: Send + Sync {
     ///
     /// This is a helper method for creating subscriptions to methods that are not
     /// "eth_subscribe" and don't require parameters. It automatically marks the
-    /// request as a subscription.
+    /// request as a subscription. Because custom protocols do not share a universal cleanup
+    /// naming convention, configure [`GetSubscription::unsubscribe_method`] when the server
+    /// exposes one. Without it, the subscription can only be reclaimed when the connection closes.
     ///
     /// # Examples
     ///
@@ -1729,10 +1731,19 @@ pub trait Provider<N: Network = Ethereum>: Send + Sync {
         GetSubscription::new(self.weak_client(), rpc_call)
     }
 
-    /// Cancels a subscription given the subscription ID.
+    /// Force-cancels a subscription and closes all local receivers sharing its key.
     #[cfg(feature = "pubsub")]
     async fn unsubscribe(&self, id: B256) -> TransportResult<()> {
         self.root().unsubscribe(id)
+    }
+
+    /// Cancels a subscription and waits for server confirmation or connection-level cleanup.
+    #[cfg(feature = "pubsub")]
+    async fn unsubscribe_and_wait(
+        &self,
+        id: B256,
+    ) -> TransportResult<alloy_pubsub::UnsubscribeOutcome> {
+        self.root().unsubscribe_and_wait(id).await
     }
 
     /// Gets syncing info.

--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -1685,6 +1685,10 @@ pub trait Provider<N: Network = Ethereum>: Send + Sync {
     }
 
     /// Subscribe to an RPC event.
+    ///
+    /// The returned typed builder defaults to cleaning up the upstream subscription after its last
+    /// local receiver is dropped. Use [`GetSubscription::retention_policy`] to retain it until an
+    /// explicit force unsubscribe instead.
     #[cfg(feature = "pubsub")]
     #[auto_impl(keep_default_for(&, &mut, Rc, Arc, Box))]
     fn subscribe<P, R>(&self, params: P) -> GetSubscription<P, R>

--- a/crates/pubsub/Cargo.toml
+++ b/crates/pubsub/Cargo.toml
@@ -39,3 +39,6 @@ tracing.workspace = true
 
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
 wasmtimer.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["test-util", "time"] }

--- a/crates/pubsub/Cargo.toml
+++ b/crates/pubsub/Cargo.toml
@@ -28,7 +28,6 @@ alloy-primitives.workspace = true
 alloy-transport.workspace = true
 
 auto_impl.workspace = true
-bimap.workspace = true
 futures.workspace = true
 parking_lot.workspace = true
 serde.workspace = true

--- a/crates/pubsub/README.md
+++ b/crates/pubsub/README.md
@@ -87,6 +87,11 @@ The local ID is derived from the complete subscription method and exact serializ
 with the same method and params share one server subscription and receive independent local
 broadcast receivers. Calls with different methods never alias merely because their params match.
 
+Typed provider subscriptions receive their first local receiver in the same service turn that
+processes the server response. There is no hidden receiver in the subscription manager, so dropping
+the final typed receiver makes the upstream subscription eligible for cleanup. Local
+`resubscribe()` and all subscription stream adapters count as receivers and keep the upstream alive.
+
 ### What is a subscription request?
 
 The **service** uses the `is_subscription()` method in the request to determine
@@ -113,6 +118,26 @@ traffic. Manually constructed requests must not use that prefix.
 `PubSubFrontend::unsubscribe_and_wait()` when the caller needs to observe server confirmation,
 server-reported absence, an RPC error, or connection-level cleanup. Both methods are force
 operations: they close all local receivers sharing the same method and params.
+
+### Retention and legacy claims
+
+[`SubscriptionRetentionPolicy`] controls ownership of the shared upstream subscription:
+
+- Typed `GetSubscription` builders default to `WhileReceivers`. After the last receiver is dropped,
+  cleanup occurs on the next notification, acquire, reconnect, or periodic sweep (at most 30 seconds
+  for a quiet subscription).
+- Low-level two-phase requests (`set_is_subscription()` followed by `get_subscription(local_id)`)
+  default to `UntilExplicitUnsubscribe` for compatibility. A successful response creates a manual
+  receiver claim and a persistent hold, with no claim deadline.
+- Both paths may explicitly select the other policy. If matching typed and legacy subscribe waiters
+  are combined, any successfully delivered `UntilExplicitUnsubscribe` waiter commits a persistent
+  hold. Later `get_subscription(local_id)` calls do not upgrade retention.
+
+A persistent hold is released only by force unsubscribe. For a `WhileReceivers` entry whose receiver
+count has already reached zero, `get_subscription(local_id)` returns not found instead of reopening
+the old generation; issue the original subscription request again to create a new generation.
+
+[`SubscriptionRetentionPolicy`]: crate::SubscriptionRetentionPolicy
 
 ### Subscription Lifecycle
 
@@ -141,6 +166,7 @@ Subscription Request Lifecycle:
 1. The **service** assigns a `local_id` to the subscription, creates a
    subscription broadcast channel, and stores the relevant information in its
    `SubscriptionManager`.
+1. Typed waiters receive a local receiver directly; legacy waiters create named manual claims.
 1. The **service** overwrites the JSON RPC response with the `local_id`.
 1. The **service** sends a response with each waiter's original JSON-RPC request ID via its oneshot.
 
@@ -149,5 +175,7 @@ Subscription Notification Lifecycle
 1. The RPC server sends a notification to the **backend**.
 1. The **backend** sends the notification to the **service**.
 1. The **service** looks up the `local_id` in its `SubscriptionManager`.
-1. If present, the **service** sends the notification to the relevant channel.
+1. If present and locally owned, the **service** sends the notification to the relevant channel.
+   1. If no receiver or persistent hold remains, the **service** removes the entry and starts
+      upstream cleanup instead.
    1. Otherwise, the **service** ignores the notification.

--- a/crates/pubsub/README.md
+++ b/crates/pubsub/README.md
@@ -63,7 +63,7 @@ For a normal request, the user sends a request to the **frontend**, and
 later receives a response via a tokio oneshot channel. This is straightforward
 and easy to reason about. Subscriptions, however, are side-effects of other
 requests, and are long-lived. They are managed by the **service** and
-identified by a `U256` id. The **service** uses this id to manage the
+identified by a local `B256` id. The **service** uses this id to manage the
 subscription lifecycle, and to dispatch notifications to the correct
 subscribers.
 
@@ -72,7 +72,7 @@ subscribers.
 When a user issues a subscription request, the **frontend** sends a
 subscription request to the **service**. The **service** dispatches it to the
 RPC server via the **backend**. The **service** then intercepts the RPC server
-response containing the serve id, and assigns a `local_id` to the subscription.
+response containing the server id, and assigns a `local_id` to the subscription.
 This `local_id` is used to identify the subscription in the **service** and in
 tasks consuming the subscription, while the `server_id` is used to identify the
 subscription to the RPC server, and to associate notifications with specific
@@ -82,6 +82,10 @@ This allows us to use long-lived `local_id` values to manage subscriptions over
 multiple reconnections, without having to notify frontend users of the ID change
 when the server connection is lost. It also prevents race conditions when
 unsubscribing during or immediately after a reconnection.
+
+The local ID is derived from the complete subscription method and exact serialized params. Calls
+with the same method and params share one server subscription and receive independent local
+broadcast receivers. Calls with different methods never alias merely because their params match.
 
 ### What is a subscription request?
 
@@ -93,9 +97,22 @@ on unknown methods, the `Request`, `SerializedRequest` and `RpcCall` expose
 `set_is_subscription()`, which can be used to mark any given request as a
 subscription.
 
-When marking a request as a subscription, the **service** will intercept the
-RPC response, which MUST be a `U256` value. Subscription requests that return
-anything other than a `U256` value will not function.
+When marking a request as a subscription, also configure the matching cleanup RPC with
+`RpcCall::set_unsubscribe_method()` when the protocol provides one. Custom subscription protocols
+do not share a universal naming convention, so the service does not guess or fall back to
+`eth_unsubscribe`. A custom subscription without a configured cleanup method can only be reclaimed
+when its connection closes.
+
+The **service** intercepts the RPC response, which must contain a numeric or string subscription
+ID. Other response types will not function as subscriptions.
+
+The service reserves string request IDs beginning with `alloy-pubsub:` for resubscribe and cleanup
+traffic. Manually constructed requests must not use that prefix.
+
+`PubSubFrontend::unsubscribe()` retains its enqueue-only behavior. Use
+`PubSubFrontend::unsubscribe_and_wait()` when the caller needs to observe server confirmation,
+server-reported absence, an RPC error, or connection-level cleanup. Both methods are force
+operations: they close all local receivers sharing the same method and params.
 
 ### Subscription Lifecycle
 
@@ -116,16 +133,16 @@ Subscription Request Lifecycle:
 1. The user issues a subscription request to the **frontend**.
 1. The **frontend** sends the request to the **service**, with a oneshot channel
    to receive the response.
-1. The **service** stores the oneshot channel in its `RequestManager`.
-1. The **service** sends the request to the **backend**.
+1. The **service** joins the request to an existing matching single-flight, or creates one and sends
+   a single request to the **backend**.
 1. The **backend** sends the request to the RPC server.
-1. The RPC server responds with a `U256` value (the `server_id`).
+1. The RPC server responds with a numeric or string `server_id`.
 1. The **backend** sends the response to the **service**.
 1. The **service** assigns a `local_id` to the subscription, creates a
    subscription broadcast channel, and stores the relevant information in its
    `SubscriptionManager`.
 1. The **service** overwrites the JSON RPC response with the `local_id`.
-1. The **service** sends the response to the waiting task via the oneshot.
+1. The **service** sends a response with each waiter's original JSON-RPC request ID via its oneshot.
 
 Subscription Notification Lifecycle
 

--- a/crates/pubsub/README.md
+++ b/crates/pubsub/README.md
@@ -23,7 +23,7 @@ The PubSub system here consists of 3 logical parts:
 - The **backend** is an actively running connection to the server. Users
   should NEVER instantiate a backend directly. Instead, they should use
   [`PubSubConnect::into_service`] for some connection object. Backends
-  are responsible for managing the connection to the server,accepting user
+  are responsible for managing the connection to the server, accepting user
   requests from the **service** and forwarding server responses to the
   **service**.
 
@@ -53,9 +53,8 @@ This crate provides the following:
   into the expected type, and allows the user to accept or discard unexpected
   responses.
 - [`SubscriptionItem`]: An item in a typed [`Subscription`]. This type is
-  yielded by the subscription via the `recv_any()` API a notification is
-  received and contains the deserialized item. If deserialization fails, it
-  contains the raw JSON value.
+  yielded by the subscription via the `recv_any()` API. It contains the
+  deserialized item, or the raw JSON value if deserialization fails.
 
 ## On Handling Subscriptions
 
@@ -72,20 +71,40 @@ subscribers.
 When a user issues a subscription request, the **frontend** sends a
 subscription request to the **service**. The **service** dispatches it to the
 RPC server via the **backend**. The **service** then intercepts the RPC server
-response containing the server id, and assigns a `local_id` to the subscription.
-This `local_id` is used to identify the subscription in the **service** and in
-tasks consuming the subscription, while the `server_id` is used to identify the
-subscription to the RPC server, and to associate notifications with specific
-active subscriptions.
+response containing the server ID and assigns a stable `B256` `local_id` to
+the subscription. Server IDs are represented by [`alloy_json_rpc::SubId`] and
+may be numeric or strings. The `local_id` identifies the subscription in the
+**service** and consumer tasks, while the current `server_id` associates
+notifications with the server-side subscription.
 
-This allows us to use long-lived `local_id` values to manage subscriptions over
-multiple reconnections, without having to notify frontend users of the ID change
-when the server connection is lost. It also prevents race conditions when
-unsubscribing during or immediately after a reconnection.
+This allows the service to keep the consumer-facing `local_id` stable while the
+server ID changes across reconnections.
 
 The local ID is derived from the complete subscription method and exact serialized params. Calls
 with the same method and params share one server subscription and receive independent local
 broadcast receivers. Calls with different methods never alias merely because their params match.
+
+### Reconnection, replay, and cancellation
+
+After a retryable established-backend failure, the service attempts reconnection under its
+configured retry policy; non-retryable failures terminate it immediately. Following a successful
+reconnect, it re-sends every
+request still awaiting a response and re-creates active subscriptions. If the
+server processed a request but its response was lost, that request may execute
+more than once. Do not rely on at-most-once execution for non-idempotent methods.
+
+Dropping a request future stops waiting locally, but does not cancel a request
+already accepted by the service. Dropping a [`RawSubscription`] or [`Subscription`]
+removes that receiver. Under `WhileReceivers`, dropping the final receiver makes the
+subscription eligible for cleanup; a persistent hold requires explicit unsubscribe.
+Call [`PubSubFrontend::unsubscribe`] with the local ID to force cleanup of a shared
+subscription. A successful return only confirms that the instruction was queued;
+use [`PubSubFrontend::unsubscribe_and_wait`] to observe the cleanup outcome.
+
+Typed provider subscriptions receive their first local receiver in the same service turn that
+processes the server response. There is no hidden receiver in the subscription manager, so dropping
+the final typed receiver makes the upstream subscription eligible for cleanup. Local
+`resubscribe()` and all subscription stream adapters count as receivers and keep the upstream alive.
 
 ### What is a subscription request?
 
@@ -103,8 +122,9 @@ do not share a universal naming convention, so the service does not guess or fal
 `eth_unsubscribe`. A custom subscription without a configured cleanup method can only be reclaimed
 when its connection closes.
 
-The **service** intercepts the RPC response, which must contain a numeric or string subscription
-ID. Other response types will not function as subscriptions.
+The **service** intercepts the RPC response, which must deserialize as an
+[`alloy_json_rpc::SubId`] (a numeric or string ID). Other response types will fail
+deserialization.
 
 The service reserves string request IDs beginning with `alloy-pubsub:` for resubscribe and cleanup
 traffic. Manually constructed requests must not use that prefix.
@@ -113,6 +133,26 @@ traffic. Manually constructed requests must not use that prefix.
 `PubSubFrontend::unsubscribe_and_wait()` when the caller needs to observe server confirmation,
 server-reported absence, an RPC error, or connection-level cleanup. Both methods are force
 operations: they close all local receivers sharing the same method and params.
+
+### Retention and legacy claims
+
+[`SubscriptionRetentionPolicy`] controls ownership of the shared upstream subscription:
+
+- Typed `GetSubscription` builders default to `WhileReceivers`. After the last receiver is dropped,
+  cleanup occurs on the next notification, acquire, reconnect, or periodic sweep (at most 30 seconds
+  for a quiet subscription).
+- Low-level two-phase requests (`set_is_subscription()` followed by `get_subscription(local_id)`)
+  default to `UntilExplicitUnsubscribe` for compatibility. A successful response creates a manual
+  receiver claim and a persistent hold, with no claim deadline.
+- Both paths may explicitly select the other policy. If matching typed and legacy subscribe waiters
+  are combined, any successfully delivered `UntilExplicitUnsubscribe` waiter commits a persistent
+  hold. Later `get_subscription(local_id)` calls do not upgrade retention.
+
+A persistent hold is released only by force unsubscribe. For a `WhileReceivers` entry whose receiver
+count has already reached zero, `get_subscription(local_id)` returns not found instead of reopening
+the old generation; issue the original subscription request again to create a new generation.
+
+[`SubscriptionRetentionPolicy`]: crate::SubscriptionRetentionPolicy
 
 ### Subscription Lifecycle
 
@@ -141,6 +181,7 @@ Subscription Request Lifecycle:
 1. The **service** assigns a `local_id` to the subscription, creates a
    subscription broadcast channel, and stores the relevant information in its
    `SubscriptionManager`.
+1. Typed waiters receive a local receiver directly; legacy waiters create named manual claims.
 1. The **service** overwrites the JSON RPC response with the `local_id`.
 1. The **service** sends a response with each waiter's original JSON-RPC request ID via its oneshot.
 
@@ -148,6 +189,9 @@ Subscription Notification Lifecycle
 
 1. The RPC server sends a notification to the **backend**.
 1. The **backend** sends the notification to the **service**.
-1. The **service** looks up the `local_id` in its `SubscriptionManager`.
-1. If present, the **service** sends the notification to the relevant channel.
+1. The **service** maps the notification's `server_id` to its stable
+   `local_id` in its `SubscriptionManager`.
+1. If present and locally owned, the **service** sends the notification to the relevant channel.
+   1. If no receiver or persistent hold remains, the **service** removes the entry and starts
+      upstream cleanup instead.
    1. Otherwise, the **service** ignores the notification.

--- a/crates/pubsub/README.md
+++ b/crates/pubsub/README.md
@@ -23,7 +23,7 @@ The PubSub system here consists of 3 logical parts:
 - The **backend** is an actively running connection to the server. Users
   should NEVER instantiate a backend directly. Instead, they should use
   [`PubSubConnect::into_service`] for some connection object. Backends
-  are responsible for managing the connection to the server, accepting user
+  are responsible for managing the connection to the server,accepting user
   requests from the **service** and forwarding server responses to the
   **service**.
 
@@ -53,8 +53,9 @@ This crate provides the following:
   into the expected type, and allows the user to accept or discard unexpected
   responses.
 - [`SubscriptionItem`]: An item in a typed [`Subscription`]. This type is
-  yielded by the subscription via the `recv_any()` API. It contains the
-  deserialized item, or the raw JSON value if deserialization fails.
+  yielded by the subscription via the `recv_any()` API a notification is
+  received and contains the deserialized item. If deserialization fails, it
+  contains the raw JSON value.
 
 ## On Handling Subscriptions
 
@@ -62,44 +63,29 @@ For a normal request, the user sends a request to the **frontend**, and
 later receives a response via a tokio oneshot channel. This is straightforward
 and easy to reason about. Subscriptions, however, are side-effects of other
 requests, and are long-lived. They are managed by the **service** and
-identified locally by a `B256`. This value is a params-derived alias: it is the
-Keccak-256 hash of the serialized parameters and does not include the method.
-Requests with identical parameters therefore share an alias, including custom
-subscription methods with different names. The service uses this ID to manage
-the subscription lifecycle and dispatch notifications to receivers.
+identified by a local `B256` id. The **service** uses this id to manage the
+subscription lifecycle, and to dispatch notifications to the correct
+subscribers.
 
 ### Server & Local IDs
 
 When a user issues a subscription request, the **frontend** sends a
 subscription request to the **service**. The **service** dispatches it to the
 RPC server via the **backend**. The **service** then intercepts the RPC server
-response containing the server ID and assigns a stable `B256` `local_id` to
-the subscription. Server IDs are represented by [`alloy_json_rpc::SubId`] and
-may be numeric or strings. The `local_id` identifies the subscription in the
-**service** and consumer tasks, while the current `server_id` associates
-notifications with the server-side subscription.
+response containing the server id, and assigns a `local_id` to the subscription.
+This `local_id` is used to identify the subscription in the **service** and in
+tasks consuming the subscription, while the `server_id` is used to identify the
+subscription to the RPC server, and to associate notifications with specific
+active subscriptions.
 
-This allows the service to keep the consumer-facing `local_id` stable while the
-server ID changes across reconnections.
+This allows us to use long-lived `local_id` values to manage subscriptions over
+multiple reconnections, without having to notify frontend users of the ID change
+when the server connection is lost. It also prevents race conditions when
+unsubscribing during or immediately after a reconnection.
 
-### Reconnection, replay, and cancellation
-
-After a retryable established-backend failure, the service attempts reconnection under its
-configured retry policy; non-retryable failures terminate it immediately. Following a successful
-reconnect, it re-sends every
-request still awaiting a response and re-creates active subscriptions. If the
-server processed a request but its response was lost, that request may execute
-more than once. Do not rely on at-most-once execution for non-idempotent methods.
-
-Dropping a request future stops waiting locally, but does not cancel a request
-already accepted by the service. Likewise, dropping a [`RawSubscription`] or
-[`Subscription`] only drops that receiver; it does not send
-`eth_unsubscribe`. Call [`PubSubFrontend::unsubscribe`] with the local ID when
-the server-side subscription is no longer needed. `unsubscribe` only queues
-the instruction and does not wait for the server's response. It is best effort:
-an unsubscribe processed while reconnection is re-creating the subscription can
-race with the replacement response, so it is not confirmation of server-side
-teardown.
+The local ID is derived from the complete subscription method and exact serialized params. Calls
+with the same method and params share one server subscription and receive independent local
+broadcast receivers. Calls with different methods never alias merely because their params match.
 
 ### What is a subscription request?
 
@@ -111,9 +97,22 @@ on unknown methods, the `Request`, `SerializedRequest` and `RpcCall` expose
 `set_is_subscription()`, which can be used to mark any given request as a
 subscription.
 
-When marking a request as a subscription, the **service** will intercept the
-RPC response, which must deserialize as an [`alloy_json_rpc::SubId`] (a numeric
-or string ID). Other response types will fail deserialization.
+When marking a request as a subscription, also configure the matching cleanup RPC with
+`RpcCall::set_unsubscribe_method()` when the protocol provides one. Custom subscription protocols
+do not share a universal naming convention, so the service does not guess or fall back to
+`eth_unsubscribe`. A custom subscription without a configured cleanup method can only be reclaimed
+when its connection closes.
+
+The **service** intercepts the RPC response, which must contain a numeric or string subscription
+ID. Other response types will not function as subscriptions.
+
+The service reserves string request IDs beginning with `alloy-pubsub:` for resubscribe and cleanup
+traffic. Manually constructed requests must not use that prefix.
+
+`PubSubFrontend::unsubscribe()` retains its enqueue-only behavior. Use
+`PubSubFrontend::unsubscribe_and_wait()` when the caller needs to observe server confirmation,
+server-reported absence, an RPC error, or connection-level cleanup. Both methods are force
+operations: they close all local receivers sharing the same method and params.
 
 ### Subscription Lifecycle
 
@@ -134,8 +133,8 @@ Subscription Request Lifecycle:
 1. The user issues a subscription request to the **frontend**.
 1. The **frontend** sends the request to the **service**, with a oneshot channel
    to receive the response.
-1. The **service** stores the oneshot channel in its `RequestManager`.
-1. The **service** sends the request to the **backend**.
+1. The **service** joins the request to an existing matching single-flight, or creates one and sends
+   a single request to the **backend**.
 1. The **backend** sends the request to the RPC server.
 1. The RPC server responds with a numeric or string `server_id`.
 1. The **backend** sends the response to the **service**.
@@ -143,13 +142,12 @@ Subscription Request Lifecycle:
    subscription broadcast channel, and stores the relevant information in its
    `SubscriptionManager`.
 1. The **service** overwrites the JSON RPC response with the `local_id`.
-1. The **service** sends the response to the waiting task via the oneshot.
+1. The **service** sends a response with each waiter's original JSON-RPC request ID via its oneshot.
 
 Subscription Notification Lifecycle
 
 1. The RPC server sends a notification to the **backend**.
 1. The **backend** sends the notification to the **service**.
-1. The **service** maps the notification's `server_id` to its stable
-   `local_id`.
+1. The **service** looks up the `local_id` in its `SubscriptionManager`.
 1. If present, the **service** sends the notification to the relevant channel.
    1. Otherwise, the **service** ignores the notification.

--- a/crates/pubsub/src/frontend.rs
+++ b/crates/pubsub/src/frontend.rs
@@ -1,4 +1,4 @@
-use crate::{ix::PubSubInstruction, managers::InFlight, RawSubscription};
+use crate::{ix::PubSubInstruction, managers::InFlight, RawSubscription, UnsubscribeOutcome};
 use alloy_json_rpc::{RequestPacket, Response, ResponsePacket, SerializedRequest};
 use alloy_primitives::B256;
 use alloy_transport::{TransportError, TransportErrorKind, TransportFut, TransportResult};
@@ -49,11 +49,26 @@ impl PubSubFrontend {
         }
     }
 
-    /// Unsubscribe from a subscription.
+    /// Force-unsubscribe a subscription, closing all local receivers sharing its key.
     pub fn unsubscribe(&self, id: B256) -> TransportResult<()> {
         self.tx
             .send(PubSubInstruction::Unsubscribe(id))
             .map_err(|_| TransportErrorKind::backend_gone())
+    }
+
+    /// Unsubscribe and wait until the server confirms cleanup or the owning connection closes.
+    pub fn unsubscribe_and_wait(
+        &self,
+        id: B256,
+    ) -> impl Future<Output = TransportResult<UnsubscribeOutcome>> + Send + 'static {
+        let backend_tx = self.tx.clone();
+        async move {
+            let (tx, rx) = oneshot::channel();
+            backend_tx
+                .send(PubSubInstruction::UnsubscribeAndWait(id, tx))
+                .map_err(|_| TransportErrorKind::backend_gone())?;
+            rx.await.map_err(|_| TransportErrorKind::backend_gone())?
+        }
     }
 
     /// Send a request.
@@ -104,9 +119,9 @@ impl PubSubFrontend {
     /// Set the channel size. This is the number of items to buffer in new
     /// subscription channels. Defaults to 16. See
     /// [`tokio::sync::broadcast`] for a description of relevant
-    /// behavior.
+    /// behavior. A zero capacity is rejected as a local usage error when a
+    /// subscription request is sent.
     pub fn set_channel_size(&self, channel_size: usize) {
-        debug_assert_ne!(channel_size, 0, "channel size must be non-zero");
         self.channel_size.store(channel_size, Ordering::Relaxed);
     }
 }

--- a/crates/pubsub/src/frontend.rs
+++ b/crates/pubsub/src/frontend.rs
@@ -32,7 +32,10 @@ impl PubSubFrontend {
         Self { tx, channel_size: Arc::new(AtomicUsize::new(16)) }
     }
 
-    /// Get the subscription ID for a local ID.
+    /// Get a legacy/manual receiver claim for a local subscription ID.
+    ///
+    /// This does not add a persistent hold or reopen a receiver-scoped generation that the service
+    /// has already observed at zero receivers.
     pub fn get_subscription(
         &self,
         id: B256,

--- a/crates/pubsub/src/frontend.rs
+++ b/crates/pubsub/src/frontend.rs
@@ -32,7 +32,10 @@ impl PubSubFrontend {
         Self { tx, channel_size: Arc::new(AtomicUsize::new(16)) }
     }
 
-    /// Get the subscription ID for a local ID.
+    /// Get a legacy/manual receiver claim for a local subscription ID.
+    ///
+    /// This does not add a persistent hold or reopen a receiver-scoped generation that the service
+    /// has already observed at zero receivers.
     pub fn get_subscription(
         &self,
         id: B256,
@@ -49,7 +52,12 @@ impl PubSubFrontend {
         }
     }
 
-    /// Force-unsubscribe a subscription, closing all local receivers sharing its key.
+    /// Queue a force-unsubscribe instruction for a local subscription ID.
+    ///
+    /// The service closes all local receivers sharing the subscription's key.
+    /// A successful return only means the instruction was queued; it does not
+    /// confirm server-side teardown. Use [`Self::unsubscribe_and_wait`] to
+    /// observe the cleanup outcome.
     pub fn unsubscribe(&self, id: B256) -> TransportResult<()> {
         self.tx
             .send(PubSubInstruction::Unsubscribe(id))

--- a/crates/pubsub/src/frontend.rs
+++ b/crates/pubsub/src/frontend.rs
@@ -1,4 +1,4 @@
-use crate::{ix::PubSubInstruction, managers::InFlight, RawSubscription};
+use crate::{ix::PubSubInstruction, managers::InFlight, RawSubscription, UnsubscribeOutcome};
 use alloy_json_rpc::{RequestPacket, Response, ResponsePacket, SerializedRequest};
 use alloy_primitives::B256;
 use alloy_transport::{TransportError, TransportErrorKind, TransportFut, TransportResult};
@@ -49,19 +49,26 @@ impl PubSubFrontend {
         }
     }
 
-    /// Queue an unsubscribe instruction for a local subscription ID.
-    ///
-    /// A successful return means the instruction was sent to the pubsub
-    /// service. It does not wait for the server's `eth_unsubscribe` response.
-    /// Dropping a [`RawSubscription`] does not call this automatically. This is
-    /// best effort: during reconnection it can race with a replacement
-    /// subscription response, so success does not confirm server-side teardown.
-    ///
-    /// [`RawSubscription`]: crate::RawSubscription
+    /// Force-unsubscribe a subscription, closing all local receivers sharing its key.
     pub fn unsubscribe(&self, id: B256) -> TransportResult<()> {
         self.tx
             .send(PubSubInstruction::Unsubscribe(id))
             .map_err(|_| TransportErrorKind::backend_gone())
+    }
+
+    /// Unsubscribe and wait until the server confirms cleanup or the owning connection closes.
+    pub fn unsubscribe_and_wait(
+        &self,
+        id: B256,
+    ) -> impl Future<Output = TransportResult<UnsubscribeOutcome>> + Send + 'static {
+        let backend_tx = self.tx.clone();
+        async move {
+            let (tx, rx) = oneshot::channel();
+            backend_tx
+                .send(PubSubInstruction::UnsubscribeAndWait(id, tx))
+                .map_err(|_| TransportErrorKind::backend_gone())?;
+            rx.await.map_err(|_| TransportErrorKind::backend_gone())?
+        }
     }
 
     /// Send a request.
@@ -112,9 +119,9 @@ impl PubSubFrontend {
     /// Set the channel size. This is the number of items to buffer in new
     /// subscription channels. Defaults to 16. See
     /// [`tokio::sync::broadcast`] for a description of relevant
-    /// behavior.
+    /// behavior. A zero capacity is rejected as a local usage error when a
+    /// subscription request is sent.
     pub fn set_channel_size(&self, channel_size: usize) {
-        debug_assert_ne!(channel_size, 0, "channel size must be non-zero");
         self.channel_size.store(channel_size, Ordering::Relaxed);
     }
 }

--- a/crates/pubsub/src/ix.rs
+++ b/crates/pubsub/src/ix.rs
@@ -1,5 +1,6 @@
-use crate::{managers::InFlight, RawSubscription};
+use crate::{managers::InFlight, RawSubscription, UnsubscribeOutcome};
 use alloy_primitives::B256;
+use alloy_transport::TransportResult;
 use std::fmt;
 use tokio::sync::oneshot;
 
@@ -11,6 +12,8 @@ pub enum PubSubInstruction {
     GetSub(B256, oneshot::Sender<Option<RawSubscription>>),
     /// Unsubscribe from a subscription.
     Unsubscribe(B256),
+    /// Unsubscribe and wait for the server-side cleanup to reach a terminal state.
+    UnsubscribeAndWait(B256, oneshot::Sender<TransportResult<UnsubscribeOutcome>>),
 }
 
 impl fmt::Debug for PubSubInstruction {
@@ -19,6 +22,9 @@ impl fmt::Debug for PubSubInstruction {
             Self::Request(arg0) => f.debug_tuple("Request").field(arg0).finish(),
             Self::GetSub(arg0, _) => f.debug_tuple("GetSub").field(arg0).finish(),
             Self::Unsubscribe(arg0) => f.debug_tuple("Unsubscribe").field(arg0).finish(),
+            Self::UnsubscribeAndWait(arg0, _) => {
+                f.debug_tuple("UnsubscribeAndWait").field(arg0).finish()
+            }
         }
     }
 }

--- a/crates/pubsub/src/lib.rs
+++ b/crates/pubsub/src/lib.rs
@@ -16,7 +16,10 @@ mod frontend;
 pub use frontend::PubSubFrontend;
 
 mod options;
-pub use options::{SubscriptionOptions, UnsubscribeOutcome};
+pub use options::{
+    SubscriptionOptions, SubscriptionReceiverTicket, SubscriptionRetentionPolicy,
+    UnsubscribeOutcome,
+};
 
 mod ix;
 pub use ix::PubSubInstruction;

--- a/crates/pubsub/src/lib.rs
+++ b/crates/pubsub/src/lib.rs
@@ -15,6 +15,9 @@ pub use connect::PubSubConnect;
 mod frontend;
 pub use frontend::PubSubFrontend;
 
+mod options;
+pub use options::{SubscriptionOptions, UnsubscribeOutcome};
+
 mod ix;
 pub use ix::PubSubInstruction;
 

--- a/crates/pubsub/src/managers/active_sub.rs
+++ b/crates/pubsub/src/managers/active_sub.rs
@@ -3,17 +3,21 @@ use alloy_json_rpc::SerializedRequest;
 use alloy_primitives::B256;
 use parking_lot::Mutex;
 use serde_json::value::RawValue;
-use std::{fmt, hash::Hash, ops::DerefMut};
+use std::{borrow::Cow, fmt, ops::DerefMut};
 use tokio::sync::broadcast;
 
 /// An active subscription.
 pub(crate) struct ActiveSubscription {
-    /// Cached hash of the request, used for sorting and equality.
+    /// Subscription identity and public alias.
     pub(crate) local_id: B256,
     /// The serialized subscription request.
     pub(crate) request: SerializedRequest,
     /// The channel via which notifications are broadcast.
     pub(crate) tx: broadcast::Sender<Box<RawValue>>,
+    /// The configured channel capacity.
+    pub(crate) channel_size: usize,
+    /// The server-side cleanup method.
+    pub(crate) unsubscribe_method: Option<Cow<'static, str>>,
     /// The initial channel via which notifications are received.
     ///
     /// This is stored so that we don't drop any notifications between initializing
@@ -24,39 +28,13 @@ pub(crate) struct ActiveSubscription {
     pub(crate) rx: Mutex<Option<broadcast::Receiver<Box<RawValue>>>>,
 }
 
-// NB: We implement this to prevent any incorrect future implementations.
-// See: https://doc.rust-lang.org/std/hash/trait.Hash.html#hash-and-eq
-impl Hash for ActiveSubscription {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.local_id.hash(state);
-    }
-}
-
-impl PartialEq for ActiveSubscription {
-    fn eq(&self, other: &Self) -> bool {
-        self.local_id == other.local_id
-    }
-}
-
-impl Eq for ActiveSubscription {}
-
-impl PartialOrd for ActiveSubscription {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for ActiveSubscription {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.local_id.cmp(&other.local_id)
-    }
-}
-
 impl fmt::Debug for ActiveSubscription {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ActiveSubscription")
             .field("local_id", &self.local_id)
             .field("request", &self.request)
+            .field("channel_size", &self.channel_size)
+            .field("unsubscribe_method", &self.unsubscribe_method)
             .field("subscribers", &self.tx.receiver_count())
             .finish()
     }
@@ -64,10 +42,14 @@ impl fmt::Debug for ActiveSubscription {
 
 impl ActiveSubscription {
     /// Create a new active subscription.
-    pub(crate) fn new(request: SerializedRequest, channel_size: usize) -> Self {
-        let local_id = request.params_hash();
+    pub(crate) fn new(
+        local_id: B256,
+        request: SerializedRequest,
+        channel_size: usize,
+        unsubscribe_method: Option<Cow<'static, str>>,
+    ) -> Self {
         let (tx, rx) = broadcast::channel(channel_size);
-        Self { request, local_id, tx, rx: Mutex::new(Some(rx)) }
+        Self { request, local_id, tx, channel_size, unsubscribe_method, rx: Mutex::new(Some(rx)) }
     }
 
     /// Serialize the request as a boxed [`RawValue`].

--- a/crates/pubsub/src/managers/active_sub.rs
+++ b/crates/pubsub/src/managers/active_sub.rs
@@ -1,9 +1,8 @@
 use crate::RawSubscription;
 use alloy_json_rpc::SerializedRequest;
 use alloy_primitives::B256;
-use parking_lot::Mutex;
 use serde_json::value::RawValue;
-use std::{borrow::Cow, fmt, ops::DerefMut};
+use std::{borrow::Cow, collections::VecDeque, fmt};
 use tokio::sync::broadcast;
 
 /// An active subscription.
@@ -18,14 +17,10 @@ pub(crate) struct ActiveSubscription {
     pub(crate) channel_size: usize,
     /// The server-side cleanup method.
     pub(crate) unsubscribe_method: Option<Cow<'static, str>>,
-    /// The initial channel via which notifications are received.
-    ///
-    /// This is stored so that we don't drop any notifications between initializing
-    /// using [`ActiveSubscription::new`] and [`ActiveSubscription::subscribe`]. Ref: <https://github.com/alloy-rs/alloy/issues/2187>
-    ///
-    /// This is wrapped in a [`Mutex`] to allow for mutable access to the receiver without making
-    /// [`ActiveSubscription::subscribe`] require mutable self.
-    pub(crate) rx: Mutex<Option<broadcast::Receiver<Box<RawValue>>>>,
+    /// Receivers awaiting a legacy two-phase `get_subscription` claim.
+    manual_claims: VecDeque<RawSubscription>,
+    /// Whether explicit unsubscribe is required even when no receiver remains.
+    persistent_hold: bool,
 }
 
 impl fmt::Debug for ActiveSubscription {
@@ -36,6 +31,8 @@ impl fmt::Debug for ActiveSubscription {
             .field("channel_size", &self.channel_size)
             .field("unsubscribe_method", &self.unsubscribe_method)
             .field("subscribers", &self.tx.receiver_count())
+            .field("manual_claims", &self.manual_claims.len())
+            .field("persistent_hold", &self.persistent_hold)
             .finish()
     }
 }
@@ -47,9 +44,21 @@ impl ActiveSubscription {
         request: SerializedRequest,
         channel_size: usize,
         unsubscribe_method: Option<Cow<'static, str>>,
-    ) -> Self {
+    ) -> (Self, RawSubscription) {
         let (tx, rx) = broadcast::channel(channel_size);
-        Self { request, local_id, tx, channel_size, unsubscribe_method, rx: Mutex::new(Some(rx)) }
+        let initial = RawSubscription { rx, local_id };
+        (
+            Self {
+                request,
+                local_id,
+                tx,
+                channel_size,
+                unsubscribe_method,
+                manual_claims: VecDeque::new(),
+                persistent_hold: false,
+            },
+            initial,
+        )
     }
 
     /// Serialize the request as a boxed [`RawValue`].
@@ -61,20 +70,40 @@ impl ActiveSubscription {
 
     /// Get a subscription.
     pub(crate) fn subscribe(&self) -> RawSubscription {
-        if self.tx.is_empty() {
-            // If there are no pending notifications, we can subscribe directly and return a new
-            // subscriber.
-            return RawSubscription { rx: self.tx.subscribe(), local_id: self.local_id };
-        }
+        RawSubscription { rx: self.tx.subscribe(), local_id: self.local_id }
+    }
 
-        // If there are pending notifications, we need to ensure that they are not dropped.
-        // Hence, we first try to return the initial receiver (if it exists), which will receive
-        // those pending notifications.
-        // Ref: <https://github.com/alloy-rs/alloy/issues/2187>
-        RawSubscription {
-            rx: self.rx.lock().deref_mut().take().unwrap_or_else(|| self.tx.subscribe()),
-            local_id: self.local_id,
-        }
+    pub(crate) fn push_manual_claim(&mut self, subscription: RawSubscription) {
+        self.manual_claims.push_back(subscription);
+    }
+
+    pub(crate) fn pop_manual_claim(&mut self) -> Option<RawSubscription> {
+        self.manual_claims.pop_front()
+    }
+
+    pub(crate) fn restore_manual_claim(&mut self, subscription: RawSubscription) {
+        self.manual_claims.push_front(subscription);
+    }
+
+    pub(crate) const fn commit_persistent_hold(&mut self) {
+        self.persistent_hold = true;
+    }
+
+    pub(crate) const fn has_persistent_hold(&self) -> bool {
+        self.persistent_hold
+    }
+
+    pub(crate) fn receiver_count(&self) -> usize {
+        self.tx.receiver_count()
+    }
+
+    pub(crate) fn should_auto_cleanup(&self) -> bool {
+        !self.has_persistent_hold() && self.receiver_count() == 0
+    }
+
+    #[cfg(test)]
+    pub(crate) fn manual_claim_count(&self) -> usize {
+        self.manual_claims.len()
     }
 
     /// Notify the subscription channel of a new value, if any receiver exists.

--- a/crates/pubsub/src/managers/in_flight.rs
+++ b/crates/pubsub/src/managers/in_flight.rs
@@ -1,4 +1,4 @@
-use crate::SubscriptionOptions;
+use crate::{SubscriptionOptions, SubscriptionReceiverTicket, SubscriptionRetentionPolicy};
 use alloy_json_rpc::{Response, ResponsePayload, SerializedRequest, SubId};
 use alloy_transport::{TransportError, TransportResult};
 use std::{borrow::Cow, fmt};
@@ -18,6 +18,12 @@ pub struct InFlight {
     /// The method used to remove the server-side subscription.
     pub(crate) unsubscribe_method: Option<Cow<'static, str>>,
 
+    /// One-shot receiver delivery for the typed provider path.
+    pub(crate) receiver_ticket: Option<SubscriptionReceiverTicket>,
+
+    /// The retention requested by this waiter.
+    pub(crate) retention_policy: SubscriptionRetentionPolicy,
+
     /// The channel to send the response on.
     pub tx: oneshot::Sender<TransportResult<Response>>,
 }
@@ -28,6 +34,8 @@ impl fmt::Debug for InFlight {
             .field("request", &self.request)
             .field("channel_size", &self.channel_size)
             .field("unsubscribe_method", &self.unsubscribe_method)
+            .field("typed", &self.receiver_ticket.is_some())
+            .field("retention_policy", &self.retention_policy)
             .field("tx_is_closed", &self.tx.is_closed())
             .finish()
     }
@@ -36,21 +44,46 @@ impl fmt::Debug for InFlight {
 impl InFlight {
     /// Create a new in-flight request.
     pub fn new(
-        request: SerializedRequest,
+        mut request: SerializedRequest,
         default_channel_size: usize,
     ) -> (Self, oneshot::Receiver<TransportResult<Response>>) {
         let (tx, rx) = oneshot::channel();
+        let receiver_ticket =
+            request.meta_mut().extensions_mut().remove::<SubscriptionReceiverTicket>();
         let options = request.meta().extensions().get::<SubscriptionOptions>();
         let channel_size =
             options.and_then(SubscriptionOptions::channel_size).unwrap_or(default_channel_size);
         let unsubscribe_method = options.and_then(SubscriptionOptions::unsubscribe_method_owned);
+        let retention_policy = options.and_then(SubscriptionOptions::retention_policy).unwrap_or(
+            if receiver_ticket.is_some() {
+                SubscriptionRetentionPolicy::WhileReceivers
+            } else {
+                SubscriptionRetentionPolicy::UntilExplicitUnsubscribe
+            },
+        );
 
-        (Self { request, channel_size, unsubscribe_method, tx }, rx)
+        (
+            Self {
+                request,
+                channel_size,
+                unsubscribe_method,
+                receiver_ticket,
+                retention_policy,
+                tx,
+            },
+            rx,
+        )
     }
 
     /// Check if the request is a subscription.
     pub fn is_subscription(&self) -> bool {
         self.request.is_subscription()
+    }
+
+    /// Returns whether the caller can still receive both subscription ownership and its response.
+    pub(crate) fn is_live_subscription_waiter(&self) -> bool {
+        !self.tx.is_closed()
+            && self.receiver_ticket.as_ref().is_none_or(|ticket| !ticket.is_closed())
     }
 
     /// Get a reference to the serialized request.
@@ -79,5 +112,26 @@ impl InFlight {
 
         let _ = self.tx.send(Ok(resp));
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_json_rpc::{Id, Request};
+
+    #[test]
+    fn typed_and_manual_requests_have_distinct_retention_defaults() {
+        let raw = Request::new("eth_subscribe", Id::Number(1), ("newHeads",)).serialize().unwrap();
+        let (raw, _rx) = InFlight::new(raw, 16);
+        assert_eq!(raw.retention_policy, SubscriptionRetentionPolicy::UntilExplicitUnsubscribe);
+
+        let mut typed =
+            Request::new("eth_subscribe", Id::Number(2), ("newHeads",)).serialize().unwrap();
+        let (ticket, _subscription_rx) = SubscriptionReceiverTicket::channel();
+        typed.meta_mut().extensions_mut().insert(ticket);
+        let (typed, _rx) = InFlight::new(typed, 16);
+        assert_eq!(typed.retention_policy, SubscriptionRetentionPolicy::WhileReceivers);
+        assert!(typed.request.meta().extensions().get::<SubscriptionReceiverTicket>().is_none());
     }
 }

--- a/crates/pubsub/src/managers/in_flight.rs
+++ b/crates/pubsub/src/managers/in_flight.rs
@@ -1,6 +1,7 @@
+use crate::SubscriptionOptions;
 use alloy_json_rpc::{Response, ResponsePayload, SerializedRequest, SubId};
 use alloy_transport::{TransportError, TransportResult};
-use std::fmt;
+use std::{borrow::Cow, fmt};
 use tokio::sync::oneshot;
 
 /// An in-flight JSON-RPC request.
@@ -14,6 +15,9 @@ pub struct InFlight {
     /// The number of items to buffer in the subscription channel.
     pub channel_size: usize,
 
+    /// The method used to remove the server-side subscription.
+    pub(crate) unsubscribe_method: Option<Cow<'static, str>>,
+
     /// The channel to send the response on.
     pub tx: oneshot::Sender<TransportResult<Response>>,
 }
@@ -23,6 +27,7 @@ impl fmt::Debug for InFlight {
         f.debug_struct("InFlight")
             .field("request", &self.request)
             .field("channel_size", &self.channel_size)
+            .field("unsubscribe_method", &self.unsubscribe_method)
             .field("tx_is_closed", &self.tx.is_closed())
             .finish()
     }
@@ -32,11 +37,15 @@ impl InFlight {
     /// Create a new in-flight request.
     pub fn new(
         request: SerializedRequest,
-        channel_size: usize,
+        default_channel_size: usize,
     ) -> (Self, oneshot::Receiver<TransportResult<Response>>) {
         let (tx, rx) = oneshot::channel();
+        let options = request.meta().extensions().get::<SubscriptionOptions>();
+        let channel_size =
+            options.and_then(SubscriptionOptions::channel_size).unwrap_or(default_channel_size);
+        let unsubscribe_method = options.and_then(SubscriptionOptions::unsubscribe_method_owned);
 
-        (Self { request, channel_size, tx }, rx)
+        (Self { request, channel_size, unsubscribe_method, tx }, rx)
     }
 
     /// Check if the request is a subscription.

--- a/crates/pubsub/src/managers/sub.rs
+++ b/crates/pubsub/src/managers/sub.rs
@@ -1,7 +1,7 @@
-use crate::{managers::ActiveSubscription, RawSubscription};
-use alloy_json_rpc::{EthNotification, SerializedRequest, SubId};
+use crate::managers::ActiveSubscription;
+use alloy_json_rpc::{EthNotification, SubId};
 use alloy_primitives::B256;
-use std::{borrow::Cow, collections::BTreeMap};
+use std::collections::BTreeMap;
 
 #[derive(Debug, Default)]
 pub(crate) struct SubscriptionManager {
@@ -23,15 +23,8 @@ impl SubscriptionManager {
     }
 
     /// Insert a subscription.
-    pub(crate) fn insert(
-        &mut self,
-        local_id: B256,
-        request: SerializedRequest,
-        server_id: SubId,
-        channel_size: usize,
-        unsubscribe_method: Option<Cow<'static, str>>,
-    ) {
-        let active = ActiveSubscription::new(local_id, request, channel_size, unsubscribe_method);
+    pub(crate) fn insert(&mut self, active: ActiveSubscription, server_id: SubId) {
+        let local_id = active.local_id;
         let previous_server = self.servers.insert(server_id, local_id);
         debug_assert!(previous_server.is_none(), "server subscription id must not be overwritten");
         let previous = self.subscriptions.insert(local_id, active);
@@ -84,13 +77,12 @@ impl SubscriptionManager {
         }
     }
 
-    /// Get a receiver for a subscription.
-    pub(crate) fn get_subscription(&self, local_id: B256) -> Option<RawSubscription> {
-        self.get(&local_id).map(ActiveSubscription::subscribe)
-    }
-
     pub(crate) fn get(&self, local_id: &B256) -> Option<&ActiveSubscription> {
         self.subscriptions.get(local_id)
+    }
+
+    pub(crate) fn get_mut(&mut self, local_id: &B256) -> Option<&mut ActiveSubscription> {
+        self.subscriptions.get_mut(local_id)
     }
 
     pub(crate) fn contains_server_id(&self, server_id: &SubId) -> bool {

--- a/crates/pubsub/src/managers/sub.rs
+++ b/crates/pubsub/src/managers/sub.rs
@@ -1,87 +1,76 @@
 use crate::{managers::ActiveSubscription, RawSubscription};
 use alloy_json_rpc::{EthNotification, SerializedRequest, SubId};
 use alloy_primitives::B256;
-use bimap::BiBTreeMap;
+use std::{borrow::Cow, collections::BTreeMap};
 
 #[derive(Debug, Default)]
 pub(crate) struct SubscriptionManager {
-    /// The subscriptions.
-    local_to_sub: BiBTreeMap<B256, ActiveSubscription>,
-    /// Tracks the CURRENT server id for a subscription.
-    local_to_server: BiBTreeMap<B256, SubId>,
+    /// Active subscriptions keyed by their local ID.
+    subscriptions: BTreeMap<B256, ActiveSubscription>,
+    /// Current server IDs to local IDs.
+    servers: BTreeMap<SubId, B256>,
 }
 
 impl SubscriptionManager {
     /// Get an iterator over the subscriptions.
     pub(crate) fn iter(&self) -> impl Iterator<Item = (&B256, &ActiveSubscription)> {
-        self.local_to_sub.iter()
+        self.subscriptions.iter()
     }
 
     /// Get the number of subscriptions.
     pub(crate) fn len(&self) -> usize {
-        self.local_to_sub.len()
+        self.subscriptions.len()
     }
 
     /// Insert a subscription.
-    fn insert(
+    pub(crate) fn insert(
         &mut self,
+        local_id: B256,
         request: SerializedRequest,
         server_id: SubId,
         channel_size: usize,
-    ) -> RawSubscription {
-        let active = ActiveSubscription::new(request, channel_size);
-        let sub = active.subscribe();
-
-        let local_id = active.local_id;
-        self.local_to_server.insert(local_id, server_id);
-        self.local_to_sub.insert(local_id, active);
-
-        sub
+        unsubscribe_method: Option<Cow<'static, str>>,
+    ) {
+        let active = ActiveSubscription::new(local_id, request, channel_size, unsubscribe_method);
+        let previous_server = self.servers.insert(server_id, local_id);
+        debug_assert!(previous_server.is_none(), "server subscription id must not be overwritten");
+        let previous = self.subscriptions.insert(local_id, active);
+        debug_assert!(previous.is_none(), "active subscription must not be overwritten");
     }
 
-    /// Insert or update the server_id for a subscription.
-    pub(crate) fn upsert(
-        &mut self,
-        request: SerializedRequest,
-        server_id: SubId,
-        channel_size: usize,
-    ) -> RawSubscription {
-        let local_id = request.params_hash();
-
-        // If we already know a subscription with the exact params,
-        // we can just update the server_id and get a new listener.
-        if self.local_to_sub.contains_left(&local_id) {
-            self.change_server_id(local_id, server_id);
-            self.get_subscription(local_id).expect("checked existence")
-        } else {
-            self.insert(request, server_id, channel_size)
-        }
-    }
-
-    /// De-alias an alias, getting the original ID.
+    /// Get the local ID associated with a server ID.
     pub(crate) fn local_id_for(&self, server_id: &SubId) -> Option<B256> {
-        self.local_to_server.get_by_right(server_id).copied()
-    }
-
-    /// De-alias an alias, getting the original ID.
-    pub(crate) fn server_id_for(&self, local_id: &B256) -> Option<&SubId> {
-        self.local_to_server.get_by_left(local_id)
+        self.servers.get(server_id).copied()
     }
 
     /// Drop all server_ids.
     pub(crate) fn drop_server_ids(&mut self) {
-        self.local_to_server.clear();
+        self.servers.clear();
     }
 
-    /// Change the server_id of a subscription.
-    fn change_server_id(&mut self, local_id: B256, server_id: SubId) {
-        self.local_to_server.insert(local_id, server_id);
+    /// Associate a new server id with an existing subscription without overwriting another id.
+    pub(crate) fn set_server_id(&mut self, local_id: &B256, server_id: SubId) -> bool {
+        if !self.subscriptions.contains_key(local_id)
+            || self.server_id_for_local_id(local_id).is_some()
+            || self.servers.contains_key(&server_id)
+        {
+            return false;
+        }
+        self.servers.insert(server_id, *local_id);
+        true
     }
 
     /// Remove a subscription by its local_id.
-    pub(crate) fn remove_sub(&mut self, local_id: B256) {
-        let _ = self.local_to_sub.remove_by_left(&local_id);
-        let _ = self.local_to_server.remove_by_left(&local_id);
+    pub(crate) fn remove_sub(
+        &mut self,
+        local_id: B256,
+    ) -> Option<(ActiveSubscription, Option<SubId>)> {
+        let subscription = self.subscriptions.remove(&local_id)?;
+        let server_id = self.server_id_for_local_id(&local_id).cloned();
+        if let Some(server_id) = &server_id {
+            self.servers.remove(server_id);
+        }
+        Some((subscription, server_id))
     }
 
     /// Notify the subscription channel of a new value, if the sub is known,
@@ -89,7 +78,7 @@ impl SubscriptionManager {
     /// exists, the notification is dropped.
     pub(crate) fn notify(&mut self, notification: EthNotification) {
         if let Some(local_id) = self.local_id_for(&notification.subscription) {
-            if let Some(sub) = self.local_to_sub.get_by_left(&local_id) {
+            if let Some(sub) = self.get(&local_id) {
                 sub.notify(notification.result);
             }
         }
@@ -97,6 +86,20 @@ impl SubscriptionManager {
 
     /// Get a receiver for a subscription.
     pub(crate) fn get_subscription(&self, local_id: B256) -> Option<RawSubscription> {
-        self.local_to_sub.get_by_left(&local_id).map(ActiveSubscription::subscribe)
+        self.get(&local_id).map(ActiveSubscription::subscribe)
+    }
+
+    pub(crate) fn get(&self, local_id: &B256) -> Option<&ActiveSubscription> {
+        self.subscriptions.get(local_id)
+    }
+
+    pub(crate) fn contains_server_id(&self, server_id: &SubId) -> bool {
+        self.servers.contains_key(server_id)
+    }
+
+    pub(crate) fn server_id_for_local_id(&self, local_id: &B256) -> Option<&SubId> {
+        self.servers
+            .iter()
+            .find_map(|(server_id, candidate)| (candidate == local_id).then_some(server_id))
     }
 }

--- a/crates/pubsub/src/options.rs
+++ b/crates/pubsub/src/options.rs
@@ -1,0 +1,56 @@
+use std::borrow::Cow;
+
+/// Per-request configuration for a pubsub subscription.
+///
+/// This value is carried in the JSON-RPC request extensions and consumed by the pubsub service.
+/// It is never serialized onto the wire.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct SubscriptionOptions {
+    /// The requested local broadcast channel capacity.
+    channel_size: Option<usize>,
+    /// The RPC method used to clean up the server-side subscription.
+    unsubscribe_method: Option<Cow<'static, str>>,
+}
+
+impl SubscriptionOptions {
+    /// Returns the requested local broadcast channel capacity.
+    pub const fn channel_size(&self) -> Option<usize> {
+        self.channel_size
+    }
+
+    /// Sets the requested local broadcast channel capacity.
+    ///
+    /// A zero capacity is invalid and is rejected before wire dispatch.
+    pub const fn set_channel_size(&mut self, channel_size: usize) {
+        self.channel_size = Some(channel_size);
+    }
+
+    /// Returns the configured server-side unsubscribe method.
+    ///
+    /// `None` means the protocol provides no known cleanup RPC and the subscription can only be
+    /// reclaimed when its connection closes.
+    pub fn unsubscribe_method(&self) -> Option<&str> {
+        self.unsubscribe_method.as_deref()
+    }
+
+    /// Sets the server-side unsubscribe method.
+    pub fn set_unsubscribe_method(&mut self, method: impl Into<Cow<'static, str>>) {
+        self.unsubscribe_method = Some(method.into());
+    }
+
+    pub(crate) fn unsubscribe_method_owned(&self) -> Option<Cow<'static, str>> {
+        self.unsubscribe_method.clone()
+    }
+}
+
+/// The terminal result of a tracked server-side unsubscribe request.
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum UnsubscribeOutcome {
+    /// The server confirmed that the subscription was removed.
+    ServerConfirmed,
+    /// The server or local service reported that the subscription was already absent.
+    AlreadyAbsent,
+    /// The connection closed, which releases all subscriptions owned by that connection.
+    TransportClosed,
+}

--- a/crates/pubsub/src/options.rs
+++ b/crates/pubsub/src/options.rs
@@ -1,4 +1,54 @@
-use std::borrow::Cow;
+use crate::RawSubscription;
+use parking_lot::Mutex;
+use std::{borrow::Cow, fmt, sync::Arc};
+use tokio::sync::oneshot;
+
+/// Controls when a server-side subscription is eligible for automatic cleanup.
+///
+/// This enum defaults to [`Self::WhileReceivers`], matching typed provider builders.
+/// Low-level/manual subscription requests apply [`Self::UntilExplicitUnsubscribe`] as a separate
+/// compatibility default.
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum SubscriptionRetentionPolicy {
+    /// Keep the server-side subscription until it is explicitly unsubscribed.
+    UntilExplicitUnsubscribe,
+    /// Clean up the server-side subscription after its last local receiver is dropped.
+    #[default]
+    WhileReceivers,
+}
+
+/// A clone-safe, one-shot delivery ticket for a typed subscription receiver.
+///
+/// This is public only so the provider and RPC client crates can carry it through request
+/// metadata. It is not part of the user-facing subscription API.
+#[doc(hidden)]
+#[derive(Clone)]
+pub struct SubscriptionReceiverTicket(Arc<Mutex<Option<oneshot::Sender<RawSubscription>>>>);
+
+impl fmt::Debug for SubscriptionReceiverTicket {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SubscriptionReceiverTicket").field("closed", &self.is_closed()).finish()
+    }
+}
+
+impl SubscriptionReceiverTicket {
+    /// Creates a ticket and its receiving half.
+    #[doc(hidden)]
+    pub fn channel() -> (Self, oneshot::Receiver<RawSubscription>) {
+        let (tx, rx) = oneshot::channel();
+        (Self(Arc::new(Mutex::new(Some(tx)))), rx)
+    }
+
+    pub(crate) fn is_closed(&self) -> bool {
+        self.0.lock().as_ref().is_none_or(oneshot::Sender::is_closed)
+    }
+
+    pub(crate) fn send(&self, subscription: RawSubscription) -> Result<(), RawSubscription> {
+        let Some(tx) = self.0.lock().take() else { return Err(subscription) };
+        tx.send(subscription)
+    }
+}
 
 /// Per-request configuration for a pubsub subscription.
 ///
@@ -10,6 +60,8 @@ pub struct SubscriptionOptions {
     channel_size: Option<usize>,
     /// The RPC method used to clean up the server-side subscription.
     unsubscribe_method: Option<Cow<'static, str>>,
+    /// The requested retention behavior.
+    retention_policy: Option<SubscriptionRetentionPolicy>,
 }
 
 impl SubscriptionOptions {
@@ -38,6 +90,16 @@ impl SubscriptionOptions {
         self.unsubscribe_method = Some(method.into());
     }
 
+    /// Returns the configured retention policy.
+    pub const fn retention_policy(&self) -> Option<SubscriptionRetentionPolicy> {
+        self.retention_policy
+    }
+
+    /// Sets the retention policy for this subscription request.
+    pub const fn set_retention_policy(&mut self, policy: SubscriptionRetentionPolicy) {
+        self.retention_policy = Some(policy);
+    }
+
     pub(crate) fn unsubscribe_method_owned(&self) -> Option<Cow<'static, str>> {
         self.unsubscribe_method.clone()
     }
@@ -53,4 +115,17 @@ pub enum UnsubscribeOutcome {
     AlreadyAbsent,
     /// The connection closed, which releases all subscriptions owned by that connection.
     TransportClosed,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn retention_policy_default_matches_typed_option_a() {
+        assert_eq!(
+            SubscriptionRetentionPolicy::default(),
+            SubscriptionRetentionPolicy::WhileReceivers
+        );
+    }
 }

--- a/crates/pubsub/src/service.rs
+++ b/crates/pubsub/src/service.rs
@@ -1,8 +1,9 @@
 use crate::{
     handle::ConnectionHandle,
     ix::PubSubInstruction,
-    managers::{InFlight, RequestManager, SubscriptionManager},
-    PubSubConnect, PubSubFrontend, RawSubscription, UnsubscribeOutcome,
+    managers::{ActiveSubscription, InFlight, RequestManager, SubscriptionManager},
+    PubSubConnect, PubSubFrontend, RawSubscription, SubscriptionRetentionPolicy,
+    UnsubscribeOutcome,
 };
 use alloy_json_rpc::{
     Id, PubSubItem, Request, Response, ResponsePayload, RpcError, SerializedRequest, SubId,
@@ -23,6 +24,7 @@ use wasmtimer::tokio::sleep;
 use tokio::time::sleep;
 
 const MAX_RECONNECT_RETRY_INTERVAL: Duration = Duration::from_secs(30);
+const SUBSCRIPTION_SWEEP_INTERVAL: Duration = Duration::from_secs(30);
 
 type CleanupWaiter = oneshot::Sender<TransportResult<UnsubscribeOutcome>>;
 
@@ -184,7 +186,7 @@ impl<T: PubSubConnect> PubSubService<T> {
         let starting_local_ids = self.starting.keys().copied().collect::<Vec<_>>();
         for local_id in starting_local_ids {
             let has_live_waiter = self.starting.get_mut(&local_id).is_some_and(|starting| {
-                starting.waiters.retain(|waiter| !waiter.tx.is_closed());
+                starting.waiters.retain(InFlight::is_live_subscription_waiter);
                 !starting.waiters.is_empty()
             });
             if !has_live_waiter {
@@ -211,6 +213,17 @@ impl<T: PubSubConnect> PubSubService<T> {
         // Drop all server IDs. We'll re-insert them as we get responses.
         self.subs.drop_server_ids();
         self.reconnecting.clear();
+
+        let unowned = self
+            .subs
+            .iter()
+            .filter(|(_, sub)| sub.should_auto_cleanup())
+            .map(|(_, sub)| sub.local_id)
+            .collect::<Vec<_>>();
+        for local_id in unowned {
+            debug!(?local_id, "dropping unowned subscription during reconnect");
+            self.subs.remove_sub(local_id);
+        }
 
         // Dispatch all subscription requests.
         let active = self
@@ -305,7 +318,7 @@ impl<T: PubSubConnect> PubSubService<T> {
             return Ok(());
         }
 
-        if in_flight.tx.is_closed() {
+        if !in_flight.is_live_subscription_waiter() {
             return Ok(());
         }
 
@@ -339,9 +352,26 @@ impl<T: PubSubConnect> PubSubService<T> {
                 in_flight.channel_size,
                 unsubscribe_method.as_deref(),
             );
-            return Self::send_subscription_alias(in_flight, active.local_id);
+            if active.should_auto_cleanup() {
+                let local_id = active.local_id;
+                self.cleanup_unowned_subscription(local_id)?;
+            } else {
+                let active = self.subs.get_mut(&local_id).expect("checked above");
+                let subscription = active.subscribe();
+                Self::deliver_subscription_waiter(active, in_flight, subscription)?;
+                return Ok(());
+            }
         }
 
+        self.start_subscription(local_id, in_flight, unsubscribe_method)
+    }
+
+    fn start_subscription(
+        &mut self,
+        local_id: B256,
+        in_flight: InFlight,
+        unsubscribe_method: Option<Cow<'static, str>>,
+    ) -> TransportResult<()> {
         let wire_request_id = in_flight.request.id().clone();
         let request = in_flight.request.clone();
         let message = request.serialized().to_owned();
@@ -401,20 +431,100 @@ impl<T: PubSubConnect> PubSubService<T> {
         }
     }
 
-    fn send_subscription_alias(in_flight: InFlight, local_id: B256) -> TransportResult<()> {
-        let id = in_flight.request.id().clone();
-        let alias = to_json_raw_value(&local_id)?;
-        let _ = in_flight.tx.send(Ok(Response { id, payload: ResponsePayload::Success(alias) }));
+    fn deliver_subscription_waiter(
+        active: &mut ActiveSubscription,
+        in_flight: InFlight,
+        subscription: RawSubscription,
+    ) -> TransportResult<bool> {
+        if !in_flight.is_live_subscription_waiter() {
+            return Ok(false);
+        }
 
-        Ok(())
+        let id = in_flight.request.id().clone();
+        let retention_policy = in_flight.retention_policy;
+        let alias = to_json_raw_value(&active.local_id)?;
+        let response = Ok(Response { id, payload: ResponsePayload::Success(alias) });
+
+        let delivered = if let Some(ticket) = &in_flight.receiver_ticket {
+            let receiver_delivered = ticket.send(subscription).is_ok();
+            let response_delivered = in_flight.tx.send(response).is_ok();
+            receiver_delivered && response_delivered
+        } else if in_flight.tx.send(response).is_ok() {
+            active.push_manual_claim(subscription);
+            true
+        } else {
+            false
+        };
+
+        if delivered && retention_policy == SubscriptionRetentionPolicy::UntilExplicitUnsubscribe {
+            active.commit_persistent_hold();
+        }
+
+        Ok(delivered)
     }
 
     /// Service a GetSub instruction.
     ///
     /// If the subscription exists, the waiter is sent `Some` broadcast receiver. If
     /// the subscription does not exist, the waiter is sent `None`.
-    fn service_get_sub(&self, local_id: B256, tx: oneshot::Sender<Option<RawSubscription>>) {
-        let _ = tx.send(self.subs.get_subscription(local_id));
+    fn service_get_sub(
+        &mut self,
+        local_id: B256,
+        tx: oneshot::Sender<Option<RawSubscription>>,
+    ) -> TransportResult<()> {
+        let Some(active) = self.subs.get(&local_id) else {
+            let _ = tx.send(None);
+            return Ok(());
+        };
+        if active.should_auto_cleanup() {
+            self.cleanup_unowned_subscription(local_id)?;
+            let _ = tx.send(None);
+            return Ok(());
+        }
+
+        let active = self.subs.get_mut(&local_id).expect("checked above");
+        let (subscription, was_claim) = active
+            .pop_manual_claim()
+            .map_or_else(|| (active.subscribe(), false), |claim| (claim, true));
+        if let Err(Some(subscription)) = tx.send(Some(subscription)) {
+            if was_claim {
+                active.restore_manual_claim(subscription);
+            }
+        }
+        Ok(())
+    }
+
+    fn cleanup_unowned_subscription(&mut self, local_id: B256) -> TransportResult<()> {
+        let Some((subscription, server_id)) = self.subs.remove_sub(local_id) else { return Ok(()) };
+        debug_assert!(subscription.should_auto_cleanup());
+
+        if let Some(server_id) = server_id {
+            if let Some(unsubscribe_method) = subscription.unsubscribe_method {
+                return self.start_cleanup(server_id, unsubscribe_method, Vec::new());
+            }
+            warn!(
+                ?server_id,
+                "unowned subscription has no cleanup method; it will remain until connection close"
+            );
+            return Ok(());
+        }
+
+        self.reconnecting.remove(&subscription.local_id);
+        Ok(())
+    }
+
+    fn sweep_subscriptions(&mut self) -> TransportResult<()> {
+        let unowned = self
+            .subs
+            .iter()
+            .filter(|(_, subscription)| subscription.should_auto_cleanup())
+            .map(|(_, subscription)| subscription.local_id)
+            .collect::<Vec<_>>();
+        for local_id in unowned {
+            debug!(?local_id, "cleaning up subscription without local receivers");
+            self.cleanup_unowned_subscription(local_id)?;
+        }
+        Ok(())
     }
 
     /// Service an unsubscribe instruction.
@@ -466,10 +576,7 @@ impl<T: PubSubConnect> PubSubService<T> {
         trace!(?ix, "servicing instruction");
         match ix {
             PubSubInstruction::Request(in_flight) => self.service_request(in_flight),
-            PubSubInstruction::GetSub(alias, tx) => {
-                self.service_get_sub(alias, tx);
-                Ok(())
-            }
+            PubSubInstruction::GetSub(alias, tx) => self.service_get_sub(alias, tx),
             PubSubInstruction::Unsubscribe(alias) => self.service_unsubscribe(alias, None),
             PubSubInstruction::UnsubscribeAndWait(alias, tx) => {
                 self.service_unsubscribe(alias, Some(tx))
@@ -491,6 +598,13 @@ impl<T: PubSubConnect> PubSubService<T> {
                 }
             }
             PubSubItem::Notification(notification) => {
+                let local_id = self.subs.local_id_for(&notification.subscription);
+                if let Some(local_id) = local_id {
+                    if self.subs.get(&local_id).is_some_and(ActiveSubscription::should_auto_cleanup)
+                    {
+                        return self.cleanup_unowned_subscription(local_id);
+                    }
+                }
                 self.subs.notify(notification);
                 Ok(())
             }
@@ -533,7 +647,7 @@ impl<T: PubSubConnect> PubSubService<T> {
             .is_some_and(|starting| starting.wire_request_id == response_id);
         if is_expected_start {
             let mut starting = self.starting.remove(&local_id).expect("checked above");
-            starting.waiters.retain(|waiter| !waiter.tx.is_closed());
+            starting.waiters.retain(InFlight::is_live_subscription_waiter);
             if starting.waiters.is_empty() || self.subs.get(&local_id).is_some() {
                 return self.compensate_subscription(response_id, server_id, unsubscribe_method);
             }
@@ -547,30 +661,26 @@ impl<T: PubSubConnect> PubSubService<T> {
                 return Ok(());
             }
 
-            self.subs.insert(
+            let (mut active, initial_subscription) = ActiveSubscription::new(
                 local_id,
                 starting.request,
-                server_id.clone(),
                 starting.channel_size,
                 starting.unsubscribe_method,
             );
+            let mut initial_subscription = Some(initial_subscription);
             let mut delivered = false;
             for in_flight in starting.waiters {
-                let id = in_flight.request.id().clone();
-                let alias = to_json_raw_value(&local_id)?;
-                delivered |= in_flight
-                    .tx
-                    .send(Ok(Response { id, payload: ResponsePayload::Success(alias) }))
-                    .is_ok();
+                let subscription =
+                    initial_subscription.take().unwrap_or_else(|| active.subscribe());
+                delivered |=
+                    Self::deliver_subscription_waiter(&mut active, in_flight, subscription)?;
             }
-            if !delivered {
-                if let Some((subscription, _)) = self.subs.remove_sub(local_id) {
-                    if let Some(unsubscribe_method) = subscription.unsubscribe_method {
-                        self.start_cleanup(server_id, unsubscribe_method, Vec::new())?;
-                    } else {
-                        warn!(?server_id, "abandoned subscription has no cleanup method; it will remain until connection close");
-                    }
-                }
+            drop(initial_subscription);
+            if delivered {
+                self.subs.insert(active, server_id);
+            } else {
+                drop(active);
+                self.compensate_subscription(response_id, server_id, unsubscribe_method)?;
             }
             return Ok(());
         }
@@ -579,6 +689,10 @@ impl<T: PubSubConnect> PubSubService<T> {
             self.reconnecting.get(&local_id).is_some_and(|request_id| request_id == &response_id);
         if is_expected_reconnect {
             self.reconnecting.remove(&local_id);
+            if self.subs.get(&local_id).is_some_and(ActiveSubscription::should_auto_cleanup) {
+                self.subs.remove_sub(local_id);
+                return self.compensate_subscription(response_id, server_id, unsubscribe_method);
+            }
             if self.subs.set_server_id(&local_id, server_id.clone()) {
                 return Ok(());
             }
@@ -818,6 +932,8 @@ impl<T: PubSubConnect> PubSubService<T> {
     /// Spawn the service.
     pub(crate) fn spawn(mut self) {
         let fut = async move {
+            let sweep_timer = sleep(SUBSCRIPTION_SWEEP_INTERVAL);
+            tokio::pin!(sweep_timer);
             let result: TransportResult<()> = loop {
                 // We bias the loop so that we always handle new messages before
                 // reconnecting, and always reconnect before dispatching new
@@ -883,6 +999,22 @@ impl<T: PubSubConnect> PubSubService<T> {
                            break Ok(())
                         }
                     }
+
+                    _ = &mut sweep_timer => {
+                        sweep_timer.set(sleep(SUBSCRIPTION_SWEEP_INTERVAL));
+                        if let Err(err) = self.sweep_subscriptions() {
+                            if err
+                                .as_transport_err()
+                                .is_some_and(TransportErrorKind::is_backend_gone)
+                            {
+                                if let Err(e) = self.reconnect_with_retries().await {
+                                    break Err(e)
+                                }
+                            } else {
+                                break Err(err)
+                            }
+                        }
+                    }
                 }
             };
 
@@ -912,7 +1044,7 @@ fn reconnect_retry_interval(base_interval: Duration, retry_count: u32) -> Durati
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{ConnectionInterface, SubscriptionOptions};
+    use crate::{ConnectionInterface, SubscriptionOptions, SubscriptionReceiverTicket};
     use alloy_json_rpc::{Request, SerializedRequest};
     use std::{
         sync::{
@@ -980,6 +1112,30 @@ mod tests {
         request
     }
 
+    fn with_retention(
+        mut request: SerializedRequest,
+        retention_policy: SubscriptionRetentionPolicy,
+    ) -> SerializedRequest {
+        request
+            .meta_mut()
+            .extensions_mut()
+            .get_or_insert_default::<SubscriptionOptions>()
+            .set_retention_policy(retention_policy);
+        request
+    }
+
+    fn typed_in_flight(
+        mut request: SerializedRequest,
+        retention_policy: SubscriptionRetentionPolicy,
+    ) -> (InFlight, oneshot::Receiver<TransportResult<Response>>, oneshot::Receiver<RawSubscription>)
+    {
+        request = with_retention(request, retention_policy);
+        let (ticket, subscription_rx) = SubscriptionReceiverTicket::channel();
+        request.meta_mut().extensions_mut().insert(ticket);
+        let (in_flight, response_rx) = InFlight::new(request, 16);
+        (in_flight, response_rx, subscription_rx)
+    }
+
     fn subscription_response(id: Id, server_id: &str) -> Response {
         Response {
             id,
@@ -991,6 +1147,14 @@ mod tests {
 
     fn bool_response(id: Id, value: bool) -> Response {
         Response { id, payload: ResponsePayload::Success(to_json_raw_value(&value).unwrap()) }
+    }
+
+    fn notification(server_id: &str, value: serde_json::Value) -> PubSubItem {
+        alloy_json_rpc::EthNotification {
+            subscription: SubId::String(server_id.to_owned()),
+            result: to_json_raw_value(&value).unwrap(),
+        }
+        .into()
     }
 
     fn take_wire(interface: &mut ConnectionInterface) -> serde_json::Value {
@@ -1026,6 +1190,31 @@ mod tests {
         service.handle_item(subscription_response(request_id.clone(), server_id).into()).unwrap();
         let response = rx.try_recv().unwrap().unwrap();
         alias_from_response(response, request_id)
+    }
+
+    fn activate_typed(
+        service: &mut PubSubService<MockConnect>,
+        interface: &mut ConnectionInterface,
+        request: SerializedRequest,
+        server_id: &str,
+        retention_policy: SubscriptionRetentionPolicy,
+    ) -> (B256, RawSubscription) {
+        let request_id = request.id().clone();
+        let (in_flight, mut response_rx, mut subscription_rx) =
+            typed_in_flight(request, retention_policy);
+        service.service_request(in_flight).unwrap();
+        let _ = take_wire(interface);
+        service.handle_item(subscription_response(request_id.clone(), server_id).into()).unwrap();
+        let alias = alias_from_response(response_rx.try_recv().unwrap().unwrap(), request_id);
+        let subscription = subscription_rx.try_recv().unwrap();
+        assert_eq!(&alias, subscription.local_id());
+        (alias, subscription)
+    }
+
+    fn get_subscription(service: &mut PubSubService<MockConnect>, alias: B256) -> RawSubscription {
+        let (tx, mut rx) = oneshot::channel();
+        service.service_get_sub(alias, tx).unwrap();
+        rx.try_recv().unwrap().expect("subscription should exist")
     }
 
     #[test]
@@ -1074,8 +1263,8 @@ mod tests {
         assert_eq!(first_alias, second_alias);
         assert_eq!(service.subs.len(), 1);
 
-        let first_local = service.subs.get_subscription(first_alias).unwrap();
-        let second_local = service.subs.get_subscription(second_alias).unwrap();
+        let first_local = get_subscription(&mut service, first_alias);
+        let second_local = get_subscription(&mut service, second_alias);
         assert_eq!(first_local.local_id, second_local.local_id);
 
         let (third, mut third_rx) = InFlight::new(eth_subscription(3, "newHeads"), 16);
@@ -1085,6 +1274,460 @@ mod tests {
             alias_from_response(third_rx.try_recv().unwrap().unwrap(), Id::Number(3)),
             first_alias
         );
+    }
+
+    #[test]
+    fn typed_ticket_owns_the_initial_receiver_before_the_next_notification() {
+        let (mut service, mut interface) = test_service();
+        let request = eth_subscription(1, "newHeads");
+        let local_id = subscription_local_id(&request);
+        let (in_flight, mut response_rx, mut subscription_rx) =
+            typed_in_flight(request, SubscriptionRetentionPolicy::WhileReceivers);
+        service.service_request(in_flight).unwrap();
+        let _ = take_wire(&mut interface);
+        service.handle_item(subscription_response(Id::Number(1), "typed").into()).unwrap();
+
+        let active = service.subs.get(&local_id).unwrap();
+        assert_eq!(active.receiver_count(), 1);
+        assert_eq!(active.manual_claim_count(), 0);
+        assert!(!active.has_persistent_hold());
+        assert!(active.request.meta().extensions().get::<SubscriptionReceiverTicket>().is_none());
+
+        service.handle_item(notification("typed", serde_json::json!("first"))).unwrap();
+        let alias = alias_from_response(response_rx.try_recv().unwrap().unwrap(), Id::Number(1));
+        let mut subscription = subscription_rx.try_recv().unwrap();
+        assert_eq!(&alias, subscription.local_id());
+        assert_eq!(subscription.try_recv().unwrap().get(), "\"first\"");
+    }
+
+    #[test]
+    fn later_typed_acquire_starts_at_the_current_tail() {
+        let (mut service, mut interface) = test_service();
+        let (_alias, mut first) = activate_typed(
+            &mut service,
+            &mut interface,
+            eth_subscription(1, "newHeads"),
+            "typed",
+            SubscriptionRetentionPolicy::WhileReceivers,
+        );
+        service.handle_item(notification("typed", serde_json::json!("old"))).unwrap();
+
+        let (second, mut response_rx, mut subscription_rx) = typed_in_flight(
+            eth_subscription(2, "newHeads"),
+            SubscriptionRetentionPolicy::WhileReceivers,
+        );
+        service.service_request(second).unwrap();
+        assert_no_wire(&mut interface);
+        let _ = alias_from_response(response_rx.try_recv().unwrap().unwrap(), Id::Number(2));
+        let mut second = subscription_rx.try_recv().unwrap();
+
+        assert_eq!(first.try_recv().unwrap().get(), "\"old\"");
+        assert!(matches!(
+            second.try_recv(),
+            Err(tokio::sync::broadcast::error::TryRecvError::Empty)
+        ));
+    }
+
+    #[test]
+    fn typed_ticket_cancellation_after_response_is_cleaned_by_receiver_count() {
+        let (mut service, mut interface) = test_service();
+        let (in_flight, mut response_rx, subscription_rx) = typed_in_flight(
+            eth_subscription(1, "newHeads"),
+            SubscriptionRetentionPolicy::WhileReceivers,
+        );
+        service.service_request(in_flight).unwrap();
+        let _ = take_wire(&mut interface);
+        service.handle_item(subscription_response(Id::Number(1), "typed").into()).unwrap();
+        let _ = response_rx.try_recv().unwrap().unwrap();
+        drop(subscription_rx);
+
+        service.sweep_subscriptions().unwrap();
+        let cleanup = take_wire(&mut interface);
+        assert_eq!(cleanup["method"], "eth_unsubscribe");
+        assert_eq!(cleanup["params"], serde_json::json!(["typed"]));
+        assert_eq!(service.subs.len(), 0);
+    }
+
+    #[test]
+    fn dropping_only_the_last_typed_receiver_triggers_cleanup() {
+        let (mut service, mut interface) = test_service();
+        let (_alias, first) = activate_typed(
+            &mut service,
+            &mut interface,
+            eth_subscription(1, "newHeads"),
+            "typed",
+            SubscriptionRetentionPolicy::WhileReceivers,
+        );
+        let (second, mut response_rx, mut subscription_rx) = typed_in_flight(
+            eth_subscription(2, "newHeads"),
+            SubscriptionRetentionPolicy::WhileReceivers,
+        );
+        service.service_request(second).unwrap();
+        let _ = response_rx.try_recv().unwrap().unwrap();
+        let second = subscription_rx.try_recv().unwrap();
+
+        drop(first);
+        service.sweep_subscriptions().unwrap();
+        assert_no_wire(&mut interface);
+        assert_eq!(service.subs.len(), 1);
+
+        drop(second);
+        service.handle_item(notification("typed", serde_json::json!("ignored"))).unwrap();
+        assert_eq!(take_wire(&mut interface)["method"], "eth_unsubscribe");
+        assert_eq!(service.subs.len(), 0);
+        service.sweep_subscriptions().unwrap();
+        assert_no_wire(&mut interface);
+    }
+
+    #[test]
+    fn resubscribe_receiver_keeps_upstream_alive_until_it_is_dropped() {
+        let (mut service, mut interface) = test_service();
+        let (_alias, first) = activate_typed(
+            &mut service,
+            &mut interface,
+            eth_subscription(1, "newHeads"),
+            "typed",
+            SubscriptionRetentionPolicy::WhileReceivers,
+        );
+        let second = first.resubscribe();
+
+        drop(first);
+        service.sweep_subscriptions().unwrap();
+        assert_no_wire(&mut interface);
+
+        drop(second);
+        service.sweep_subscriptions().unwrap();
+        assert_eq!(take_wire(&mut interface)["method"], "eth_unsubscribe");
+    }
+
+    #[test]
+    fn zero_receiver_active_generation_is_not_reopened() {
+        let (mut service, mut interface) = test_service();
+        let (old_alias, old) = activate_typed(
+            &mut service,
+            &mut interface,
+            eth_subscription(1, "newHeads"),
+            "old",
+            SubscriptionRetentionPolicy::WhileReceivers,
+        );
+        drop(old);
+
+        let (next, mut response_rx, mut subscription_rx) = typed_in_flight(
+            eth_subscription(2, "newHeads"),
+            SubscriptionRetentionPolicy::WhileReceivers,
+        );
+        service.service_request(next).unwrap();
+        let cleanup = take_wire(&mut interface);
+        let subscribe = take_wire(&mut interface);
+        assert_eq!(cleanup["method"], "eth_unsubscribe");
+        assert_eq!(cleanup["params"], serde_json::json!(["old"]));
+        assert_eq!(subscribe["method"], "eth_subscribe");
+        assert_eq!(subscribe["id"], 2);
+
+        service.handle_item(subscription_response(Id::Number(2), "new").into()).unwrap();
+        let new_alias =
+            alias_from_response(response_rx.try_recv().unwrap().unwrap(), Id::Number(2));
+        let new = subscription_rx.try_recv().unwrap();
+        assert_eq!(new_alias, old_alias);
+        assert_eq!(&new_alias, new.local_id());
+    }
+
+    #[test]
+    fn direct_get_does_not_reopen_an_unowned_typed_generation() {
+        let (mut service, mut interface) = test_service();
+        let (alias, subscription) = activate_typed(
+            &mut service,
+            &mut interface,
+            eth_subscription(1, "newHeads"),
+            "typed",
+            SubscriptionRetentionPolicy::WhileReceivers,
+        );
+        drop(subscription);
+
+        let (tx, mut rx) = oneshot::channel();
+        service.service_get_sub(alias, tx).unwrap();
+        assert!(rx.try_recv().unwrap().is_none());
+        assert_eq!(take_wire(&mut interface)["method"], "eth_unsubscribe");
+        assert_eq!(service.subs.len(), 0);
+    }
+
+    #[test]
+    fn legacy_claim_defaults_to_persistent_retention_and_can_be_reacquired() {
+        let (mut service, mut interface) = test_service();
+        let alias =
+            activate(&mut service, &mut interface, eth_subscription(1, "newHeads"), "legacy");
+        let active = service.subs.get(&alias).unwrap();
+        assert!(active.has_persistent_hold());
+        assert_eq!(active.manual_claim_count(), 1);
+
+        let (tx, mut rx) = oneshot::channel();
+        service.service_get_sub(alias, tx).unwrap();
+        let claim = rx.try_recv().unwrap().unwrap();
+        drop(claim);
+        service.sweep_subscriptions().unwrap();
+        assert_no_wire(&mut interface);
+        assert_eq!(service.subs.len(), 1);
+
+        let (tx, mut rx) = oneshot::channel();
+        service.service_get_sub(alias, tx).unwrap();
+        assert!(rx.try_recv().unwrap().is_some());
+        assert_no_wire(&mut interface);
+    }
+
+    #[test]
+    fn mixed_typed_and_legacy_waiters_commit_persistent_hold_regardless_of_order() {
+        for typed_first in [true, false] {
+            let (mut service, mut interface) = test_service();
+            let (typed, mut typed_response, mut typed_subscription) = typed_in_flight(
+                eth_subscription(1, "newHeads"),
+                SubscriptionRetentionPolicy::WhileReceivers,
+            );
+            let (legacy, mut legacy_response) = InFlight::new(eth_subscription(2, "newHeads"), 16);
+            if typed_first {
+                service.service_request(typed).unwrap();
+                service.service_request(legacy).unwrap();
+            } else {
+                service.service_request(legacy).unwrap();
+                service.service_request(typed).unwrap();
+            }
+            let wire = take_wire(&mut interface);
+            let wire_id = if typed_first { Id::Number(1) } else { Id::Number(2) };
+            assert_eq!(wire["id"], serde_json::json!(if typed_first { 1 } else { 2 }));
+            service.handle_item(subscription_response(wire_id, "mixed").into()).unwrap();
+            let typed_alias =
+                alias_from_response(typed_response.try_recv().unwrap().unwrap(), Id::Number(1));
+            let legacy_alias =
+                alias_from_response(legacy_response.try_recv().unwrap().unwrap(), Id::Number(2));
+            assert_eq!(typed_alias, legacy_alias);
+            let typed_subscription = typed_subscription.try_recv().unwrap();
+
+            let (tx, mut claim_rx) = oneshot::channel();
+            service.service_get_sub(legacy_alias, tx).unwrap();
+            let legacy_claim = claim_rx.try_recv().unwrap().unwrap();
+            drop(typed_subscription);
+            drop(legacy_claim);
+            service.sweep_subscriptions().unwrap();
+
+            assert!(service.subs.get(&typed_alias).unwrap().has_persistent_hold());
+            assert_no_wire(&mut interface);
+        }
+    }
+
+    #[test]
+    fn cancelled_legacy_waiter_does_not_upgrade_typed_retention() {
+        let (mut service, mut interface) = test_service();
+        let (typed, mut typed_response, mut typed_subscription) = typed_in_flight(
+            eth_subscription(1, "newHeads"),
+            SubscriptionRetentionPolicy::WhileReceivers,
+        );
+        let (legacy, legacy_response) = InFlight::new(eth_subscription(2, "newHeads"), 16);
+        service.service_request(typed).unwrap();
+        let _ = take_wire(&mut interface);
+        service.service_request(legacy).unwrap();
+        drop(legacy_response);
+
+        service.handle_item(subscription_response(Id::Number(1), "typed").into()).unwrap();
+        let alias = alias_from_response(typed_response.try_recv().unwrap().unwrap(), Id::Number(1));
+        let typed_subscription = typed_subscription.try_recv().unwrap();
+        assert!(!service.subs.get(&alias).unwrap().has_persistent_hold());
+
+        drop(typed_subscription);
+        service.sweep_subscriptions().unwrap();
+        assert_eq!(take_wire(&mut interface)["method"], "eth_unsubscribe");
+    }
+
+    #[test]
+    fn explicit_retention_overrides_typed_and_legacy_defaults() {
+        let (mut service, mut interface) = test_service();
+        let (typed_alias, typed) = activate_typed(
+            &mut service,
+            &mut interface,
+            eth_subscription(1, "newHeads"),
+            "typed",
+            SubscriptionRetentionPolicy::UntilExplicitUnsubscribe,
+        );
+        drop(typed);
+        service.sweep_subscriptions().unwrap();
+        assert!(service.subs.get(&typed_alias).unwrap().has_persistent_hold());
+        assert_no_wire(&mut interface);
+
+        let raw_request = with_retention(
+            eth_subscription(2, "logs"),
+            SubscriptionRetentionPolicy::WhileReceivers,
+        );
+        let raw_alias = activate(&mut service, &mut interface, raw_request, "raw");
+        assert!(!service.subs.get(&raw_alias).unwrap().has_persistent_hold());
+        let (tx, mut claim_rx) = oneshot::channel();
+        service.service_get_sub(raw_alias, tx).unwrap();
+        drop(claim_rx.try_recv().unwrap().unwrap());
+        service.sweep_subscriptions().unwrap();
+        let cleanup = take_wire(&mut interface);
+        assert_eq!(cleanup["params"], serde_json::json!(["raw"]));
+    }
+
+    #[test]
+    fn direct_get_of_live_typed_entry_does_not_upgrade_retention() {
+        let (mut service, mut interface) = test_service();
+        let (alias, typed) = activate_typed(
+            &mut service,
+            &mut interface,
+            eth_subscription(1, "newHeads"),
+            "typed",
+            SubscriptionRetentionPolicy::WhileReceivers,
+        );
+        let receiver_count = service.subs.get(&alias).unwrap().receiver_count();
+        let (tx, rx) = oneshot::channel();
+        drop(rx);
+        service.service_get_sub(alias, tx).unwrap();
+        assert_eq!(service.subs.get(&alias).unwrap().receiver_count(), receiver_count);
+
+        let (tx, mut rx) = oneshot::channel();
+        service.service_get_sub(alias, tx).unwrap();
+        let acquired = rx.try_recv().unwrap().unwrap();
+        assert!(!service.subs.get(&alias).unwrap().has_persistent_hold());
+
+        drop(typed);
+        drop(acquired);
+        service.sweep_subscriptions().unwrap();
+        assert_eq!(take_wire(&mut interface)["method"], "eth_unsubscribe");
+    }
+
+    #[test]
+    fn failed_direct_get_restores_an_existing_manual_claim() {
+        let (mut service, mut interface) = test_service();
+        let alias =
+            activate(&mut service, &mut interface, eth_subscription(1, "newHeads"), "legacy");
+        service.handle_item(notification("legacy", serde_json::json!("buffered"))).unwrap();
+
+        let (tx, rx) = oneshot::channel();
+        drop(rx);
+        service.service_get_sub(alias, tx).unwrap();
+        assert_eq!(service.subs.get(&alias).unwrap().manual_claim_count(), 1);
+
+        let (tx, mut rx) = oneshot::channel();
+        service.service_get_sub(alias, tx).unwrap();
+        let mut claim = rx.try_recv().unwrap().unwrap();
+        assert_eq!(claim.try_recv().unwrap().get(), "\"buffered\"");
+    }
+
+    #[test]
+    fn cancelled_active_fast_path_does_not_create_a_receiver_or_hold() {
+        let (mut service, mut interface) = test_service();
+        let (alias, _owner) = activate_typed(
+            &mut service,
+            &mut interface,
+            eth_subscription(1, "newHeads"),
+            "typed",
+            SubscriptionRetentionPolicy::WhileReceivers,
+        );
+        let receiver_count = service.subs.get(&alias).unwrap().receiver_count();
+        let (in_flight, response_rx, subscription_rx) = typed_in_flight(
+            eth_subscription(2, "newHeads"),
+            SubscriptionRetentionPolicy::UntilExplicitUnsubscribe,
+        );
+        drop(response_rx);
+        drop(subscription_rx);
+
+        service.service_request(in_flight).unwrap();
+        let active = service.subs.get(&alias).unwrap();
+        assert_eq!(active.receiver_count(), receiver_count);
+        assert!(!active.has_persistent_hold());
+        assert_no_wire(&mut interface);
+    }
+
+    #[test]
+    fn subscription_stream_variants_keep_receiver_ownership() {
+        let (mut service, mut interface) = test_service();
+
+        let (_alias, raw) = activate_typed(
+            &mut service,
+            &mut interface,
+            eth_subscription(1, "newHeads"),
+            "stream",
+            SubscriptionRetentionPolicy::WhileReceivers,
+        );
+        let stream = raw.into_typed::<serde_json::Value>().into_stream();
+        service.sweep_subscriptions().unwrap();
+        assert_no_wire(&mut interface);
+        drop(stream);
+        service.sweep_subscriptions().unwrap();
+        assert_eq!(take_wire(&mut interface)["params"], serde_json::json!(["stream"]));
+
+        let (_alias, raw) = activate_typed(
+            &mut service,
+            &mut interface,
+            eth_subscription(2, "logs"),
+            "result-stream",
+            SubscriptionRetentionPolicy::WhileReceivers,
+        );
+        let stream = raw.into_typed::<serde_json::Value>().into_result_stream();
+        service.sweep_subscriptions().unwrap();
+        assert_no_wire(&mut interface);
+        drop(stream);
+        service.sweep_subscriptions().unwrap();
+        assert_eq!(take_wire(&mut interface)["params"], serde_json::json!(["result-stream"]));
+
+        let (_alias, raw) = activate_typed(
+            &mut service,
+            &mut interface,
+            eth_subscription(3, "newPendingTransactions"),
+            "any-stream",
+            SubscriptionRetentionPolicy::WhileReceivers,
+        );
+        let stream = raw.into_typed::<serde_json::Value>().into_any_stream();
+        service.sweep_subscriptions().unwrap();
+        assert_no_wire(&mut interface);
+        drop(stream);
+        service.sweep_subscriptions().unwrap();
+        assert_eq!(take_wire(&mut interface)["params"], serde_json::json!(["any-stream"]));
+    }
+
+    #[test]
+    fn lagged_receiver_is_not_mistaken_for_zero_receivers() {
+        let (mut service, mut interface) = test_service();
+        let request = with_channel_size(eth_subscription(1, "newHeads"), 1);
+        let (_alias, mut subscription) = activate_typed(
+            &mut service,
+            &mut interface,
+            request,
+            "typed",
+            SubscriptionRetentionPolicy::WhileReceivers,
+        );
+        service.handle_item(notification("typed", serde_json::json!(1))).unwrap();
+        service.handle_item(notification("typed", serde_json::json!(2))).unwrap();
+        assert!(matches!(
+            subscription.try_recv(),
+            Err(tokio::sync::broadcast::error::TryRecvError::Lagged(_))
+        ));
+
+        service.sweep_subscriptions().unwrap();
+        assert_eq!(service.subs.len(), 1);
+        assert_no_wire(&mut interface);
+    }
+
+    #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+    #[tokio::test(start_paused = true)]
+    async fn quiet_subscription_is_cleaned_by_the_periodic_sweep() {
+        let (handle, mut interface) = ConnectionHandle::new();
+        let (tx, reqs) = mpsc::unbounded_channel();
+        let mut service = PubSubService::new(handle, MockConnect::default(), reqs);
+        let (_alias, subscription) = activate_typed(
+            &mut service,
+            &mut interface,
+            eth_subscription(1, "newHeads"),
+            "quiet",
+            SubscriptionRetentionPolicy::WhileReceivers,
+        );
+        service.spawn();
+        tokio::task::yield_now().await;
+        drop(subscription);
+
+        tokio::time::advance(SUBSCRIPTION_SWEEP_INTERVAL).await;
+        tokio::task::yield_now().await;
+        assert_eq!(take_wire(&mut interface)["method"], "eth_unsubscribe");
+
+        drop(tx);
+        tokio::task::yield_now().await;
     }
 
     #[test]
@@ -1361,8 +2004,8 @@ mod tests {
         let (mut service, mut interface) = test_service();
         let alias =
             activate(&mut service, &mut interface, eth_subscription(1, "newHeads"), "active");
-        let mut first = service.subs.get_subscription(alias).unwrap();
-        let mut second = service.subs.get_subscription(alias).unwrap();
+        let mut first = get_subscription(&mut service, alias);
+        let mut second = get_subscription(&mut service, alias);
 
         service.service_unsubscribe(alias, None).unwrap();
         let _ = take_wire(&mut interface);
@@ -1509,6 +2152,23 @@ mod tests {
         assert_eq!(rx.try_recv().unwrap().unwrap(), UnsubscribeOutcome::TransportClosed);
     }
 
+    #[test]
+    fn dropped_custom_typed_subscription_without_cleanup_method_never_falls_back() {
+        let (mut service, mut interface) = test_service();
+        let (_alias, subscription) = activate_typed(
+            &mut service,
+            &mut interface,
+            custom_subscription(1, "custom_events", None),
+            "custom",
+            SubscriptionRetentionPolicy::WhileReceivers,
+        );
+        drop(subscription);
+
+        service.sweep_subscriptions().unwrap();
+        assert_eq!(service.subs.len(), 0);
+        assert_no_wire(&mut interface);
+    }
+
     #[tokio::test]
     async fn reconnect_uses_unique_route_and_preserves_channel_capacity() {
         let (old_handle, mut old_interface) = ConnectionHandle::new();
@@ -1534,6 +2194,79 @@ mod tests {
             service.subs.server_id_for_local_id(&local_id),
             Some(&SubId::String("new-server".into()))
         );
+    }
+
+    #[tokio::test]
+    async fn reconnect_drops_typed_entry_without_receivers() {
+        let (old_handle, mut old_interface) = ConnectionHandle::new();
+        let (new_handle, mut new_interface) = ConnectionHandle::new();
+        let connector = MockConnect(Arc::new(Mutex::new(Some(new_handle))));
+        let (_tx, reqs) = mpsc::unbounded_channel();
+        let mut service = PubSubService::new(old_handle, connector, reqs);
+        let (_alias, subscription) = activate_typed(
+            &mut service,
+            &mut old_interface,
+            eth_subscription(1, "newHeads"),
+            "old-server",
+            SubscriptionRetentionPolicy::WhileReceivers,
+        );
+        drop(subscription);
+
+        service.reconnect().await.unwrap();
+        assert_eq!(service.subs.len(), 0);
+        assert_no_wire(&mut new_interface);
+    }
+
+    #[tokio::test]
+    async fn reconnect_restores_persistent_entry_without_receivers() {
+        let (old_handle, mut old_interface) = ConnectionHandle::new();
+        let (new_handle, mut new_interface) = ConnectionHandle::new();
+        let connector = MockConnect(Arc::new(Mutex::new(Some(new_handle))));
+        let (_tx, reqs) = mpsc::unbounded_channel();
+        let mut service = PubSubService::new(old_handle, connector, reqs);
+        let alias = activate(
+            &mut service,
+            &mut old_interface,
+            eth_subscription(1, "newHeads"),
+            "old-server",
+        );
+        let (tx, mut claim_rx) = oneshot::channel();
+        service.service_get_sub(alias, tx).unwrap();
+        drop(claim_rx.try_recv().unwrap().unwrap());
+        assert_eq!(service.subs.get(&alias).unwrap().receiver_count(), 0);
+
+        service.reconnect().await.unwrap();
+        assert_eq!(take_wire(&mut new_interface)["method"], "eth_subscribe");
+        assert!(service.subs.get(&alias).unwrap().has_persistent_hold());
+    }
+
+    #[tokio::test]
+    async fn receiver_drop_during_reconnect_compensates_late_server_id() {
+        let (old_handle, mut old_interface) = ConnectionHandle::new();
+        let (new_handle, mut new_interface) = ConnectionHandle::new();
+        let connector = MockConnect(Arc::new(Mutex::new(Some(new_handle))));
+        let (_tx, reqs) = mpsc::unbounded_channel();
+        let mut service = PubSubService::new(old_handle, connector, reqs);
+        let (_alias, subscription) = activate_typed(
+            &mut service,
+            &mut old_interface,
+            eth_subscription(1, "newHeads"),
+            "old-server",
+            SubscriptionRetentionPolicy::WhileReceivers,
+        );
+
+        service.reconnect().await.unwrap();
+        let replay = take_wire(&mut new_interface);
+        let replay_id = Id::String(replay["id"].as_str().unwrap().to_owned());
+        drop(subscription);
+        service.sweep_subscriptions().unwrap();
+        assert_eq!(service.subs.len(), 0);
+        assert_no_wire(&mut new_interface);
+
+        service.handle_item(subscription_response(replay_id, "late-server").into()).unwrap();
+        let cleanup = take_wire(&mut new_interface);
+        assert_eq!(cleanup["method"], "eth_unsubscribe");
+        assert_eq!(cleanup["params"], serde_json::json!(["late-server"]));
     }
 
     #[tokio::test]

--- a/crates/pubsub/src/service.rs
+++ b/crates/pubsub/src/service.rs
@@ -2,16 +2,18 @@ use crate::{
     handle::ConnectionHandle,
     ix::PubSubInstruction,
     managers::{InFlight, RequestManager, SubscriptionManager},
-    PubSubConnect, PubSubFrontend, RawSubscription,
+    PubSubConnect, PubSubFrontend, RawSubscription, UnsubscribeOutcome,
 };
-use alloy_json_rpc::{Id, PubSubItem, Request, Response, ResponsePayload, RpcError, SubId};
-use alloy_primitives::B256;
+use alloy_json_rpc::{
+    Id, PubSubItem, Request, Response, ResponsePayload, RpcError, SerializedRequest, SubId,
+};
+use alloy_primitives::{Keccak256, B256};
 use alloy_transport::{
     utils::{to_json_raw_value, Spawnable},
     TransportErrorKind, TransportResult,
 };
 use serde_json::value::RawValue;
-use std::time::Duration;
+use std::{borrow::Cow, collections::BTreeMap, time::Duration};
 use tokio::sync::{mpsc, oneshot};
 
 #[cfg(all(target_family = "wasm", target_os = "unknown"))]
@@ -21,6 +23,49 @@ use wasmtimer::tokio::sleep;
 use tokio::time::sleep;
 
 const MAX_RECONNECT_RETRY_INTERVAL: Duration = Duration::from_secs(30);
+
+type CleanupWaiter = oneshot::Sender<TransportResult<UnsubscribeOutcome>>;
+
+fn subscription_local_id(request: &SerializedRequest) -> B256 {
+    let method = request.method().as_bytes();
+    let mut hasher = Keccak256::new();
+    hasher.update((method.len() as u64).to_be_bytes());
+    hasher.update(method);
+    match request.params_with_presence() {
+        Some(params) => {
+            hasher.update([1]);
+            hasher.update((params.get().len() as u64).to_be_bytes());
+            hasher.update(params.get().as_bytes());
+        }
+        None => hasher.update([0]),
+    }
+    hasher.finalize()
+}
+
+#[derive(Debug)]
+struct StartingSubscription {
+    request: SerializedRequest,
+    wire_request_id: Id,
+    waiters: Vec<InFlight>,
+    channel_size: usize,
+    unsubscribe_method: Option<Cow<'static, str>>,
+}
+
+#[derive(Debug)]
+struct SubscribeRoute {
+    local_id: B256,
+    unsubscribe_method: Option<Cow<'static, str>>,
+    connection_epoch: u64,
+    cleanup_waiters: Vec<CleanupWaiter>,
+}
+
+#[derive(Debug)]
+struct PendingCleanup {
+    server_id: SubId,
+    unsubscribe_method: Cow<'static, str>,
+    connection_epoch: u64,
+    waiters: Vec<CleanupWaiter>,
+}
 
 /// The service contains the backend handle, a subscription manager, and the
 /// configuration details required to reconnect.
@@ -40,21 +85,58 @@ pub(crate) struct PubSubService<T> {
 
     /// The request manager.
     pub(crate) in_flights: RequestManager,
+
+    /// Subscription requests that have been dispatched but are not active yet.
+    starting: BTreeMap<B256, StartingSubscription>,
+
+    /// Every subscribe request ID remains routed until its connection closes so duplicate or late
+    /// successful responses can be compensated with an unsubscribe.
+    subscribe_routes: BTreeMap<Id, SubscribeRoute>,
+
+    /// Active keys currently awaiting a resubscribe response.
+    reconnecting: BTreeMap<B256, Id>,
+
+    /// Tracked server-side unsubscribe requests.
+    pending_cleanups: BTreeMap<Id, PendingCleanup>,
+
+    /// Monotonically increasing connection generation.
+    connection_epoch: u64,
+
+    /// Monotonically increasing sequence for service-owned request IDs.
+    request_sequence: u64,
+
+    /// Waiters for subscriptions whose protocol provides no cleanup method.
+    connection_cleanup_waiters: BTreeMap<u64, Vec<CleanupWaiter>>,
 }
 
 impl<T: PubSubConnect> PubSubService<T> {
-    /// Create a new service from a connector.
-    pub(crate) async fn connect(connector: T) -> TransportResult<PubSubFrontend> {
-        let handle = connector.connect().await?;
-
-        let (tx, reqs) = mpsc::unbounded_channel();
-        let this = Self {
+    fn new(
+        handle: ConnectionHandle,
+        connector: T,
+        reqs: mpsc::UnboundedReceiver<PubSubInstruction>,
+    ) -> Self {
+        Self {
             handle,
             connector,
             reqs,
             subs: SubscriptionManager::default(),
             in_flights: Default::default(),
-        };
+            starting: BTreeMap::new(),
+            subscribe_routes: BTreeMap::new(),
+            reconnecting: BTreeMap::new(),
+            pending_cleanups: BTreeMap::new(),
+            connection_epoch: 0,
+            request_sequence: 0,
+            connection_cleanup_waiters: BTreeMap::new(),
+        }
+    }
+
+    /// Create a new service from a connector.
+    pub(crate) async fn connect(connector: T) -> TransportResult<PubSubFrontend> {
+        let handle = connector.connect().await?;
+
+        let (tx, reqs) = mpsc::unbounded_channel();
+        let this = Self::new(handle, connector, reqs);
         this.spawn();
         Ok(PubSubFrontend::new(tx))
     }
@@ -71,6 +153,7 @@ impl<T: PubSubConnect> PubSubService<T> {
     async fn reconnect(&mut self) -> TransportResult<()> {
         debug!("Reconnecting pubsub service backend");
 
+        let old_epoch = self.connection_epoch;
         let mut old_handle = self.get_new_backend().await?;
 
         debug!("Draining old backend to_handle");
@@ -81,12 +164,45 @@ impl<T: PubSubConnect> PubSubService<T> {
         }
 
         old_handle.shutdown();
+        self.finish_connection_epoch(old_epoch);
+        self.connection_epoch =
+            self.connection_epoch.checked_add(1).expect("connection epoch exhausted");
 
         // Re-issue pending requests.
         debug!(count = self.in_flights.len(), "Reissuing pending requests");
-        for (_, in_flight) in self.in_flights.iter() {
-            let msg = in_flight.request.serialized().to_owned();
+        let pending_requests = self
+            .in_flights
+            .iter()
+            .map(|(_, in_flight)| in_flight.request.serialized().to_owned())
+            .collect::<Vec<_>>();
+        for msg in pending_requests {
             self.dispatch_request(msg)?;
+        }
+
+        // Re-issue live single-flight subscriptions. Fully cancelled requests are discarded: the
+        // old connection closing has already reclaimed any server-side resource they created.
+        let starting_local_ids = self.starting.keys().copied().collect::<Vec<_>>();
+        for local_id in starting_local_ids {
+            let has_live_waiter = self.starting.get_mut(&local_id).is_some_and(|starting| {
+                starting.waiters.retain(|waiter| !waiter.tx.is_closed());
+                !starting.waiters.is_empty()
+            });
+            if !has_live_waiter {
+                self.starting.remove(&local_id);
+                continue;
+            }
+
+            let wire_request_id = self.next_service_id();
+            let (request, unsubscribe_method) = {
+                let starting = self.starting.get_mut(&local_id).expect("checked above");
+                starting.wire_request_id = wire_request_id.clone();
+                (
+                    starting.request.with_id(wire_request_id.clone()).map_err(RpcError::ser_err)?,
+                    starting.unsubscribe_method.clone(),
+                )
+            };
+            self.insert_subscribe_route(wire_request_id, local_id, unsubscribe_method);
+            self.dispatch_request(request.into_serialized())?;
         }
 
         // Re-subscribe to all active subscriptions
@@ -94,15 +210,22 @@ impl<T: PubSubConnect> PubSubService<T> {
 
         // Drop all server IDs. We'll re-insert them as we get responses.
         self.subs.drop_server_ids();
+        self.reconnecting.clear();
 
         // Dispatch all subscription requests.
-        for (_, sub) in self.subs.iter() {
-            let req = sub.request().to_owned();
-            let (in_flight, _) = InFlight::new(req.clone(), sub.tx.receiver_count());
-            self.in_flights.insert(in_flight);
-
-            let msg = req.into_serialized();
-            self.dispatch_request(msg)?;
+        let active = self
+            .subs
+            .iter()
+            .map(|(&local_id, sub)| {
+                (local_id, sub.request().clone(), sub.unsubscribe_method.clone())
+            })
+            .collect::<Vec<_>>();
+        for (local_id, request, unsubscribe_method) in active {
+            let wire_request_id = self.next_service_id();
+            let request = request.with_id(wire_request_id.clone()).map_err(RpcError::ser_err)?;
+            self.reconnecting.insert(local_id, wire_request_id.clone());
+            self.insert_subscribe_route(wire_request_id, local_id, unsubscribe_method);
+            self.dispatch_request(request.into_serialized())?;
         }
 
         Ok(())
@@ -113,12 +236,175 @@ impl<T: PubSubConnect> PubSubService<T> {
         self.handle.to_socket.send(brv).map(drop).map_err(|_| TransportErrorKind::backend_gone())
     }
 
+    fn next_service_id(&mut self) -> Id {
+        let sequence = self.request_sequence;
+        self.request_sequence =
+            self.request_sequence.checked_add(1).expect("service request ID sequence exhausted");
+        Id::String(format!("alloy-pubsub:{}:{sequence}", self.connection_epoch))
+    }
+
+    fn insert_subscribe_route(
+        &mut self,
+        request_id: Id,
+        local_id: B256,
+        unsubscribe_method: Option<Cow<'static, str>>,
+    ) {
+        let route = SubscribeRoute {
+            local_id,
+            unsubscribe_method,
+            connection_epoch: self.connection_epoch,
+            cleanup_waiters: Vec::new(),
+        };
+        let previous = self.subscribe_routes.insert(request_id, route);
+        debug_assert!(previous.is_none(), "service request IDs must never be reused");
+    }
+
+    fn finish_connection_epoch(&mut self, epoch: u64) {
+        let cleanup_ids = self
+            .pending_cleanups
+            .iter()
+            .filter(|(_, cleanup)| cleanup.connection_epoch == epoch)
+            .map(|(id, _)| id.clone())
+            .collect::<Vec<_>>();
+        for id in cleanup_ids {
+            if let Some(cleanup) = self.pending_cleanups.remove(&id) {
+                debug!(?cleanup.server_id, method=%cleanup.unsubscribe_method, "cleanup completed by transport close");
+                Self::complete_cleanup_waiters(
+                    cleanup.waiters,
+                    UnsubscribeOutcome::TransportClosed,
+                );
+            }
+        }
+
+        let route_ids = self
+            .subscribe_routes
+            .iter()
+            .filter(|(_, route)| route.connection_epoch == epoch)
+            .map(|(id, _)| id.clone())
+            .collect::<Vec<_>>();
+        for id in route_ids {
+            if let Some(route) = self.subscribe_routes.remove(&id) {
+                Self::complete_cleanup_waiters(
+                    route.cleanup_waiters,
+                    UnsubscribeOutcome::TransportClosed,
+                );
+            }
+        }
+        if let Some(waiters) = self.connection_cleanup_waiters.remove(&epoch) {
+            Self::complete_cleanup_waiters(waiters, UnsubscribeOutcome::TransportClosed);
+        }
+    }
+
     /// Service a request.
     fn service_request(&mut self, in_flight: InFlight) -> TransportResult<()> {
-        let brv = in_flight.request();
+        if !in_flight.is_subscription() {
+            let brv = in_flight.request();
 
-        self.dispatch_request(brv.serialized().to_owned())?;
-        self.in_flights.insert(in_flight);
+            self.dispatch_request(brv.serialized().to_owned())?;
+            self.in_flights.insert(in_flight);
+            return Ok(());
+        }
+
+        if in_flight.tx.is_closed() {
+            return Ok(());
+        }
+
+        if in_flight.channel_size == 0 {
+            let _ = in_flight
+                .tx
+                .send(Err(RpcError::local_usage_str("subscription channel size must be non-zero")));
+            return Ok(());
+        }
+
+        let local_id = subscription_local_id(in_flight.request());
+        let unsubscribe_method = Self::unsubscribe_method(&in_flight);
+
+        if let Some(starting) = self.starting.get_mut(&local_id) {
+            Self::warn_config_conflict(
+                local_id,
+                starting.channel_size,
+                starting.unsubscribe_method.as_deref(),
+                in_flight.channel_size,
+                unsubscribe_method.as_deref(),
+            );
+            starting.waiters.push(in_flight);
+            return Ok(());
+        }
+
+        if let Some(active) = self.subs.get(&local_id) {
+            Self::warn_config_conflict(
+                local_id,
+                active.channel_size,
+                active.unsubscribe_method.as_deref(),
+                in_flight.channel_size,
+                unsubscribe_method.as_deref(),
+            );
+            return Self::send_subscription_alias(in_flight, active.local_id);
+        }
+
+        let wire_request_id = in_flight.request.id().clone();
+        let request = in_flight.request.clone();
+        let message = request.serialized().to_owned();
+        let channel_size = in_flight.channel_size;
+        self.starting.insert(
+            local_id,
+            StartingSubscription {
+                request,
+                wire_request_id: wire_request_id.clone(),
+                waiters: vec![in_flight],
+                channel_size,
+                unsubscribe_method: unsubscribe_method.clone(),
+            },
+        );
+        self.insert_subscribe_route(wire_request_id, local_id, unsubscribe_method);
+        self.dispatch_request(message)?;
+
+        Ok(())
+    }
+
+    fn unsubscribe_method(in_flight: &InFlight) -> Option<Cow<'static, str>> {
+        if let Some(method) = &in_flight.unsubscribe_method {
+            return Some(method.clone());
+        }
+        if in_flight.request.method() == "eth_subscribe" {
+            return Some(Cow::Borrowed("eth_unsubscribe"));
+        }
+        warn!(
+            method = in_flight.request.method(),
+            "custom subscription has no cleanup method; it can only be reclaimed by closing the connection"
+        );
+        None
+    }
+
+    fn warn_config_conflict(
+        local_id: B256,
+        existing_channel_size: usize,
+        existing_unsubscribe_method: Option<&str>,
+        requested_channel_size: usize,
+        requested_unsubscribe_method: Option<&str>,
+    ) {
+        if existing_channel_size != requested_channel_size {
+            warn!(
+                ?local_id,
+                existing_channel_size,
+                requested_channel_size,
+                "subscription already exists; keeping its channel size"
+            );
+        }
+        if existing_unsubscribe_method != requested_unsubscribe_method {
+            warn!(
+                ?local_id,
+                existing_unsubscribe_method,
+                requested_unsubscribe_method,
+                "subscription already exists; keeping its unsubscribe method"
+            );
+        }
+    }
+
+    fn send_subscription_alias(in_flight: InFlight, local_id: B256) -> TransportResult<()> {
+        let id = in_flight.request.id().clone();
+        let alias = to_json_raw_value(&local_id)?;
+        let _ = in_flight.tx.send(Ok(Response { id, payload: ResponsePayload::Success(alias) }));
 
         Ok(())
     }
@@ -132,15 +418,46 @@ impl<T: PubSubConnect> PubSubService<T> {
     }
 
     /// Service an unsubscribe instruction.
-    fn service_unsubscribe(&mut self, local_id: B256) -> TransportResult<()> {
-        if let Some(server_id) = self.subs.server_id_for(&local_id) {
-            // TODO: ideally we can send this with an unused id
-            let req = Request::new("eth_unsubscribe", Id::Number(1), [server_id]);
-            let brv = req.serialize().expect("no ser error").take_request();
+    fn service_unsubscribe(
+        &mut self,
+        local_id: B256,
+        waiter: Option<CleanupWaiter>,
+    ) -> TransportResult<()> {
+        let mut waiters = waiter.into_iter().collect::<Vec<_>>();
+        if let Some((subscription, server_id)) = self.subs.remove_sub(local_id) {
+            if let Some(server_id) = server_id {
+                if let Some(unsubscribe_method) = subscription.unsubscribe_method {
+                    return self.start_cleanup(server_id, unsubscribe_method, waiters);
+                }
+                warn!(?server_id, "subscription has no cleanup method; deferring reclamation until connection close");
+                self.defer_cleanup_until_connection_close(waiters);
+                return Ok(());
+            }
 
-            self.dispatch_request(brv)?;
+            if let Some(route_id) = self.reconnecting.remove(&subscription.local_id) {
+                if let Some(route) = self.subscribe_routes.get_mut(&route_id) {
+                    route.cleanup_waiters.append(&mut waiters);
+                    return Ok(());
+                }
+            }
+
+            Self::complete_cleanup_waiters(waiters, UnsubscribeOutcome::TransportClosed);
+            return Ok(());
         }
-        self.subs.remove_sub(local_id);
+
+        if let Some(starting) = self.starting.remove(&local_id) {
+            for in_flight in starting.waiters {
+                let _ = in_flight.tx.send(Err(RpcError::local_usage_str(
+                    "subscription was unsubscribed before activation",
+                )));
+            }
+            if let Some(route) = self.subscribe_routes.get_mut(&starting.wire_request_id) {
+                route.cleanup_waiters.append(&mut waiters);
+                return Ok(());
+            }
+        }
+
+        Self::complete_cleanup_waiters(waiters, UnsubscribeOutcome::AlreadyAbsent);
         Ok(())
     }
 
@@ -153,17 +470,26 @@ impl<T: PubSubConnect> PubSubService<T> {
                 self.service_get_sub(alias, tx);
                 Ok(())
             }
-            PubSubInstruction::Unsubscribe(alias) => self.service_unsubscribe(alias),
+            PubSubInstruction::Unsubscribe(alias) => self.service_unsubscribe(alias, None),
+            PubSubInstruction::UnsubscribeAndWait(alias, tx) => {
+                self.service_unsubscribe(alias, Some(tx))
+            }
         }
     }
 
     /// Handle an item from the backend.
     fn handle_item(&mut self, item: PubSubItem) -> TransportResult<()> {
         match item {
-            PubSubItem::Response(resp) => match self.in_flights.handle_response(resp) {
-                Some((server_id, in_flight)) => self.handle_sub_response(in_flight, server_id),
-                None => Ok(()),
-            },
+            PubSubItem::Response(resp) => {
+                if self.pending_cleanups.contains_key(&resp.id) {
+                    self.handle_cleanup_response(resp)
+                } else if self.subscribe_routes.contains_key(&resp.id) {
+                    self.handle_sub_response(resp)
+                } else {
+                    let _ = self.in_flights.handle_response(resp);
+                    Ok(())
+                }
+            }
             PubSubItem::Notification(notification) => {
                 self.subs.notify(notification);
                 Ok(())
@@ -171,26 +497,288 @@ impl<T: PubSubConnect> PubSubService<T> {
         }
     }
 
-    /// Rewrite the subscription id and insert into the subscriptions manager
-    fn handle_sub_response(
+    /// Route a subscribe or resubscribe response without ever overwriting an active server ID.
+    fn handle_sub_response(&mut self, response: Response) -> TransportResult<()> {
+        let route = self.subscribe_routes.get(&response.id).expect("checked by caller");
+        let local_id = route.local_id;
+        let unsubscribe_method = route.unsubscribe_method.clone();
+
+        match response.payload {
+            ResponsePayload::Success(value) => match serde_json::from_str::<SubId>(value.get()) {
+                Ok(server_id) => {
+                    self.handle_sub_success(response.id, local_id, unsubscribe_method, server_id)
+                }
+                Err(error) => {
+                    self.handle_invalid_sub_response(response.id, local_id, value.get(), error);
+                    Ok(())
+                }
+            },
+            ResponsePayload::Failure(error) => {
+                self.handle_sub_failure(response.id, local_id, error);
+                Ok(())
+            }
+        }
+    }
+
+    fn handle_sub_success(
         &mut self,
-        in_flight: InFlight,
+        response_id: Id,
+        local_id: B256,
+        unsubscribe_method: Option<Cow<'static, str>>,
         server_id: SubId,
     ) -> TransportResult<()> {
-        let request = in_flight.request;
-        let id = request.id().clone();
+        let is_expected_start = self
+            .starting
+            .get(&local_id)
+            .is_some_and(|starting| starting.wire_request_id == response_id);
+        if is_expected_start {
+            let mut starting = self.starting.remove(&local_id).expect("checked above");
+            starting.waiters.retain(|waiter| !waiter.tx.is_closed());
+            if starting.waiters.is_empty() || self.subs.get(&local_id).is_some() {
+                return self.compensate_subscription(response_id, server_id, unsubscribe_method);
+            }
+            if self.subs.contains_server_id(&server_id) {
+                warn!(?server_id, ?local_id, "subscription response reused a live server id");
+                for in_flight in starting.waiters {
+                    let _ = in_flight.tx.send(Err(RpcError::local_usage_str(
+                        "subscription response reused a live server id",
+                    )));
+                }
+                return Ok(());
+            }
 
-        let sub = self.subs.upsert(request, server_id, in_flight.channel_size);
+            self.subs.insert(
+                local_id,
+                starting.request,
+                server_id.clone(),
+                starting.channel_size,
+                starting.unsubscribe_method,
+            );
+            let mut delivered = false;
+            for in_flight in starting.waiters {
+                let id = in_flight.request.id().clone();
+                let alias = to_json_raw_value(&local_id)?;
+                delivered |= in_flight
+                    .tx
+                    .send(Ok(Response { id, payload: ResponsePayload::Success(alias) }))
+                    .is_ok();
+            }
+            if !delivered {
+                if let Some((subscription, _)) = self.subs.remove_sub(local_id) {
+                    if let Some(unsubscribe_method) = subscription.unsubscribe_method {
+                        self.start_cleanup(server_id, unsubscribe_method, Vec::new())?;
+                    } else {
+                        warn!(?server_id, "abandoned subscription has no cleanup method; it will remain until connection close");
+                    }
+                }
+            }
+            return Ok(());
+        }
 
-        // Serialized B256 is always a valid serialized U256 too.
-        let ser_alias = to_json_raw_value(sub.local_id())?;
+        let is_expected_reconnect =
+            self.reconnecting.get(&local_id).is_some_and(|request_id| request_id == &response_id);
+        if is_expected_reconnect {
+            self.reconnecting.remove(&local_id);
+            if self.subs.set_server_id(&local_id, server_id.clone()) {
+                return Ok(());
+            }
+            self.subs.remove_sub(local_id);
+        }
 
-        // We send back a success response with the new subscription ID.
-        // We don't care if the channel is dead.
-        let _ =
-            in_flight.tx.send(Ok(Response { id, payload: ResponsePayload::Success(ser_alias) }));
+        self.compensate_subscription(response_id, server_id, unsubscribe_method)
+    }
 
+    fn handle_invalid_sub_response(
+        &mut self,
+        response_id: Id,
+        local_id: B256,
+        value: &str,
+        error: serde_json::Error,
+    ) {
+        warn!(?local_id, %error, "invalid subscription response");
+        let is_expected_start = self
+            .starting
+            .get(&local_id)
+            .is_some_and(|starting| starting.wire_request_id == response_id);
+        if is_expected_start {
+            if let Some(starting) = self.starting.remove(&local_id) {
+                for in_flight in starting.waiters {
+                    let error = serde_json::from_str::<SubId>(value).unwrap_err();
+                    let _ = in_flight
+                        .tx
+                        .send(Err(alloy_transport::TransportError::deser_err(error, value)));
+                }
+            }
+        } else if self
+            .reconnecting
+            .get(&local_id)
+            .is_some_and(|request_id| request_id == &response_id)
+        {
+            self.reconnecting.remove(&local_id);
+            self.subs.remove_sub(local_id);
+        }
+
+        if let Some(route) = self.subscribe_routes.get_mut(&response_id) {
+            for waiter in std::mem::take(&mut route.cleanup_waiters) {
+                let error = serde_json::from_str::<SubId>(value).unwrap_err();
+                let _ = waiter.send(Err(alloy_transport::TransportError::deser_err(error, value)));
+            }
+        }
+    }
+
+    fn handle_sub_failure(
+        &mut self,
+        response_id: Id,
+        local_id: B256,
+        error: alloy_json_rpc::ErrorPayload,
+    ) {
+        let is_expected_start = self
+            .starting
+            .get(&local_id)
+            .is_some_and(|starting| starting.wire_request_id == response_id);
+        if is_expected_start {
+            if let Some(starting) = self.starting.remove(&local_id) {
+                for in_flight in starting.waiters {
+                    let id = in_flight.request.id().clone();
+                    let _ = in_flight.tx.send(Ok(Response {
+                        id,
+                        payload: ResponsePayload::Failure(error.clone()),
+                    }));
+                }
+            }
+        } else if self
+            .reconnecting
+            .get(&local_id)
+            .is_some_and(|request_id| request_id == &response_id)
+        {
+            self.reconnecting.remove(&local_id);
+            self.subs.remove_sub(local_id);
+            warn!(?local_id, %error, "failed to restore subscription after reconnect");
+        }
+
+        if let Some(route) = self.subscribe_routes.get_mut(&response_id) {
+            Self::complete_cleanup_waiters(
+                std::mem::take(&mut route.cleanup_waiters),
+                UnsubscribeOutcome::AlreadyAbsent,
+            );
+        }
+    }
+
+    fn compensate_subscription(
+        &mut self,
+        response_id: Id,
+        server_id: SubId,
+        unsubscribe_method: Option<Cow<'static, str>>,
+    ) -> TransportResult<()> {
+        if self.subs.contains_server_id(&server_id) {
+            let waiters = self
+                .subscribe_routes
+                .get_mut(&response_id)
+                .map(|route| std::mem::take(&mut route.cleanup_waiters))
+                .unwrap_or_default();
+            warn!(?server_id, "refusing to clean up a server id held by a live subscription");
+            for waiter in waiters {
+                let _ = waiter.send(Err(RpcError::local_usage_str(
+                    "stale cleanup targeted a live subscription",
+                )));
+            }
+            return Ok(());
+        }
+        let Some(unsubscribe_method) = unsubscribe_method else {
+            warn!(?server_id, "unclaimed subscription has no cleanup method; it will remain until connection close");
+            return Ok(());
+        };
+        let waiters = self
+            .subscribe_routes
+            .get_mut(&response_id)
+            .map(|route| std::mem::take(&mut route.cleanup_waiters))
+            .unwrap_or_default();
+        warn!(?server_id, "cleaning up an unclaimed subscription response");
+        self.start_cleanup(server_id, unsubscribe_method, waiters)
+    }
+
+    fn defer_cleanup_until_connection_close(&mut self, waiters: Vec<CleanupWaiter>) {
+        if !waiters.is_empty() {
+            self.connection_cleanup_waiters
+                .entry(self.connection_epoch)
+                .or_default()
+                .extend(waiters);
+        }
+    }
+
+    fn start_cleanup(
+        &mut self,
+        server_id: SubId,
+        unsubscribe_method: Cow<'static, str>,
+        waiters: Vec<CleanupWaiter>,
+    ) -> TransportResult<()> {
+        if let Some((_, cleanup)) =
+            self.pending_cleanups.iter_mut().find(|(_, cleanup)| cleanup.server_id == server_id)
+        {
+            cleanup.waiters.extend(waiters);
+            return Ok(());
+        }
+
+        let request_id = self.next_service_id();
+        let request =
+            Request::new(unsubscribe_method.clone(), request_id.clone(), [server_id.clone()])
+                .serialize()
+                .map_err(RpcError::ser_err)?;
+        self.pending_cleanups.insert(
+            request_id,
+            PendingCleanup {
+                server_id,
+                unsubscribe_method,
+                connection_epoch: self.connection_epoch,
+                waiters,
+            },
+        );
+        self.dispatch_request(request.into_serialized())
+    }
+
+    fn handle_cleanup_response(&mut self, response: Response) -> TransportResult<()> {
+        let cleanup = self.pending_cleanups.remove(&response.id).expect("checked by caller");
+        match response.payload {
+            ResponsePayload::Success(value) => match serde_json::from_str::<bool>(value.get()) {
+                Ok(true) => {
+                    trace!(?cleanup.server_id, method=%cleanup.unsubscribe_method, "subscription cleanup confirmed");
+                    Self::complete_cleanup_waiters(
+                        cleanup.waiters,
+                        UnsubscribeOutcome::ServerConfirmed,
+                    );
+                }
+                Ok(false) => {
+                    info!(?cleanup.server_id, method=%cleanup.unsubscribe_method, "subscription was already absent");
+                    Self::complete_cleanup_waiters(
+                        cleanup.waiters,
+                        UnsubscribeOutcome::AlreadyAbsent,
+                    );
+                }
+                Err(error) => {
+                    warn!(?cleanup.server_id, method=%cleanup.unsubscribe_method, %error, "invalid subscription cleanup response");
+                    for waiter in cleanup.waiters {
+                        let error = serde_json::from_str::<bool>(value.get()).unwrap_err();
+                        let _ = waiter.send(Err(alloy_transport::TransportError::deser_err(
+                            error,
+                            value.get(),
+                        )));
+                    }
+                }
+            },
+            ResponsePayload::Failure(error) => {
+                warn!(?cleanup.server_id, method=%cleanup.unsubscribe_method, %error, "subscription cleanup failed");
+                for waiter in cleanup.waiters {
+                    let _ = waiter.send(Err(RpcError::ErrorResp(error.clone())));
+                }
+            }
+        }
         Ok(())
+    }
+
+    fn complete_cleanup_waiters(waiters: Vec<CleanupWaiter>, outcome: UnsubscribeOutcome) {
+        for waiter in waiters {
+            let _ = waiter.send(Ok(outcome));
+        }
     }
 
     /// Attempt to reconnect with retries.
@@ -298,6 +886,8 @@ impl<T: PubSubConnect> PubSubService<T> {
                 }
             };
 
+            let epoch = self.connection_epoch;
+            self.finish_connection_epoch(epoch);
             if let Err(err) = result {
                 error!(%err, "pubsub service reconnection error");
             }
@@ -322,8 +912,8 @@ fn reconnect_retry_interval(base_interval: Duration, retry_count: u32) -> Durati
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ConnectionInterface;
-    use alloy_json_rpc::Request;
+    use crate::{ConnectionInterface, SubscriptionOptions};
+    use alloy_json_rpc::{Request, SerializedRequest};
     use std::{
         sync::{
             atomic::{AtomicUsize, Ordering},
@@ -352,6 +942,615 @@ mod tests {
                 .take()
                 .ok_or_else(|| TransportErrorKind::custom_str("missing mock connection handle"))
         }
+    }
+
+    fn test_service() -> (PubSubService<MockConnect>, ConnectionInterface) {
+        let (handle, interface) = ConnectionHandle::new();
+        let (_tx, reqs) = mpsc::unbounded_channel();
+        (PubSubService::new(handle, MockConnect::default(), reqs), interface)
+    }
+
+    fn eth_subscription(id: u64, topic: &'static str) -> SerializedRequest {
+        Request::new("eth_subscribe", Id::Number(id), (topic,)).serialize().unwrap()
+    }
+
+    fn custom_subscription(
+        id: u64,
+        method: &'static str,
+        unsubscribe_method: Option<&'static str>,
+    ) -> SerializedRequest {
+        let mut request = Request::new(method, Id::Number(id), ());
+        request.set_is_subscription();
+        if let Some(unsubscribe_method) = unsubscribe_method {
+            request
+                .meta
+                .extensions_mut()
+                .get_or_insert_default::<SubscriptionOptions>()
+                .set_unsubscribe_method(unsubscribe_method);
+        }
+        request.serialize().unwrap()
+    }
+
+    fn with_channel_size(mut request: SerializedRequest, channel_size: usize) -> SerializedRequest {
+        request
+            .meta_mut()
+            .extensions_mut()
+            .get_or_insert_default::<SubscriptionOptions>()
+            .set_channel_size(channel_size);
+        request
+    }
+
+    fn subscription_response(id: Id, server_id: &str) -> Response {
+        Response {
+            id,
+            payload: ResponsePayload::Success(
+                to_json_raw_value(&SubId::String(server_id.to_owned())).unwrap(),
+            ),
+        }
+    }
+
+    fn bool_response(id: Id, value: bool) -> Response {
+        Response { id, payload: ResponsePayload::Success(to_json_raw_value(&value).unwrap()) }
+    }
+
+    fn take_wire(interface: &mut ConnectionInterface) -> serde_json::Value {
+        let request = interface.from_frontend.try_recv().expect("expected outbound request");
+        serde_json::from_str(request.get()).unwrap()
+    }
+
+    fn assert_no_wire(interface: &mut ConnectionInterface) {
+        assert!(matches!(
+            interface.from_frontend.try_recv(),
+            Err(mpsc::error::TryRecvError::Empty)
+        ));
+    }
+
+    fn alias_from_response(response: Response, expected_id: Id) -> B256 {
+        assert_eq!(response.id, expected_id);
+        match response.payload {
+            ResponsePayload::Success(value) => serde_json::from_str(value.get()).unwrap(),
+            ResponsePayload::Failure(error) => panic!("unexpected error response: {error}"),
+        }
+    }
+
+    fn activate(
+        service: &mut PubSubService<MockConnect>,
+        interface: &mut ConnectionInterface,
+        request: SerializedRequest,
+        server_id: &str,
+    ) -> B256 {
+        let request_id = request.id().clone();
+        let (in_flight, mut rx) = InFlight::new(request, 16);
+        service.service_request(in_flight).unwrap();
+        let _ = take_wire(interface);
+        service.handle_item(subscription_response(request_id.clone(), server_id).into()).unwrap();
+        let response = rx.try_recv().unwrap().unwrap();
+        alias_from_response(response, request_id)
+    }
+
+    #[test]
+    fn subscription_local_id_includes_the_method() {
+        let admin = Request::new("admin_peerEvents", Id::Number(1), ()).serialize().unwrap();
+        let reth = Request::new("reth_subscribeChainNotifications", Id::Number(2), ())
+            .serialize()
+            .unwrap();
+
+        assert_ne!(subscription_local_id(&admin), subscription_local_id(&reth));
+    }
+
+    #[test]
+    fn subscription_local_id_distinguishes_params_presence_and_value() {
+        let omitted = Request::new("custom_subscribe", Id::Number(1), ()).serialize().unwrap();
+        let null = Request::new("custom_subscribe", Id::Number(2), serde_json::Value::Null)
+            .serialize()
+            .unwrap();
+        let empty =
+            Request::new("custom_subscribe", Id::Number(3), Vec::<u8>::new()).serialize().unwrap();
+
+        let omitted = subscription_local_id(&omitted);
+        let null = subscription_local_id(&null);
+        let empty = subscription_local_id(&empty);
+        assert_ne!(omitted, null);
+        assert_ne!(omitted, empty);
+        assert_ne!(null, empty);
+    }
+
+    #[test]
+    fn identical_subscriptions_share_one_wire_request_and_preserve_waiter_ids() {
+        let (mut service, mut interface) = test_service();
+        let (first, mut first_rx) = InFlight::new(eth_subscription(1, "newHeads"), 16);
+        let (second, mut second_rx) = InFlight::new(eth_subscription(2, "newHeads"), 16);
+
+        service.service_request(first).unwrap();
+        let wire = take_wire(&mut interface);
+        assert_eq!(wire["id"], 1);
+        service.service_request(second).unwrap();
+        assert_no_wire(&mut interface);
+
+        service.handle_item(subscription_response(Id::Number(1), "server-1").into()).unwrap();
+        let first_alias = alias_from_response(first_rx.try_recv().unwrap().unwrap(), Id::Number(1));
+        let second_alias =
+            alias_from_response(second_rx.try_recv().unwrap().unwrap(), Id::Number(2));
+        assert_eq!(first_alias, second_alias);
+        assert_eq!(service.subs.len(), 1);
+
+        let first_local = service.subs.get_subscription(first_alias).unwrap();
+        let second_local = service.subs.get_subscription(second_alias).unwrap();
+        assert_eq!(first_local.local_id, second_local.local_id);
+
+        let (third, mut third_rx) = InFlight::new(eth_subscription(3, "newHeads"), 16);
+        service.service_request(third).unwrap();
+        assert_no_wire(&mut interface);
+        assert_eq!(
+            alias_from_response(third_rx.try_recv().unwrap().unwrap(), Id::Number(3)),
+            first_alias
+        );
+    }
+
+    #[test]
+    fn different_methods_with_omitted_params_do_not_collide() {
+        let (mut service, mut interface) = test_service();
+        let (admin, _admin_rx) =
+            InFlight::new(custom_subscription(1, "admin_peerEvents", None), 16);
+        let (reth, _reth_rx) =
+            InFlight::new(custom_subscription(2, "reth_subscribeChainNotifications", None), 16);
+
+        service.service_request(admin).unwrap();
+        service.service_request(reth).unwrap();
+        assert_eq!(take_wire(&mut interface)["method"], "admin_peerEvents");
+        assert_eq!(take_wire(&mut interface)["method"], "reth_subscribeChainNotifications");
+        assert_eq!(service.starting.len(), 2);
+    }
+
+    #[test]
+    fn cancelled_single_flight_is_compensated_after_success() {
+        let (mut service, mut interface) = test_service();
+        let (in_flight, rx) = InFlight::new(eth_subscription(1, "logs"), 16);
+        service.service_request(in_flight).unwrap();
+        let _ = take_wire(&mut interface);
+        drop(rx);
+
+        service.handle_item(subscription_response(Id::Number(1), "abandoned").into()).unwrap();
+        assert_eq!(service.subs.len(), 0);
+        let cleanup = take_wire(&mut interface);
+        assert_eq!(cleanup["method"], "eth_unsubscribe");
+        assert_eq!(cleanup["params"], serde_json::json!(["abandoned"]));
+    }
+
+    #[test]
+    fn cancelling_first_waiter_does_not_cancel_other_waiters() {
+        let (mut service, mut interface) = test_service();
+        let (first, first_rx) = InFlight::new(eth_subscription(1, "logs"), 16);
+        let (second, mut second_rx) = InFlight::new(eth_subscription(2, "logs"), 16);
+        service.service_request(first).unwrap();
+        let _ = take_wire(&mut interface);
+        service.service_request(second).unwrap();
+        drop(first_rx);
+
+        service.handle_item(subscription_response(Id::Number(1), "shared").into()).unwrap();
+        let _ = alias_from_response(second_rx.try_recv().unwrap().unwrap(), Id::Number(2));
+        assert_eq!(service.subs.len(), 1);
+        assert_no_wire(&mut interface);
+    }
+
+    #[test]
+    fn new_waiter_joins_existing_single_flight_after_earlier_waiters_cancel() {
+        let (mut service, mut interface) = test_service();
+        let (first, first_rx) = InFlight::new(eth_subscription(1, "logs"), 16);
+        service.service_request(first).unwrap();
+        let _ = take_wire(&mut interface);
+        drop(first_rx);
+
+        let (second, mut second_rx) = InFlight::new(eth_subscription(2, "logs"), 16);
+        service.service_request(second).unwrap();
+        assert_no_wire(&mut interface);
+
+        service.handle_item(subscription_response(Id::Number(1), "shared").into()).unwrap();
+        let _ = alias_from_response(second_rx.try_recv().unwrap().unwrap(), Id::Number(2));
+        assert_eq!(service.subs.len(), 1);
+        assert_no_wire(&mut interface);
+    }
+
+    #[test]
+    fn cancelled_before_service_dispatch_has_no_side_effect() {
+        let (mut service, mut interface) = test_service();
+        let (in_flight, rx) = InFlight::new(eth_subscription(1, "logs"), 16);
+        drop(rx);
+
+        service.service_request(in_flight).unwrap();
+        assert!(service.starting.is_empty());
+        assert_no_wire(&mut interface);
+    }
+
+    #[test]
+    fn subscription_error_is_fanned_out_with_each_waiter_id() {
+        let (mut service, mut interface) = test_service();
+        let (first, mut first_rx) = InFlight::new(eth_subscription(1, "logs"), 16);
+        let (second, mut second_rx) = InFlight::new(eth_subscription(2, "logs"), 16);
+        service.service_request(first).unwrap();
+        let _ = take_wire(&mut interface);
+        service.service_request(second).unwrap();
+
+        service.handle_item(Response::internal_error(Id::Number(1)).into()).unwrap();
+        let first = first_rx.try_recv().unwrap().unwrap();
+        let second = second_rx.try_recv().unwrap().unwrap();
+        assert_eq!(first.id, Id::Number(1));
+        assert_eq!(second.id, Id::Number(2));
+        assert!(first.is_error());
+        assert!(second.is_error());
+        assert!(service.starting.is_empty());
+        assert_eq!(service.subs.len(), 0);
+    }
+
+    #[test]
+    fn different_params_create_independent_upstream_subscriptions() {
+        let (mut service, mut interface) = test_service();
+        let (heads, _heads_rx) = InFlight::new(eth_subscription(1, "newHeads"), 16);
+        let (logs, _logs_rx) = InFlight::new(eth_subscription(2, "logs"), 16);
+
+        service.service_request(heads).unwrap();
+        service.service_request(logs).unwrap();
+
+        assert_eq!(take_wire(&mut interface)["params"], serde_json::json!(["newHeads"]));
+        assert_eq!(take_wire(&mut interface)["params"], serde_json::json!(["logs"]));
+        assert_eq!(service.starting.len(), 2);
+    }
+
+    #[test]
+    fn duplicate_server_response_is_cleaned_without_overwriting_active_id() {
+        let (mut service, mut interface) = test_service();
+        let alias =
+            activate(&mut service, &mut interface, eth_subscription(1, "newHeads"), "active");
+
+        service.handle_item(subscription_response(Id::Number(1), "duplicate").into()).unwrap();
+        let cleanup = take_wire(&mut interface);
+        assert_eq!(cleanup["params"], serde_json::json!(["duplicate"]));
+        assert_eq!(
+            service.subs.server_id_for_local_id(&alias),
+            Some(&SubId::String("active".into()))
+        );
+
+        service.handle_item(subscription_response(Id::Number(1), "active").into()).unwrap();
+        assert_no_wire(&mut interface);
+    }
+
+    #[test]
+    fn per_request_channel_size_is_first_creator_wins_and_zero_is_rejected() {
+        let (mut service, mut interface) = test_service();
+        let first_request = with_channel_size(eth_subscription(1, "newHeads"), 7);
+        let second_request = with_channel_size(eth_subscription(2, "newHeads"), 11);
+        let local_id = subscription_local_id(&first_request);
+        let (first, mut first_rx) = InFlight::new(first_request, 16);
+        let (second, mut second_rx) = InFlight::new(second_request, 16);
+        service.service_request(first).unwrap();
+        let _ = take_wire(&mut interface);
+        service.service_request(second).unwrap();
+        assert_no_wire(&mut interface);
+        service.handle_item(subscription_response(Id::Number(1), "sized").into()).unwrap();
+        first_rx.try_recv().unwrap().unwrap();
+        second_rx.try_recv().unwrap().unwrap();
+        assert_eq!(service.subs.get(&local_id).unwrap().channel_size, 7);
+
+        let active_request = with_channel_size(eth_subscription(3, "newHeads"), 19);
+        let (active, mut active_rx) = InFlight::new(active_request, 16);
+        service.service_request(active).unwrap();
+        assert_no_wire(&mut interface);
+        active_rx.try_recv().unwrap().unwrap();
+        assert_eq!(service.subs.get(&local_id).unwrap().channel_size, 7);
+
+        let independent_request = with_channel_size(eth_subscription(4, "logs"), 13);
+        let independent_local_id = subscription_local_id(&independent_request);
+        let _ = activate(&mut service, &mut interface, independent_request, "independent");
+        assert_eq!(service.subs.get(&independent_local_id).unwrap().channel_size, 13);
+        assert_eq!(service.subs.get(&local_id).unwrap().channel_size, 7);
+
+        let zero = with_channel_size(eth_subscription(5, "newPendingTransactions"), 0);
+        let (zero, mut zero_rx) = InFlight::new(zero, 16);
+        service.service_request(zero).unwrap();
+        assert!(zero_rx.try_recv().unwrap().unwrap_err().is_local_usage_error());
+        assert_no_wire(&mut interface);
+    }
+
+    #[test]
+    fn tracked_cleanup_uses_reserved_id_and_waits_for_ack() {
+        let (mut service, mut interface) = test_service();
+        let alias =
+            activate(&mut service, &mut interface, eth_subscription(1, "newHeads"), "active");
+        let (tx, mut rx) = oneshot::channel();
+        service.service_unsubscribe(alias, Some(tx)).unwrap();
+        let cleanup = take_wire(&mut interface);
+        assert_eq!(cleanup["method"], "eth_unsubscribe");
+        let cleanup_id = cleanup["id"].as_str().unwrap().to_owned();
+        assert!(cleanup_id.starts_with("alloy-pubsub:0:"));
+        assert!(matches!(rx.try_recv(), Err(oneshot::error::TryRecvError::Empty)));
+
+        service.handle_item(bool_response(Id::String(cleanup_id.clone()), true).into()).unwrap();
+        assert_eq!(rx.try_recv().unwrap().unwrap(), UnsubscribeOutcome::ServerConfirmed);
+
+        let live = activate(&mut service, &mut interface, eth_subscription(2, "logs"), "live");
+        service.handle_item(bool_response(Id::String(cleanup_id), true).into()).unwrap();
+        assert!(service.subs.get(&live).is_some());
+        assert_no_wire(&mut interface);
+    }
+
+    #[test]
+    fn concurrent_cleanups_use_distinct_service_request_ids() {
+        let (mut service, mut interface) = test_service();
+        let first =
+            activate(&mut service, &mut interface, eth_subscription(1, "newHeads"), "first");
+        let second = activate(&mut service, &mut interface, eth_subscription(2, "logs"), "second");
+
+        service.service_unsubscribe(first, None).unwrap();
+        service.service_unsubscribe(second, None).unwrap();
+        let first_cleanup = take_wire(&mut interface);
+        let second_cleanup = take_wire(&mut interface);
+
+        assert_ne!(first_cleanup["id"], second_cleanup["id"]);
+        assert!(first_cleanup["id"].as_str().unwrap().starts_with("alloy-pubsub:0:"));
+        assert!(second_cleanup["id"].as_str().unwrap().starts_with("alloy-pubsub:0:"));
+    }
+
+    #[test]
+    fn cleanup_response_cannot_hijack_numeric_in_flight_request() {
+        let (mut service, mut interface) = test_service();
+        let normal = Request::new("eth_blockNumber", Id::Number(1), ()).serialize().unwrap();
+        let (normal, mut normal_rx) = InFlight::new(normal, 16);
+        service.service_request(normal).unwrap();
+        let _ = take_wire(&mut interface);
+
+        let alias =
+            activate(&mut service, &mut interface, eth_subscription(2, "newHeads"), "active");
+        let (tx, mut cleanup_rx) = oneshot::channel();
+        service.service_unsubscribe(alias, Some(tx)).unwrap();
+        let cleanup = take_wire(&mut interface);
+        let cleanup_id = Id::String(cleanup["id"].as_str().unwrap().to_owned());
+        service.handle_item(bool_response(cleanup_id, true).into()).unwrap();
+        assert_eq!(cleanup_rx.try_recv().unwrap().unwrap(), UnsubscribeOutcome::ServerConfirmed);
+        assert!(matches!(normal_rx.try_recv(), Err(oneshot::error::TryRecvError::Empty)));
+
+        let normal_response = Response {
+            id: Id::Number(1),
+            payload: ResponsePayload::Success(to_json_raw_value(&"0x1").unwrap()),
+        };
+        service.handle_item(normal_response.into()).unwrap();
+        assert_eq!(normal_rx.try_recv().unwrap().unwrap().id, Id::Number(1));
+    }
+
+    #[test]
+    fn tracked_cleanup_reports_false_and_rpc_error_without_retry() {
+        let (mut service, mut interface) = test_service();
+        let alias =
+            activate(&mut service, &mut interface, eth_subscription(1, "newHeads"), "first");
+        let (tx, mut rx) = oneshot::channel();
+        service.service_unsubscribe(alias, Some(tx)).unwrap();
+        let cleanup = take_wire(&mut interface);
+        let cleanup_id = Id::String(cleanup["id"].as_str().unwrap().to_owned());
+        service.handle_item(bool_response(cleanup_id, false).into()).unwrap();
+        assert_eq!(rx.try_recv().unwrap().unwrap(), UnsubscribeOutcome::AlreadyAbsent);
+
+        let alias = activate(&mut service, &mut interface, eth_subscription(2, "logs"), "second");
+        let (tx, mut rx) = oneshot::channel();
+        service.service_unsubscribe(alias, Some(tx)).unwrap();
+        let cleanup = take_wire(&mut interface);
+        let cleanup_id = Id::String(cleanup["id"].as_str().unwrap().to_owned());
+        service.handle_item(Response::internal_error(cleanup_id).into()).unwrap();
+        assert!(rx.try_recv().unwrap().unwrap_err().is_error_resp());
+        assert_no_wire(&mut interface);
+    }
+
+    #[tokio::test]
+    async fn pending_cleanup_completes_on_close_and_is_not_replayed() {
+        let (old_handle, mut old_interface) = ConnectionHandle::new();
+        let (new_handle, mut new_interface) = ConnectionHandle::new();
+        let connector = MockConnect(Arc::new(Mutex::new(Some(new_handle))));
+        let (_tx, reqs) = mpsc::unbounded_channel();
+        let mut service = PubSubService::new(old_handle, connector, reqs);
+        let alias =
+            activate(&mut service, &mut old_interface, eth_subscription(1, "newHeads"), "active");
+        let (tx, mut rx) = oneshot::channel();
+        service.service_unsubscribe(alias, Some(tx)).unwrap();
+        let _ = take_wire(&mut old_interface);
+
+        service.reconnect().await.unwrap();
+        assert_eq!(rx.try_recv().unwrap().unwrap(), UnsubscribeOutcome::TransportClosed);
+        assert_no_wire(&mut new_interface);
+    }
+
+    #[test]
+    fn force_unsubscribe_closes_all_local_receivers() {
+        let (mut service, mut interface) = test_service();
+        let alias =
+            activate(&mut service, &mut interface, eth_subscription(1, "newHeads"), "active");
+        let mut first = service.subs.get_subscription(alias).unwrap();
+        let mut second = service.subs.get_subscription(alias).unwrap();
+
+        service.service_unsubscribe(alias, None).unwrap();
+        let _ = take_wire(&mut interface);
+        assert!(matches!(
+            first.rx.try_recv(),
+            Err(tokio::sync::broadcast::error::TryRecvError::Closed)
+        ));
+        assert!(matches!(
+            second.rx.try_recv(),
+            Err(tokio::sync::broadcast::error::TryRecvError::Closed)
+        ));
+    }
+
+    #[test]
+    fn force_unsubscribe_while_starting_compensates_the_late_server_id() {
+        let (mut service, mut interface) = test_service();
+        let request = eth_subscription(1, "newHeads");
+        let alias = subscription_local_id(&request);
+        let (in_flight, mut response_rx) = InFlight::new(request, 16);
+        service.service_request(in_flight).unwrap();
+        let _ = take_wire(&mut interface);
+
+        let (tx, mut cleanup_rx) = oneshot::channel();
+        service.service_unsubscribe(alias, Some(tx)).unwrap();
+        assert!(response_rx.try_recv().unwrap().unwrap_err().is_local_usage_error());
+        assert_no_wire(&mut interface);
+
+        service.handle_item(subscription_response(Id::Number(1), "late").into()).unwrap();
+        let cleanup = take_wire(&mut interface);
+        assert_eq!(cleanup["params"], serde_json::json!(["late"]));
+        let cleanup_id = Id::String(cleanup["id"].as_str().unwrap().to_owned());
+        service.handle_item(bool_response(cleanup_id, true).into()).unwrap();
+        assert_eq!(cleanup_rx.try_recv().unwrap().unwrap(), UnsubscribeOutcome::ServerConfirmed);
+        assert_eq!(service.subs.len(), 0);
+    }
+
+    #[test]
+    fn force_unsubscribe_while_starting_reports_an_invalid_subscribe_response() {
+        let (mut service, mut interface) = test_service();
+        let request = eth_subscription(1, "newHeads");
+        let alias = subscription_local_id(&request);
+        let (in_flight, _response_rx) = InFlight::new(request, 16);
+        service.service_request(in_flight).unwrap();
+        let _ = take_wire(&mut interface);
+
+        let (tx, mut cleanup_rx) = oneshot::channel();
+        service.service_unsubscribe(alias, Some(tx)).unwrap();
+        let invalid = Response {
+            id: Id::Number(1),
+            payload: ResponsePayload::Success(to_json_raw_value(&true).unwrap()),
+        };
+        service.handle_item(invalid.into()).unwrap();
+
+        assert!(cleanup_rx.try_recv().unwrap().unwrap_err().is_deser_error());
+        assert_no_wire(&mut interface);
+        assert_eq!(service.subs.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn force_unsubscribe_during_reconnect_tracks_late_server_id() {
+        let (old_handle, mut old_interface) = ConnectionHandle::new();
+        let (new_handle, mut new_interface) = ConnectionHandle::new();
+        let connector = MockConnect(Arc::new(Mutex::new(Some(new_handle))));
+        let (_tx, reqs) = mpsc::unbounded_channel();
+        let mut service = PubSubService::new(old_handle, connector, reqs);
+        let alias = activate(
+            &mut service,
+            &mut old_interface,
+            eth_subscription(1, "newHeads"),
+            "old-server",
+        );
+
+        service.reconnect().await.unwrap();
+        let replay = take_wire(&mut new_interface);
+        let replay_id = Id::String(replay["id"].as_str().unwrap().to_owned());
+        let (tx, mut rx) = oneshot::channel();
+        service.service_unsubscribe(alias, Some(tx)).unwrap();
+        assert_no_wire(&mut new_interface);
+
+        service.handle_item(subscription_response(replay_id, "late-server").into()).unwrap();
+        let cleanup = take_wire(&mut new_interface);
+        assert_eq!(cleanup["params"], serde_json::json!(["late-server"]));
+        let cleanup_id = Id::String(cleanup["id"].as_str().unwrap().to_owned());
+        service.handle_item(bool_response(cleanup_id, true).into()).unwrap();
+        assert_eq!(rx.try_recv().unwrap().unwrap(), UnsubscribeOutcome::ServerConfirmed);
+    }
+
+    #[test]
+    fn verified_custom_cleanup_methods_are_used_exactly() {
+        let cases = [
+            ("admin_peerEvents", "admin_unsubscribe"),
+            ("reth_subscribeChainNotifications", "reth_unsubscribeChainNotifications"),
+            ("reth_subscribePersistedBlock", "reth_unsubscribePersistedBlock"),
+        ];
+
+        for (index, (subscribe, unsubscribe)) in cases.into_iter().enumerate() {
+            let (mut service, mut interface) = test_service();
+            let alias = activate(
+                &mut service,
+                &mut interface,
+                custom_subscription(index as u64 + 1, subscribe, Some(unsubscribe)),
+                &format!("server-{index}"),
+            );
+            service.service_unsubscribe(alias, None).unwrap();
+            assert_eq!(take_wire(&mut interface)["method"], unsubscribe);
+        }
+    }
+
+    #[test]
+    fn conflicting_custom_cleanup_method_keeps_first_creator_value() {
+        let (mut service, mut interface) = test_service();
+        let (first, mut first_rx) =
+            InFlight::new(custom_subscription(1, "custom_events", Some("custom_unsubscribeA")), 16);
+        let (second, mut second_rx) =
+            InFlight::new(custom_subscription(2, "custom_events", Some("custom_unsubscribeB")), 16);
+        service.service_request(first).unwrap();
+        let _ = take_wire(&mut interface);
+        service.service_request(second).unwrap();
+        service.handle_item(subscription_response(Id::Number(1), "custom").into()).unwrap();
+        let alias = alias_from_response(first_rx.try_recv().unwrap().unwrap(), Id::Number(1));
+        let second_alias =
+            alias_from_response(second_rx.try_recv().unwrap().unwrap(), Id::Number(2));
+        assert_eq!(alias, second_alias);
+
+        service.service_unsubscribe(alias, None).unwrap();
+        assert_eq!(take_wire(&mut interface)["method"], "custom_unsubscribeA");
+    }
+
+    #[test]
+    fn custom_subscription_without_cleanup_method_waits_for_connection_close() {
+        let (mut service, mut interface) = test_service();
+        let alias = activate(
+            &mut service,
+            &mut interface,
+            custom_subscription(1, "custom_events", None),
+            "custom",
+        );
+        let (tx, mut rx) = oneshot::channel();
+        service.service_unsubscribe(alias, Some(tx)).unwrap();
+        assert_no_wire(&mut interface);
+        assert!(matches!(rx.try_recv(), Err(oneshot::error::TryRecvError::Empty)));
+
+        service.finish_connection_epoch(0);
+        assert_eq!(rx.try_recv().unwrap().unwrap(), UnsubscribeOutcome::TransportClosed);
+    }
+
+    #[tokio::test]
+    async fn reconnect_uses_unique_route_and_preserves_channel_capacity() {
+        let (old_handle, mut old_interface) = ConnectionHandle::new();
+        let (new_handle, mut new_interface) = ConnectionHandle::new();
+        let connector = MockConnect(Arc::new(Mutex::new(Some(new_handle))));
+        let (_tx, reqs) = mpsc::unbounded_channel();
+        let mut service = PubSubService::new(old_handle, connector, reqs);
+        let request = with_channel_size(eth_subscription(1, "newHeads"), 23);
+        let local_id = subscription_local_id(&request);
+        let _ = activate(&mut service, &mut old_interface, request, "old-server");
+
+        service.reconnect().await.unwrap();
+        let replay = take_wire(&mut new_interface);
+        assert_eq!(replay["method"], "eth_subscribe");
+        let replay_id = replay["id"].as_str().unwrap().to_owned();
+        assert!(replay_id.starts_with("alloy-pubsub:1:"));
+        assert_eq!(service.subs.get(&local_id).unwrap().channel_size, 23);
+
+        service
+            .handle_item(subscription_response(Id::String(replay_id), "new-server").into())
+            .unwrap();
+        assert_eq!(
+            service.subs.server_id_for_local_id(&local_id),
+            Some(&SubId::String("new-server".into()))
+        );
+    }
+
+    #[tokio::test]
+    async fn reconnect_does_not_reissue_fully_cancelled_starting_request() {
+        let (old_handle, mut old_interface) = ConnectionHandle::new();
+        let (new_handle, mut new_interface) = ConnectionHandle::new();
+        let connector = MockConnect(Arc::new(Mutex::new(Some(new_handle))));
+        let (_tx, reqs) = mpsc::unbounded_channel();
+        let mut service = PubSubService::new(old_handle, connector, reqs);
+        let (in_flight, rx) = InFlight::new(eth_subscription(1, "newHeads"), 16);
+        service.service_request(in_flight).unwrap();
+        let _ = take_wire(&mut old_interface);
+        drop(rx);
+
+        service.reconnect().await.unwrap();
+        assert!(service.starting.is_empty());
+        assert_no_wire(&mut new_interface);
     }
 
     /// Mock connector that counts every `try_reconnect` invocation and
@@ -445,13 +1644,7 @@ mod tests {
         let (reconnected_handle, mut reconnected_interface) = ConnectionHandle::new();
         let connector = MockConnect(Arc::new(Mutex::new(Some(reconnected_handle))));
         let (tx, reqs) = mpsc::unbounded_channel();
-        let service = PubSubService {
-            handle: dead_handle,
-            connector,
-            reqs,
-            subs: SubscriptionManager::default(),
-            in_flights: RequestManager::default(),
-        };
+        let service = PubSubService::new(dead_handle, connector, reqs);
         service.spawn();
 
         let first = Request::new("eth_blockNumber", Id::Number(1), ()).serialize().unwrap();
@@ -486,13 +1679,7 @@ mod tests {
         let connector = NonRetryableConnect::default();
         let counter = connector.0.clone();
         let (tx, reqs) = mpsc::unbounded_channel();
-        let service = PubSubService {
-            handle: dead_handle,
-            connector,
-            reqs,
-            subs: SubscriptionManager::default(),
-            in_flights: RequestManager::default(),
-        };
+        let service = PubSubService::new(dead_handle, connector, reqs);
         service.spawn();
 
         let req = Request::new("eth_blockNumber", Id::Number(1), ()).serialize().unwrap();
@@ -523,13 +1710,7 @@ mod tests {
         let calls = connector.calls.clone();
 
         let (_tx, reqs) = mpsc::unbounded_channel();
-        let service = PubSubService {
-            handle: live_handle,
-            connector,
-            reqs,
-            subs: SubscriptionManager::default(),
-            in_flights: RequestManager::default(),
-        };
+        let service = PubSubService::new(live_handle, connector, reqs);
         service.spawn();
 
         // Backend signals a deterministic, non-retryable failure.
@@ -558,13 +1739,7 @@ mod tests {
         let calls = connector.calls.clone();
 
         let (tx, reqs) = mpsc::unbounded_channel();
-        let service = PubSubService {
-            handle: live_handle,
-            connector,
-            reqs,
-            subs: SubscriptionManager::default(),
-            in_flights: RequestManager::default(),
-        };
+        let service = PubSubService::new(live_handle, connector, reqs);
         service.spawn();
 
         // Trigger the legacy close path.

--- a/crates/pubsub/src/sub.rs
+++ b/crates/pubsub/src/sub.rs
@@ -10,8 +10,10 @@ use tokio_stream::wrappers::{errors::BroadcastStreamRecvError, BroadcastStream};
 /// local ID.
 ///
 /// This type is mostly a wrapper around [`broadcast::Receiver`], and exposes
-/// the same methods. Dropping it removes this receiver but does not unsubscribe
-/// from the server; use [`PubSubFrontend::unsubscribe`] for that.
+/// the same methods. Dropping it removes this receiver. Under
+/// [`crate::SubscriptionRetentionPolicy::WhileReceivers`], dropping the final
+/// receiver makes the subscription eligible for cleanup. Use
+/// [`PubSubFrontend::unsubscribe`] to force cleanup regardless of retention.
 ///
 /// [`PubSubFrontend::unsubscribe`]: crate::PubSubFrontend::unsubscribe
 #[derive(Debug)]
@@ -131,9 +133,10 @@ impl<T: DeserializeOwned> From<Box<RawValue>> for SubscriptionItem<T> {
 /// that fail to deserialize, while [`SubResultStream`] yields those
 /// deserialization errors.
 ///
-/// Dropping this receiver does not unsubscribe from the server. Use
-/// [`PubSubFrontend::unsubscribe`] with [`Subscription::local_id`] when the
-/// subscription is no longer needed.
+/// Dropping this receiver makes the subscription eligible for cleanup when it
+/// is the final receiver under [`crate::SubscriptionRetentionPolicy::WhileReceivers`].
+/// Use [`PubSubFrontend::unsubscribe`] with [`Subscription::local_id`] to force
+/// cleanup regardless of retention.
 ///
 /// [`PubSubFrontend::unsubscribe`]: crate::PubSubFrontend::unsubscribe
 #[derive(Debug)]

--- a/crates/rpc-client/src/call.rs
+++ b/crates/rpc-client/src/call.rs
@@ -216,6 +216,9 @@ where
     /// Set the request to be a non-standard subscription (i.e. not
     /// "eth_subscribe").
     ///
+    /// Call [`Self::set_unsubscribe_method`] as well when the custom protocol exposes a cleanup
+    /// RPC. Otherwise the subscription can only be reclaimed when its connection closes.
+    ///
     /// # Panics
     ///
     /// Panics if called after the request has been sent.
@@ -226,6 +229,30 @@ where
     /// Set the subscription status of the request.
     pub fn set_subscription_status(&mut self, status: bool) {
         self.request_mut().meta.set_subscription_status(status);
+    }
+
+    /// Set the server-side method used to unsubscribe a non-standard subscription.
+    ///
+    /// This configuration is consumed by pubsub transports and is not serialized onto the wire.
+    #[cfg(feature = "pubsub")]
+    pub fn set_unsubscribe_method(&mut self, method: impl Into<std::borrow::Cow<'static, str>>) {
+        self.request_mut()
+            .meta
+            .extensions_mut()
+            .get_or_insert_default::<alloy_pubsub::SubscriptionOptions>()
+            .set_unsubscribe_method(method);
+    }
+
+    /// Set the local broadcast channel capacity for this subscription request.
+    ///
+    /// This configuration is consumed by pubsub transports and is not serialized onto the wire.
+    #[cfg(feature = "pubsub")]
+    pub fn set_subscription_channel_size(&mut self, channel_size: usize) {
+        self.request_mut()
+            .meta
+            .extensions_mut()
+            .get_or_insert_default::<alloy_pubsub::SubscriptionOptions>()
+            .set_channel_size(channel_size);
     }
 
     /// Get a mutable reference to the params of the request.

--- a/crates/rpc-client/src/call.rs
+++ b/crates/rpc-client/src/call.rs
@@ -218,6 +218,8 @@ where
     ///
     /// Call [`Self::set_unsubscribe_method`] as well when the custom protocol exposes a cleanup
     /// RPC. Otherwise the subscription can only be reclaimed when its connection closes.
+    /// Low-level subscription calls retain their upstream subscription until explicit unsubscribe
+    /// unless [`Self::set_subscription_retention_policy`] selects receiver-scoped retention.
     ///
     /// # Panics
     ///
@@ -253,6 +255,33 @@ where
             .extensions_mut()
             .get_or_insert_default::<alloy_pubsub::SubscriptionOptions>()
             .set_channel_size(channel_size);
+    }
+
+    /// Set when the server-side subscription is eligible for automatic cleanup.
+    ///
+    /// Low-level/manual subscription requests default to
+    /// [`alloy_pubsub::SubscriptionRetentionPolicy::UntilExplicitUnsubscribe`]. Typed provider
+    /// builders set receiver-scoped retention by default.
+    #[cfg(feature = "pubsub")]
+    pub fn set_subscription_retention_policy(
+        &mut self,
+        policy: alloy_pubsub::SubscriptionRetentionPolicy,
+    ) {
+        self.request_mut()
+            .meta
+            .extensions_mut()
+            .get_or_insert_default::<alloy_pubsub::SubscriptionOptions>()
+            .set_retention_policy(policy);
+    }
+
+    /// Attach the one-shot receiver ticket used by typed subscription builders.
+    #[doc(hidden)]
+    #[cfg(feature = "pubsub")]
+    pub fn set_subscription_receiver_ticket(
+        &mut self,
+        ticket: alloy_pubsub::SubscriptionReceiverTicket,
+    ) {
+        self.request_mut().meta.extensions_mut().insert(ticket);
     }
 
     /// Get a mutable reference to the params of the request.

--- a/crates/rpc-client/src/call.rs
+++ b/crates/rpc-client/src/call.rs
@@ -227,6 +227,9 @@ where
     /// Set the request to be a non-standard subscription (i.e. not
     /// "eth_subscribe").
     ///
+    /// Call [`Self::set_unsubscribe_method`] as well when the custom protocol exposes a cleanup
+    /// RPC. Otherwise the subscription can only be reclaimed when its connection closes.
+    ///
     /// # Panics
     ///
     /// Panics if called after the request has been sent.
@@ -237,6 +240,30 @@ where
     /// Set the subscription status of the request.
     pub fn set_subscription_status(&mut self, status: bool) {
         self.request_mut().meta.set_subscription_status(status);
+    }
+
+    /// Set the server-side method used to unsubscribe a non-standard subscription.
+    ///
+    /// This configuration is consumed by pubsub transports and is not serialized onto the wire.
+    #[cfg(feature = "pubsub")]
+    pub fn set_unsubscribe_method(&mut self, method: impl Into<std::borrow::Cow<'static, str>>) {
+        self.request_mut()
+            .meta
+            .extensions_mut()
+            .get_or_insert_default::<alloy_pubsub::SubscriptionOptions>()
+            .set_unsubscribe_method(method);
+    }
+
+    /// Set the local broadcast channel capacity for this subscription request.
+    ///
+    /// This configuration is consumed by pubsub transports and is not serialized onto the wire.
+    #[cfg(feature = "pubsub")]
+    pub fn set_subscription_channel_size(&mut self, channel_size: usize) {
+        self.request_mut()
+            .meta
+            .extensions_mut()
+            .get_or_insert_default::<alloy_pubsub::SubscriptionOptions>()
+            .set_channel_size(channel_size);
     }
 
     /// Get a mutable reference to the params of the request.

--- a/crates/rpc-client/src/call.rs
+++ b/crates/rpc-client/src/call.rs
@@ -229,6 +229,8 @@ where
     ///
     /// Call [`Self::set_unsubscribe_method`] as well when the custom protocol exposes a cleanup
     /// RPC. Otherwise the subscription can only be reclaimed when its connection closes.
+    /// Low-level subscription calls retain their upstream subscription until explicit unsubscribe
+    /// unless [`Self::set_subscription_retention_policy`] selects receiver-scoped retention.
     ///
     /// # Panics
     ///
@@ -264,6 +266,33 @@ where
             .extensions_mut()
             .get_or_insert_default::<alloy_pubsub::SubscriptionOptions>()
             .set_channel_size(channel_size);
+    }
+
+    /// Set when the server-side subscription is eligible for automatic cleanup.
+    ///
+    /// Low-level/manual subscription requests default to
+    /// [`alloy_pubsub::SubscriptionRetentionPolicy::UntilExplicitUnsubscribe`]. Typed provider
+    /// builders set receiver-scoped retention by default.
+    #[cfg(feature = "pubsub")]
+    pub fn set_subscription_retention_policy(
+        &mut self,
+        policy: alloy_pubsub::SubscriptionRetentionPolicy,
+    ) {
+        self.request_mut()
+            .meta
+            .extensions_mut()
+            .get_or_insert_default::<alloy_pubsub::SubscriptionOptions>()
+            .set_retention_policy(policy);
+    }
+
+    /// Attach the one-shot receiver ticket used by typed subscription builders.
+    #[doc(hidden)]
+    #[cfg(feature = "pubsub")]
+    pub fn set_subscription_receiver_ticket(
+        &mut self,
+        ticket: alloy_pubsub::SubscriptionReceiverTicket,
+    ) {
+        self.request_mut().meta.extensions_mut().insert(ticket);
     }
 
     /// Get a mutable reference to the params of the request.


### PR DESCRIPTION
## Summary

This is the complete implementation for #4082 and supersedes #4083. It intentionally combines the wire-level correctness fixes and receiver lifecycle semantics into one review and merge unit.

- deduplicate matching subscriptions before wire dispatch while preserving every caller's JSON-RPC response ID;
- derive local subscription identity from the RPC method, params presence, and exact serialized params;
- compensate unexpected, duplicate, late, and cancelled successful subscribe responses so they cannot leave orphan server subscriptions;
- track cleanup requests with collision-safe service IDs and add `unsubscribe_and_wait` without changing existing `unsubscribe` enqueue semantics;
- carry channel capacity and verified custom cleanup methods as per-request metadata;
- model typed receiver ownership explicitly, clean receiver-scoped subscriptions after the last receiver is dropped, and reconnect only entries that remain locally owned.

## Retention semantics

This draft implements **Option A** proposed in #4082:

- typed `Provider::subscribe_*` builders default to `WhileReceivers`;
- the low-level two-phase/raw path keeps the compatible `UntilExplicitUnsubscribe` default;
- both paths can override the policy per request.

A successfully delivered `UntilExplicitUnsubscribe` waiter commits the shared persistent hold, independent of waiter arrival order. A later `get_subscription(local_id)` does not upgrade receiver-scoped retention.

## Wire lifecycle correctness

Subscription creation is single-flighted before dispatch. Matching sequential or concurrent callers share one upstream subscription, while response fanout restores each caller's original request ID. Cancelled waiters and duplicate or late server responses are compensated without replacing a live server ID.

Cleanup requests use unique service-owned string IDs and their boolean or RPC-error result is tracked. The existing `unsubscribe` API remains enqueue-only; `unsubscribe_and_wait` is additive.

Reconnect routing is epoch-aware, preserves channel capacity, skips fully cancelled starts, restores only owned entries, and compensates a late resubscribe response if ownership disappears.

## Receiver ownership

Typed subscription ownership is delivered through an ephemeral one-shot receiver ticket in the same service turn as the subscribe response. The manager's hidden initial receiver is removed; legacy delivery is represented by explicit manual claims and a persistent hold.

Receiver-scoped subscriptions are checked at notification, acquire, reconnect, and periodic 30-second sweep checkpoints. A zero-receiver generation cannot be reopened by `get_subscription` or an identical subscribe request.

## Identity and route retention

The service computes one fixed-size `B256` local ID from an unambiguous encoding of the RPC method, params presence, and exact serialized params. Service maps and response routes store only that local ID; large params remain only in the serialized request retained for replay.

Subscribe response routes remain until their connection closes so duplicate or late successful responses can still be associated with their cleanup method and compensated. This trades a small amount of connection-lifetime route state for stronger orphan protection; active reuse does not create additional routes.

## Custom cleanup metadata

The existing helpers carry protocol methods verified against their implementations:

- `eth_subscribe` -> `eth_unsubscribe`
- `admin_peerEvents` -> `admin_unsubscribe`
- `reth_subscribeChainNotifications` -> `reth_unsubscribeChainNotifications`
- `reth_subscribePersistedBlock` -> `reth_unsubscribePersistedBlock`

Generic custom subscriptions do not guess a cleanup method and do not fall back to `eth_unsubscribe`. If none is configured, the entry is connection-owned and cleanup completes only when that connection closes.

References:

- https://github.com/ethereum/go-ethereum/blob/06b23b4293950d8c08b624b90f310d1e918048e8/rpc/json.go
- https://github.com/ethereum/go-ethereum/blob/06b23b4293950d8c08b624b90f310d1e918048e8/rpc/handler.go
- https://github.com/paradigmxyz/reth/blob/4ed6acaffdf0823cfef0f512fc7319b332710c3d/crates/rpc/rpc-api/src/reth.rs

## Compatibility

- Existing low-level/manual subscriptions remain persistent by default and have no claim deadline.
- Typed builders adopt Option A's receiver-scoped default.
- Force unsubscribe still closes every local receiver for the shared entry.
- Local aliases now include the method and exact params, so aliases produced by the old params-only scheme change.
- Unknown custom namespaces require explicit cleanup metadata; there is no naming fallback.
- Existing `unsubscribe` behavior is unchanged.

## Validation

- `cargo +1.94.1 test -p alloy-json-rpc -p alloy-pubsub`
- `cargo +1.94.1 test -p alloy-rpc-client --features pubsub,ws`
- `cargo +1.94.1 test -p alloy-provider --features pubsub,ws --lib -- --skip provider::r#trait::tests::test_fill_transaction`
- `cargo +1.94.1 test -p alloy-provider --features pubsub,ws --test it`
- `cargo +1.94.1 test -p alloy-provider --all-features --doc`
- `cargo +1.94.1 clippy -p alloy-pubsub -p alloy-rpc-client -p alloy-provider --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo +1.94.1 doc -p alloy-pubsub -p alloy-rpc-client -p alloy-provider --all-features --no-deps`
- `cargo +1.94.1 check -p alloy-pubsub --target wasm32-unknown-unknown`

The PR conversation also records the downstream Base node 1,024-subscription cap reproduction and validates same-key sharing plus complete slot reclamation after the 30-second sweep.

Supersedes #4083.

Fixes #4082.
