### PR TITLE
fix(rpc): align transaction response types

### DIFF
--- a/crates/provider/src/fillers/mod.rs
+++ b/crates/provider/src/fillers/mod.rs
@@ -61,7 +61,7 @@ use alloy_rpc_types_eth::{
     erc4337::TransactionConditional,
     simulate::{SimulatePayload, SimulatedBlock},
     AccessListResult, EIP1186AccountProofResponse, EthCallResponse, FeeHistory, Filter,
-    FilterChanges, Log, StorageValuesRequest, StorageValuesResponse,
+    FilterChanges, Log, SignTransaction, StorageValuesRequest, StorageValuesResponse,
 };
 use alloy_transport::{TransportError, TransportResult};
 use async_trait::async_trait;
@@ -766,7 +766,10 @@ where
         self.inner.send_transaction_sync_internal(tx).await
     }
 
-    async fn sign_transaction(&self, tx: N::TransactionRequest) -> TransportResult<Bytes> {
+    async fn sign_transaction(
+        &self,
+        tx: N::TransactionRequest,
+    ) -> TransportResult<SignTransaction<N::TransactionResponse>> {
         let tx = self.fill(tx).await?;
         let tx = tx.try_into_request().map_err(TransportError::local_usage)?;
         self.inner.sign_transaction(tx).await

--- a/crates/provider/src/provider/erased.rs
+++ b/crates/provider/src/provider/erased.rs
@@ -23,7 +23,7 @@ use alloy_rpc_types_eth::{
     simulate::{SimulatePayload, SimulatedBlock},
     AccessListResult, BlockId, BlockNumberOrTag, Bundle, EIP1186AccountProofResponse,
     EthCallResponse, FeeHistory, FillTransaction, Filter, FilterChanges, Index, Log,
-    StorageValuesRequest, StorageValuesResponse, SyncStatus,
+    SignTransaction, StorageValuesRequest, StorageValuesResponse, SyncStatus,
 };
 use alloy_transport::TransportResult;
 use serde_json::value::RawValue;
@@ -426,16 +426,19 @@ impl<N: Network> Provider<N> for DynProvider<N> {
         self.0.send_transaction_sync_internal(SendableTx::Builder(tx)).await
     }
 
-    async fn sign_transaction(&self, tx: N::TransactionRequest) -> TransportResult<Bytes> {
+    async fn sign_transaction(
+        &self,
+        tx: N::TransactionRequest,
+    ) -> TransportResult<SignTransaction<N::TransactionResponse>> {
         self.0.sign_transaction(tx).await
     }
 
     async fn fill_transaction(
         &self,
         tx: N::TransactionRequest,
-    ) -> TransportResult<FillTransaction<N::TxEnvelope>>
+    ) -> TransportResult<FillTransaction<N::UnsignedTx>>
     where
-        N::TxEnvelope: RpcRecv,
+        N::UnsignedTx: RpcRecv,
     {
         self.0.fill_transaction(tx).await
     }

--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -34,7 +34,7 @@ use alloy_rpc_types_eth::{
     simulate::{SimulatePayload, SimulatedBlock},
     AccessListResult, BlockId, BlockNumberOrTag, Bundle, EIP1186AccountProofResponse,
     EthCallResponse, FeeHistory, FillTransaction, Filter, FilterChanges, Index, Log,
-    StorageValuesRequest, StorageValuesResponse, SyncStatus,
+    SignTransaction, StorageValuesRequest, StorageValuesResponse, SyncStatus,
 };
 use alloy_transport::TransportResult;
 use serde_json::value::RawValue;
@@ -1493,21 +1493,23 @@ pub trait Provider<N: Network = Ethereum>: Send + Sync {
     /// [`send_raw_transaction`](Self::send_raw_transaction).
     ///
     /// The `eth_signTransaction` method is not supported by regular nodes.
-    async fn sign_transaction(&self, tx: N::TransactionRequest) -> TransportResult<Bytes> {
+    async fn sign_transaction(
+        &self,
+        tx: N::TransactionRequest,
+    ) -> TransportResult<SignTransaction<N::TransactionResponse>> {
         self.client().request("eth_signTransaction", (tx,)).await
     }
 
     /// Fills a transaction with missing fields using default values.
     ///
     /// This method prepares a transaction by populating missing fields such as gas limit,
-    /// gas price, or nonce with appropriate default values. The response includes both the
-    /// RLP-encoded signed transaction and the filled transaction.
+    /// gas price, or nonce with appropriate default values.
     async fn fill_transaction(
         &self,
         tx: N::TransactionRequest,
-    ) -> TransportResult<FillTransaction<N::TxEnvelope>>
+    ) -> TransportResult<FillTransaction<N::UnsignedTx>>
     where
-        N::TxEnvelope: RpcRecv,
+        N::UnsignedTx: RpcRecv,
     {
         self.client().request("eth_fillTransaction", (tx,)).await
     }
@@ -2838,11 +2840,11 @@ mod tests {
                     .value(U256::from(100))
                     .gas_limit(21000);
 
-                let signed_tx = provider.sign_transaction(tx).await.unwrap().to_vec();
+                let signed = provider.sign_transaction(tx).await.unwrap();
+                let tx = TxEnvelope::decode(&mut signed.raw.as_ref()).unwrap();
 
-                let tx = TxEnvelope::decode(&mut signed_tx.as_slice()).unwrap();
-
-                let signer = tx.recover_signer().unwrap();
+                assert_eq!(signed.tx.as_ref(), &tx);
+                let signer = signed.tx.inner.recover_signer().unwrap();
 
                 assert_eq!(signer, from);
             })
@@ -2950,9 +2952,6 @@ mod tests {
             .with_value(U256::from(100));
 
         let filled = provider.fill_transaction(tx).await.unwrap();
-
-        // Verify the response contains RLP-encoded raw bytes
-        assert!(!filled.raw.is_empty(), "raw transaction bytes should not be empty");
 
         // Verify the filled transaction has required fields populated
         let filled_tx = &filled.tx;

--- a/crates/provider/src/provider/web3_signer.rs
+++ b/crates/provider/src/provider/web3_signer.rs
@@ -55,7 +55,11 @@ impl<P: Provider<N> + Clone, N: Network> Web3Signer<P, N> {
     ) -> alloy_signer::Result<Bytes> {
         // Always overrides the `from` field with the web3 signer's address.
         tx.set_from(self.address);
-        self.provider.sign_transaction(tx).await.map_err(alloy_signer::Error::other)
+        self.provider
+            .sign_transaction(tx)
+            .await
+            .map(|signed| signed.raw)
+            .map_err(alloy_signer::Error::other)
     }
 
     /// Signs a transaction request using [`Web3Signer::sign_transaction`] and decodes the raw bytes

--- a/crates/rpc-types-eth/src/transaction/mod.rs
+++ b/crates/rpc-types-eth/src/transaction/mod.rs
@@ -26,7 +26,9 @@ mod receipt;
 pub use receipt::TransactionReceipt;
 
 pub mod request;
-pub use request::{FillTransaction, TransactionInput, TransactionInputKind, TransactionRequest};
+pub use request::{
+    FillTransaction, SignTransaction, TransactionInput, TransactionInputKind, TransactionRequest,
+};
 
 /// Serde-bincode-compat
 #[cfg(all(feature = "serde", feature = "serde-bincode-compat"))]

--- a/crates/rpc-types-eth/src/transaction/request.rs
+++ b/crates/rpc-types-eth/src/transaction/request.rs
@@ -1809,9 +1809,17 @@ pub struct TransactionInputError;
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FillTransaction<T = TypedTransaction> {
-    /// RLP-encoded signed transaction bytes.
+    /// Filled unsigned transaction with populated default values.
+    pub tx: T,
+}
+
+/// Response type for `eth_signTransaction`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct SignTransaction<T = Transaction> {
+    /// EIP-2718 encoded signed transaction bytes.
     pub raw: Bytes,
-    /// Filled transaction request with populated default values.
+    /// Signed RPC transaction object.
     pub tx: T,
 }
 
@@ -1825,6 +1833,19 @@ mod tests {
     use alloy_serde::WithOtherFields;
     use assert_matches::assert_matches;
     use similar_asserts::assert_eq;
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn transaction_response_serde() {
+        let filled = FillTransaction { tx: 1u64 };
+        assert_eq!(serde_json::to_value(filled).unwrap(), serde_json::json!({ "tx": 1 }));
+
+        let signed = SignTransaction { raw: Bytes::from_static(&[1]), tx: 1u64 };
+        assert_eq!(
+            serde_json::to_value(signed).unwrap(),
+            serde_json::json!({ "raw": "0x01", "tx": 1 })
+        );
+    }
 
     // <https://github.com/paradigmxyz/reth/issues/6670>
     #[test]


### PR DESCRIPTION
Aligns `eth_fillTransaction` and `eth_signTransaction` with ethereum/execution-apis#803. Fill now returns only the unsigned filled transaction, while sign returns both encoded bytes and the signed RPC transaction object.

This updates provider return types and preserves `Web3Signer::sign_transaction`'s raw-byte convenience API.

Checks:
- `cargo test -p alloy-rpc-types-eth`
- `cargo check -p alloy-provider --all-features --all-targets`
- `cargo clippy -p alloy-rpc-types-eth -p alloy-provider --all-targets --all-features -- -D warnings`
