### PR TITLE
feat(contract): add call timeout futures

### DIFF
--- a/crates/contract/Cargo.toml
+++ b/crates/contract/Cargo.toml
@@ -43,6 +43,12 @@ serde_json = { workspace = true, features = ["raw_value"] }
 
 alloy-pubsub = { workspace = true, optional = true }
 
+[target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]
+tokio = { workspace = true, features = ["time"] }
+
+[target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
+wasmtimer.workspace = true
+
 [dev-dependencies]
 alloy-node-bindings.workspace = true
 alloy-provider = { workspace = true, features = ["anvil-node"] }

--- a/crates/contract/src/call.rs
+++ b/crates/contract/src/call.rs
@@ -15,7 +15,20 @@ use alloy_rpc_types_eth::{
     BlockId, SignedAuthorization,
 };
 use alloy_sol_types::SolCall;
-use std::marker::PhantomData;
+use alloy_transport::{BoxFuture, TransportResult};
+use std::{
+    future::Future,
+    marker::PhantomData,
+    pin::Pin,
+    task::{Context, Poll},
+    time::Duration,
+};
+
+#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+use tokio::time::{timeout as timeout_future, Timeout};
+
+#[cfg(all(target_family = "wasm", target_os = "unknown"))]
+use wasmtimer::tokio::{timeout as timeout_future, Timeout};
 
 // NOTE: The `T` generic here is kept to mitigate breakage with the `sol!` macro.
 // It should always be `()` and has no effect on the implementation.
@@ -29,6 +42,60 @@ pub type DynCallBuilder<P, N = Ethereum> = CallBuilder<P, Function, N>;
 
 /// [`CallBuilder`] that does not have a call decoder.
 pub type RawCallBuilder<P, N = Ethereum> = CallBuilder<P, (), N>;
+
+/// Future returned by [`CallBuilder::send_sync`].
+#[must_use = "futures do nothing unless you `.await` or poll them"]
+pub struct SendSyncFut<'a, N: Network> {
+    inner: BoxFuture<'a, TransportResult<N::ReceiptResponse>>,
+}
+
+impl<'a, N: Network> SendSyncFut<'a, N> {
+    fn new(inner: BoxFuture<'a, TransportResult<N::ReceiptResponse>>) -> Self {
+        Self { inner }
+    }
+
+    /// Wraps this future in a timeout.
+    ///
+    /// The timeout only stops waiting for the response. The transaction may still have been
+    /// submitted to the network, so it may be unsafe to retry it without checking its status.
+    /// Awaiting the returned future produces a timeout result around the existing contract result,
+    /// so the two error cases can be handled separately.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # async fn example<P: alloy_provider::Provider>(
+    /// #     call: &alloy_contract::RawCallBuilder<P>,
+    /// # ) -> Result<(), Box<dyn std::error::Error>> {
+    /// use std::time::Duration;
+    ///
+    /// let receipt = call.send_sync().timeout(Duration::from_secs(30)).await??;
+    /// # let _ = receipt;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// On Tokio-backed targets, including WASI, this panics if there is no current Tokio timer.
+    pub fn timeout(self, duration: Duration) -> Timeout<Self> {
+        timeout_future(duration, self)
+    }
+}
+
+impl<N: Network> std::fmt::Debug for SendSyncFut<'_, N> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SendSyncFut").finish_non_exhaustive()
+    }
+}
+
+impl<N: Network> Future for SendSyncFut<'_, N> {
+    type Output = Result<N::ReceiptResponse>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.inner.as_mut().poll(cx).map(|result| result.map_err(Into::into))
+    }
+}
 
 /// A builder for sending a transaction via `eth_sendTransaction`, or calling a contract via
 /// `eth_call`.
@@ -626,12 +693,13 @@ impl<P: Provider<N>, D: CallDecoder, N: Network> CallBuilder<P, D, N> {
     /// Returns the transaction receipt if the transaction was confirmed.
     ///
     /// See [`Provider::send_transaction_sync`] for more information.
+    /// Use [`SendSyncFut::timeout`] to limit how long to wait for the response.
     ///
     /// # Note
     ///
     /// Not all providers and clients support `eth_sendRawTransactionSync` yet.
-    pub async fn send_sync(&self) -> Result<N::ReceiptResponse> {
-        Ok(self.provider.send_transaction_sync(self.request.clone()).await?)
+    pub fn send_sync(&self) -> SendSyncFut<'_, N> {
+        SendSyncFut::new(self.provider.send_transaction_sync(self.request.clone()))
     }
 
     /// Calculates the address that will be created by the transaction, if any.
@@ -693,6 +761,15 @@ mod tests {
         let provider = ProviderBuilder::new().connect_anvil();
         let call_builder = EmptyConstructor::deploy_builder(&provider);
         assert_eq!(*call_builder.calldata(), bytes!("6942"));
+    }
+
+    #[tokio::test]
+    async fn send_sync_with_timeout() {
+        let inner: BoxFuture<'_, TransportResult<<Ethereum as Network>::ReceiptResponse>> =
+            Box::pin(std::future::pending());
+        let future = SendSyncFut::<Ethereum>::new(inner);
+
+        assert!(future.timeout(Duration::ZERO).await.is_err());
     }
 
     sol! {
@@ -858,7 +935,12 @@ mod tests {
 
         let my_state_builder = my_contract.myState();
         assert_eq!(my_state_builder.calldata()[..], MyContract::myStateCall {}.abi_encode(),);
-        let my_state = my_state_builder.call().await.unwrap();
+        let my_state = my_state_builder
+            .call()
+            .timeout(Duration::from_secs(30))
+            .await
+            .expect("eth_call timed out")
+            .unwrap();
         assert!(my_state);
 
         let do_stuff_builder = my_contract.doStuff(U256::from(0x69), true);
@@ -923,7 +1005,9 @@ mod tests {
             .max_fee_per_gas(max_fee_per_gas.to())
             .max_priority_fee_per_gas(max_priority_fee_per_gas.to())
             .send_sync()
+            .timeout(Duration::from_secs(30))
             .await
+            .expect("synchronous transaction timed out")
             .expect("Could not send transaction");
         let transaction_hash = receipt.transaction_hash;
         let transaction = provider

--- a/crates/contract/src/call.rs
+++ b/crates/contract/src/call.rs
@@ -54,12 +54,17 @@ impl<'a, N: Network> SendSyncFut<'a, N> {
         Self { inner }
     }
 
-    /// Wraps this future in a timeout.
+    /// Wraps this future in a client-side timeout.
     ///
     /// The timeout only stops waiting for the response. The transaction may still have been
     /// submitted to the network, so it may be unsafe to retry it without checking its status.
     /// Awaiting the returned future produces a timeout result around the existing contract result,
     /// so the two error cases can be handled separately.
+    ///
+    /// This is unrelated to the server-side `timeout` parameter of `eth_sendRawTransactionSync`
+    /// defined by [EIP-7966], which will be exposed separately as a request option.
+    ///
+    /// [EIP-7966]: https://eips.ethereum.org/EIPS/eip-7966
     ///
     /// # Examples
     ///
@@ -77,7 +82,8 @@ impl<'a, N: Network> SendSyncFut<'a, N> {
     ///
     /// # Panics
     ///
-    /// On Tokio-backed targets, including WASI, this panics if there is no current Tokio timer.
+    /// On Tokio-backed targets, including WASI, the returned future panics when polled if there
+    /// is no current Tokio timer, for example when polled outside of a Tokio runtime.
     pub fn timeout(self, duration: Duration) -> Timeout<Self> {
         timeout_future(duration, self)
     }

--- a/crates/contract/src/eth_call.rs
+++ b/crates/contract/src/eth_call.rs
@@ -75,7 +75,7 @@ where
         EthCall { inner: self.inner, decoder }
     }
 
-    /// Wraps this call in a timeout.
+    /// Wraps this call in a client-side timeout that only stops waiting for the response.
     ///
     /// Awaiting the returned future produces a timeout result around the existing contract result,
     /// so the two error cases can be handled separately.
@@ -105,7 +105,8 @@ where
     ///
     /// # Panics
     ///
-    /// On Tokio-backed targets, including WASI, this panics if there is no current Tokio timer.
+    /// On Tokio-backed targets, including WASI, the returned future panics when polled if there
+    /// is no current Tokio timer, for example when polled outside of a Tokio runtime.
     pub fn timeout(self, duration: Duration) -> Timeout<<Self as IntoFuture>::IntoFuture> {
         timeout_future(duration, self.into_future())
     }

--- a/crates/contract/src/eth_call.rs
+++ b/crates/contract/src/eth_call.rs
@@ -1,4 +1,4 @@
-use std::{future::IntoFuture, marker::PhantomData};
+use std::{future::IntoFuture, marker::PhantomData, time::Duration};
 
 use crate::{Error, Result};
 use alloy_dyn_abi::{DynSolValue, FunctionExt};
@@ -10,6 +10,12 @@ use alloy_rpc_types_eth::{
     BlockId, BlockOverrides,
 };
 use alloy_sol_types::SolCall;
+
+#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+use tokio::time::{timeout as timeout_future, Timeout};
+
+#[cfg(all(target_family = "wasm", target_os = "unknown"))]
+use wasmtimer::tokio::{timeout as timeout_future, Timeout};
 
 /// Raw coder.
 const RAW_CODER: () = ();
@@ -67,6 +73,41 @@ where
         E: CallDecoder,
     {
         EthCall { inner: self.inner, decoder }
+    }
+
+    /// Wraps this call in a timeout.
+    ///
+    /// Awaiting the returned future produces a timeout result around the existing contract result,
+    /// so the two error cases can be handled separately.
+    ///
+    /// ```no_run
+    /// # async fn example<P: alloy_provider::Provider>(
+    /// #     provider: P,
+    /// # ) -> Result<(), Box<dyn std::error::Error>> {
+    /// use alloy_primitives::Address;
+    /// use alloy_sol_types::sol;
+    /// use std::time::Duration;
+    ///
+    /// sol! {
+    ///     #[sol(rpc)]
+    ///     contract Token {
+    ///         function balanceOf(address owner) external view returns (uint256);
+    ///     }
+    /// }
+    ///
+    /// let contract = Token::new(Address::ZERO, &provider);
+    /// let call = contract.balanceOf(Address::ZERO);
+    /// let balance = call.call().timeout(Duration::from_secs(10)).await??;
+    /// # let _ = balance;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// On Tokio-backed targets, including WASI, this panics if there is no current Tokio timer.
+    pub fn timeout(self, duration: Duration) -> Timeout<<Self as IntoFuture>::IntoFuture> {
+        timeout_future(duration, self.into_future())
     }
 
     /// Set the state overrides for this call.

--- a/crates/provider/Cargo.toml
+++ b/crates/provider/Cargo.toml
@@ -69,6 +69,9 @@ url = { workspace = true, optional = true }
 either.workspace = true
 http = { workspace = true, optional = true }
 
+[target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]
+tokio = { workspace = true, features = ["time"] }
+
 [target.'cfg(not(all(target_os = "wasi", target_env = "p1")))'.dependencies]
 reqwest = { workspace = true, optional = true }
 

--- a/crates/provider/src/provider/eth_call/mod.rs
+++ b/crates/provider/src/provider/eth_call/mod.rs
@@ -246,7 +246,7 @@ where
         }
     }
 
-    /// Wraps this call in a timeout.
+    /// Wraps this call in a client-side timeout that only stops waiting for the response.
     ///
     /// Awaiting the returned future produces a timeout result around the existing transport result,
     /// so the two error cases can be handled separately.
@@ -267,7 +267,8 @@ where
     ///
     /// # Panics
     ///
-    /// On Tokio-backed targets, including WASI, this panics if there is no current Tokio timer.
+    /// On Tokio-backed targets, including WASI, the returned future panics when polled if there
+    /// is no current Tokio timer, for example when polled outside of a Tokio runtime.
     pub fn timeout(self, duration: Duration) -> Timeout<<Self as IntoFuture>::IntoFuture>
     where
         Output: 'static,

--- a/crates/provider/src/provider/eth_call/mod.rs
+++ b/crates/provider/src/provider/eth_call/mod.rs
@@ -10,7 +10,19 @@ use alloy_rpc_types_eth::{
 use alloy_sol_types::SolCall;
 use alloy_transport::TransportResult;
 use futures::FutureExt;
-use std::{future::Future, marker::PhantomData, sync::Arc, task::Poll};
+use std::{
+    future::{Future, IntoFuture},
+    marker::PhantomData,
+    sync::Arc,
+    task::Poll,
+    time::Duration,
+};
+
+#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+use tokio::time::{timeout as timeout_future, Timeout};
+
+#[cfg(all(target_family = "wasm", target_os = "unknown"))]
+use wasmtimer::tokio::{timeout as timeout_future, Timeout};
 
 mod params;
 pub use params::{EthCallManyParams, EthCallParams};
@@ -234,6 +246,35 @@ where
         }
     }
 
+    /// Wraps this call in a timeout.
+    ///
+    /// Awaiting the returned future produces a timeout result around the existing transport result,
+    /// so the two error cases can be handled separately.
+    ///
+    /// ```no_run
+    /// # async fn example<P: alloy_provider::Provider>(
+    /// #     provider: P,
+    /// #     tx: alloy_rpc_types_eth::TransactionRequest,
+    /// # ) -> Result<(), Box<dyn std::error::Error>> {
+    /// use alloy_provider::Provider as _;
+    /// use std::time::Duration;
+    ///
+    /// let output = provider.call(tx).timeout(Duration::from_secs(10)).await??;
+    /// # let _: alloy_primitives::Bytes = output;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// On Tokio-backed targets, including WASI, this panics if there is no current Tokio timer.
+    pub fn timeout(self, duration: Duration) -> Timeout<<Self as IntoFuture>::IntoFuture>
+    where
+        Output: 'static,
+    {
+        timeout_future(duration, self.into_future())
+    }
+
     /// Set the state overrides for this call.
     pub fn overrides(mut self, overrides: impl Into<StateOverride>) -> Self {
         self.params.overrides = Some(overrides.into());
@@ -384,6 +425,39 @@ mod test {
     use alloy_network::{Ethereum, TransactionBuilder};
     use alloy_primitives::{address, U256};
     use alloy_rpc_types_eth::{state::StateOverride, TransactionRequest};
+
+    #[derive(Clone, Copy, Debug)]
+    struct PendingCaller;
+
+    impl Caller<Ethereum, U256> for PendingCaller {
+        fn call(
+            &self,
+            _params: EthCallParams<Ethereum>,
+        ) -> TransportResult<ProviderCall<EthCallParams<Ethereum>, U256>> {
+            Ok(ProviderCall::BoxedFuture(Box::pin(std::future::pending())))
+        }
+
+        fn estimate_gas(
+            &self,
+            _params: EthCallParams<Ethereum>,
+        ) -> TransportResult<ProviderCall<EthCallParams<Ethereum>, U256>> {
+            Ok(ProviderCall::BoxedFuture(Box::pin(std::future::pending())))
+        }
+
+        fn call_many(
+            &self,
+            _params: EthCallManyParams<'_>,
+        ) -> TransportResult<ProviderCall<EthCallManyParams<'static>, U256>> {
+            Ok(ProviderCall::BoxedFuture(Box::pin(std::future::pending())))
+        }
+    }
+
+    #[tokio::test]
+    async fn test_eth_call_with_timeout() {
+        let call = EthCall::call(PendingCaller, TransactionRequest::default());
+
+        assert!(call.timeout(Duration::ZERO).await.is_err());
+    }
 
     #[test]
     fn test_serialize_eth_call_params() {


### PR DESCRIPTION
## Summary

- replace the opaque `CallBuilder::send_sync` future with a named `SendSyncFut`
- add fluent `.timeout(Duration)` adapters to synchronous sends and both provider and contract `EthCall` builders
- use Tokio's concrete `Timeout` on native/WASI targets and Alloy's existing `wasmtimer` path on browser WASM
- document and test the nested timeout plus RPC/contract result behavior

## Motivation

Contract callers currently have to wrap calls manually with `tokio::time::timeout`, which breaks up fluent call-builder chains and makes the common timeout pattern noisy. A named sync-send future allows the timeout adapter to live directly on the returned future, while `EthCall` can expose the same ergonomics through its existing `IntoFuture` implementation.

```rust
let receipt = call.send_sync().timeout(duration).await??;
let output = call.call().timeout(duration).await??;
```

The timeout is client-side and only stops waiting for the response; a submitted transaction may still be processed. The outer timeout result remains separate from the existing transport or contract result so callers can attach operation-specific timeout context. This is distinct from the EIP-7966 server-side timeout parameter tracked in #4041.

## Compatibility

Existing `.send_sync().await` call sites remain source-compatible. The method now exposes a named future so downstream code can compose it directly with timeout-aware APIs.
