### PR TITLE
fix(consensus): default missing receipt type to legacy

### DIFF
--- a/crates/consensus/src/receipt/envelope.rs
+++ b/crates/consensus/src/receipt/envelope.rs
@@ -22,7 +22,7 @@ use core::fmt;
 ///
 /// [EIP-2718]: https://eips.ethereum.org/EIPS/eip-2718
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[cfg_attr(feature = "serde", serde(tag = "type"))]
 #[cfg_attr(feature = "borsh", derive(borsh::BorshSerialize, borsh::BorshDeserialize))]
 #[doc(alias = "TransactionReceiptEnvelope", alias = "TxReceiptEnvelope")]
@@ -50,6 +50,32 @@ pub enum ReceiptEnvelope<T = Log> {
     /// [EIP-7702]: https://eips.ethereum.org/EIPS/eip-7702
     #[cfg_attr(feature = "serde", serde(rename = "0x4", alias = "0x04"))]
     Eip7702(ReceiptWithBloom<Receipt<T>>),
+}
+
+/// Deserializes a receipt, treating a missing `type` field as [`TxType::Legacy`].
+///
+/// The `type` field is required by the JSON-RPC specification, but some
+/// Ethereum-compatible nodes omit it entirely. A receipt without a type flag is a
+/// pre-[EIP-2718] receipt, which is unambiguously legacy, so it is accepted rather
+/// than rejected.
+///
+/// [EIP-2718]: https://eips.ethereum.org/EIPS/eip-2718
+#[cfg(feature = "serde")]
+impl<'de, T: serde::Deserialize<'de>> serde::Deserialize<'de> for ReceiptEnvelope<T> {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[derive(serde::Deserialize)]
+        struct ReceiptEnvelopeHelper<T> {
+            #[serde(default, rename = "type", with = "alloy_serde::quantity::opt")]
+            ty: Option<u8>,
+            #[serde(flatten)]
+            receipt: ReceiptWithBloom<Receipt<T>>,
+        }
+
+        let helper = ReceiptEnvelopeHelper::<T>::deserialize(deserializer)?;
+        let ty = TxType::try_from(helper.ty.unwrap_or(LEGACY_TX_TYPE_ID))
+            .map_err(serde::de::Error::custom)?;
+        Ok(Self::from_typed(ty, helper.receipt))
+    }
 }
 
 impl<T> ReceiptEnvelope<T> {
@@ -494,6 +520,33 @@ mod test {
                 "284d35bf53b82ef480ab4208527325477439c64fb90ef518450f05ee151c8e10"
             ))
         );
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn deser_receipt_envelope_without_type() {
+        let inner = super::ReceiptWithBloom::<Receipt<()>> {
+            receipt: Receipt {
+                status: super::Eip658Value::Eip658(true),
+                cumulative_gas_used: 0xc3b68,
+                logs: Default::default(),
+            },
+            logs_bloom: Default::default(),
+        };
+        let mut json = serde_json::to_value(&inner).unwrap();
+        assert!(json.get("type").is_none());
+
+        let envelope: ReceiptEnvelope<()> = serde_json::from_value(json.clone()).unwrap();
+        assert_eq!(envelope, ReceiptEnvelope::Legacy(inner.clone()));
+
+        // An explicit type flag is still honored.
+        json["type"] = "0x2".into();
+        let envelope: ReceiptEnvelope<()> = serde_json::from_value(json.clone()).unwrap();
+        assert_eq!(envelope, ReceiptEnvelope::Eip1559(inner));
+
+        // An unknown type flag is still rejected.
+        json["type"] = "0x7f".into();
+        serde_json::from_value::<ReceiptEnvelope<()>>(json).unwrap_err();
     }
 
     #[test]

--- a/crates/rpc-types-eth/src/transaction/receipt.rs
+++ b/crates/rpc-types-eth/src/transaction/receipt.rs
@@ -441,4 +441,16 @@ mod test {
         let proper_receipt: TransactionReceipt = serde_json::from_str(proper_receipt).unwrap();
         assert_eq!(proper_receipt.effective_gas_price, 12500000000);
     }
+
+    #[test]
+    fn no_type_deser() {
+        // Receipt from a Geth-derived chain whose `marshalReceipt` never sets the `type` field.
+        let json = r#"{"blockHash":"0x18cf669d61484fafd3fd01ca88c0b6706332f444f90de28d04fe84c6a922c5d2","blockNumber":"0x6abbdf1","contractAddress":"0xd937e6195ddf60b91de26a27c59492bbb48690fa","cumulativeGasUsed":"0xc3b68","from":"0xeff507ead35c808439741f5d1b228918c00a4329","gasUsed":"0xc3b68","logs":[],"logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","status":"0x1","to":null,"transactionHash":"0x13c2e2de4e886256727ac69efd52d066fae21c37d4e458f009e47a033d09e252","transactionIndex":"0x0"}"#;
+
+        let receipt: TransactionReceipt = serde_json::from_str(json).unwrap();
+
+        assert_eq!(receipt.transaction_type(), TxType::Legacy);
+        assert_eq!(receipt.gas_used, 0xc3b68);
+        assert!(receipt.status());
+    }
 }


### PR DESCRIPTION
<!--
  Thank you for your Pull Request. Please provide a description above and review
  the requirements below.

  Bug fixes and new features should include tests.

  Contributors guide: https://github.com/alloy-rs/alloy/blob/main/CONTRIBUTING.md

  The contributors guide includes instructions for running rustfmt and building the
  documentation.
  -->

  <!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

  ## Motivation

  `ReceiptEnvelope` is deserialized as an internally tagged enum (`#[serde(tag = "type")]`), and
  serde has no way to default a missing tag, so a receipt JSON object without a `type` field is
  rejected with `missing field type`. Several Geth-derived chains never emit the field — their
  `marshalReceipt` builds the response map without it — which makes every receipt from those chains
  undeserializable, on both `eth_getTransactionReceipt` and `eth_getBlockReceipts`.

  It surfaces downstream as a hard failure. In Foundry, `forge script --broadcast` can never confirm
  a deployment against such a chain:

  ```
  Error: Failure on receiving a receipt for 0x13c2e2de…:
  deserialization error: missing field type at line 1 column 949
  ```
  
  Closes #4106

  ## Solution

  Replace the derived `Deserialize` with a manual one that reads `type` as an optional quantity and
  falls back to `TxType::Legacy` when absent. A receipt with no type flag predates EIP-2718 and is
  unambiguously legacy, so it can be accepted rather than rejected. Explicit and unknown type flags
  behave as before.

  `Serialize` stays derived, so serialized output is byte-identical. The helper is generic over the
  `Deserializer` rather than round-tripping through `serde_json::Value`, so `no_std` support is unaffected.

  This mirrors the existing leniency for `effectiveGasPrice`, which is also required by the spec but
  defaults to 0 when a node omits it (#2019). Unlike that fallback, defaulting a missing `type` to
  legacy recovers the correct value rather than a placeholder.

  ## PR Checklist

  - [x] Added Tests
  - [x] Added Documentation
  - [ ] Breaking changes