### PR TITLE
fix(tx-macros): restrict TransactionEnvelope fallback decode to legacy (EIP-2718)

### DIFF
--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -1473,6 +1473,77 @@ mod tests {
         assert_eq!(buf, raw.as_slice());
     }
 
+    #[test]
+    fn untagged_fallback_decode_only_accepts_legacy() {
+        // Per EIP-2718, a byte string with no type-byte prefix (first byte >= 0xc0, i.e. it
+        // is an RLP list) can only ever represent a legacy transaction; if it fails the legacy
+        // schema, decoding must fail outright -- it must never be reinterpreted as some other
+        // (typed) transaction kind.
+        //
+        // This 107-byte RLP list is invalid as a legacy tx: list-index 3 (the would-be `to`)
+        // is a 3-byte string, not a 20-byte address or an empty string, and list-index 8 (the
+        // would-be `s`) is RLP-typed as an empty list, not an integer. But the very same bytes
+        // happen to be a byte-for-byte-valid 12-field `TxEip1559` list (chain_id, nonce,
+        // max_priority_fee_per_gas, max_fee_per_gas, gas_limit, to, value, input, access_list,
+        // y_parity, r, s). Before the fix, `EthereumTxEnvelope`'s generated `fallback_decode`
+        // tried every declared variant in enum-declaration order and accepted this input as
+        // `Eip1559`, since that's the first (and only) variant whose raw-field RLP schema
+        // happens to fully consume the buffer.
+        let untagged_invalid_as_legacy_valid_as_eip1559 = hex!(
+            "f8690180830f4240830f424083ffff0c94e1000000000000000000000000000000c0de0000"
+            "8020c080a079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+            "a05168112c1d71e40b6b60530adbd2c4aaf9e4f94b6cca0f5717fac601350af7d3"
+        );
+        assert!(
+            TxEnvelope::decode_2718_exact(&untagged_invalid_as_legacy_valid_as_eip1559).is_err(),
+            "untagged input that is not a valid legacy tx must be rejected, not reinterpreted \
+             as another transaction type"
+        );
+
+        // Guard against over-correction (1): a genuine untagged legacy tx must still decode as
+        // `Legacy`.
+        let legacy = TxLegacy {
+            chain_id: None,
+            nonce: 2,
+            gas_limit: 1_000_000,
+            gas_price: 10_000_000_000,
+            to: Address::left_padding_from(&[6]).into(),
+            value: U256::from(7_u64),
+            ..Default::default()
+        }
+        .into_signed(Signature::test_signature().with_parity(true));
+        let legacy_envelope: TxEnvelope = legacy.into();
+        let legacy_encoded = legacy_envelope.encoded_2718();
+        assert_eq!(
+            TxEnvelope::decode_2718_exact(&legacy_encoded).unwrap(),
+            legacy_envelope,
+            "a genuine legacy transaction must still decode correctly"
+        );
+
+        // Guard against over-correction (2): a genuine, correctly type-tagged (0x02-prefixed)
+        // EIP-1559 tx must still decode as `Eip1559` via `typed_decode` (not `fallback_decode`).
+        let eip1559 = TxEip1559 {
+            chain_id: 1,
+            nonce: 2,
+            max_fee_per_gas: 3,
+            max_priority_fee_per_gas: 4,
+            gas_limit: 5,
+            to: Address::left_padding_from(&[6]).into(),
+            value: U256::from(7_u64),
+            input: vec![8].into(),
+            access_list: Default::default(),
+        }
+        .into_signed(Signature::test_signature());
+        let eip1559_envelope: TxEnvelope = eip1559.into();
+        let eip1559_encoded = eip1559_envelope.encoded_2718();
+        assert_eq!(eip1559_encoded[0], 0x02, "sanity: must be type-tagged, not untagged");
+        assert_eq!(
+            TxEnvelope::decode_2718_exact(&eip1559_encoded).unwrap(),
+            eip1559_envelope,
+            "a genuine type-tagged EIP-1559 transaction must still decode correctly"
+        );
+    }
+
     #[cfg(feature = "serde")]
     fn test_serde_roundtrip<T: SignableTransaction<Signature>>(tx: T)
     where

--- a/crates/consensus/src/transaction/mod.rs
+++ b/crates/consensus/src/transaction/mod.rs
@@ -645,3 +645,58 @@ mod tests {
         );
     }
 }
+
+/// Regression coverage for the `fallback_decode_arms` fix in `alloy-tx-macros`
+/// (`crates/tx-macros/src/expand.rs`): `#[envelope(flatten)]` composes another
+/// `TransactionEnvelope`-derived type into a larger envelope, and that flattened variant may be
+/// the *only* place a legacy transaction is reachable from (as below: `MyEnvelope` declares no
+/// `#[envelope(ty = 0)]` variant of its own). A fix that restricts `fallback_decode` to
+/// `ProcessedVariant::is_legacy()` alone -- dropping `Flattened` variants outright -- would
+/// silently break decoding of untagged legacy transactions for every envelope built this way.
+/// The correct restriction (mirroring `generate_untagged_variants`'s serde untagged path, which
+/// tries flattened variants and the legacy variant, and only those) keeps `Flattened` variants
+/// eligible for fallback decode alongside the legacy variant.
+#[cfg(test)]
+mod fallback_decode_flatten_tests {
+    use crate::{
+        SignableTransaction, Signed, TransactionEnvelope, TxEip1559, TxEnvelope, TxLegacy,
+    };
+    use alloy_eips::eip2718::{Decodable2718, Encodable2718};
+    use alloy_primitives::{Address, Signature, U256};
+
+    #[derive(Debug, Clone, TransactionEnvelope)]
+    #[envelope(alloy_consensus = crate, tx_type_name = MyTxType)]
+    enum MyEnvelope {
+        #[envelope(flatten)]
+        Ethereum(TxEnvelope),
+        #[envelope(ty = 10)]
+        MyTx(Signed<TxEip1559>),
+    }
+
+    #[test]
+    fn flattened_variant_still_decodes_untagged_legacy() {
+        let legacy = TxLegacy {
+            chain_id: None,
+            nonce: 2,
+            gas_limit: 1_000_000,
+            gas_price: 10_000_000_000,
+            to: Address::left_padding_from(&[6]).into(),
+            value: U256::from(7_u64),
+            ..Default::default()
+        }
+        .into_signed(Signature::test_signature().with_parity(true));
+
+        let ethereum_envelope: TxEnvelope = legacy.into();
+        let encoded = ethereum_envelope.encoded_2718();
+        // Sanity: legacy transactions have no EIP-2718 type-byte prefix on the wire, so decoding
+        // this necessarily goes through `fallback_decode`, not `typed_decode`.
+        assert!(encoded[0] >= 0xc0);
+
+        let my_envelope = MyEnvelope::decode_2718_exact(&encoded)
+            .expect("untagged legacy tx must still decode through the flattened variant");
+        match my_envelope {
+            MyEnvelope::Ethereum(TxEnvelope::Legacy(_)) => {}
+            other => panic!("expected Ethereum(Legacy(..)), got {other:?}"),
+        }
+    }
+}


### PR DESCRIPTION
**Issue.** The `#[derive(TransactionEnvelope)]`-generated `Decodable2718::fallback_decode` tries *every* transaction variant against un-typed input (no EIP-2718 type byte, i.e. an RLP list) and returns the first that parses. Per EIP-2718 an untagged byte string can only be a legacy transaction, so input that fails the legacy schema must be rejected — but a byte string that is invalid as legacy yet happens to be a valid field list of another type (e.g. EIP-1559) is silently mis-decoded as that type instead of erroring. Found via differential fuzzing across six EVM implementations: only alloy accepts the sample input, all others reject it. (Decoder-conformance bug, not a consensus split — reth independently cross-checks the transactions-root and rejects such a block regardless — but the decoder should be correct on its own; consumers without that cross-check would accept a non-conformant transaction.)

**Fix.** Restrict the untagged/fallback decode path to the legacy variant only — plus flattened variants, which delegate to an inner envelope that may itself carry the legacy variant — mirroring the crate's existing serde untagged-path logic. Includes regression tests for both the mis-decode rejection and the flatten carve-out.

Related: #2585 (introduced the derive), #4059 (fixed a narrower manifestation of the same fallback loop).
