### PR TITLE
fix(rpc-types): preserve contract creation on decode

### DIFF
--- a/crates/rpc-types-eth/src/transaction/request.rs
+++ b/crates/rpc-types-eth/src/transaction/request.rs
@@ -16,6 +16,14 @@ use alloy_network_primitives::{TransactionBuilder4844, TransactionBuilder7702};
 use alloy_primitives::{Address, Bytes, ChainId, Signature, TxKind, B256, U256};
 use core::{hash::Hash, str::FromStr};
 
+#[cfg(feature = "serde")]
+fn deserialize_to<'de, D>(deserializer: D) -> Result<Option<TxKind>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    <TxKind as serde::Deserialize>::deserialize(deserializer).map(Some)
+}
+
 /// Represents _all_ transaction requests to/from RPC.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
 #[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
@@ -27,7 +35,14 @@ pub struct TransactionRequest {
     #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
     pub from: Option<Address>,
     /// The destination address of the transaction.
-    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(
+            default,
+            skip_serializing_if = "Option::is_none",
+            deserialize_with = "deserialize_to"
+        )
+    )]
     pub to: Option<TxKind>,
     /// The legacy gas price.
     #[cfg_attr(
@@ -1893,6 +1908,18 @@ mod tests {
         let tx = TransactionRequest::default();
         let serialized = serde_json::to_string(&tx).unwrap();
         assert_eq!(serialized, "{}");
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn serde_to_distinguishes_create_from_missing() {
+        let create = TransactionRequest::default().create();
+        let json = serde_json::to_value(create).unwrap();
+        let decoded = serde_json::from_value::<TransactionRequest>(json).unwrap();
+        let missing = serde_json::from_str::<TransactionRequest>("{}").unwrap();
+
+        assert_eq!(decoded.to, Some(TxKind::Create));
+        assert_eq!(missing.to, None);
     }
 
     #[test]


### PR DESCRIPTION
## Motivation

`TransactionRequest::default().create()` serializes `to` as JSON `null`, but deserializing that payload currently turns the destination into `None`. This loses the distinction between a known contract creation and a request whose destination was omitted.

Closes #4076.

## Solution

Deserialize a present `to` field through `TxKind` before wrapping it in `Some`, while retaining the existing serde default for an omitted field. The bincode-compatible adapter remains unchanged.

## Validation

- `cargo +nightly fmt --all -- --check`
- `cargo +1.94.1 check -p alloy-rpc-types-eth --all-features`
- `cargo +1.94.1 build -p alloy-rpc-types-eth --all-features`
- `cargo +1.94.1 test -p alloy-rpc-types-eth --all-features`
- `cargo +1.94.1 check -p alloy-rpc-types-eth --no-default-features`
- `cargo +nightly clippy -p alloy-rpc-types-eth --all-features`

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes