### PR TITLE
feat(rpc-types-eth): generalize filter change logs

### DIFF
--- a/crates/rpc-types-eth/src/filter.rs
+++ b/crates/rpc-types-eth/src/filter.rs
@@ -1191,16 +1191,18 @@ where
 }
 
 /// Response of the `eth_getFilterChanges` RPC.
+///
+/// `T` is the transaction response type and `L` is the log response type.
 #[derive(Default, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[cfg_attr(feature = "serde", serde(untagged))]
-pub enum FilterChanges<T = Transaction> {
+pub enum FilterChanges<T = Transaction, L = RpcLog> {
     /// Empty result.
     #[cfg_attr(feature = "serde", serde(with = "empty_array"))]
     #[default]
     Empty,
     /// New logs.
-    Logs(Vec<RpcLog>),
+    Logs(Vec<L>),
     /// New hashes (block or transactions).
     Hashes(Vec<B256>),
     /// New transactions.
@@ -1225,7 +1227,7 @@ impl From<Vec<Transaction>> for FilterChanges {
     }
 }
 
-impl<T> FilterChanges<T> {
+impl<T, L> FilterChanges<T, L> {
     /// Get the hashes if present.
     pub fn as_hashes(&self) -> Option<&[B256]> {
         if let Self::Hashes(hashes) = self {
@@ -1236,7 +1238,7 @@ impl<T> FilterChanges<T> {
     }
 
     /// Get the logs if present.
-    pub fn as_logs(&self) -> Option<&[RpcLog]> {
+    pub fn as_logs(&self) -> Option<&[L]> {
         if let Self::Logs(logs) = self {
             Some(logs)
         } else {
@@ -1287,9 +1289,10 @@ mod empty_array {
 }
 
 #[cfg(feature = "serde")]
-impl<'de, T> serde::Deserialize<'de> for FilterChanges<T>
+impl<'de, T, L> serde::Deserialize<'de> for FilterChanges<T, L>
 where
     T: serde::Deserialize<'de>,
+    L: serde::Deserialize<'de>,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -1297,13 +1300,13 @@ where
     {
         #[derive(serde::Deserialize)]
         #[serde(untagged)]
-        enum Changes<T = Transaction> {
+        enum Changes<T, L> {
             Hashes(Vec<B256>),
-            Logs(Vec<RpcLog>),
+            Logs(Vec<L>),
             Transactions(Vec<T>),
         }
 
-        let changes = Changes::deserialize(deserializer)?;
+        let changes = Changes::<T, L>::deserialize(deserializer)?;
         let changes = match changes {
             Changes::Logs(vals) => {
                 if vals.is_empty() {
@@ -1607,6 +1610,39 @@ mod tests {
     #[cfg(feature = "serde")]
     fn serialize<T: serde::Serialize>(t: &T) -> serde_json::Value {
         serde_json::to_value(t).expect("Failed to serialize value")
+    }
+
+    #[test]
+    fn filter_changes_defaults_to_rpc_log() {
+        fn assert_default_log_type(_: FilterChanges<u64, RpcLog>) {}
+        fn transaction_changes<T>(transactions: Vec<T>) -> FilterChanges<T> {
+            FilterChanges::Transactions(transactions)
+        }
+
+        let logs: FilterChanges<u64> = FilterChanges::Logs(Vec::new());
+        assert_default_log_type(logs);
+
+        let transactions = transaction_changes(vec![1]);
+        assert_eq!(transactions.as_transactions(), Some([1].as_slice()));
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn filter_changes_supports_custom_logs() {
+        #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+        struct CustomLog {
+            value: u64,
+        }
+
+        let changes = FilterChanges::<Transaction, CustomLog>::Logs(vec![CustomLog { value: 42 }]);
+        assert_eq!(changes.as_logs(), Some([CustomLog { value: 42 }].as_slice()));
+
+        let value = serde_json::to_value(&changes).unwrap();
+        assert_eq!(value, json!([{ "value": 42 }]));
+        assert_eq!(
+            serde_json::from_value::<FilterChanges<Transaction, CustomLog>>(value).unwrap(),
+            changes
+        );
     }
 
     #[test]


### PR DESCRIPTION
Adds a defaulted log response type to `FilterChanges`, allowing network-specific `eth_getFilterChanges` log responses while existing `FilterChanges<T>` type positions continue to use Ethereum's standard `Log`.

Context-free `FilterChanges::Transactions(...)` expressions may require a type annotation because Rust does not use default type parameters as inference fallback. Reth's constructors already have expected return types; paradigmxyz/reth#26491 compiles against this change after removing its local compatibility enum.

Validated with `cargo test -p alloy-rpc-types-eth --all-features`, no-default-features checking, clippy, and a patched Reth `cargo check -p reth-rpc`.
