### PR TITLE
chore(deps): bump `tokio-tungstenite` to 0.29

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,7 +126,7 @@ tokio = "1"
 tokio-util = "0.7"
 tokio-stream = "0.1"
 tokio-test = "0.4"
-tokio-tungstenite = "0.28"
+tokio-tungstenite = "0.29"
 tower = { version = "0.5", features = ["util"] }
 
 # tracing


### PR DESCRIPTION
## Motivation

Downstream users cannot pass a `tokio-tungstenite` 0.29 websocket stream to `alloy-transport-ws`, which currently uses 0.28. In Foundry, the resulting type mismatch prevents `WsBackend::spawn()` from being used. See https://github.com/foundry-rs/foundry/pull/15906#pullrequestreview-4788033255

## Solution

Bump the workspace `tokio-tungstenite` dependency from 0.28 to 0.29. No Alloy source changes are required, and a local Foundry build pinned to this Alloy checkout compiles with a unified 0.29 websocket stack.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
