### PR TITLE
fix(rpc-types-anvil): accept MineOptions object without timestamp key

### DIFF
--- a/crates/rpc-types-anvil/src/lib.rs
+++ b/crates/rpc-types-anvil/src/lib.rs
@@ -159,7 +159,7 @@ pub enum MineOptions {
     /// The options for mining
     Options {
         /// The timestamp the block should be mined with
-        #[serde(with = "alloy_serde::quantity::opt")]
+        #[serde(default, with = "alloy_serde::quantity::opt")]
         timestamp: Option<u64>,
         /// If `blocks` is given, it will mine exactly blocks number of blocks, regardless of any
         /// other blocks mined or reverted during it's operation
@@ -246,6 +246,22 @@ mod tests {
             deserialized,
             MineOptions::Options { timestamp: Some(1620000000), blocks: Some(10) }
         );
+    }
+
+    #[test]
+    fn test_serde_deserialize_options_without_timestamp() {
+        let data = r#"{"blocks": 5}"#;
+        let deserialized: MineOptions = serde_json::from_str(data).expect("Deserialization failed");
+        assert_eq!(deserialized, MineOptions::Options { timestamp: None, blocks: Some(5) });
+
+        let data = r#"{}"#;
+        let deserialized: MineOptions = serde_json::from_str(data).expect("Deserialization failed");
+        assert_eq!(deserialized, MineOptions::default());
+
+        // Unknown keys are ignored, matching maps with a `timestamp` key.
+        let data = r#"{"foo": 1}"#;
+        let deserialized: MineOptions = serde_json::from_str(data).expect("Deserialization failed");
+        assert_eq!(deserialized, MineOptions::default());
     }
 
     #[test]


### PR DESCRIPTION
MineOptions is an untagged enum whose object variant annotates timestamp with serde(with = "alloy_serde::quantity::opt"). A with attribute suppresses serde's implicit optionality for Option fields, so the timestamp key was required and {"blocks": 5} failed to match either variant — anvil's evm_mine rejects blocks-only option objects as a result (found while validating documented examples against a live node).

Adding serde(default) lets blocks-only and empty objects deserialize as MineOptions::Options. A before/after sweep over the accepted input space shows the only behavior change is that timestamp-less maps now deserialize instead of erroring: all bare-number/string forms still hit the Timestamp variant, a present-but-invalid timestamp still errors, and serialization is byte-identical. Forking in the same file already uses the default + quantity::opt combination for its optional block number.

Written with Claude Code.