### PR TITLE
fix(eips): saturate EIP-1559 base fee increase to avoid u64 overflow

### DIFF
--- a/crates/eips/src/eip1559/helpers.rs
+++ b/crates/eips/src/eip1559/helpers.rs
@@ -122,13 +122,17 @@ pub fn calc_next_block_base_fee(
         // increased base fee.
         core::cmp::Ordering::Greater => {
             // Calculate the increase in base fee based on the formula defined by EIP-1559.
-            base_fee
-                + (core::cmp::max(
-                    // Ensure a minimum increase of 1.
-                    1,
-                    base_fee as u128 * (gas_used - gas_target) as u128
-                        / (gas_target as u128 * base_fee_params.max_change_denominator),
-                ) as u64)
+            // Use a saturating add to mirror the saturating subtraction in the decrease branch:
+            // `base_fee` and the computed increase are both valid `u64`s, but their sum can exceed
+            // `u64::MAX` (e.g. a congested block with a base fee near `u64::MAX`, or aggressive
+            // custom `BaseFeeParams`), which would panic in debug builds and silently wrap in
+            // release builds.
+            base_fee.saturating_add(core::cmp::max(
+                // Ensure a minimum increase of 1.
+                1,
+                base_fee as u128 * (gas_used - gas_target) as u128
+                    / (gas_target as u128 * base_fee_params.max_change_denominator),
+            ) as u64)
         }
         // If the gas used in the current block is less than the gas target, calculate a new
         // decreased base fee.
@@ -384,5 +388,16 @@ mod tests {
         let p = BaseFeeParams::ethereum();
         // gas_target = 1 / 2 = 0; gas_used > 0 used to hit a divide-by-zero in the increase path.
         assert_eq!(calc_next_block_base_fee(1, 1, 1_000_000_000, p), 1_000_000_000);
+    }
+
+    #[test]
+    fn next_base_fee_saturates_on_increase_overflow() {
+        let p = BaseFeeParams::ethereum();
+        // Congested block (gas_used == gas_limit, so gas_used > gas_target) with a base fee near
+        // `u64::MAX`. The increase (~base_fee / 8) used to be added to `base_fee` with an unchecked
+        // `+`, overflowing `u64`: this panicked in debug builds and silently wrapped to a
+        // garbage-low base fee in release builds. It must saturate at `u64::MAX` instead, mirroring
+        // the saturating decrease branch.
+        assert_eq!(calc_next_block_base_fee(30_000_000, 30_000_000, u64::MAX, p), u64::MAX);
     }
 }


### PR DESCRIPTION
## Motivation

The increase branch of `calc_next_block_base_fee` (`crates/eips/src/eip1559/helpers.rs`) adds the computed increase to `base_fee` with an unchecked `+`:

```rust
core::cmp::Ordering::Greater => {
    base_fee
        + (core::cmp::max(
            1,
            base_fee as u128 * (gas_used - gas_target) as u128
                / (gas_target as u128 * base_fee_params.max_change_denominator),
        ) as u64)
}
```

`base_fee` and the computed increase are each valid `u64`s, but their **sum** can exceed `u64::MAX`. When that happens this panics in debug builds (`attempt to add with overflow`) and silently wraps to a garbage-low base fee in release builds.

Concrete failing input (all structurally valid `u64` header fields, reachable via the public `calc_next_block_base_fee` / `Header::next_block_base_fee` and the public `BaseFeeParams::new`):

```rust
// congested block, base fee near u64::MAX, mainnet params
calc_next_block_base_fee(30_000_000, 30_000_000, u64::MAX, BaseFeeParams::ethereum());
// gas_target = 15_000_000, increase ~= base_fee / 8 -> base_fee + increase overflows u64
```

With aggressive custom `BaseFeeParams` (e.g. a small `max_change_denominator`) the overflow threshold drops well below `u64::MAX`, so this is not only a `u64::MAX` corner case.

The asymmetry is the tell: the sibling **decrease** branch already guards this with `saturating_sub`, and this function has recently grown a series of hardening guards (zero elasticity/denominator, `gas_limit < elasticity`) each with a `next_base_fee_no_panic_*` regression test. The increase path was simply never made overflow-safe.

## Solution

Mirror the decrease branch: use `base_fee.saturating_add(...)` instead of `base_fee + ...`. On honest mainnet state (`gas_used <= gas_limit`, base fee ~1e9) the result is unchanged; the only behavioral change is that a would-be overflow now saturates at `u64::MAX` instead of panicking/wrapping.

Adds `next_base_fee_saturates_on_increase_overflow`, which panics (`attempt to add with overflow`) on the current code and passes after the fix. No existing test asserts the old wrapping behavior.

`cargo test -p alloy-eips` passes (13 `eip1559::helpers` tests, including the new one); `cargo +nightly fmt` clean.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes