### PR TITLE
feat(network): support network-specific log responses

### DIFF
--- a/crates/contract/Cargo.toml
+++ b/crates/contract/Cargo.toml
@@ -23,6 +23,7 @@ rustdoc-args = [
 workspace = true
 
 [dependencies]
+alloy-json-rpc.workspace = true
 alloy-network.workspace = true
 alloy-network-primitives.workspace = true
 alloy-consensus.workspace = true

--- a/crates/contract/src/event.rs
+++ b/crates/contract/src/event.rs
@@ -1,6 +1,7 @@
 use crate::Error;
-use alloy_network::Ethereum;
-use alloy_primitives::{Address, LogData, B256};
+use alloy_json_rpc::RpcObject;
+use alloy_network::{Ethereum, LogResponse};
+use alloy_primitives::{Address, B256};
 use alloy_provider::{FilterPollerBuilder, Network, Provider};
 use alloy_rpc_types_eth::{BlockNumberOrTag, Filter, FilterBlockOption, Log, Topic, ValueOrArray};
 use alloy_sol_types::SolEvent;
@@ -51,14 +52,14 @@ impl<P: Provider<N>, E: SolEvent, N: Network> Event<P, E, N> {
     }
 
     /// Queries the blockchain for the selected filter and returns a vector of matching event logs.
-    pub async fn query(&self) -> Result<Vec<(E, Log)>, Error> {
+    pub async fn query(&self) -> Result<Vec<(E, N::LogResponse)>, Error> {
         let logs = self.query_raw().await?;
         logs.into_iter().map(|log| Ok((decode_log(&log)?, log))).collect()
     }
 
     /// Queries the blockchain for the selected filter and returns a vector of matching event logs,
     /// without decoding them.
-    pub async fn query_raw(&self) -> TransportResult<Vec<Log>> {
+    pub async fn query_raw(&self) -> TransportResult<Vec<N::LogResponse>> {
         self.provider.get_logs(&self.filter).await
     }
 
@@ -67,7 +68,7 @@ impl<P: Provider<N>, E: SolEvent, N: Network> Event<P, E, N> {
     /// Returns a stream of decoded events and raw logs.
     #[doc(alias = "stream")]
     #[doc(alias = "stream_with_meta")]
-    pub async fn watch(&self) -> TransportResult<EventPoller<E>> {
+    pub async fn watch(&self) -> TransportResult<EventPoller<E, N::LogResponse>> {
         let poller = self.provider.watch_logs(&self.filter).await?;
         Ok(poller.into())
     }
@@ -76,7 +77,9 @@ impl<P: Provider<N>, E: SolEvent, N: Network> Event<P, E, N> {
     ///
     /// Returns a stream of decoded events and raw logs.
     #[cfg(feature = "pubsub")]
-    pub async fn subscribe(&self) -> TransportResult<subscription::EventSubscription<E>> {
+    pub async fn subscribe(
+        &self,
+    ) -> TransportResult<subscription::EventSubscription<E, N::LogResponse>> {
         let sub = self.provider.subscribe_logs(&self.filter).await?;
         Ok(sub.into())
     }
@@ -251,7 +254,7 @@ impl<P, E, N> ChunkedEvent<P, E, N> {
 impl<P: Provider<N> + Clone + 'static, E: SolEvent + Send + Sync + 'static, N: Network>
     std::future::IntoFuture for ChunkedEvent<P, E, N>
 {
-    type Output = Result<Vec<(E, Log)>, Error>;
+    type Output = Result<Vec<(E, N::LogResponse)>, Error>;
     type IntoFuture = BoxFuture<'static, Self::Output>;
 
     fn into_future(self) -> Self::IntoFuture {
@@ -263,7 +266,7 @@ impl<P: Provider<N> + Clone, E: SolEvent, N: Network> ChunkedEvent<P, E, N> {
     /// Queries the blockchain for matching event logs, decoding them.
     ///
     /// See [`query_raw`](Self::query_raw) for the full description of the chunked strategy.
-    pub async fn query(&self) -> Result<Vec<(E, Log)>, Error> {
+    pub async fn query(&self) -> Result<Vec<(E, N::LogResponse)>, Error> {
         let logs = self.query_raw().await?;
         logs.into_iter().map(|log| Ok((decode_log(&log)?, log))).collect()
     }
@@ -273,7 +276,7 @@ impl<P: Provider<N> + Clone, E: SolEvent, N: Network> ChunkedEvent<P, E, N> {
     /// Attempts the full block range optimistically first. If that fails, splits the range into
     /// `chunk_size`-block windows queried concurrently (up to `max_concurrent` at a time). If an
     /// individual chunk still fails, falls back to querying each block individually.
-    pub async fn query_raw(&self) -> TransportResult<Vec<Log>> {
+    pub async fn query_raw(&self) -> TransportResult<Vec<N::LogResponse>> {
         if let Ok(logs) = self.provider.get_logs(&self.filter).await {
             return Ok(logs);
         }
@@ -282,7 +285,7 @@ impl<P: Provider<N> + Clone, E: SolEvent, N: Network> ChunkedEvent<P, E, N> {
 
     /// Divides the block range into chunks and queries them concurrently, falling back to
     /// single-block queries for any chunk that fails.
-    async fn get_logs_chunked(&self) -> TransportResult<Vec<Log>> {
+    async fn get_logs_chunked(&self) -> TransportResult<Vec<N::LogResponse>> {
         let FilterBlockOption::Range { from_block, to_block } = self.filter.block_option else {
             return Err(RpcError::local_usage_str(
                 "chunked queries require a block range filter, not a block hash filter",
@@ -299,10 +302,10 @@ impl<P: Provider<N> + Clone, E: SolEvent, N: Network> ChunkedEvent<P, E, N> {
             return Ok(vec![]);
         }
 
-        let all_results: Vec<TransportResult<(u64, Vec<Log>)>> =
+        let all_results: Vec<TransportResult<(u64, Vec<N::LogResponse>)>> =
             self.chunk_stream(from, to).collect().await;
 
-        let mut resolved: Vec<(u64, Vec<Log>)> =
+        let mut resolved: Vec<(u64, Vec<N::LogResponse>)> =
             all_results.into_iter().collect::<TransportResult<Vec<_>>>()?;
 
         resolved.sort_by_key(|(block_num, _)| *block_num);
@@ -318,7 +321,7 @@ impl<P: Provider<N> + Clone, E: SolEvent, N: Network> ChunkedEvent<P, E, N> {
         &self,
         from: u64,
         to: u64,
-    ) -> impl Stream<Item = TransportResult<(u64, Vec<Log>)>> {
+    ) -> impl Stream<Item = TransportResult<(u64, Vec<N::LogResponse>)>> {
         let filter = self.filter.clone();
         let provider = self.provider.clone();
         let max_concurrent = self.max_concurrent;
@@ -352,7 +355,7 @@ async fn query_chunk<P: Provider<N>, N: Network>(
     filter: &Filter,
     start_block: u64,
     end_block: u64,
-) -> TransportResult<(u64, Vec<Log>)> {
+) -> TransportResult<(u64, Vec<N::LogResponse>)> {
     match provider.get_logs(filter).await {
         Ok(logs) => Ok((start_block, logs)),
         Err(err) => {
@@ -375,27 +378,30 @@ async fn query_chunk<P: Provider<N>, N: Network>(
 /// An event poller.
 ///
 /// Polling configuration is available through the [`poller`](Self::poller) field.
-pub struct EventPoller<E> {
+pub struct EventPoller<E, L = Log> {
     /// The inner poller.
-    pub poller: FilterPollerBuilder<Log>,
+    pub poller: FilterPollerBuilder<L>,
     _phantom: PhantomData<E>,
 }
 
-impl<E> AsRef<FilterPollerBuilder<Log>> for EventPoller<E> {
+impl<E, L> AsRef<FilterPollerBuilder<L>> for EventPoller<E, L> {
     #[inline]
-    fn as_ref(&self) -> &FilterPollerBuilder<Log> {
+    fn as_ref(&self) -> &FilterPollerBuilder<L> {
         &self.poller
     }
 }
 
-impl<E> AsMut<FilterPollerBuilder<Log>> for EventPoller<E> {
+impl<E, L> AsMut<FilterPollerBuilder<L>> for EventPoller<E, L> {
     #[inline]
-    fn as_mut(&mut self) -> &mut FilterPollerBuilder<Log> {
+    fn as_mut(&mut self) -> &mut FilterPollerBuilder<L> {
         &mut self.poller
     }
 }
 
-impl<E> fmt::Debug for EventPoller<E> {
+impl<E, L> fmt::Debug for EventPoller<E, L>
+where
+    FilterPollerBuilder<L>: fmt::Debug,
+{
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("EventPoller")
             .field("poller", &self.poller)
@@ -404,17 +410,17 @@ impl<E> fmt::Debug for EventPoller<E> {
     }
 }
 
-impl<E> From<FilterPollerBuilder<Log>> for EventPoller<E> {
-    fn from(poller: FilterPollerBuilder<Log>) -> Self {
+impl<E, L> From<FilterPollerBuilder<L>> for EventPoller<E, L> {
+    fn from(poller: FilterPollerBuilder<L>) -> Self {
         Self { poller, _phantom: PhantomData }
     }
 }
 
-impl<E: SolEvent> EventPoller<E> {
+impl<E: SolEvent, L: LogResponse + RpcObject> EventPoller<E, L> {
     /// Starts the poller and returns a stream that yields the decoded event and the raw log.
     ///
     /// Note that this stream will not return `None` until the provider is dropped.
-    pub fn into_stream(self) -> impl Stream<Item = alloy_sol_types::Result<(E, Log)>> + Unpin {
+    pub fn into_stream(self) -> impl Stream<Item = alloy_sol_types::Result<(E, L)>> + Unpin {
         self.poller
             .into_stream()
             .flat_map(futures_util::stream::iter)
@@ -437,8 +443,8 @@ async fn resolve_block_tag<P: Provider<N>, N: Network>(
     }
 }
 
-fn decode_log<E: SolEvent>(log: &Log) -> alloy_sol_types::Result<E> {
-    let log_data: &LogData = log.as_ref();
+fn decode_log<E: SolEvent>(log: &impl LogResponse) -> alloy_sol_types::Result<E> {
+    let log_data = &log.as_ref().data;
 
     E::decode_raw_log(log_data.topics().iter().copied(), &log_data.data)
 }
@@ -451,27 +457,30 @@ pub(crate) mod subscription {
     /// An event subscription.
     ///
     /// Underlying subscription is available through the [`sub`](Self::sub) field.
-    pub struct EventSubscription<E> {
+    pub struct EventSubscription<E, L = Log> {
         /// The inner poller.
-        pub sub: Subscription<Log>,
+        pub sub: Subscription<L>,
         _phantom: PhantomData<E>,
     }
 
-    impl<E> AsRef<Subscription<Log>> for EventSubscription<E> {
+    impl<E, L> AsRef<Subscription<L>> for EventSubscription<E, L> {
         #[inline]
-        fn as_ref(&self) -> &Subscription<Log> {
+        fn as_ref(&self) -> &Subscription<L> {
             &self.sub
         }
     }
 
-    impl<E> AsMut<Subscription<Log>> for EventSubscription<E> {
+    impl<E, L> AsMut<Subscription<L>> for EventSubscription<E, L> {
         #[inline]
-        fn as_mut(&mut self) -> &mut Subscription<Log> {
+        fn as_mut(&mut self) -> &mut Subscription<L> {
             &mut self.sub
         }
     }
 
-    impl<E> fmt::Debug for EventSubscription<E> {
+    impl<E, L> fmt::Debug for EventSubscription<E, L>
+    where
+        Subscription<L>: fmt::Debug,
+    {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             f.debug_struct("EventSubscription")
                 .field("sub", &self.sub)
@@ -480,15 +489,15 @@ pub(crate) mod subscription {
         }
     }
 
-    impl<E> From<Subscription<Log>> for EventSubscription<E> {
-        fn from(sub: Subscription<Log>) -> Self {
+    impl<E, L> From<Subscription<L>> for EventSubscription<E, L> {
+        fn from(sub: Subscription<L>) -> Self {
             Self { sub, _phantom: PhantomData }
         }
     }
 
-    impl<E: SolEvent> EventSubscription<E> {
+    impl<E: SolEvent, L: LogResponse + RpcObject> EventSubscription<E, L> {
         /// Converts the subscription into a stream.
-        pub fn into_stream(self) -> impl Stream<Item = alloy_sol_types::Result<(E, Log)>> + Unpin {
+        pub fn into_stream(self) -> impl Stream<Item = alloy_sol_types::Result<(E, L)>> + Unpin {
             self.sub.into_stream().map(|log| decode_log(&log).map(|e| (e, log)))
         }
     }
@@ -497,10 +506,12 @@ pub(crate) mod subscription {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_network::EthereumWallet;
-    use alloy_primitives::U256;
+    use alloy_network::{AnyNetwork, AnyRpcLog, EthereumWallet};
+    use alloy_primitives::{Log as PrimitiveLog, LogData, U256};
+    use alloy_provider::ProviderBuilder;
     use alloy_signer_local::PrivateKeySigner;
     use alloy_sol_types::sol;
+    use alloy_transport::mock::Asserter;
 
     sol! {
         // solc v0.8.24; solc a.sol --via-ir --optimize --bin
@@ -521,6 +532,36 @@ mod tests {
                 emit WrongEvent(42, "hello", true, bytes32(uint256(0xdeadbeef)));
             }
         }
+    }
+
+    #[tokio::test]
+    async fn any_network_event_preserves_log_fields() {
+        let expected = MyContract::MyEvent {
+            _0: 42,
+            _1: "hello".to_string(),
+            _2: true,
+            _3: U256::from(0xdeadbeefu64).into(),
+        };
+        let topics = expected.encode_topics().into_iter().map(|topic| topic.0).collect();
+        let mut log = AnyRpcLog::new(Log {
+            inner: PrimitiveLog {
+                address: Address::ZERO,
+                data: LogData::new_unchecked(topics, expected.encode_data().into()),
+            },
+            ..Default::default()
+        });
+        log.other.insert("blockTimestampMs".to_owned(), serde_json::json!("0xa4d8"));
+
+        let asserter = Asserter::new();
+        asserter.push_success(&vec![log]);
+        let provider =
+            ProviderBuilder::new().network::<AnyNetwork>().connect_mocked_client(asserter);
+        let event: Event<_, MyContract::MyEvent, AnyNetwork> = Event::new(&provider, Filter::new());
+
+        let mut logs = event.query().await.unwrap();
+        let (decoded, raw) = logs.pop().unwrap();
+        assert_eq!(decoded, expected);
+        assert_eq!(raw.other.get("blockTimestampMs"), Some(&serde_json::json!("0xa4d8")));
     }
 
     #[tokio::test]

--- a/crates/network-primitives/src/lib.rs
+++ b/crates/network-primitives/src/lib.rs
@@ -11,7 +11,8 @@ extern crate alloc;
 
 mod traits;
 pub use traits::{
-    BlockResponse, HeaderResponse, ReceiptResponse, TransactionFailedError, TransactionResponse,
+    BlockResponse, HeaderResponse, LogResponse, ReceiptResponse, TransactionFailedError,
+    TransactionResponse,
 };
 
 mod block;

--- a/crates/network-primitives/src/traits.rs
+++ b/crates/network-primitives/src/traits.rs
@@ -1,7 +1,7 @@
 use crate::{BlockTransactions, InclusionInfo};
 use alloy_consensus::{BlockHeader, Transaction};
 use alloy_eips::BlockNumHash;
-use alloy_primitives::{Address, BlockHash, TxHash, B256};
+use alloy_primitives::{Address, BlockHash, Log, TxHash, B256};
 use alloy_serde::WithOtherFields;
 
 /// Error returned when a transaction failed.
@@ -193,6 +193,35 @@ pub trait BlockResponse {
     }
 }
 
+/// Log JSON-RPC response.
+pub trait LogResponse: AsRef<Log> {
+    /// Hash of the block containing the log.
+    fn block_hash(&self) -> Option<BlockHash>;
+
+    /// Number of the block containing the log.
+    fn block_number(&self) -> Option<u64>;
+
+    /// Timestamp of the block containing the log.
+    fn block_timestamp(&self) -> Option<u64>;
+
+    /// Hash of the transaction that emitted the log.
+    fn transaction_hash(&self) -> Option<TxHash>;
+
+    /// Index of the transaction that emitted the log.
+    fn transaction_index(&self) -> Option<u64>;
+
+    /// Index of the log in the block.
+    fn log_index(&self) -> Option<u64>;
+
+    /// Whether the log was removed due to a chain reorganization.
+    fn removed(&self) -> bool;
+
+    /// Returns additional flattened response fields, if available.
+    fn other_fields(&self) -> Option<&alloy_serde::OtherFields> {
+        None
+    }
+}
+
 impl<T: TransactionResponse> TransactionResponse for WithOtherFields<T> {
     fn tx_hash(&self) -> TxHash {
         self.inner.tx_hash()
@@ -287,6 +316,40 @@ impl<T: BlockResponse> BlockResponse for WithOtherFields<T> {
 
     fn transactions_mut(&mut self) -> &mut BlockTransactions<Self::Transaction> {
         self.inner.transactions_mut()
+    }
+
+    fn other_fields(&self) -> Option<&alloy_serde::OtherFields> {
+        Some(&self.other)
+    }
+}
+
+impl<T: LogResponse> LogResponse for WithOtherFields<T> {
+    fn block_hash(&self) -> Option<BlockHash> {
+        self.inner.block_hash()
+    }
+
+    fn block_number(&self) -> Option<u64> {
+        self.inner.block_number()
+    }
+
+    fn block_timestamp(&self) -> Option<u64> {
+        self.inner.block_timestamp()
+    }
+
+    fn transaction_hash(&self) -> Option<TxHash> {
+        self.inner.transaction_hash()
+    }
+
+    fn transaction_index(&self) -> Option<u64> {
+        self.inner.transaction_index()
+    }
+
+    fn log_index(&self) -> Option<u64> {
+        self.inner.log_index()
+    }
+
+    fn removed(&self) -> bool {
+        self.inner.removed()
     }
 
     fn other_fields(&self) -> Option<&alloy_serde::OtherFields> {

--- a/crates/network/README.md
+++ b/crates/network/README.md
@@ -19,7 +19,7 @@ networking. The core model is as follows:
   types to define the input and output types of the RPC methods.
 - `TransactionBuilder` - A trait for constructing and validating network-specific transaction requests. Used to build typed transactions for signing and submission. See [`TransactionBuilder`](./src/transaction/builder.rs).
 - `NetworkWallet` - A trait for wallets that can sign transactions for a given network. Used to abstract over different signing backends. See [`NetworkWallet`](./src/transaction/signer.rs).
-- `BlockResponse`, `TransactionResponse`, `ReceiptResponse`, `HeaderResponse` - Traits (from `alloy-network-primitives`) that define the structure of block, transaction, receipt, and header types used in RPC responses. These are associated types in the `Network` trait and are implemented by network-specific types. See [`alloy-network-primitives`](https://docs.rs/alloy-network-primitives/).
+- `BlockResponse`, `TransactionResponse`, `ReceiptResponse`, `HeaderResponse`, `LogResponse` - Types that define network-specific RPC responses. These are associated types in the `Network` trait. See [`alloy-network-primitives`](https://docs.rs/alloy-network-primitives/) for the response traits.
 
 ## Usage
 
@@ -48,6 +48,7 @@ impl Network for Foo {
     type ReceiptResponse = FooReceiptResponse;
     type HeaderResponse = FooHeaderResponse;
     type BlockResponse = FooBlockResponse;
+    type LogResponse = FooLogResponse;
 }
 ```
 

--- a/crates/network/src/any/mod.rs
+++ b/crates/network/src/any/mod.rs
@@ -23,7 +23,9 @@ use alloy_consensus::{
 };
 use alloy_network_primitives::{BlockResponse, TransactionResponse};
 pub use alloy_rpc_types_any::{AnyRpcHeader, AnyTransactionReceipt};
-use alloy_rpc_types_eth::{AccessList, Block, BlockTransactions, Transaction, TransactionRequest};
+use alloy_rpc_types_eth::{
+    AccessList, Block, BlockTransactions, Log, Transaction, TransactionRequest,
+};
 use alloy_serde::WithOtherFields;
 use derive_more::From;
 use serde::{Deserialize, Serialize};
@@ -81,7 +83,12 @@ impl Network for AnyNetwork {
     type HeaderResponse = AnyRpcHeader;
 
     type BlockResponse = AnyRpcBlock;
+
+    type LogResponse = AnyRpcLog;
 }
+
+/// Catch-all RPC log preserving unknown response fields.
+pub type AnyRpcLog = WithOtherFields<Log>;
 
 /// A wrapper for [`AnyRpcBlock`] that allows for handling unknown block types.
 ///
@@ -603,6 +610,17 @@ mod tests {
 
         assert_eq!(header.hash, B256::ZERO);
         assert_eq!(header.other.get("timestampMillis"), Some(&serde_json::json!(1_234_567)));
+    }
+
+    #[test]
+    fn any_rpc_log_preserves_other_fields() {
+        let mut log = AnyRpcLog::new(Log::default());
+        log.other.insert("blockTimestampMs".to_owned(), serde_json::json!(42_200));
+
+        let value = serde_json::to_value(&log).unwrap();
+        let decoded: AnyRpcLog = serde_json::from_value(value).unwrap();
+
+        assert_eq!(decoded.other.get("blockTimestampMs"), Some(&serde_json::json!(42_200)));
     }
 
     #[test]

--- a/crates/network/src/ethereum/mod.rs
+++ b/crates/network/src/ethereum/mod.rs
@@ -31,4 +31,6 @@ impl Network for Ethereum {
     type HeaderResponse = alloy_rpc_types_eth::Header;
 
     type BlockResponse = alloy_rpc_types_eth::Block;
+
+    type LogResponse = alloy_rpc_types_eth::Log;
 }

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -25,15 +25,15 @@ pub use ethereum::{Ethereum, EthereumWallet, IntoWallet};
 /// Types for handling unknown network types.
 pub mod any;
 pub use any::{
-    AnyHeader, AnyNetwork, AnyReceiptEnvelope, AnyRpcBlock, AnyRpcHeader, AnyRpcTransaction,
-    AnyTransactionReceipt, AnyTxEnvelope, AnyTxType, AnyTypedTransaction, UnknownTxEnvelope,
-    UnknownTypedTransaction,
+    AnyHeader, AnyNetwork, AnyReceiptEnvelope, AnyRpcBlock, AnyRpcHeader, AnyRpcLog,
+    AnyRpcTransaction, AnyTransactionReceipt, AnyTxEnvelope, AnyTxType, AnyTypedTransaction,
+    UnknownTxEnvelope, UnknownTypedTransaction,
 };
 
 pub use alloy_eips::eip2718;
 use alloy_eips::Typed2718;
 pub use alloy_network_primitives::{
-    self as primitives, BlockResponse, ReceiptResponse, TransactionResponse,
+    self as primitives, BlockResponse, LogResponse, ReceiptResponse, TransactionResponse,
 };
 
 /// Captures type info for network-specific RPC requests/responses.
@@ -100,6 +100,9 @@ pub trait Network: Debug + Clone + Copy + Sized + Send + Sync + 'static {
     /// The JSON body of a block response.
     type BlockResponse: RpcObject
         + BlockResponse<Transaction = Self::TransactionResponse, Header = Self::HeaderResponse>;
+
+    /// The JSON body of a log response.
+    type LogResponse: RpcObject + LogResponse;
 }
 
 /// Utility to implement IntoWallet for signer over the specified network.

--- a/crates/provider/src/fillers/mod.rs
+++ b/crates/provider/src/fillers/mod.rs
@@ -61,7 +61,7 @@ use alloy_rpc_types_eth::{
     erc4337::TransactionConditional,
     simulate::{SimulatePayload, SimulatedBlock},
     AccessListResult, EIP1186AccountProofResponse, EthCallResponse, FeeHistory, Filter,
-    FilterChanges, Log, StorageValuesRequest, StorageValuesResponse,
+    FilterChanges, StorageValuesRequest, StorageValuesResponse,
 };
 use alloy_transport::{TransportError, TransportResult};
 use async_trait::async_trait;
@@ -570,7 +570,10 @@ where
         self.inner.watch_pending_transactions().await
     }
 
-    async fn watch_logs(&self, filter: &Filter) -> TransportResult<FilterPollerBuilder<Log>> {
+    async fn watch_logs(
+        &self,
+        filter: &Filter,
+    ) -> TransportResult<FilterPollerBuilder<N::LogResponse>> {
         self.inner.watch_logs(filter).await
     }
 
@@ -580,11 +583,14 @@ where
         self.inner.watch_full_pending_transactions().await
     }
 
-    async fn get_filter_changes_dyn(&self, id: U256) -> TransportResult<FilterChanges> {
+    async fn get_filter_changes_dyn(
+        &self,
+        id: U256,
+    ) -> TransportResult<FilterChanges<N::TransactionResponse, N::LogResponse>> {
         self.inner.get_filter_changes_dyn(id).await
     }
 
-    async fn get_filter_logs(&self, id: U256) -> TransportResult<Vec<Log>> {
+    async fn get_filter_logs(&self, id: U256) -> TransportResult<Vec<N::LogResponse>> {
         self.inner.get_filter_logs(id).await
     }
 
@@ -599,7 +605,7 @@ where
         self.inner.watch_pending_transaction(config).await
     }
 
-    async fn get_logs(&self, filter: &Filter) -> TransportResult<Vec<Log>> {
+    async fn get_logs(&self, filter: &Filter) -> TransportResult<Vec<N::LogResponse>> {
         self.inner.get_logs(filter).await
     }
 
@@ -790,7 +796,10 @@ where
     }
 
     #[cfg(feature = "pubsub")]
-    fn subscribe_logs(&self, filter: &Filter) -> GetSubscription<(SubscriptionKind, Params), Log> {
+    fn subscribe_logs(
+        &self,
+        filter: &Filter,
+    ) -> GetSubscription<(SubscriptionKind, Params), N::LogResponse> {
         self.inner.subscribe_logs(filter)
     }
 

--- a/crates/provider/src/layers/cache.rs
+++ b/crates/provider/src/layers/cache.rs
@@ -9,7 +9,7 @@ use alloy_primitives::{
     keccak256, Address, Bytes, StorageKey, StorageValue, TxHash, B256, U256, U64,
 };
 use alloy_rpc_types_eth::{
-    BlockNumberOrTag, EIP1186AccountProofResponse, Filter, Log, StorageValuesRequest,
+    BlockNumberOrTag, EIP1186AccountProofResponse, Filter, StorageValuesRequest,
     StorageValuesResponse,
 };
 use alloy_transport::{TransportErrorKind, TransportResult};
@@ -215,7 +215,7 @@ where
         })
     }
 
-    async fn get_logs(&self, filter: &Filter) -> TransportResult<Vec<Log>> {
+    async fn get_logs(&self, filter: &Filter) -> TransportResult<Vec<N::LogResponse>> {
         if filter.block_option.as_block_hash().is_none() {
             // if block options have dynamic range we can't cache them
             let from_is_number = filter

--- a/crates/provider/src/provider/erased.rs
+++ b/crates/provider/src/provider/erased.rs
@@ -22,7 +22,7 @@ use alloy_rpc_types_eth::{
     erc4337::TransactionConditional,
     simulate::{SimulatePayload, SimulatedBlock},
     AccessListResult, BlockId, BlockNumberOrTag, Bundle, EIP1186AccountProofResponse,
-    EthCallResponse, FeeHistory, FillTransaction, Filter, FilterChanges, Index, Log,
+    EthCallResponse, FeeHistory, FillTransaction, Filter, FilterChanges, Index,
     StorageValuesRequest, StorageValuesResponse, SyncStatus,
 };
 use alloy_transport::TransportResult;
@@ -218,7 +218,10 @@ impl<N: Network> Provider<N> for DynProvider<N> {
         self.0.watch_pending_transactions().await
     }
 
-    async fn watch_logs(&self, filter: &Filter) -> TransportResult<FilterPollerBuilder<Log>> {
+    async fn watch_logs(
+        &self,
+        filter: &Filter,
+    ) -> TransportResult<FilterPollerBuilder<N::LogResponse>> {
         self.0.watch_logs(filter).await
     }
 
@@ -248,11 +251,14 @@ impl<N: Network> Provider<N> for DynProvider<N> {
         self.0.watch_full_pending_transactions().await
     }
 
-    async fn get_filter_changes_dyn(&self, id: U256) -> TransportResult<FilterChanges> {
+    async fn get_filter_changes_dyn(
+        &self,
+        id: U256,
+    ) -> TransportResult<FilterChanges<N::TransactionResponse, N::LogResponse>> {
         self.0.get_filter_changes_dyn(id).await
     }
 
-    async fn get_filter_logs(&self, id: U256) -> TransportResult<Vec<Log>> {
+    async fn get_filter_logs(&self, id: U256) -> TransportResult<Vec<N::LogResponse>> {
         self.0.get_filter_logs(id).await
     }
 
@@ -267,7 +273,7 @@ impl<N: Network> Provider<N> for DynProvider<N> {
         self.0.watch_pending_transaction(config).await
     }
 
-    async fn get_logs(&self, filter: &Filter) -> TransportResult<Vec<Log>> {
+    async fn get_logs(&self, filter: &Filter) -> TransportResult<Vec<N::LogResponse>> {
         self.0.get_logs(filter).await
     }
 
@@ -458,7 +464,10 @@ impl<N: Network> Provider<N> for DynProvider<N> {
     }
 
     #[cfg(feature = "pubsub")]
-    fn subscribe_logs(&self, filter: &Filter) -> GetSubscription<(SubscriptionKind, Params), Log> {
+    fn subscribe_logs(
+        &self,
+        filter: &Filter,
+    ) -> GetSubscription<(SubscriptionKind, Params), N::LogResponse> {
         self.0.subscribe_logs(filter)
     }
 

--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -33,7 +33,7 @@ use alloy_rpc_types_eth::{
     erc4337::TransactionConditional,
     simulate::{SimulatePayload, SimulatedBlock},
     AccessListResult, BlockId, BlockNumberOrTag, Bundle, EIP1186AccountProofResponse,
-    EthCallResponse, FeeHistory, FillTransaction, Filter, FilterChanges, Index, Log,
+    EthCallResponse, FeeHistory, FillTransaction, Filter, FilterChanges, Index,
     StorageValuesRequest, StorageValuesResponse, SyncStatus,
 };
 use alloy_transport::TransportResult;
@@ -752,7 +752,10 @@ pub trait Provider<N: Network = Ethereum>: Send + Sync {
     /// # Ok(())
     /// # }
     /// ```
-    async fn watch_logs(&self, filter: &Filter) -> TransportResult<FilterPollerBuilder<Log>> {
+    async fn watch_logs(
+        &self,
+        filter: &Filter,
+    ) -> TransportResult<FilterPollerBuilder<N::LogResponse>> {
         let id = self.new_filter(filter).await?;
         Ok(PollerBuilder::new(self.weak_client(), "eth_getFilterChanges", (id,)))
     }
@@ -1032,12 +1035,15 @@ pub trait Provider<N: Network = Ethereum>: Send + Sync {
     ///
     /// This returns an enum over all possible return values. You probably want to use
     /// [`get_filter_changes`](Self::get_filter_changes) instead.
-    async fn get_filter_changes_dyn(&self, id: U256) -> TransportResult<FilterChanges> {
+    async fn get_filter_changes_dyn(
+        &self,
+        id: U256,
+    ) -> TransportResult<FilterChanges<N::TransactionResponse, N::LogResponse>> {
         self.client().request("eth_getFilterChanges", (id,)).await
     }
 
-    /// Retrieves a [`Vec<Log>`] for the given filter ID.
-    async fn get_filter_logs(&self, id: U256) -> TransportResult<Vec<Log>> {
+    /// Retrieves logs for the given filter ID.
+    async fn get_filter_logs(&self, id: U256) -> TransportResult<Vec<N::LogResponse>> {
         self.client().request("eth_getFilterLogs", (id,)).await
     }
 
@@ -1058,8 +1064,8 @@ pub trait Provider<N: Network = Ethereum>: Send + Sync {
         self.root().watch_pending_transaction(config).await
     }
 
-    /// Retrieves a [`Vec<Log>`] with the given [`Filter`].
-    async fn get_logs(&self, filter: &Filter) -> TransportResult<Vec<Log>> {
+    /// Retrieves logs with the given [`Filter`].
+    async fn get_logs(&self, filter: &Filter) -> TransportResult<Vec<N::LogResponse>> {
         self.client().request("eth_getLogs", (filter,)).await
     }
 
@@ -1675,7 +1681,10 @@ pub trait Provider<N: Network = Ethereum>: Send + Sync {
     /// # }
     /// ```
     #[cfg(feature = "pubsub")]
-    fn subscribe_logs(&self, filter: &Filter) -> GetSubscription<(SubscriptionKind, Params), Log> {
+    fn subscribe_logs(
+        &self,
+        filter: &Filter,
+    ) -> GetSubscription<(SubscriptionKind, Params), N::LogResponse> {
         let rpc_call = self.client().request(
             "eth_subscribe",
             (SubscriptionKind::Logs, Params::Logs(Box::new(filter.clone()))),

--- a/crates/provider/tests/it/mock.rs
+++ b/crates/provider/tests/it/mock.rs
@@ -1,7 +1,10 @@
+use alloy_network::{AnyNetwork, AnyRpcLog, AnyRpcTransaction};
 use alloy_primitives::{bytes, Address, U256};
 use alloy_provider::{Provider, ProviderBuilder};
-use alloy_rpc_types_eth::TransactionRequest;
+use alloy_rpc_types_eth::{Filter, FilterChanges, Log, TransactionRequest};
+use alloy_serde::WithOtherFields;
 use alloy_transport::mock::Asserter;
+use futures::StreamExt;
 
 #[tokio::test]
 async fn mocked_default_provider() {
@@ -41,4 +44,38 @@ async fn mocked_default_provider() {
     asserter.push_success(&assert_bal);
     let response = provider.get_balance(Address::default()).await.unwrap();
     assert_eq!(response, assert_bal);
+}
+
+#[tokio::test]
+async fn mocked_any_network_preserves_log_fields() {
+    let asserter = Asserter::new();
+    let provider =
+        ProviderBuilder::new().network::<AnyNetwork>().connect_mocked_client(asserter.clone());
+    let mut log = WithOtherFields::new(Log::default());
+    log.other.insert("blockTimestampMs".to_owned(), serde_json::json!("0xa4d8"));
+
+    asserter.push_success(&vec![log.clone()]);
+    let logs = provider.get_logs(&Filter::new()).await.unwrap();
+    assert_eq!(logs[0].other.get("blockTimestampMs"), log.other.get("blockTimestampMs"));
+
+    let changes = FilterChanges::<AnyRpcTransaction, AnyRpcLog>::Logs(vec![log.clone()]);
+    asserter.push_success(&changes);
+    let changes = provider.get_filter_changes_dyn(U256::from(1)).await.unwrap();
+    assert_eq!(
+        changes.as_logs().unwrap()[0].other.get("blockTimestampMs"),
+        log.other.get("blockTimestampMs")
+    );
+
+    asserter.push_success(&U256::from(1));
+    asserter.push_success(&vec![log.clone()]);
+    let logs = provider
+        .watch_logs(&Filter::new())
+        .await
+        .unwrap()
+        .with_limit(Some(1))
+        .into_stream()
+        .next()
+        .await
+        .unwrap();
+    assert_eq!(logs[0].other.get("blockTimestampMs"), log.other.get("blockTimestampMs"));
 }

--- a/crates/rpc-types-eth/src/filter.rs
+++ b/crates/rpc-types-eth/src/filter.rs
@@ -1194,13 +1194,13 @@ where
 #[derive(Default, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[cfg_attr(feature = "serde", serde(untagged))]
-pub enum FilterChanges<T = Transaction> {
+pub enum FilterChanges<T = Transaction, L = RpcLog> {
     /// Empty result.
     #[cfg_attr(feature = "serde", serde(with = "empty_array"))]
     #[default]
     Empty,
     /// New logs.
-    Logs(Vec<RpcLog>),
+    Logs(Vec<L>),
     /// New hashes (block or transactions).
     Hashes(Vec<B256>),
     /// New transactions.
@@ -1225,7 +1225,7 @@ impl From<Vec<Transaction>> for FilterChanges {
     }
 }
 
-impl<T> FilterChanges<T> {
+impl<T, L> FilterChanges<T, L> {
     /// Get the hashes if present.
     pub fn as_hashes(&self) -> Option<&[B256]> {
         if let Self::Hashes(hashes) = self {
@@ -1236,7 +1236,7 @@ impl<T> FilterChanges<T> {
     }
 
     /// Get the logs if present.
-    pub fn as_logs(&self) -> Option<&[RpcLog]> {
+    pub fn as_logs(&self) -> Option<&[L]> {
         if let Self::Logs(logs) = self {
             Some(logs)
         } else {
@@ -1287,9 +1287,10 @@ mod empty_array {
 }
 
 #[cfg(feature = "serde")]
-impl<'de, T> serde::Deserialize<'de> for FilterChanges<T>
+impl<'de, T, L> serde::Deserialize<'de> for FilterChanges<T, L>
 where
     T: serde::Deserialize<'de>,
+    L: serde::Deserialize<'de>,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -1297,13 +1298,13 @@ where
     {
         #[derive(serde::Deserialize)]
         #[serde(untagged)]
-        enum Changes<T = Transaction> {
+        enum Changes<T, L> {
             Hashes(Vec<B256>),
-            Logs(Vec<RpcLog>),
+            Logs(Vec<L>),
             Transactions(Vec<T>),
         }
 
-        let changes = Changes::deserialize(deserializer)?;
+        let changes = Changes::<T, L>::deserialize(deserializer)?;
         let changes = match changes {
             Changes::Logs(vals) => {
                 if vals.is_empty() {
@@ -1607,6 +1608,26 @@ mod tests {
     #[cfg(feature = "serde")]
     fn serialize<T: serde::Serialize>(t: &T) -> serde_json::Value {
         serde_json::to_value(t).expect("Failed to serialize value")
+    }
+
+    #[cfg(feature = "serde")]
+    #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct CustomLog {
+        custom_field: u64,
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn filter_changes_supports_custom_logs() {
+        let value = json!([{ "customField": 42 }]);
+        let changes: FilterChanges<(), CustomLog> = serde_json::from_value(value.clone()).unwrap();
+
+        assert_eq!(changes.as_logs(), Some(&[CustomLog { custom_field: 42 }][..]));
+        assert_eq!(serialize(&changes), value);
+
+        let empty: FilterChanges<(), CustomLog> = serde_json::from_value(json!([])).unwrap();
+        assert!(empty.is_empty());
     }
 
     #[test]

--- a/crates/rpc-types-eth/src/log.rs
+++ b/crates/rpc-types-eth/src/log.rs
@@ -197,6 +197,36 @@ impl<T> AsRef<alloy_primitives::Log<T>> for Log<T> {
     }
 }
 
+impl alloy_network_primitives::LogResponse for Log {
+    fn block_hash(&self) -> Option<BlockHash> {
+        self.block_hash
+    }
+
+    fn block_number(&self) -> Option<u64> {
+        self.block_number
+    }
+
+    fn block_timestamp(&self) -> Option<u64> {
+        self.block_timestamp
+    }
+
+    fn transaction_hash(&self) -> Option<TxHash> {
+        self.transaction_hash
+    }
+
+    fn transaction_index(&self) -> Option<u64> {
+        self.transaction_index
+    }
+
+    fn log_index(&self) -> Option<u64> {
+        self.log_index
+    }
+
+    fn removed(&self) -> bool {
+        self.removed
+    }
+}
+
 impl<T> AsMut<alloy_primitives::Log<T>> for Log<T> {
     fn as_mut(&mut self) -> &mut alloy_primitives::Log<T> {
         &mut self.inner


### PR DESCRIPTION
Adds a network-specific log response associated type and carries it through provider filters, polling, subscriptions, and contract events. AnyNetwork now preserves unknown log fields while Ethereum retains its existing log response and wire format.