### PR TITLE
fix: fail in `Signed<T>` `fallback_decode`

### DIFF
--- a/crates/consensus/src/signed.rs
+++ b/crates/consensus/src/signed.rs
@@ -547,7 +547,13 @@ where
     }
 
     fn fallback_decode(buf: &mut &[u8]) -> Eip2718Result<Self> {
-        T::rlp_decode_signed(buf).map_err(Into::into)
+        let decoded = T::rlp_decode_signed(buf)?;
+
+        if decoded.ty() != 0 {
+            return Err(Eip2718Error::UnexpectedType(0));
+        }
+
+        Ok(decoded)
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/alloy/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

`fallback_decode` is supposed to only be called for legacy transactions but right now e.g `Signed<TxEip1559>` is decodeable via it as well

## Solution

Restricts `Signed::fallback_decode` to transactions with zero type byte

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
