### PR TITLE
fix(json-rpc): allow deep recursive RPC JSON deserialization

### DIFF
--- a/crates/json-rpc/Cargo.toml
+++ b/crates/json-rpc/Cargo.toml
@@ -25,7 +25,7 @@ workspace = true
 [dependencies]
 alloy-primitives = { workspace = true, features = ["std", "serde", "map"] }
 serde.workspace = true
-serde_json = { workspace = true, features = ["std", "raw_value"] }
+serde_json = { workspace = true, features = ["std", "raw_value", "unbounded_depth"] }
 thiserror = { workspace = true, features = ["std"] }
 tracing.workspace = true
 alloy-sol-types.workspace = true

--- a/crates/json-rpc/src/result.rs
+++ b/crates/json-rpc/src/result.rs
@@ -75,7 +75,12 @@ where
     let _guard = debug_span!("deserialize_response", ty=%std::any::type_name::<T>()).entered();
     let json = json.borrow().get();
     trace!(%json, "deserializing");
-    serde_json::from_str(json)
+    // Geth callTracer / similar RPC payloads can nest deeper than serde_json's default
+    // recursion limit (~128). RPC responses are treated as trusted; disable the limit so
+    // deep CallFrame trees deserialize (alloy#1156).
+    let mut de = serde_json::Deserializer::from_str(json);
+    de.disable_recursion_limit();
+    T::deserialize(&mut de)
         .inspect(|response| trace!(?response, "deserialized"))
         .inspect_err(|err| trace!(?err, "failed to deserialize"))
         .map_err(|err| RpcError::deser_err(err, json))
@@ -108,5 +113,36 @@ mod tests {
         let input: RpcResult<Box<RawValue>, (), Box<RawValue>> = Ok(raw);
         let out = try_deserialize_ok::<_, u64, (), Box<RawValue>>(input).unwrap();
         assert_eq!(out, 42);
+    }
+
+    /// Synthetic deep nesting exceeds serde_json's default recursion limit (~128).
+    /// Regression for https://github.com/alloy-rs/alloy/issues/1156 (CallTracer trees).
+    #[test]
+    fn deep_nested_json_does_not_hit_recursion_limit() {
+        #[derive(Debug, serde::Deserialize, PartialEq)]
+        struct Nested {
+            v: u32,
+            #[serde(default)]
+            child: Option<Box<Nested>>,
+        }
+
+        let depth = 200usize;
+        let mut json = String::from("null");
+        for i in (0..depth).rev() {
+            json = format!(r#"{{"v":{i},"child":{json}}}"#);
+        }
+        let raw = RawValue::from_string(json).unwrap();
+        let input: RpcResult<Box<RawValue>, (), Box<RawValue>> = Ok(raw);
+        let out = try_deserialize_ok::<_, Nested, (), Box<RawValue>>(input).unwrap();
+        // Walk to leaf
+        let mut cur = &out;
+        let mut n = 0;
+        while let Some(ch) = cur.child.as_ref() {
+            n += 1;
+            cur = ch;
+        }
+        assert_eq!(n, depth - 1);
+        assert_eq!(out.v, 0);
+        assert_eq!(cur.v, (depth - 1) as u32);
     }
 }


### PR DESCRIPTION
## Summary
- Deserialize RPC success payloads with `serde_json::Deserializer::from_str` and `disable_recursion_limit()` instead of `from_str` alone.
- Enable the `serde_json` `unbounded_depth` feature on `alloy-json-rpc`.
- Add a depth-200 nested JSON unit test as a regression for deep `CallFrame` trees from Geth `callTracer`.

## Context
Fixes https://github.com/alloy-rs/alloy/issues/1156

`debug_trace_*` with `callTracer` can nest beyond serde_json’s default recursion limit (~128), producing `recursion limit exceeded` on real mainnet traces. RPC responses are treated as trusted client-side data; this matches the usual approach for deep trusted JSON rather than a custom recursive `CallFrame` deserializer.

## Test plan
- [x] Local: `cargo test -p alloy-json-rpc --lib` → **29 passed** (includes `deep_nested_json_does_not_hit_recursion_limit`)
- [ ] CI: upstream checks on this PR