### PR TITLE
feat(rpc-types-trace): add EIP-8037 state-gas fields

### DIFF
--- a/crates/rpc-types-trace/src/geth/call.rs
+++ b/crates/rpc-types-trace/src/geth/call.rs
@@ -17,13 +17,13 @@ pub struct CallFrame {
     /// How much gas was used by the call.
     #[serde(default, rename = "gasUsed")]
     pub gas_used: U256,
-    /// Gross regular-dimension gas used by the transaction.
+    /// Gross execution-dimension gas used by the transaction.
     ///
     /// This is present on the top-level frame for Amsterdam and later blocks.
     /// See [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037) and the
     /// [execution-apis call tracer proposal](https://github.com/ethereum/execution-apis/pull/852).
-    #[serde(default, rename = "regularGasUsed", skip_serializing_if = "Option::is_none")]
-    pub regular_gas_used: Option<U256>,
+    #[serde(default, rename = "executionGasUsed", skip_serializing_if = "Option::is_none")]
+    pub execution_gas_used: Option<U256>,
     /// Gross state-dimension gas used by the transaction.
     #[serde(default, rename = "stateGasUsed", skip_serializing_if = "Option::is_none")]
     pub state_gas_used: Option<U256>,

--- a/crates/rpc-types-trace/src/geth/call.rs
+++ b/crates/rpc-types-trace/src/geth/call.rs
@@ -17,6 +17,22 @@ pub struct CallFrame {
     /// How much gas was used by the call.
     #[serde(default, rename = "gasUsed")]
     pub gas_used: U256,
+    /// Gross regular-dimension gas used by the transaction.
+    ///
+    /// This is present on the top-level frame for Amsterdam and later blocks.
+    /// See [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037) and the
+    /// [execution-apis call tracer proposal](https://github.com/ethereum/execution-apis/pull/852).
+    #[serde(default, rename = "regularGasUsed", skip_serializing_if = "Option::is_none")]
+    pub regular_gas_used: Option<U256>,
+    /// Gross state-dimension gas used by the transaction.
+    #[serde(default, rename = "stateGasUsed", skip_serializing_if = "Option::is_none")]
+    pub state_gas_used: Option<U256>,
+    /// EIP-3529 gas refund applied at the transaction boundary.
+    #[serde(default, rename = "gasRefund", skip_serializing_if = "Option::is_none")]
+    pub gas_refund: Option<U256>,
+    /// State gas refunded within the transaction.
+    #[serde(default, rename = "stateGasRefund", skip_serializing_if = "Option::is_none")]
+    pub state_gas_refund: Option<U256>,
     /// The address of the contract that was called.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub to: Option<Address>,

--- a/crates/rpc-types-trace/src/geth/mod.rs
+++ b/crates/rpc-types-trace/src/geth/mod.rs
@@ -18,6 +18,7 @@ pub use self::{
         AccountChangeKind, AccountState, DiffMode, DiffStateKind, PreStateConfig, PreStateFrame,
         PreStateMode,
     },
+    state_gas::StateGasTrace,
 };
 
 pub mod call;
@@ -26,6 +27,7 @@ pub mod four_byte;
 pub mod mux;
 pub mod noop;
 pub mod pre_state;
+pub mod state_gas;
 
 /// Error when the inner tracer from [GethTrace] is mismatching to the target tracer.
 #[derive(Debug, thiserror::Error)]
@@ -74,6 +76,35 @@ pub struct DefaultFrame {
     pub failed: bool,
     /// How much gas was used.
     pub gas: u64,
+    /// Gross regular-dimension gas used by the transaction.
+    ///
+    /// These fields are optional because pre-Amsterdam responses omit them. The
+    /// optional representation preserves decoding of both old and new responses;
+    /// adding them is JSON-RPC backward-compatible, but adding public Rust fields
+    /// can require downstream struct literals to use `..Default::default()`.
+    #[serde(
+        default,
+        with = "alloy_serde::quantity::opt",
+        rename = "regularGasUsed",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub regular_gas_used: Option<u64>,
+    /// Gross state-dimension gas used by the transaction.
+    #[serde(
+        default,
+        with = "alloy_serde::quantity::opt",
+        rename = "stateGasUsed",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub state_gas_used: Option<u64>,
+    /// EIP-3529 gas refund applied at the transaction boundary.
+    #[serde(
+        default,
+        with = "alloy_serde::quantity::opt",
+        rename = "gasRefund",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub gas_refund: Option<u64>,
     /// Output of the transaction
     pub return_value: Bytes,
     /// Recorded traces of the transaction
@@ -94,6 +125,13 @@ pub struct StructLog {
     /// cost for executing op
     #[serde(rename = "gasCost")]
     pub gas_cost: u64,
+    /// Net state-dimension gas change caused by this opcode. This can be negative
+    /// for source-based state-gas refunds under EIP-8037.
+    #[serde(default, rename = "stateGasCost", skip_serializing_if = "Option::is_none")]
+    pub state_gas_cost: Option<alloy_primitives::I256>,
+    /// State-gas reservoir remaining before this opcode.
+    #[serde(default, rename = "stateGasReservoir", skip_serializing_if = "Option::is_none")]
+    pub state_gas_reservoir: Option<u64>,
     /// Current call depth
     pub depth: u64,
     /// Error message if any
@@ -151,6 +189,8 @@ pub enum GethTrace {
     FourByteTracer(FourByteFrame),
     /// The response for pre-state byte tracer
     PreStateTracer(PreStateFrame),
+    /// The response for the EIP-8037 state-gas tracer
+    StateGasTracer(StateGasTrace),
     /// An empty json response
     NoopTracer(NoopFrame),
     /// The response for mux tracer
@@ -183,6 +223,11 @@ impl GethTrace {
     /// Returns true if this is a pre-state frame.
     pub const fn is_pre_state(&self) -> bool {
         matches!(self, Self::PreStateTracer(_))
+    }
+
+    /// Returns true if this is a state-gas trace.
+    pub const fn is_state_gas(&self) -> bool {
+        matches!(self, Self::StateGasTracer(_))
     }
 
     /// Returns true if this is a noop frame.
@@ -236,6 +281,14 @@ impl GethTrace {
     pub fn try_into_pre_state_frame(self) -> Result<PreStateFrame, UnexpectedTracerError> {
         match self {
             Self::PreStateTracer(inner) => Ok(inner),
+            _ => Err(UnexpectedTracerError(self)),
+        }
+    }
+
+    /// Try to convert the inner tracer to [StateGasTrace]
+    pub fn try_into_state_gas_trace(self) -> Result<StateGasTrace, UnexpectedTracerError> {
+        match self {
+            Self::StateGasTracer(inner) => Ok(inner),
             _ => Err(UnexpectedTracerError(self)),
         }
     }
@@ -309,6 +362,12 @@ impl From<PreStateFrame> for GethTrace {
     }
 }
 
+impl From<StateGasTrace> for GethTrace {
+    fn from(value: StateGasTrace) -> Self {
+        Self::StateGasTracer(value)
+    }
+}
+
 impl From<NoopFrame> for GethTrace {
     fn from(value: NoopFrame) -> Self {
         Self::NoopTracer(value)
@@ -361,6 +420,9 @@ pub enum GethDebugBuiltInTracerType {
     /// The output is an object where the keys correspond to account addresses.
     #[serde(rename = "prestateTracer")]
     PreStateTracer,
+    /// The EIP-8037 state-gas summary tracer.
+    #[serde(rename = "stateGasTracer")]
+    StateGasTracer,
     /// This tracer is a noop. It returns an empty object and is only meant for testing the setup.
     #[serde(rename = "noopTracer")]
     NoopTracer,
@@ -402,6 +464,7 @@ impl GethDebugTracerType {
                 GethDebugBuiltInTracerType::CallTracer => "callTracer",
                 GethDebugBuiltInTracerType::FlatCallTracer => "flatCallTracer",
                 GethDebugBuiltInTracerType::PreStateTracer => "prestateTracer",
+                GethDebugBuiltInTracerType::StateGasTracer => "stateGasTracer",
                 GethDebugBuiltInTracerType::NoopTracer => "noopTracer",
                 GethDebugBuiltInTracerType::MuxTracer => "muxTracer",
                 GethDebugBuiltInTracerType::Erc7562Tracer => "erc7562Tracer",
@@ -571,6 +634,11 @@ impl GethDebugTracingOptions {
     /// Creates new options for [`GethDebugBuiltInTracerType::PreStateTracer`]
     pub fn prestate_tracer(config: PreStateConfig) -> Self {
         Self::new_tracer(GethDebugBuiltInTracerType::PreStateTracer).with_prestate_config(config)
+    }
+
+    /// Creates new options for the EIP-8037 state-gas tracer.
+    pub fn state_gas_tracer() -> Self {
+        Self::new_tracer(GethDebugBuiltInTracerType::StateGasTracer)
     }
 
     /// Creates new options for [`GethDebugBuiltInTracerType::FourByteTracer`]

--- a/crates/rpc-types-trace/src/geth/mod.rs
+++ b/crates/rpc-types-trace/src/geth/mod.rs
@@ -76,7 +76,7 @@ pub struct DefaultFrame {
     pub failed: bool,
     /// How much gas was used.
     pub gas: u64,
-    /// Gross regular-dimension gas used by the transaction.
+    /// Gross execution-dimension gas used by the transaction.
     ///
     /// These fields are optional because pre-Amsterdam responses omit them. The
     /// optional representation preserves decoding of both old and new responses;
@@ -85,10 +85,10 @@ pub struct DefaultFrame {
     #[serde(
         default,
         with = "alloy_serde::quantity::opt",
-        rename = "regularGasUsed",
+        rename = "executionGasUsed",
         skip_serializing_if = "Option::is_none"
     )]
-    pub regular_gas_used: Option<u64>,
+    pub execution_gas_used: Option<u64>,
     /// Gross state-dimension gas used by the transaction.
     #[serde(
         default,

--- a/crates/rpc-types-trace/src/geth/mod.rs
+++ b/crates/rpc-types-trace/src/geth/mod.rs
@@ -128,7 +128,7 @@ pub struct StructLog {
     /// Net state-dimension gas change caused by this opcode. This can be negative
     /// for source-based state-gas refunds under EIP-8037.
     #[serde(default, rename = "stateGasCost", skip_serializing_if = "Option::is_none")]
-    pub state_gas_cost: Option<alloy_primitives::I256>,
+    pub state_gas_cost: Option<i64>,
     /// State-gas reservoir remaining before this opcode.
     #[serde(default, rename = "stateGasReservoir", skip_serializing_if = "Option::is_none")]
     pub state_gas_reservoir: Option<u64>,

--- a/crates/rpc-types-trace/src/geth/state_gas.rs
+++ b/crates/rpc-types-trace/src/geth/state_gas.rs
@@ -27,7 +27,6 @@ pub struct StateGasTrace {
 mod tests {
     use super::*;
     use crate::geth::{GethDebugTracingOptions, GethTrace, StructLog};
-    use alloy_primitives::I256;
 
     #[test]
     fn test_state_gas_trace_serde() {
@@ -89,7 +88,8 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(log.state_gas_cost, Some(I256::try_from(-5).unwrap()));
+        assert_eq!(log.state_gas_cost, Some(-5));
         assert_eq!(log.state_gas_reservoir, Some(90));
+        assert_eq!(serde_json::to_value(&log).unwrap()["stateGasCost"], -5);
     }
 }

--- a/crates/rpc-types-trace/src/geth/state_gas.rs
+++ b/crates/rpc-types-trace/src/geth/state_gas.rs
@@ -1,0 +1,95 @@
+//! EIP-8037 state-gas tracer types.
+
+use serde::{Deserialize, Serialize};
+
+/// The per-transaction two-dimensional gas summary returned by `stateGasTracer`.
+///
+/// The shape is specified by the
+/// [execution-apis state-gas tracer proposal](https://github.com/ethereum/execution-apis/pull/852).
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StateGasTrace {
+    /// Receipt gas used, after refunds and any calldata floor.
+    #[serde(with = "alloy_serde::quantity")]
+    pub gas_used: u64,
+    /// Gross regular-dimension gas used by the transaction.
+    #[serde(with = "alloy_serde::quantity")]
+    pub regular_gas_used: u64,
+    /// Gross state-dimension gas used by the transaction.
+    #[serde(with = "alloy_serde::quantity")]
+    pub state_gas_used: u64,
+    /// EIP-3529 gas refund applied at the transaction boundary.
+    #[serde(with = "alloy_serde::quantity")]
+    pub gas_refund: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::geth::{GethDebugTracingOptions, GethTrace, StructLog};
+    use alloy_primitives::I256;
+
+    #[test]
+    fn test_state_gas_trace_serde() {
+        let trace: StateGasTrace = serde_json::from_str(
+            r#"{
+                "gasUsed": "0x5208",
+                "regularGasUsed": "0x5208",
+                "stateGasUsed": "0x0",
+                "gasRefund": "0x0"
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(trace.gas_used, 21000);
+        assert_eq!(trace.regular_gas_used, 21000);
+        assert_eq!(trace.state_gas_used, 0);
+        assert_eq!(trace.gas_refund, 0);
+        assert_eq!(
+            serde_json::to_value(&trace).unwrap(),
+            serde_json::json!({
+                "gasUsed": "0x5208",
+                "regularGasUsed": "0x5208",
+                "stateGasUsed": "0x0",
+                "gasRefund": "0x0"
+            })
+        );
+    }
+
+    #[test]
+    fn test_state_gas_trace_response_and_options() {
+        let trace: GethTrace = serde_json::from_str(
+            r#"{
+                "gasUsed": "0x5208",
+                "regularGasUsed": "0x5208",
+                "stateGasUsed": "0x0",
+                "gasRefund": "0x0"
+            }"#,
+        )
+        .unwrap();
+        assert!(trace.is_state_gas());
+        assert_eq!(trace.try_into_state_gas_trace().unwrap().gas_used, 21000);
+
+        let options = GethDebugTracingOptions::state_gas_tracer();
+        assert_eq!(options.tracer.unwrap().as_str(), "stateGasTracer");
+    }
+
+    #[test]
+    fn test_signed_state_gas_cost() {
+        let log: StructLog = serde_json::from_str(
+            r#"{
+                "pc": 0,
+                "op": "CREATE",
+                "gas": 100,
+                "gasCost": 10,
+                "stateGasCost": -5,
+                "stateGasReservoir": 90,
+                "depth": 1
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(log.state_gas_cost, Some(I256::try_from(-5).unwrap()));
+        assert_eq!(log.state_gas_reservoir, Some(90));
+    }
+}

--- a/crates/rpc-types-trace/src/geth/state_gas.rs
+++ b/crates/rpc-types-trace/src/geth/state_gas.rs
@@ -12,9 +12,9 @@ pub struct StateGasTrace {
     /// Receipt gas used, after refunds and any calldata floor.
     #[serde(with = "alloy_serde::quantity")]
     pub gas_used: u64,
-    /// Gross regular-dimension gas used by the transaction.
+    /// Gross execution-dimension gas used by the transaction.
     #[serde(with = "alloy_serde::quantity")]
-    pub regular_gas_used: u64,
+    pub execution_gas_used: u64,
     /// Gross state-dimension gas used by the transaction.
     #[serde(with = "alloy_serde::quantity")]
     pub state_gas_used: u64,
@@ -33,7 +33,7 @@ mod tests {
         let trace: StateGasTrace = serde_json::from_str(
             r#"{
                 "gasUsed": "0x5208",
-                "regularGasUsed": "0x5208",
+                "executionGasUsed": "0x5208",
                 "stateGasUsed": "0x0",
                 "gasRefund": "0x0"
             }"#,
@@ -41,14 +41,14 @@ mod tests {
         .unwrap();
 
         assert_eq!(trace.gas_used, 21000);
-        assert_eq!(trace.regular_gas_used, 21000);
+        assert_eq!(trace.execution_gas_used, 21000);
         assert_eq!(trace.state_gas_used, 0);
         assert_eq!(trace.gas_refund, 0);
         assert_eq!(
             serde_json::to_value(&trace).unwrap(),
             serde_json::json!({
                 "gasUsed": "0x5208",
-                "regularGasUsed": "0x5208",
+                "executionGasUsed": "0x5208",
                 "stateGasUsed": "0x0",
                 "gasRefund": "0x0"
             })
@@ -60,7 +60,7 @@ mod tests {
         let trace: GethTrace = serde_json::from_str(
             r#"{
                 "gasUsed": "0x5208",
-                "regularGasUsed": "0x5208",
+                "executionGasUsed": "0x5208",
                 "stateGasUsed": "0x0",
                 "gasRefund": "0x0"
             }"#,


### PR DESCRIPTION
## Summary

- add EIP-8037 two-dimensional gas fields to Geth call and opcode trace RPC types
- add typed `stateGasTracer` responses and tracer options
- reference [execution-apis#852](https://github.com/ethereum/execution-apis/pull/852) and cover quantity/signed-field serde behavior

The new response fields are optional, so decoding existing pre-Amsterdam responses remains compatible and unknown fields remain additive at the JSON-RPC boundary. This is source-breaking for downstream Rust struct literals that construct `DefaultFrame` or `StructLog` without `..Default::default()`; current `revm-inspectors` v0.42.0 has both patterns and will require an update before consuming this change.

Tests: `cargo test -p alloy-rpc-types-trace`; `cargo +nightly clippy -p alloy-rpc-types-trace --all-targets -- -D warnings`

Prompted by: @mattsse