### PR TITLE
fix(rpc-types-trace): serialize state gas cost as integer

### DIFF
--- a/crates/rpc-types-trace/src/geth/mod.rs
+++ b/crates/rpc-types-trace/src/geth/mod.rs
@@ -113,7 +113,7 @@ pub struct StructLog {
     /// Net state-dimension gas change caused by this opcode. This can be negative
     /// for source-based state-gas refunds under EIP-8037.
     #[serde(default, rename = "stateGasCost", skip_serializing_if = "Option::is_none")]
-    pub state_gas_cost: Option<alloy_primitives::I256>,
+    pub state_gas_cost: Option<i64>,
     /// State-gas reservoir remaining before this opcode.
     #[serde(default, rename = "stateGasReservoir", skip_serializing_if = "Option::is_none")]
     pub state_gas_reservoir: Option<u64>,

--- a/crates/rpc-types-trace/src/geth/state_gas.rs
+++ b/crates/rpc-types-trace/src/geth/state_gas.rs
@@ -27,7 +27,6 @@ pub struct StateGasTrace {
 mod tests {
     use super::*;
     use crate::geth::{GethDebugTracingOptions, GethTrace, StructLog};
-    use alloy_primitives::I256;
 
     #[test]
     fn test_state_gas_trace_serde() {
@@ -89,7 +88,8 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(log.state_gas_cost, Some(I256::try_from(-5).unwrap()));
+        assert_eq!(log.state_gas_cost, Some(-5));
         assert_eq!(log.state_gas_reservoir, Some(90));
+        assert_eq!(serde_json::to_value(&log).unwrap()["stateGasCost"], -5);
     }
 }


### PR DESCRIPTION
Targets [#4113](https://github.com/alloy-rs/alloy/pull/4113).

`stateGasCost` is a signed JSON integer in [execution-apis#852](https://github.com/ethereum/execution-apis/pull/852), and REVM tracks its opcode delta as `i64`. Using `I256` serializes negative values as JSON strings, so this switches the field to `i64` and verifies that `-5` remains a JSON number.

Tests: `cargo test -p alloy-rpc-types-trace`; `cargo +nightly clippy -p alloy-rpc-types-trace --all-targets -- -D warnings`.
