### PR TITLE
feat(eip7594): reconstruct sidecars from sparse cells

### DIFF
--- a/crates/eips/src/eip4844/mod.rs
+++ b/crates/eips/src/eip4844/mod.rs
@@ -414,7 +414,7 @@ impl_ckzg_conversions!(Bytes48, c_kzg::Bytes48);
 #[cfg(feature = "kzg")]
 impl_ckzg_conversions!(reverse Bytes48, c_kzg::KzgProof);
 #[cfg(feature = "kzg")]
-impl_ckzg_conversions!(reverse crate::eip7594::Cell, c_kzg::Cell);
+impl_ckzg_conversions!(crate::eip7594::Cell, c_kzg::Cell);
 
 /// Returns blobs as c-kzg blobs.
 #[cfg(feature = "kzg")]

--- a/crates/eips/src/eip7594/sidecar.rs
+++ b/crates/eips/src/eip7594/sidecar.rs
@@ -3,7 +3,7 @@ use crate::{
         Blob, BlobAndProofV2, BlobTransactionSidecar, Bytes48, BYTES_PER_BLOB,
         BYTES_PER_COMMITMENT, BYTES_PER_PROOF,
     },
-    eip7594::{CELLS_PER_EXT_BLOB, EIP_7594_WRAPPER_VERSION, FIELD_ELEMENTS_PER_EXT_BLOB},
+    eip7594::{CELLS_PER_EXT_BLOB, EIP_7594_WRAPPER_VERSION},
 };
 use alloc::{boxed::Box, format, vec::Vec};
 use alloy_primitives::{B128, B256};
@@ -11,14 +11,6 @@ use alloy_rlp::{BufMut, Decodable, Encodable, Header};
 
 use super::{Decodable7594, Encodable7594};
 use crate::eip4844::VersionedHashIter;
-#[cfg(feature = "kzg")]
-use crate::eip4844::{
-    AsAlloy, AsCkzg, BlobTransactionValidationError, BLS_MODULUS, FIELD_ELEMENTS_PER_BLOB,
-};
-#[cfg(feature = "kzg")]
-use crate::eip7594::{Cell, BYTES_PER_CELL};
-#[cfg(feature = "kzg")]
-use alloy_primitives::U256;
 
 /// This represents a set of blobs, and its corresponding commitments and proofs.
 /// Proof type depends on the sidecar variant.
@@ -300,7 +292,7 @@ impl BlobTransactionSidecarVariant {
     pub fn try_from_sparse_cells(
         commitments: Vec<Bytes48>,
         cell_indices: &[u64],
-        cells: &[Vec<Cell>],
+        cells: &[Vec<crate::eip7594::Cell>],
     ) -> Result<Self, c_kzg::Error> {
         BlobTransactionSidecarEip7594::try_from_sparse_cells(commitments, cell_indices, cells)
             .map(Self::Eip7594)
@@ -311,7 +303,7 @@ impl BlobTransactionSidecarVariant {
     pub fn try_from_sparse_cells_with_settings(
         commitments: Vec<Bytes48>,
         cell_indices: &[u64],
-        cells: &[Vec<Cell>],
+        cells: &[Vec<crate::eip7594::Cell>],
         settings: &c_kzg::KzgSettings,
     ) -> Result<Self, c_kzg::Error> {
         BlobTransactionSidecarEip7594::try_from_sparse_cells_with_settings(
@@ -329,7 +321,7 @@ impl BlobTransactionSidecarVariant {
         &self,
         blob_versioned_hashes: &[B256],
         proof_settings: &c_kzg::KzgSettings,
-    ) -> Result<(), BlobTransactionValidationError> {
+    ) -> Result<(), crate::eip4844::BlobTransactionValidationError> {
         match self {
             Self::Eip4844(sidecar) => sidecar.validate(blob_versioned_hashes, proof_settings),
             Self::Eip7594(sidecar) => sidecar.validate(blob_versioned_hashes, proof_settings),
@@ -596,7 +588,7 @@ impl BlobTransactionSidecarEip7594 {
     /// proofs. This uses the default KZG settings.
     #[cfg(feature = "kzg")]
     pub fn try_from_cells(
-        cells: Vec<Cell>,
+        cells: Vec<crate::eip7594::Cell>,
         commitments: Vec<Bytes48>,
         cell_proofs: Vec<Bytes48>,
     ) -> Result<Self, c_kzg::Error> {
@@ -618,7 +610,7 @@ impl BlobTransactionSidecarEip7594 {
     /// proofs.
     #[cfg(feature = "kzg")]
     pub fn try_from_cells_with_settings(
-        cells: Vec<Cell>,
+        cells: Vec<crate::eip7594::Cell>,
         commitments: Vec<Bytes48>,
         cell_proofs: Vec<Bytes48>,
         settings: &c_kzg::KzgSettings,
@@ -675,7 +667,7 @@ impl BlobTransactionSidecarEip7594 {
     pub fn try_from_sparse_cells(
         commitments: Vec<Bytes48>,
         cell_indices: &[u64],
-        cells: &[Vec<Cell>],
+        cells: &[Vec<crate::eip7594::Cell>],
     ) -> Result<Self, c_kzg::Error> {
         use crate::eip4844::env_settings::EnvKzgSettings;
 
@@ -693,7 +685,7 @@ impl BlobTransactionSidecarEip7594 {
     pub fn try_from_sparse_cells_with_settings(
         commitments: Vec<Bytes48>,
         cell_indices: &[u64],
-        cells: &[Vec<Cell>],
+        cells: &[Vec<crate::eip7594::Cell>],
         settings: &c_kzg::KzgSettings,
     ) -> Result<Self, c_kzg::Error> {
         if commitments.len() != cells.len() {
@@ -754,8 +746,9 @@ impl BlobTransactionSidecarEip7594 {
                 settings.recover_cells_and_kzg_proofs(cell_indices, &ckzg_cells)?;
             let blob = reconstruct_blob(recovered_cells.as_ref())?;
 
-            let commitment = settings.blob_to_kzg_commitment(blob.as_ckzg())?;
-            let commitment = Bytes48::from_ckzg(commitment.to_bytes());
+            let commitment =
+                settings.blob_to_kzg_commitment(crate::eip4844::AsCkzg::as_ckzg(&blob))?;
+            let commitment = <Bytes48 as crate::eip4844::AsCkzg>::from_ckzg(commitment.to_bytes());
             if commitment != commitments[blob_index] {
                 return Err(c_kzg::Error::InvalidKzgCommitment(format!(
                     "reconstructed blob {blob_index} does not match its commitment"
@@ -768,7 +761,7 @@ impl BlobTransactionSidecarEip7594 {
             let recovered_proofs_bytes =
                 recovered_proofs.iter().map(|proof| proof.to_bytes()).collect::<Vec<_>>();
             let valid = settings.verify_cell_kzg_proof_batch(
-                Bytes48::slice_as_ckzg(&commitments),
+                <Bytes48 as crate::eip4844::AsCkzg>::slice_as_ckzg(&commitments),
                 &cell_indices,
                 recovered_cells.as_ref(),
                 &recovered_proofs_bytes,
@@ -780,8 +773,11 @@ impl BlobTransactionSidecarEip7594 {
             }
 
             blobs.push(blob);
-            cell_proofs
-                .extend_from_slice(c_kzg::KzgProof::slice_as_alloy(recovered_proofs.as_ref()));
+            cell_proofs.extend_from_slice(
+                <c_kzg::KzgProof as crate::eip4844::AsAlloy>::slice_as_alloy(
+                    recovered_proofs.as_ref(),
+                ),
+            );
         }
 
         Ok(Self::new(blobs, commitments, cell_proofs))
@@ -844,23 +840,28 @@ impl BlobTransactionSidecarEip7594 {
         settings: &c_kzg::KzgSettings,
     ) -> Result<Self, c_kzg::Error> {
         if let [blob] = blobs.as_slice() {
-            let blob = blob.as_ckzg();
+            let blob = crate::eip4844::AsCkzg::as_ckzg(blob);
             let commitment = settings.blob_to_kzg_commitment(blob)?;
             let (_cells, kzg_proofs) = settings.compute_cells_and_kzg_proofs(blob)?;
-            let commitments = vec![Bytes48::from_ckzg(commitment.to_bytes())];
-            let proofs = c_kzg::KzgProof::boxed_slice_as_alloy(kzg_proofs).into();
+            let commitments =
+                vec![<Bytes48 as crate::eip4844::AsCkzg>::from_ckzg(commitment.to_bytes())];
+            let proofs =
+                <c_kzg::KzgProof as crate::eip4844::AsAlloy>::boxed_slice_as_alloy(kzg_proofs)
+                    .into();
             return Ok(Self::new(blobs, commitments, proofs));
         }
 
         let mut commitments = Vec::with_capacity(blobs.len());
         let mut proofs = Vec::with_capacity(blobs.len() * CELLS_PER_EXT_BLOB);
         for blob in &blobs {
-            let blob = blob.as_ckzg();
+            let blob = crate::eip4844::AsCkzg::as_ckzg(blob);
             let commitment = settings.blob_to_kzg_commitment(blob)?;
             let (_cells, kzg_proofs) = settings.compute_cells_and_kzg_proofs(blob)?;
 
-            commitments.push(Bytes48::from_ckzg(commitment.to_bytes()));
-            proofs.extend_from_slice(c_kzg::KzgProof::slice_as_alloy(kzg_proofs.as_ref()));
+            commitments.push(<Bytes48 as crate::eip4844::AsCkzg>::from_ckzg(commitment.to_bytes()));
+            proofs.extend_from_slice(<c_kzg::KzgProof as crate::eip4844::AsAlloy>::slice_as_alloy(
+                kzg_proofs.as_ref(),
+            ));
         }
 
         Ok(Self::new(blobs, commitments, proofs))
@@ -905,14 +906,18 @@ impl BlobTransactionSidecarEip7594 {
         settings: &c_kzg::KzgSettings,
     ) -> Result<Vec<crate::eip7594::Cell>, c_kzg::Error> {
         if let [blob] = self.blobs.as_slice() {
-            let blob_cells = settings.compute_cells(blob.as_ckzg())?;
-            return Ok(c_kzg::Cell::boxed_slice_as_alloy(blob_cells).into());
+            let blob_cells = settings.compute_cells(crate::eip4844::AsCkzg::as_ckzg(blob))?;
+            return Ok(
+                <c_kzg::Cell as crate::eip4844::AsAlloy>::boxed_slice_as_alloy(blob_cells).into()
+            );
         }
 
         let mut cells = Vec::with_capacity(self.blobs.len() * CELLS_PER_EXT_BLOB);
         for blob in &self.blobs {
-            let blob_cells = settings.compute_cells(blob.as_ckzg())?;
-            cells.extend_from_slice(c_kzg::Cell::slice_as_alloy(blob_cells.as_ref()));
+            let blob_cells = settings.compute_cells(crate::eip4844::AsCkzg::as_ckzg(blob))?;
+            cells.extend_from_slice(<c_kzg::Cell as crate::eip4844::AsAlloy>::slice_as_alloy(
+                blob_cells.as_ref(),
+            ));
         }
         Ok(cells)
     }
@@ -961,7 +966,8 @@ impl BlobTransactionSidecarEip7594 {
     /// elements, commitments, and proofs. The cells are constructed from each blob and verified
     /// against the commitments and proofs.
     ///
-    /// Returns [BlobTransactionValidationError::InvalidProof] if any blob KZG proof in the response
+    /// Returns [crate::eip4844::BlobTransactionValidationError::InvalidProof] if any blob KZG proof
+    /// in the response
     /// fails to verify, or if the versioned hashes in the transaction do not match the actual
     /// commitment versioned hashes.
     #[cfg(feature = "kzg")]
@@ -969,7 +975,7 @@ impl BlobTransactionSidecarEip7594 {
         &self,
         blob_versioned_hashes: &[B256],
         proof_settings: &c_kzg::KzgSettings,
-    ) -> Result<(), BlobTransactionValidationError> {
+    ) -> Result<(), crate::eip4844::BlobTransactionValidationError> {
         // Ensure the versioned hashes and commitments have the same length.
         if blob_versioned_hashes.len() != self.commitments.len() {
             return Err(c_kzg::Error::MismatchLength(format!(
@@ -1000,7 +1006,7 @@ impl BlobTransactionSidecarEip7594 {
             let calculated_versioned_hash =
                 crate::eip4844::kzg_to_versioned_hash(commitment.as_slice());
             if *versioned_hash != calculated_versioned_hash {
-                return Err(BlobTransactionValidationError::WrongVersionedHash {
+                return Err(crate::eip4844::BlobTransactionValidationError::WrongVersionedHash {
                     have: *versioned_hash,
                     expected: calculated_versioned_hash,
                 });
@@ -1018,25 +1024,27 @@ impl BlobTransactionSidecarEip7594 {
         }
 
         let cells = if let [blob] = self.blobs.as_slice() {
-            let cells: Box<[c_kzg::Cell]> = proof_settings.compute_cells(blob.as_ckzg())?;
+            let cells: Box<[c_kzg::Cell]> =
+                proof_settings.compute_cells(crate::eip4844::AsCkzg::as_ckzg(blob))?;
             cells.into()
         } else {
             let mut cells = Vec::with_capacity(blobs_len * CELLS_PER_EXT_BLOB);
             for blob in &self.blobs {
-                let blob_cells = proof_settings.compute_cells(blob.as_ckzg())?;
+                let blob_cells =
+                    proof_settings.compute_cells(crate::eip4844::AsCkzg::as_ckzg(blob))?;
                 cells.extend_from_slice(blob_cells.as_ref());
             }
             cells
         };
 
         let res = proof_settings.verify_cell_kzg_proof_batch(
-            Bytes48::slice_as_ckzg(&commitments),
+            <Bytes48 as crate::eip4844::AsCkzg>::slice_as_ckzg(&commitments),
             &cell_indices,
             &cells,
-            Bytes48::slice_as_ckzg(self.cell_proofs.as_slice()),
+            <Bytes48 as crate::eip4844::AsCkzg>::slice_as_ckzg(self.cell_proofs.as_slice()),
         )?;
 
-        res.then_some(()).ok_or(BlobTransactionValidationError::InvalidProof)
+        res.then_some(()).ok_or(crate::eip4844::BlobTransactionValidationError::InvalidProof)
     }
 
     /// Returns an iterator over the versioned hashes of the commitments.
@@ -1094,7 +1102,7 @@ impl BlobTransactionSidecarEip7594 {
             return Ok(Some(crate::eip4844::BlobCellsAndProofsV1::default()));
         }
 
-        let cells = settings.compute_cells(blob.as_ckzg())?;
+        let cells = settings.compute_cells(crate::eip4844::AsCkzg::as_ckzg(blob))?;
 
         Ok(Some(Self::blob_cells_and_proofs_from_computed_cells(cell_mask, cells.as_ref(), proofs)))
     }
@@ -1213,7 +1221,7 @@ impl BlobTransactionSidecarEip7594 {
                 {
                     cells_and_proofs.clone()
                 } else {
-                    let cells = settings.compute_cells(blob.as_ckzg())?;
+                    let cells = settings.compute_cells(crate::eip4844::AsCkzg::as_ckzg(blob))?;
                     let cells_and_proofs = Self::blob_cells_and_proofs_from_computed_cells(
                         cell_mask,
                         cells.as_ref(),
@@ -1304,95 +1312,26 @@ impl BlobTransactionSidecarEip7594 {
 }
 
 #[cfg(feature = "kzg")]
-const EIP7594_ROOT_OF_UNITY: U256 = U256::from_be_bytes([
-    0x71, 0xdb, 0x41, 0xab, 0xda, 0x03, 0xe0, 0x55, 0x06, 0x5d, 0x22, 0x7f, 0xea, 0xd1, 0x13, 0x9b,
-    0x41, 0xfa, 0xc7, 0x9f, 0x59, 0xe9, 0x19, 0x72, 0xa3, 0x3d, 0x27, 0x9f, 0xf0, 0xcc, 0xff, 0xc9,
-]);
-
-#[cfg(feature = "kzg")]
 fn reconstruct_blob(recovered_cells: &[c_kzg::Cell]) -> Result<Blob, c_kzg::Error> {
-    let mut evaluations = Vec::with_capacity(CELLS_PER_EXT_BLOB * BYTES_PER_CELL / 32);
-    for cell in recovered_cells {
-        for field_element in cell.to_bytes().chunks_exact(32) {
-            let value = U256::from_be_slice(field_element);
-            if value >= BLS_MODULUS {
-                return Err(c_kzg::Error::CError(c_kzg::CkzgError::C_KZG_BADARGS));
-            }
-            evaluations.push(value);
-        }
+    // `RecoverCells` returns cells in the canonical EIP-7594 order. The first half is the
+    // original blob data; the remaining cells are the extension used for sampling and proofs.
+    // This is the same boundary used by Geth's `kzg4844.RecoverBlobs`: the KZG backend performs
+    // the recovery, while the wrapper only materializes the first `DataPerBlob` cells.
+    if recovered_cells.len() < CELLS_PER_EXT_BLOB / 2 {
+        return Err(c_kzg::Error::MismatchLength(format!(
+            "expected at least {} recovered cells, got {}",
+            CELLS_PER_EXT_BLOB / 2,
+            recovered_cells.len()
+        )));
     }
-
-    // c-kzg returns cell evaluations after bit-reversing the extended FFT output. Restore the
-    // natural evaluation order, then invert the 8192-point transform. The extended polynomial is
-    // the original 4096 blob field elements followed by 4096 zero coefficients.
-    bit_reverse_permutation(&mut evaluations);
-    fft(&mut evaluations, true);
-
-    evaluations.truncate(FIELD_ELEMENTS_PER_BLOB as usize);
 
     let mut blob = [0u8; BYTES_PER_BLOB];
-    for (output, field_element) in blob.chunks_exact_mut(32).zip(evaluations) {
-        output.copy_from_slice(&field_element.to_be_bytes::<32>());
+    for (cell_index, cell) in recovered_cells.iter().take(CELLS_PER_EXT_BLOB / 2).enumerate() {
+        let start = cell_index * crate::eip7594::BYTES_PER_CELL;
+        let end = start + crate::eip7594::BYTES_PER_CELL;
+        blob[start..end].copy_from_slice(&cell.to_bytes());
     }
     Ok(Blob::new(blob))
-}
-
-#[cfg(feature = "kzg")]
-fn fft(values: &mut [U256], inverse: bool) {
-    bit_reverse_permutation(values);
-
-    let root = if inverse {
-        EIP7594_ROOT_OF_UNITY.pow_mod(U256::from(8191u64), BLS_MODULUS)
-    } else {
-        EIP7594_ROOT_OF_UNITY
-    };
-    let n = values.len();
-    let mut width = 2;
-    while width <= n {
-        let exponent = FIELD_ELEMENTS_PER_EXT_BLOB / width;
-        let width_root = root.pow_mod(U256::from(exponent), BLS_MODULUS);
-        for chunk in values.chunks_exact_mut(width) {
-            let (left, right) = chunk.split_at_mut(width / 2);
-            let mut factor = U256::from(1u64);
-            for (left, right) in left.iter_mut().zip(right) {
-                let product = right.mul_mod(factor, BLS_MODULUS);
-                let sum = left.add_mod(product, BLS_MODULUS);
-                let difference = if *left >= product {
-                    *left - product
-                } else {
-                    BLS_MODULUS - (product - *left)
-                };
-                *left = sum;
-                *right = difference;
-                factor = factor.mul_mod(width_root, BLS_MODULUS);
-            }
-        }
-        width *= 2;
-    }
-
-    if inverse {
-        let inverse_n = U256::from(n).inv_mod(BLS_MODULUS).unwrap();
-        for value in values {
-            *value = value.mul_mod(inverse_n, BLS_MODULUS);
-        }
-    }
-}
-
-#[cfg(feature = "kzg")]
-fn bit_reverse_permutation(values: &mut [U256]) {
-    let mut reversed = 0usize;
-    for index in 1..values.len() {
-        let highest_bit = values.len() >> 1;
-        let mut bit = highest_bit;
-        while reversed & bit != 0 {
-            reversed &= !bit;
-            bit >>= 1;
-        }
-        reversed |= bit;
-        if index < reversed {
-            values.swap(index, reversed);
-        }
-    }
 }
 
 impl Encodable for BlobTransactionSidecarEip7594 {
@@ -1769,7 +1708,8 @@ mod tests {
         assert!(sidecar.compute_matching_cells(BlobCellMask::default()).unwrap().is_empty());
 
         for (blob_index, blob) in sidecar.blobs.iter().enumerate() {
-            let expected_cells = settings.compute_cells(blob.as_ckzg()).unwrap();
+            let expected_cells =
+                settings.compute_cells(crate::eip4844::AsCkzg::as_ckzg(blob)).unwrap();
             let start = blob_index * CELLS_PER_EXT_BLOB;
             let end = start + CELLS_PER_EXT_BLOB;
 
@@ -1888,7 +1828,8 @@ mod tests {
             vec![Some(sidecar.cell_proofs[0]), Some(sidecar.cell_proofs[7])]
         );
 
-        let expected_cells = settings.compute_cells(sidecar.blobs[0].as_ckzg()).unwrap();
+        let expected_cells =
+            settings.compute_cells(crate::eip4844::AsCkzg::as_ckzg(&sidecar.blobs[0])).unwrap();
         assert_eq!(
             cells_and_proofs.blob_cells,
             vec![
@@ -1926,7 +1867,7 @@ mod tests {
         let cell_mask = BlobCellMask::from_bits(1);
 
         let invalid_blob = Blob::repeat_byte(0xff);
-        assert!(settings.compute_cells(invalid_blob.as_ckzg()).is_err());
+        assert!(settings.compute_cells(crate::eip4844::AsCkzg::as_ckzg(&invalid_blob)).is_err());
 
         sidecar.blobs.push(invalid_blob);
         sidecar.commitments.push(Bytes48::ZERO);

--- a/crates/eips/src/eip7594/sidecar.rs
+++ b/crates/eips/src/eip7594/sidecar.rs
@@ -519,64 +519,6 @@ impl<'de> serde::Deserialize<'de> for BlobTransactionSidecarVariant {
     }
 }
 
-/// An error that can occur while recovering blobs from EIP-7594 cells.
-#[cfg(feature = "kzg")]
-#[derive(Debug)]
-pub enum BlobCellRecoveryError {
-    /// Fewer than half of the extended blob cells were selected.
-    InsufficientCells {
-        /// The number of cells supplied for each blob.
-        provided: usize,
-        /// The minimum number of cells required for recovery.
-        required: usize,
-    },
-    /// The flattened cell slice does not match the commitments and cell mask.
-    CellCountMismatch {
-        /// The number of cells supplied.
-        provided: usize,
-        /// The number of cells implied by the commitments and cell mask.
-        expected: usize,
-    },
-    /// The expected cell count cannot be represented as a `usize`.
-    CellCountOverflow,
-    /// A reconstructed blob does not match its supplied commitment.
-    CommitmentMismatch {
-        /// The index of the blob whose commitment did not match.
-        blob_index: usize,
-    },
-    /// An error returned by [`c_kzg`].
-    Kzg(c_kzg::Error),
-}
-
-#[cfg(feature = "kzg")]
-impl core::fmt::Display for BlobCellRecoveryError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            Self::InsufficientCells { provided, required } => {
-                write!(f, "need at least {required} cells per blob for recovery, got {provided}")
-            }
-            Self::CellCountMismatch { provided, expected } => {
-                write!(f, "expected {expected} cells, got {provided}")
-            }
-            Self::CellCountOverflow => f.write_str("the expected cell count overflows usize"),
-            Self::CommitmentMismatch { blob_index } => {
-                write!(f, "reconstructed blob {blob_index} does not match its commitment")
-            }
-            Self::Kzg(err) => write!(f, "KZG error: {err:?}"),
-        }
-    }
-}
-
-#[cfg(feature = "kzg")]
-impl core::error::Error for BlobCellRecoveryError {}
-
-#[cfg(feature = "kzg")]
-impl From<c_kzg::Error> for BlobCellRecoveryError {
-    fn from(source: c_kzg::Error) -> Self {
-        Self::Kzg(source)
-    }
-}
-
 /// This represents a set of blobs, and its corresponding commitments and cell proofs.
 ///
 /// This type encodes and decodes the fields without an rlp header.
@@ -691,25 +633,25 @@ impl BlobTransactionSidecarEip7594 {
         for (blob_index, (blob_cells, expected_commitment)) in
             cells.chunks_exact(cells_per_blob).zip(&commitments).enumerate()
         {
-            let ckzg_cells = <crate::eip7594::Cell as AsCkzg>::slice_as_ckzg(blob_cells);
+            let ckzg_cells = crate::eip7594::Cell::slice_as_ckzg(blob_cells);
             let (recovered_cells, recovered_proofs) =
                 settings.recover_cells_and_kzg_proofs(&cell_indices, ckzg_cells)?;
             let blob = reconstruct_blob(recovered_cells.as_ref());
 
-            let commitment = settings.blob_to_kzg_commitment(AsCkzg::as_ckzg(&blob))?;
-            let commitment = <Bytes48 as AsCkzg>::from_ckzg(commitment.to_bytes());
+            let commitment = settings.blob_to_kzg_commitment(blob.as_ckzg())?;
+            let commitment = Bytes48::from_ckzg(commitment.to_bytes());
             if commitment != *expected_commitment {
                 return Err(BlobCellRecoveryError::CommitmentMismatch { blob_index });
             }
 
             blobs.push(blob);
-            cell_proofs.extend_from_slice(<c_kzg::KzgProof as AsAlloy>::slice_as_alloy(
-                recovered_proofs.as_ref(),
-            ));
+            cell_proofs
+                .extend_from_slice(c_kzg::KzgProof::slice_as_alloy(recovered_proofs.as_ref()));
         }
 
         Ok(Self::new(blobs, commitments, cell_proofs))
     }
+
     /// Clears blob payloads while retaining commitments and cell proofs.
     ///
     /// This prepares the sidecar for inclusion in an eth/72 `PooledTransactions` response as
@@ -777,25 +719,23 @@ impl BlobTransactionSidecarEip7594 {
         settings: &c_kzg::KzgSettings,
     ) -> Result<Self, c_kzg::Error> {
         if let [blob] = blobs.as_slice() {
-            let blob = AsCkzg::as_ckzg(blob);
+            let blob = blob.as_ckzg();
             let commitment = settings.blob_to_kzg_commitment(blob)?;
             let (_cells, kzg_proofs) = settings.compute_cells_and_kzg_proofs(blob)?;
-            let commitments = vec![<Bytes48 as AsCkzg>::from_ckzg(commitment.to_bytes())];
-            let proofs = <c_kzg::KzgProof as AsAlloy>::boxed_slice_as_alloy(kzg_proofs).into();
+            let commitments = vec![Bytes48::from_ckzg(commitment.to_bytes())];
+            let proofs = c_kzg::KzgProof::boxed_slice_as_alloy(kzg_proofs).into();
             return Ok(Self::new(blobs, commitments, proofs));
         }
 
         let mut commitments = Vec::with_capacity(blobs.len());
         let mut proofs = Vec::with_capacity(blobs.len() * CELLS_PER_EXT_BLOB);
         for blob in &blobs {
-            let blob = AsCkzg::as_ckzg(blob);
+            let blob = blob.as_ckzg();
             let commitment = settings.blob_to_kzg_commitment(blob)?;
             let (_cells, kzg_proofs) = settings.compute_cells_and_kzg_proofs(blob)?;
 
-            commitments.push(<Bytes48 as AsCkzg>::from_ckzg(commitment.to_bytes()));
-            proofs.extend_from_slice(<c_kzg::KzgProof as AsAlloy>::slice_as_alloy(
-                kzg_proofs.as_ref(),
-            ));
+            commitments.push(Bytes48::from_ckzg(commitment.to_bytes()));
+            proofs.extend_from_slice(c_kzg::KzgProof::slice_as_alloy(kzg_proofs.as_ref()));
         }
 
         Ok(Self::new(blobs, commitments, proofs))
@@ -840,14 +780,14 @@ impl BlobTransactionSidecarEip7594 {
         settings: &c_kzg::KzgSettings,
     ) -> Result<Vec<crate::eip7594::Cell>, c_kzg::Error> {
         if let [blob] = self.blobs.as_slice() {
-            let blob_cells = settings.compute_cells(AsCkzg::as_ckzg(blob))?;
-            return Ok(<c_kzg::Cell as AsAlloy>::boxed_slice_as_alloy(blob_cells).into());
+            let blob_cells = settings.compute_cells(blob.as_ckzg())?;
+            return Ok(c_kzg::Cell::boxed_slice_as_alloy(blob_cells).into());
         }
 
         let mut cells = Vec::with_capacity(self.blobs.len() * CELLS_PER_EXT_BLOB);
         for blob in &self.blobs {
-            let blob_cells = settings.compute_cells(AsCkzg::as_ckzg(blob))?;
-            cells.extend_from_slice(<c_kzg::Cell as AsAlloy>::slice_as_alloy(blob_cells.as_ref()));
+            let blob_cells = settings.compute_cells(blob.as_ckzg())?;
+            cells.extend_from_slice(c_kzg::Cell::slice_as_alloy(blob_cells.as_ref()));
         }
         Ok(cells)
     }
@@ -953,22 +893,22 @@ impl BlobTransactionSidecarEip7594 {
         }
 
         let cells = if let [blob] = self.blobs.as_slice() {
-            let cells: Box<[c_kzg::Cell]> = proof_settings.compute_cells(AsCkzg::as_ckzg(blob))?;
+            let cells: Box<[c_kzg::Cell]> = proof_settings.compute_cells(blob.as_ckzg())?;
             cells.into()
         } else {
             let mut cells = Vec::with_capacity(blobs_len * CELLS_PER_EXT_BLOB);
             for blob in &self.blobs {
-                let blob_cells = proof_settings.compute_cells(AsCkzg::as_ckzg(blob))?;
+                let blob_cells = proof_settings.compute_cells(blob.as_ckzg())?;
                 cells.extend_from_slice(blob_cells.as_ref());
             }
             cells
         };
 
         let res = proof_settings.verify_cell_kzg_proof_batch(
-            <Bytes48 as AsCkzg>::slice_as_ckzg(&commitments),
+            Bytes48::slice_as_ckzg(&commitments),
             &cell_indices,
             &cells,
-            <Bytes48 as AsCkzg>::slice_as_ckzg(self.cell_proofs.as_slice()),
+            Bytes48::slice_as_ckzg(self.cell_proofs.as_slice()),
         )?;
 
         res.then_some(()).ok_or(BlobTransactionValidationError::InvalidProof)
@@ -1029,7 +969,7 @@ impl BlobTransactionSidecarEip7594 {
             return Ok(Some(crate::eip4844::BlobCellsAndProofsV1::default()));
         }
 
-        let cells = settings.compute_cells(AsCkzg::as_ckzg(blob))?;
+        let cells = settings.compute_cells(blob.as_ckzg())?;
 
         Ok(Some(Self::blob_cells_and_proofs_from_computed_cells(cell_mask, cells.as_ref(), proofs)))
     }
@@ -1148,7 +1088,7 @@ impl BlobTransactionSidecarEip7594 {
                 {
                     cells_and_proofs.clone()
                 } else {
-                    let cells = settings.compute_cells(AsCkzg::as_ckzg(blob))?;
+                    let cells = settings.compute_cells(blob.as_ckzg())?;
                     let cells_and_proofs = Self::blob_cells_and_proofs_from_computed_cells(
                         cell_mask,
                         cells.as_ref(),
@@ -1238,6 +1178,64 @@ impl BlobTransactionSidecarEip7594 {
     }
 }
 
+/// An error that can occur while recovering blobs from EIP-7594 cells.
+#[cfg(feature = "kzg")]
+#[derive(Debug)]
+pub enum BlobCellRecoveryError {
+    /// Fewer than half of the extended blob cells were selected.
+    InsufficientCells {
+        /// The number of cells supplied for each blob.
+        provided: usize,
+        /// The minimum number of cells required for recovery.
+        required: usize,
+    },
+    /// The flattened cell slice does not match the commitments and cell mask.
+    CellCountMismatch {
+        /// The number of cells supplied.
+        provided: usize,
+        /// The number of cells implied by the commitments and cell mask.
+        expected: usize,
+    },
+    /// The expected cell count cannot be represented as a `usize`.
+    CellCountOverflow,
+    /// A reconstructed blob does not match its supplied commitment.
+    CommitmentMismatch {
+        /// The index of the blob whose commitment did not match.
+        blob_index: usize,
+    },
+    /// An error returned by [`c_kzg`].
+    Kzg(c_kzg::Error),
+}
+
+#[cfg(feature = "kzg")]
+impl core::fmt::Display for BlobCellRecoveryError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::InsufficientCells { provided, required } => {
+                write!(f, "need at least {required} cells per blob for recovery, got {provided}")
+            }
+            Self::CellCountMismatch { provided, expected } => {
+                write!(f, "expected {expected} cells, got {provided}")
+            }
+            Self::CellCountOverflow => f.write_str("the expected cell count overflows usize"),
+            Self::CommitmentMismatch { blob_index } => {
+                write!(f, "reconstructed blob {blob_index} does not match its commitment")
+            }
+            Self::Kzg(err) => write!(f, "KZG error: {err:?}"),
+        }
+    }
+}
+
+#[cfg(feature = "kzg")]
+impl core::error::Error for BlobCellRecoveryError {}
+
+#[cfg(feature = "kzg")]
+impl From<c_kzg::Error> for BlobCellRecoveryError {
+    fn from(source: c_kzg::Error) -> Self {
+        Self::Kzg(source)
+    }
+}
+
 #[cfg(feature = "kzg")]
 fn reconstruct_blob(recovered_cells: &[c_kzg::Cell; CELLS_PER_EXT_BLOB]) -> Blob {
     // `RecoverCells` returns cells in the canonical EIP-7594 order. The first half is the
@@ -1248,7 +1246,7 @@ fn reconstruct_blob(recovered_cells: &[c_kzg::Cell; CELLS_PER_EXT_BLOB]) -> Blob
     for (cell_index, cell) in recovered_cells.iter().take(CELLS_PER_EXT_BLOB / 2).enumerate() {
         let start = cell_index * crate::eip7594::BYTES_PER_CELL;
         let end = start + crate::eip7594::BYTES_PER_CELL;
-        blob[start..end].copy_from_slice(&cell.to_bytes());
+        blob[start..end].copy_from_slice(cell.as_alloy().as_slice());
     }
     Blob::new(blob)
 }
@@ -1660,8 +1658,7 @@ mod tests {
         assert!(sidecar.compute_matching_cells(BlobCellMask::default()).unwrap().is_empty());
 
         for (blob_index, blob) in sidecar.blobs.iter().enumerate() {
-            let expected_cells =
-                settings.compute_cells(crate::eip4844::AsCkzg::as_ckzg(blob)).unwrap();
+            let expected_cells = settings.compute_cells(blob.as_ckzg()).unwrap();
             let start = blob_index * CELLS_PER_EXT_BLOB;
             let end = start + CELLS_PER_EXT_BLOB;
 
@@ -1937,8 +1934,7 @@ mod tests {
             vec![Some(sidecar.cell_proofs[0]), Some(sidecar.cell_proofs[7])]
         );
 
-        let expected_cells =
-            settings.compute_cells(crate::eip4844::AsCkzg::as_ckzg(&sidecar.blobs[0])).unwrap();
+        let expected_cells = settings.compute_cells(sidecar.blobs[0].as_ckzg()).unwrap();
         assert_eq!(
             cells_and_proofs.blob_cells,
             vec![
@@ -1976,7 +1972,7 @@ mod tests {
         let cell_mask = BlobCellMask::from_bits(1);
 
         let invalid_blob = Blob::repeat_byte(0xff);
-        assert!(settings.compute_cells(crate::eip4844::AsCkzg::as_ckzg(&invalid_blob)).is_err());
+        assert!(settings.compute_cells(invalid_blob.as_ckzg()).is_err());
 
         sidecar.blobs.push(invalid_blob);
         sidecar.commitments.push(Bytes48::ZERO);

--- a/crates/eips/src/eip7594/sidecar.rs
+++ b/crates/eips/src/eip7594/sidecar.rs
@@ -11,6 +11,8 @@ use alloy_rlp::{BufMut, Decodable, Encodable, Header};
 
 use super::{Decodable7594, Encodable7594};
 use crate::eip4844::VersionedHashIter;
+#[cfg(feature = "kzg")]
+use crate::eip4844::{AsAlloy, AsCkzg, BlobTransactionValidationError};
 
 /// This represents a set of blobs, and its corresponding commitments and proofs.
 /// Proof type depends on the sidecar variant.
@@ -321,7 +323,7 @@ impl BlobTransactionSidecarVariant {
         &self,
         blob_versioned_hashes: &[B256],
         proof_settings: &c_kzg::KzgSettings,
-    ) -> Result<(), crate::eip4844::BlobTransactionValidationError> {
+    ) -> Result<(), BlobTransactionValidationError> {
         match self {
             Self::Eip4844(sidecar) => sidecar.validate(blob_versioned_hashes, proof_settings),
             Self::Eip7594(sidecar) => sidecar.validate(blob_versioned_hashes, proof_settings),
@@ -746,9 +748,8 @@ impl BlobTransactionSidecarEip7594 {
                 settings.recover_cells_and_kzg_proofs(cell_indices, &ckzg_cells)?;
             let blob = reconstruct_blob(recovered_cells.as_ref())?;
 
-            let commitment =
-                settings.blob_to_kzg_commitment(crate::eip4844::AsCkzg::as_ckzg(&blob))?;
-            let commitment = <Bytes48 as crate::eip4844::AsCkzg>::from_ckzg(commitment.to_bytes());
+            let commitment = settings.blob_to_kzg_commitment(AsCkzg::as_ckzg(&blob))?;
+            let commitment = <Bytes48 as AsCkzg>::from_ckzg(commitment.to_bytes());
             if commitment != commitments[blob_index] {
                 return Err(c_kzg::Error::InvalidKzgCommitment(format!(
                     "reconstructed blob {blob_index} does not match its commitment"
@@ -761,7 +762,7 @@ impl BlobTransactionSidecarEip7594 {
             let recovered_proofs_bytes =
                 recovered_proofs.iter().map(|proof| proof.to_bytes()).collect::<Vec<_>>();
             let valid = settings.verify_cell_kzg_proof_batch(
-                <Bytes48 as crate::eip4844::AsCkzg>::slice_as_ckzg(&commitments),
+                <Bytes48 as AsCkzg>::slice_as_ckzg(&commitments),
                 &cell_indices,
                 recovered_cells.as_ref(),
                 &recovered_proofs_bytes,
@@ -773,11 +774,9 @@ impl BlobTransactionSidecarEip7594 {
             }
 
             blobs.push(blob);
-            cell_proofs.extend_from_slice(
-                <c_kzg::KzgProof as crate::eip4844::AsAlloy>::slice_as_alloy(
-                    recovered_proofs.as_ref(),
-                ),
-            );
+            cell_proofs.extend_from_slice(<c_kzg::KzgProof as AsAlloy>::slice_as_alloy(
+                recovered_proofs.as_ref(),
+            ));
         }
 
         Ok(Self::new(blobs, commitments, cell_proofs))
@@ -840,26 +839,23 @@ impl BlobTransactionSidecarEip7594 {
         settings: &c_kzg::KzgSettings,
     ) -> Result<Self, c_kzg::Error> {
         if let [blob] = blobs.as_slice() {
-            let blob = crate::eip4844::AsCkzg::as_ckzg(blob);
+            let blob = AsCkzg::as_ckzg(blob);
             let commitment = settings.blob_to_kzg_commitment(blob)?;
             let (_cells, kzg_proofs) = settings.compute_cells_and_kzg_proofs(blob)?;
-            let commitments =
-                vec![<Bytes48 as crate::eip4844::AsCkzg>::from_ckzg(commitment.to_bytes())];
-            let proofs =
-                <c_kzg::KzgProof as crate::eip4844::AsAlloy>::boxed_slice_as_alloy(kzg_proofs)
-                    .into();
+            let commitments = vec![<Bytes48 as AsCkzg>::from_ckzg(commitment.to_bytes())];
+            let proofs = <c_kzg::KzgProof as AsAlloy>::boxed_slice_as_alloy(kzg_proofs).into();
             return Ok(Self::new(blobs, commitments, proofs));
         }
 
         let mut commitments = Vec::with_capacity(blobs.len());
         let mut proofs = Vec::with_capacity(blobs.len() * CELLS_PER_EXT_BLOB);
         for blob in &blobs {
-            let blob = crate::eip4844::AsCkzg::as_ckzg(blob);
+            let blob = AsCkzg::as_ckzg(blob);
             let commitment = settings.blob_to_kzg_commitment(blob)?;
             let (_cells, kzg_proofs) = settings.compute_cells_and_kzg_proofs(blob)?;
 
-            commitments.push(<Bytes48 as crate::eip4844::AsCkzg>::from_ckzg(commitment.to_bytes()));
-            proofs.extend_from_slice(<c_kzg::KzgProof as crate::eip4844::AsAlloy>::slice_as_alloy(
+            commitments.push(<Bytes48 as AsCkzg>::from_ckzg(commitment.to_bytes()));
+            proofs.extend_from_slice(<c_kzg::KzgProof as AsAlloy>::slice_as_alloy(
                 kzg_proofs.as_ref(),
             ));
         }
@@ -906,18 +902,14 @@ impl BlobTransactionSidecarEip7594 {
         settings: &c_kzg::KzgSettings,
     ) -> Result<Vec<crate::eip7594::Cell>, c_kzg::Error> {
         if let [blob] = self.blobs.as_slice() {
-            let blob_cells = settings.compute_cells(crate::eip4844::AsCkzg::as_ckzg(blob))?;
-            return Ok(
-                <c_kzg::Cell as crate::eip4844::AsAlloy>::boxed_slice_as_alloy(blob_cells).into()
-            );
+            let blob_cells = settings.compute_cells(AsCkzg::as_ckzg(blob))?;
+            return Ok(<c_kzg::Cell as AsAlloy>::boxed_slice_as_alloy(blob_cells).into());
         }
 
         let mut cells = Vec::with_capacity(self.blobs.len() * CELLS_PER_EXT_BLOB);
         for blob in &self.blobs {
-            let blob_cells = settings.compute_cells(crate::eip4844::AsCkzg::as_ckzg(blob))?;
-            cells.extend_from_slice(<c_kzg::Cell as crate::eip4844::AsAlloy>::slice_as_alloy(
-                blob_cells.as_ref(),
-            ));
+            let blob_cells = settings.compute_cells(AsCkzg::as_ckzg(blob))?;
+            cells.extend_from_slice(<c_kzg::Cell as AsAlloy>::slice_as_alloy(blob_cells.as_ref()));
         }
         Ok(cells)
     }
@@ -966,8 +958,7 @@ impl BlobTransactionSidecarEip7594 {
     /// elements, commitments, and proofs. The cells are constructed from each blob and verified
     /// against the commitments and proofs.
     ///
-    /// Returns [crate::eip4844::BlobTransactionValidationError::InvalidProof] if any blob KZG proof
-    /// in the response
+    /// Returns [BlobTransactionValidationError::InvalidProof] if any blob KZG proof in the response
     /// fails to verify, or if the versioned hashes in the transaction do not match the actual
     /// commitment versioned hashes.
     #[cfg(feature = "kzg")]
@@ -975,7 +966,7 @@ impl BlobTransactionSidecarEip7594 {
         &self,
         blob_versioned_hashes: &[B256],
         proof_settings: &c_kzg::KzgSettings,
-    ) -> Result<(), crate::eip4844::BlobTransactionValidationError> {
+    ) -> Result<(), BlobTransactionValidationError> {
         // Ensure the versioned hashes and commitments have the same length.
         if blob_versioned_hashes.len() != self.commitments.len() {
             return Err(c_kzg::Error::MismatchLength(format!(
@@ -1006,7 +997,7 @@ impl BlobTransactionSidecarEip7594 {
             let calculated_versioned_hash =
                 crate::eip4844::kzg_to_versioned_hash(commitment.as_slice());
             if *versioned_hash != calculated_versioned_hash {
-                return Err(crate::eip4844::BlobTransactionValidationError::WrongVersionedHash {
+                return Err(BlobTransactionValidationError::WrongVersionedHash {
                     have: *versioned_hash,
                     expected: calculated_versioned_hash,
                 });
@@ -1024,27 +1015,25 @@ impl BlobTransactionSidecarEip7594 {
         }
 
         let cells = if let [blob] = self.blobs.as_slice() {
-            let cells: Box<[c_kzg::Cell]> =
-                proof_settings.compute_cells(crate::eip4844::AsCkzg::as_ckzg(blob))?;
+            let cells: Box<[c_kzg::Cell]> = proof_settings.compute_cells(AsCkzg::as_ckzg(blob))?;
             cells.into()
         } else {
             let mut cells = Vec::with_capacity(blobs_len * CELLS_PER_EXT_BLOB);
             for blob in &self.blobs {
-                let blob_cells =
-                    proof_settings.compute_cells(crate::eip4844::AsCkzg::as_ckzg(blob))?;
+                let blob_cells = proof_settings.compute_cells(AsCkzg::as_ckzg(blob))?;
                 cells.extend_from_slice(blob_cells.as_ref());
             }
             cells
         };
 
         let res = proof_settings.verify_cell_kzg_proof_batch(
-            <Bytes48 as crate::eip4844::AsCkzg>::slice_as_ckzg(&commitments),
+            <Bytes48 as AsCkzg>::slice_as_ckzg(&commitments),
             &cell_indices,
             &cells,
-            <Bytes48 as crate::eip4844::AsCkzg>::slice_as_ckzg(self.cell_proofs.as_slice()),
+            <Bytes48 as AsCkzg>::slice_as_ckzg(self.cell_proofs.as_slice()),
         )?;
 
-        res.then_some(()).ok_or(crate::eip4844::BlobTransactionValidationError::InvalidProof)
+        res.then_some(()).ok_or(BlobTransactionValidationError::InvalidProof)
     }
 
     /// Returns an iterator over the versioned hashes of the commitments.
@@ -1102,7 +1091,7 @@ impl BlobTransactionSidecarEip7594 {
             return Ok(Some(crate::eip4844::BlobCellsAndProofsV1::default()));
         }
 
-        let cells = settings.compute_cells(crate::eip4844::AsCkzg::as_ckzg(blob))?;
+        let cells = settings.compute_cells(AsCkzg::as_ckzg(blob))?;
 
         Ok(Some(Self::blob_cells_and_proofs_from_computed_cells(cell_mask, cells.as_ref(), proofs)))
     }
@@ -1221,7 +1210,7 @@ impl BlobTransactionSidecarEip7594 {
                 {
                     cells_and_proofs.clone()
                 } else {
-                    let cells = settings.compute_cells(crate::eip4844::AsCkzg::as_ckzg(blob))?;
+                    let cells = settings.compute_cells(AsCkzg::as_ckzg(blob))?;
                     let cells_and_proofs = Self::blob_cells_and_proofs_from_computed_cells(
                         cell_mask,
                         cells.as_ref(),
@@ -1719,6 +1708,22 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "kzg")]
+    fn sparse_cells_for_indices(
+        sidecar: &BlobTransactionSidecarEip7594,
+        cell_indices: &[u64],
+        settings: &c_kzg::KzgSettings,
+    ) -> Vec<Vec<crate::eip7594::Cell>> {
+        sidecar
+            .compute_cells_with_settings(settings)
+            .unwrap()
+            .chunks_exact(CELLS_PER_EXT_BLOB)
+            .map(|blob_cells| {
+                cell_indices.iter().map(|&index| blob_cells[index as usize]).collect()
+            })
+            .collect()
+    }
+
     #[test]
     #[cfg(feature = "kzg")]
     fn reconstruct_sidecar_from_cells() {
@@ -1765,6 +1770,138 @@ mod tests {
         )
         .unwrap();
         assert_eq!(reconstructed.blobs(), sidecar.blobs.as_slice());
+    }
+
+    /// Mirrors Geth's `RecoverBlobs` coverage: multiple blobs are recovered from a shared,
+    /// non-contiguous set of exactly `DataPerBlob` cells.
+    #[test]
+    #[cfg(feature = "kzg")]
+    fn recover_sparse_blobs_from_minimum_cells() {
+        let settings = EnvKzgSettings::Default.get();
+        let sidecar = BlobTransactionSidecarEip7594::try_from_blobs_with_settings(
+            vec![Blob::repeat_byte(0x01), Blob::repeat_byte(0x02), Blob::repeat_byte(0x03)],
+            settings,
+        )
+        .unwrap();
+
+        let cell_indices =
+            (0..CELLS_PER_EXT_BLOB as u64).filter(|index| index % 2 == 0).collect::<Vec<_>>();
+        assert_eq!(cell_indices.len(), CELLS_PER_EXT_BLOB / 2);
+        let sparse_cells = sparse_cells_for_indices(&sidecar, &cell_indices, settings);
+
+        let recovered = BlobTransactionSidecarEip7594::try_from_sparse_cells_with_settings(
+            sidecar.commitments.clone(),
+            &cell_indices,
+            &sparse_cells,
+            settings,
+        )
+        .unwrap();
+
+        assert_eq!(recovered.blobs, sidecar.blobs);
+        assert_eq!(recovered.commitments, sidecar.commitments);
+        assert_eq!(recovered.cell_proofs, sidecar.cell_proofs);
+    }
+
+    /// Geth varies the sampled count above the minimum. Check that a sparse set with an extra
+    /// cell follows the same recovery path.
+    #[test]
+    #[cfg(feature = "kzg")]
+    fn recover_sparse_blobs_with_more_than_minimum_cells() {
+        let settings = EnvKzgSettings::Default.get();
+        let sidecar = BlobTransactionSidecarEip7594::try_from_blobs_with_settings(
+            vec![Blob::repeat_byte(0x01), Blob::repeat_byte(0x02)],
+            settings,
+        )
+        .unwrap();
+
+        let cell_indices = (0..CELLS_PER_EXT_BLOB as u64 / 2)
+            .chain(core::iter::once(CELLS_PER_EXT_BLOB as u64 - 1))
+            .collect::<Vec<_>>();
+        assert_eq!(cell_indices.len(), CELLS_PER_EXT_BLOB / 2 + 1);
+        let sparse_cells = sparse_cells_for_indices(&sidecar, &cell_indices, settings);
+
+        let recovered = BlobTransactionSidecarEip7594::try_from_sparse_cells_with_settings(
+            sidecar.commitments.clone(),
+            &cell_indices,
+            &sparse_cells,
+            settings,
+        )
+        .unwrap();
+
+        assert_eq!(recovered.blobs, sidecar.blobs);
+        assert_eq!(recovered.cell_proofs, sidecar.cell_proofs);
+    }
+
+    #[test]
+    #[cfg(feature = "kzg")]
+    fn recover_sparse_blobs_rejects_insufficient_cells() {
+        let settings = EnvKzgSettings::Default.get();
+        let cell_indices = (0..CELLS_PER_EXT_BLOB as u64 / 2 - 1).collect::<Vec<_>>();
+        let cells = vec![(0..cell_indices.len())
+            .map(|_| crate::eip7594::Cell::repeat_byte(0))
+            .collect::<Vec<_>>()];
+
+        assert!(BlobTransactionSidecarEip7594::try_from_sparse_cells_with_settings(
+            vec![Bytes48::ZERO],
+            &cell_indices,
+            &cells,
+            settings,
+        )
+        .is_err());
+    }
+
+    #[test]
+    #[cfg(feature = "kzg")]
+    fn recover_sparse_blobs_rejects_invalid_indices() {
+        let settings = EnvKzgSettings::Default.get();
+        let cells = vec![(0..CELLS_PER_EXT_BLOB / 2)
+            .map(|_| crate::eip7594::Cell::repeat_byte(0))
+            .collect::<Vec<_>>()];
+
+        let mut duplicate_indices = (0..CELLS_PER_EXT_BLOB as u64 / 2).collect::<Vec<_>>();
+        duplicate_indices[CELLS_PER_EXT_BLOB / 2 - 1] =
+            duplicate_indices[CELLS_PER_EXT_BLOB / 2 - 2];
+        assert!(BlobTransactionSidecarEip7594::try_from_sparse_cells_with_settings(
+            vec![Bytes48::ZERO],
+            &duplicate_indices,
+            &cells,
+            settings,
+        )
+        .is_err());
+
+        let mut out_of_range_indices = (0..CELLS_PER_EXT_BLOB as u64 / 2).collect::<Vec<_>>();
+        out_of_range_indices[CELLS_PER_EXT_BLOB / 2 - 1] = CELLS_PER_EXT_BLOB as u64;
+        assert!(BlobTransactionSidecarEip7594::try_from_sparse_cells_with_settings(
+            vec![Bytes48::ZERO],
+            &out_of_range_indices,
+            &cells,
+            settings,
+        )
+        .is_err());
+    }
+
+    /// Mirrors Geth's corrupted-cell recovery coverage. A cell that no longer matches the
+    /// commitment must not produce a sidecar.
+    #[test]
+    #[cfg(feature = "kzg")]
+    fn recover_sparse_blobs_rejects_corrupted_cells() {
+        let settings = EnvKzgSettings::Default.get();
+        let sidecar = BlobTransactionSidecarEip7594::try_from_blobs_with_settings(
+            vec![Blob::repeat_byte(0x01), Blob::repeat_byte(0x02), Blob::repeat_byte(0x03)],
+            settings,
+        )
+        .unwrap();
+        let cell_indices = (0..CELLS_PER_EXT_BLOB as u64 / 2).collect::<Vec<_>>();
+        let mut sparse_cells = sparse_cells_for_indices(&sidecar, &cell_indices, settings);
+        sparse_cells[0][0][0] ^= 0xff;
+
+        assert!(BlobTransactionSidecarEip7594::try_from_sparse_cells_with_settings(
+            sidecar.commitments,
+            &cell_indices,
+            &sparse_cells,
+            settings,
+        )
+        .is_err());
     }
 
     #[test]

--- a/crates/eips/src/eip7594/sidecar.rs
+++ b/crates/eips/src/eip7594/sidecar.rs
@@ -1242,8 +1242,8 @@ impl BlobTransactionSidecarEip7594 {
 fn reconstruct_blob(recovered_cells: &[c_kzg::Cell; CELLS_PER_EXT_BLOB]) -> Blob {
     // `RecoverCells` returns cells in the canonical EIP-7594 order. The first half is the
     // original blob data; the remaining cells are the extension used for sampling and proofs.
-    // This is the same boundary used by Geth's `kzg4844.RecoverBlobs`: the KZG backend performs
-    // the recovery, while the wrapper only materializes the first `DataPerBlob` cells.
+    // The KZG backend performs the recovery, while this wrapper only materializes the original
+    // blob cells.
     let mut blob = [0u8; BYTES_PER_BLOB];
     for (cell_index, cell) in recovered_cells.iter().take(CELLS_PER_EXT_BLOB / 2).enumerate() {
         let start = cell_index * crate::eip7594::BYTES_PER_CELL;
@@ -1724,8 +1724,8 @@ mod tests {
         );
     }
 
-    /// Mirrors Geth's `RecoverBlobs` coverage: multiple blobs are recovered from a shared,
-    /// non-contiguous set of exactly `DataPerBlob` cells.
+    /// Multiple blobs are recovered from a shared, non-contiguous set containing the minimum
+    /// number of cells required for each blob.
     #[test]
     #[cfg(feature = "kzg")]
     fn recover_sparse_blobs_from_minimum_cells() {
@@ -1755,8 +1755,7 @@ mod tests {
         assert_eq!(recovered.cell_proofs, sidecar.cell_proofs);
     }
 
-    /// Geth varies the sampled count above the minimum. Check that a sparse set with an extra
-    /// cell follows the same recovery path.
+    /// A sparse set above the minimum cell count follows the same recovery path.
     #[test]
     #[cfg(feature = "kzg")]
     fn recover_sparse_blobs_with_more_than_minimum_cells() {
@@ -1854,8 +1853,7 @@ mod tests {
         assert!(matches!(err, BlobCellRecoveryError::CommitmentMismatch { blob_index: 0 }));
     }
 
-    /// Mirrors Geth's corrupted-cell recovery coverage. A cell that no longer matches the
-    /// commitment must not produce a sidecar.
+    /// A cell that no longer matches the commitment must not produce a sidecar.
     #[test]
     #[cfg(feature = "kzg")]
     fn recover_sparse_blobs_rejects_corrupted_cells() {

--- a/crates/eips/src/eip7594/sidecar.rs
+++ b/crates/eips/src/eip7594/sidecar.rs
@@ -3,16 +3,22 @@ use crate::{
         Blob, BlobAndProofV2, BlobTransactionSidecar, Bytes48, BYTES_PER_BLOB,
         BYTES_PER_COMMITMENT, BYTES_PER_PROOF,
     },
-    eip7594::{CELLS_PER_EXT_BLOB, EIP_7594_WRAPPER_VERSION},
+    eip7594::{CELLS_PER_EXT_BLOB, EIP_7594_WRAPPER_VERSION, FIELD_ELEMENTS_PER_EXT_BLOB},
 };
-use alloc::{boxed::Box, vec::Vec};
+use alloc::{boxed::Box, format, vec::Vec};
 use alloy_primitives::{B128, B256};
 use alloy_rlp::{BufMut, Decodable, Encodable, Header};
 
 use super::{Decodable7594, Encodable7594};
 use crate::eip4844::VersionedHashIter;
 #[cfg(feature = "kzg")]
-use crate::eip4844::{AsAlloy, AsCkzg, BlobTransactionValidationError};
+use crate::eip4844::{
+    AsAlloy, AsCkzg, BlobTransactionValidationError, BLS_MODULUS, FIELD_ELEMENTS_PER_BLOB,
+};
+#[cfg(feature = "kzg")]
+use crate::eip7594::{Cell, BYTES_PER_CELL};
+#[cfg(feature = "kzg")]
+use alloy_primitives::U256;
 
 /// This represents a set of blobs, and its corresponding commitments and proofs.
 /// Proof type depends on the sidecar variant.
@@ -282,6 +288,41 @@ impl BlobTransactionSidecarVariant {
         }
     }
 
+    /// Reconstructs an EIP-7594 sidecar from a common sparse cell set for every blob.
+    ///
+    /// `cell_indices` contains the strictly ascending cell indices represented by each inner
+    /// vector in `cells`. The inner vectors are blob-major: `cells[blob_index]` contains the cells
+    /// for `commitments[blob_index]`. At least 64 of the 128 cells must be supplied for each blob.
+    /// The recovered sidecar contains all 128 cells' proofs and the reconstructed blob bytes.
+    ///
+    /// This uses the default KZG settings.
+    #[cfg(feature = "kzg")]
+    pub fn try_from_sparse_cells(
+        commitments: Vec<Bytes48>,
+        cell_indices: &[u64],
+        cells: &[Vec<Cell>],
+    ) -> Result<Self, c_kzg::Error> {
+        BlobTransactionSidecarEip7594::try_from_sparse_cells(commitments, cell_indices, cells)
+            .map(Self::Eip7594)
+    }
+
+    /// Reconstructs an EIP-7594 sidecar from sparse cells using custom KZG settings.
+    #[cfg(feature = "kzg")]
+    pub fn try_from_sparse_cells_with_settings(
+        commitments: Vec<Bytes48>,
+        cell_indices: &[u64],
+        cells: &[Vec<Cell>],
+        settings: &c_kzg::KzgSettings,
+    ) -> Result<Self, c_kzg::Error> {
+        BlobTransactionSidecarEip7594::try_from_sparse_cells_with_settings(
+            commitments,
+            cell_indices,
+            cells,
+            settings,
+        )
+        .map(Self::Eip7594)
+    }
+
     /// Verifies that the sidecar is valid. See relevant methods for each variant for more info.
     #[cfg(feature = "kzg")]
     pub fn validate(
@@ -546,6 +587,204 @@ impl BlobTransactionSidecarEip7594 {
         cell_proofs: Vec<Bytes48>,
     ) -> Self {
         Self { blobs, commitments, cell_proofs }
+    }
+
+    /// Tries to create a new sidecar by reconstructing blobs from complete EIP-7594 cell sets.
+    ///
+    /// The cells must be laid out in blob-major order, with exactly
+    /// [`CELLS_PER_EXT_BLOB`] cells for each blob. The supplied proofs must match the recovered
+    /// proofs. This uses the default KZG settings.
+    #[cfg(feature = "kzg")]
+    pub fn try_from_cells(
+        cells: Vec<Cell>,
+        commitments: Vec<Bytes48>,
+        cell_proofs: Vec<Bytes48>,
+    ) -> Result<Self, c_kzg::Error> {
+        use crate::eip4844::env_settings::EnvKzgSettings;
+
+        Self::try_from_cells_with_settings(
+            cells,
+            commitments,
+            cell_proofs,
+            EnvKzgSettings::Default.get(),
+        )
+    }
+
+    /// Tries to create a new sidecar by reconstructing blobs from complete EIP-7594 cell sets
+    /// with custom KZG settings.
+    ///
+    /// The cells must be laid out in blob-major order, with exactly
+    /// [`CELLS_PER_EXT_BLOB`] cells for each blob. The supplied proofs must match the recovered
+    /// proofs.
+    #[cfg(feature = "kzg")]
+    pub fn try_from_cells_with_settings(
+        cells: Vec<Cell>,
+        commitments: Vec<Bytes48>,
+        cell_proofs: Vec<Bytes48>,
+        settings: &c_kzg::KzgSettings,
+    ) -> Result<Self, c_kzg::Error> {
+        if cells.len() % CELLS_PER_EXT_BLOB != 0 {
+            return Err(c_kzg::Error::MismatchLength(format!(
+                "invalid cell count {}; expected a multiple of {CELLS_PER_EXT_BLOB}",
+                cells.len()
+            )));
+        }
+
+        if cell_proofs.len() != cells.len() {
+            return Err(c_kzg::Error::MismatchLength(format!(
+                "expected {} cell proofs, got {}",
+                cells.len(),
+                cell_proofs.len()
+            )));
+        }
+
+        let blob_count = cells.len() / CELLS_PER_EXT_BLOB;
+        if commitments.len() != blob_count {
+            return Err(c_kzg::Error::MismatchLength(format!(
+                "expected {blob_count} commitments, got {}",
+                commitments.len()
+            )));
+        }
+
+        let indices: Vec<u64> = (0..CELLS_PER_EXT_BLOB as u64).collect();
+        let per_blob_cells =
+            cells.chunks_exact(CELLS_PER_EXT_BLOB).map(|chunk| chunk.to_vec()).collect::<Vec<_>>();
+        let reconstructed = Self::try_from_sparse_cells_with_settings(
+            commitments,
+            &indices,
+            &per_blob_cells,
+            settings,
+        )?;
+
+        if reconstructed.cell_proofs != cell_proofs {
+            return Err(c_kzg::Error::InvalidKzgProof(
+                "supplied cell proofs do not match the recovered proofs".into(),
+            ));
+        }
+
+        Ok(reconstructed)
+    }
+
+    /// Tries to create a new sidecar by reconstructing blobs from sparse EIP-7594 cell sets.
+    ///
+    /// `cell_indices` must be strictly ascending and describe the cells in every inner vector of
+    /// `cells`. The vectors are blob-major and must have the same length as `commitments`. At
+    /// least 64 cells are required for each blob. The recovered sidecar contains the complete blob
+    /// data and all 128 cell proofs. This uses the default KZG settings.
+    #[cfg(feature = "kzg")]
+    pub fn try_from_sparse_cells(
+        commitments: Vec<Bytes48>,
+        cell_indices: &[u64],
+        cells: &[Vec<Cell>],
+    ) -> Result<Self, c_kzg::Error> {
+        use crate::eip4844::env_settings::EnvKzgSettings;
+
+        Self::try_from_sparse_cells_with_settings(
+            commitments,
+            cell_indices,
+            cells,
+            EnvKzgSettings::Default.get(),
+        )
+    }
+
+    /// Tries to create a new sidecar by reconstructing blobs from sparse EIP-7594 cell sets with
+    /// custom KZG settings.
+    #[cfg(feature = "kzg")]
+    pub fn try_from_sparse_cells_with_settings(
+        commitments: Vec<Bytes48>,
+        cell_indices: &[u64],
+        cells: &[Vec<Cell>],
+        settings: &c_kzg::KzgSettings,
+    ) -> Result<Self, c_kzg::Error> {
+        if commitments.len() != cells.len() {
+            return Err(c_kzg::Error::MismatchLength(format!(
+                "expected one cell vector per commitment, got {} commitments and {} cell vectors",
+                commitments.len(),
+                cells.len()
+            )));
+        }
+
+        // An empty sidecar has no blob to recover and is valid without cell indices.
+        if commitments.is_empty() {
+            return Ok(Self::new(Vec::new(), commitments, Vec::new()));
+        }
+
+        if cell_indices.len() < CELLS_PER_EXT_BLOB / 2 {
+            return Err(c_kzg::Error::MismatchLength(format!(
+                "need at least {} cells for recovery, got {}",
+                CELLS_PER_EXT_BLOB / 2,
+                cell_indices.len()
+            )));
+        }
+        if cell_indices.len() > CELLS_PER_EXT_BLOB {
+            return Err(c_kzg::Error::MismatchLength(format!(
+                "got {} cells, maximum is {}",
+                cell_indices.len(),
+                CELLS_PER_EXT_BLOB
+            )));
+        }
+        if cell_indices.iter().any(|&index| index >= CELLS_PER_EXT_BLOB as u64)
+            || cell_indices.windows(2).any(|window| window[0] >= window[1])
+        {
+            return Err(c_kzg::Error::CError(c_kzg::CkzgError::C_KZG_BADARGS));
+        }
+
+        let mut blobs = Vec::with_capacity(commitments.len());
+        let mut cell_proofs = Vec::with_capacity(commitments.len() * CELLS_PER_EXT_BLOB);
+        for (blob_index, blob_cells) in cells.iter().enumerate() {
+            if blob_cells.len() != cell_indices.len() {
+                return Err(c_kzg::Error::MismatchLength(format!(
+                    "blob {blob_index} has {} cells, expected {}",
+                    blob_cells.len(),
+                    cell_indices.len()
+                )));
+            }
+
+            let ckzg_cells = blob_cells
+                .iter()
+                .map(|cell| {
+                    c_kzg::Cell::new(
+                        cell.as_slice()
+                            .try_into()
+                            .expect("EIP-7594 cells have a fixed byte length"),
+                    )
+                })
+                .collect::<Vec<_>>();
+            let (recovered_cells, recovered_proofs) =
+                settings.recover_cells_and_kzg_proofs(cell_indices, &ckzg_cells)?;
+            let blob = reconstruct_blob(recovered_cells.as_ref())?;
+
+            let commitment = settings.blob_to_kzg_commitment(blob.as_ckzg())?;
+            let commitment = Bytes48::from_ckzg(commitment.to_bytes());
+            if commitment != commitments[blob_index] {
+                return Err(c_kzg::Error::InvalidKzgCommitment(format!(
+                    "reconstructed blob {blob_index} does not match its commitment"
+                )));
+            }
+
+            let cell_indices = (0..CELLS_PER_EXT_BLOB as u64).collect::<Vec<_>>();
+            let commitments =
+                core::iter::repeat_n(commitment, CELLS_PER_EXT_BLOB).collect::<Vec<_>>();
+            let recovered_proofs_bytes =
+                recovered_proofs.iter().map(|proof| proof.to_bytes()).collect::<Vec<_>>();
+            let valid = settings.verify_cell_kzg_proof_batch(
+                Bytes48::slice_as_ckzg(&commitments),
+                &cell_indices,
+                recovered_cells.as_ref(),
+                &recovered_proofs_bytes,
+            )?;
+            if !valid {
+                return Err(c_kzg::Error::InvalidKzgProof(format!(
+                    "recovered proofs for blob {blob_index} are invalid"
+                )));
+            }
+
+            blobs.push(blob);
+            cell_proofs
+                .extend_from_slice(c_kzg::KzgProof::slice_as_alloy(recovered_proofs.as_ref()));
+        }
+
+        Ok(Self::new(blobs, commitments, cell_proofs))
     }
 
     /// Calculates a size heuristic for the in-memory size of the [BlobTransactionSidecarEip7594].
@@ -1064,6 +1303,98 @@ impl BlobTransactionSidecarEip7594 {
     }
 }
 
+#[cfg(feature = "kzg")]
+const EIP7594_ROOT_OF_UNITY: U256 = U256::from_be_bytes([
+    0x71, 0xdb, 0x41, 0xab, 0xda, 0x03, 0xe0, 0x55, 0x06, 0x5d, 0x22, 0x7f, 0xea, 0xd1, 0x13, 0x9b,
+    0x41, 0xfa, 0xc7, 0x9f, 0x59, 0xe9, 0x19, 0x72, 0xa3, 0x3d, 0x27, 0x9f, 0xf0, 0xcc, 0xff, 0xc9,
+]);
+
+#[cfg(feature = "kzg")]
+fn reconstruct_blob(recovered_cells: &[c_kzg::Cell]) -> Result<Blob, c_kzg::Error> {
+    let mut evaluations = Vec::with_capacity(CELLS_PER_EXT_BLOB * BYTES_PER_CELL / 32);
+    for cell in recovered_cells {
+        for field_element in cell.to_bytes().chunks_exact(32) {
+            let value = U256::from_be_slice(field_element);
+            if value >= BLS_MODULUS {
+                return Err(c_kzg::Error::CError(c_kzg::CkzgError::C_KZG_BADARGS));
+            }
+            evaluations.push(value);
+        }
+    }
+
+    // c-kzg returns cell evaluations after bit-reversing the extended FFT output. Restore the
+    // natural evaluation order, then invert the 8192-point transform. The extended polynomial is
+    // the original 4096 blob field elements followed by 4096 zero coefficients.
+    bit_reverse_permutation(&mut evaluations);
+    fft(&mut evaluations, true);
+
+    evaluations.truncate(FIELD_ELEMENTS_PER_BLOB as usize);
+
+    let mut blob = [0u8; BYTES_PER_BLOB];
+    for (output, field_element) in blob.chunks_exact_mut(32).zip(evaluations) {
+        output.copy_from_slice(&field_element.to_be_bytes::<32>());
+    }
+    Ok(Blob::new(blob))
+}
+
+#[cfg(feature = "kzg")]
+fn fft(values: &mut [U256], inverse: bool) {
+    bit_reverse_permutation(values);
+
+    let root = if inverse {
+        EIP7594_ROOT_OF_UNITY.pow_mod(U256::from(8191u64), BLS_MODULUS)
+    } else {
+        EIP7594_ROOT_OF_UNITY
+    };
+    let n = values.len();
+    let mut width = 2;
+    while width <= n {
+        let exponent = FIELD_ELEMENTS_PER_EXT_BLOB / width;
+        let width_root = root.pow_mod(U256::from(exponent), BLS_MODULUS);
+        for chunk in values.chunks_exact_mut(width) {
+            let (left, right) = chunk.split_at_mut(width / 2);
+            let mut factor = U256::from(1u64);
+            for (left, right) in left.iter_mut().zip(right) {
+                let product = right.mul_mod(factor, BLS_MODULUS);
+                let sum = left.add_mod(product, BLS_MODULUS);
+                let difference = if *left >= product {
+                    *left - product
+                } else {
+                    BLS_MODULUS - (product - *left)
+                };
+                *left = sum;
+                *right = difference;
+                factor = factor.mul_mod(width_root, BLS_MODULUS);
+            }
+        }
+        width *= 2;
+    }
+
+    if inverse {
+        let inverse_n = U256::from(n).inv_mod(BLS_MODULUS).unwrap();
+        for value in values {
+            *value = value.mul_mod(inverse_n, BLS_MODULUS);
+        }
+    }
+}
+
+#[cfg(feature = "kzg")]
+fn bit_reverse_permutation(values: &mut [U256]) {
+    let mut reversed = 0usize;
+    for index in 1..values.len() {
+        let highest_bit = values.len() >> 1;
+        let mut bit = highest_bit;
+        while reversed & bit != 0 {
+            reversed &= !bit;
+            bit >>= 1;
+        }
+        reversed |= bit;
+        if index < reversed {
+            values.swap(index, reversed);
+        }
+    }
+}
+
 impl Encodable for BlobTransactionSidecarEip7594 {
     /// Encodes the inner [BlobTransactionSidecarEip7594] fields as RLP bytes, without a RLP header.
     fn encode(&self, out: &mut dyn BufMut) {
@@ -1446,6 +1777,54 @@ mod tests {
                 assert_eq!(*cell, crate::eip7594::Cell::new(expected_cell.to_bytes()));
             }
         }
+    }
+
+    #[test]
+    #[cfg(feature = "kzg")]
+    fn reconstruct_sidecar_from_cells() {
+        let settings = EnvKzgSettings::Default.get();
+        let sidecar = BlobTransactionSidecarEip7594::try_from_blobs_with_settings(
+            vec![Blob::repeat_byte(0x01), Blob::repeat_byte(0x02)],
+            settings,
+        )
+        .unwrap();
+        let cells = sidecar.compute_cells_with_settings(settings).unwrap();
+
+        let reconstructed = BlobTransactionSidecarEip7594::try_from_cells_with_settings(
+            cells.clone(),
+            sidecar.commitments.clone(),
+            sidecar.cell_proofs.clone(),
+            settings,
+        )
+        .unwrap();
+        assert_eq!(reconstructed.blobs, sidecar.blobs);
+        assert_eq!(
+            BlobTransactionSidecarEip7594::try_from_cells(
+                cells,
+                reconstructed.commitments.clone(),
+                reconstructed.cell_proofs.clone(),
+            )
+            .unwrap(),
+            reconstructed
+        );
+
+        let cell_indices = (0..CELLS_PER_EXT_BLOB as u64 / 2).collect::<Vec<_>>();
+        let sparse_cells = sidecar
+            .compute_cells_with_settings(settings)
+            .unwrap()
+            .chunks_exact(CELLS_PER_EXT_BLOB)
+            .map(|blob_cells| {
+                cell_indices.iter().map(|&index| blob_cells[index as usize]).collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>();
+        let reconstructed = BlobTransactionSidecarVariant::try_from_sparse_cells_with_settings(
+            sidecar.commitments.clone(),
+            &cell_indices,
+            &sparse_cells,
+            settings,
+        )
+        .unwrap();
+        assert_eq!(reconstructed.blobs(), sidecar.blobs.as_slice());
     }
 
     #[test]

--- a/crates/eips/src/eip7594/sidecar.rs
+++ b/crates/eips/src/eip7594/sidecar.rs
@@ -607,7 +607,6 @@ impl BlobTransactionSidecarEip7594 {
         cell_proofs: Vec<Bytes48>,
     ) -> Result<Self, c_kzg::Error> {
         use crate::eip4844::env_settings::EnvKzgSettings;
-
         Self::try_from_cells_with_settings(
             cells,
             commitments,

--- a/crates/eips/src/eip7594/sidecar.rs
+++ b/crates/eips/src/eip7594/sidecar.rs
@@ -294,41 +294,6 @@ impl BlobTransactionSidecarVariant {
         }
     }
 
-    /// Reconstructs an EIP-7594 sidecar from a common sparse cell set for every blob.
-    ///
-    /// `cell_indices` contains the strictly ascending cell indices represented by each inner
-    /// vector in `cells`. The inner vectors are blob-major: `cells[blob_index]` contains the cells
-    /// for `commitments[blob_index]`. At least 64 of the 128 cells must be supplied for each blob.
-    /// The recovered sidecar contains all 128 cells' proofs and the reconstructed blob bytes.
-    ///
-    /// This uses the default KZG settings.
-    #[cfg(feature = "kzg")]
-    pub fn try_from_sparse_cells(
-        commitments: Vec<Bytes48>,
-        cell_indices: &[u64],
-        cells: &[Vec<crate::eip7594::Cell>],
-    ) -> Result<Self, c_kzg::Error> {
-        BlobTransactionSidecarEip7594::try_from_sparse_cells(commitments, cell_indices, cells)
-            .map(Self::Eip7594)
-    }
-
-    /// Reconstructs an EIP-7594 sidecar from sparse cells using custom KZG settings.
-    #[cfg(feature = "kzg")]
-    pub fn try_from_sparse_cells_with_settings(
-        commitments: Vec<Bytes48>,
-        cell_indices: &[u64],
-        cells: &[Vec<crate::eip7594::Cell>],
-        settings: &c_kzg::KzgSettings,
-    ) -> Result<Self, c_kzg::Error> {
-        BlobTransactionSidecarEip7594::try_from_sparse_cells_with_settings(
-            commitments,
-            cell_indices,
-            cells,
-            settings,
-        )
-        .map(Self::Eip7594)
-    }
-
     /// Verifies that the sidecar is valid. See relevant methods for each variant for more info.
     #[cfg(feature = "kzg")]
     pub fn validate(
@@ -554,6 +519,64 @@ impl<'de> serde::Deserialize<'de> for BlobTransactionSidecarVariant {
     }
 }
 
+/// An error that can occur while recovering blobs from EIP-7594 cells.
+#[cfg(feature = "kzg")]
+#[derive(Debug)]
+pub enum BlobCellRecoveryError {
+    /// Fewer than half of the extended blob cells were selected.
+    InsufficientCells {
+        /// The number of cells supplied for each blob.
+        provided: usize,
+        /// The minimum number of cells required for recovery.
+        required: usize,
+    },
+    /// The flattened cell slice does not match the commitments and cell mask.
+    CellCountMismatch {
+        /// The number of cells supplied.
+        provided: usize,
+        /// The number of cells implied by the commitments and cell mask.
+        expected: usize,
+    },
+    /// The expected cell count cannot be represented as a `usize`.
+    CellCountOverflow,
+    /// A reconstructed blob does not match its supplied commitment.
+    CommitmentMismatch {
+        /// The index of the blob whose commitment did not match.
+        blob_index: usize,
+    },
+    /// An error returned by [`c_kzg`].
+    Kzg(c_kzg::Error),
+}
+
+#[cfg(feature = "kzg")]
+impl core::fmt::Display for BlobCellRecoveryError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::InsufficientCells { provided, required } => {
+                write!(f, "need at least {required} cells per blob for recovery, got {provided}")
+            }
+            Self::CellCountMismatch { provided, expected } => {
+                write!(f, "expected {expected} cells, got {provided}")
+            }
+            Self::CellCountOverflow => f.write_str("the expected cell count overflows usize"),
+            Self::CommitmentMismatch { blob_index } => {
+                write!(f, "reconstructed blob {blob_index} does not match its commitment")
+            }
+            Self::Kzg(err) => write!(f, "KZG error: {err:?}"),
+        }
+    }
+}
+
+#[cfg(feature = "kzg")]
+impl core::error::Error for BlobCellRecoveryError {}
+
+#[cfg(feature = "kzg")]
+impl From<c_kzg::Error> for BlobCellRecoveryError {
+    fn from(source: c_kzg::Error) -> Self {
+        Self::Kzg(source)
+    }
+}
+
 /// This represents a set of blobs, and its corresponding commitments and cell proofs.
 ///
 /// This type encodes and decodes the fields without an rlp header.
@@ -595,193 +618,88 @@ impl BlobTransactionSidecarEip7594 {
         Self { blobs, commitments, cell_proofs }
     }
 
-    /// Tries to create a new sidecar by reconstructing blobs from complete EIP-7594 cell sets.
+    /// Recovers a sidecar from a common set of EIP-7594 cells for every blob.
     ///
-    /// The cells must be laid out in blob-major order, with exactly
-    /// [`CELLS_PER_EXT_BLOB`] cells for each blob. The supplied proofs must match the recovered
-    /// proofs. This uses the default KZG settings.
-    #[cfg(feature = "kzg")]
-    pub fn try_from_cells(
-        cells: Vec<crate::eip7594::Cell>,
-        commitments: Vec<Bytes48>,
-        cell_proofs: Vec<Bytes48>,
-    ) -> Result<Self, c_kzg::Error> {
-        use crate::eip4844::env_settings::EnvKzgSettings;
-        Self::try_from_cells_with_settings(
-            cells,
-            commitments,
-            cell_proofs,
-            EnvKzgSettings::Default.get(),
-        )
-    }
-
-    /// Tries to create a new sidecar by reconstructing blobs from complete EIP-7594 cell sets
-    /// with custom KZG settings.
+    /// `cell_mask` identifies the cells supplied for each commitment. `cells` must be flattened in
+    /// blob-major order: all selected cells for `commitments[0]`, followed by all selected cells
+    /// for `commitments[1]`, and so on. At least half of the 128 extended blob cells must be
+    /// selected. The recovered sidecar contains the complete blob data and all 128 cell proofs.
     ///
-    /// The cells must be laid out in blob-major order, with exactly
-    /// [`CELLS_PER_EXT_BLOB`] cells for each blob. The supplied proofs must match the recovered
-    /// proofs.
-    #[cfg(feature = "kzg")]
-    pub fn try_from_cells_with_settings(
-        cells: Vec<crate::eip7594::Cell>,
-        commitments: Vec<Bytes48>,
-        cell_proofs: Vec<Bytes48>,
-        settings: &c_kzg::KzgSettings,
-    ) -> Result<Self, c_kzg::Error> {
-        if !cells.len().is_multiple_of(CELLS_PER_EXT_BLOB) {
-            return Err(c_kzg::Error::MismatchLength(format!(
-                "invalid cell count {}; expected a multiple of {CELLS_PER_EXT_BLOB}",
-                cells.len()
-            )));
-        }
-
-        if cell_proofs.len() != cells.len() {
-            return Err(c_kzg::Error::MismatchLength(format!(
-                "expected {} cell proofs, got {}",
-                cells.len(),
-                cell_proofs.len()
-            )));
-        }
-
-        let blob_count = cells.len() / CELLS_PER_EXT_BLOB;
-        if commitments.len() != blob_count {
-            return Err(c_kzg::Error::MismatchLength(format!(
-                "expected {blob_count} commitments, got {}",
-                commitments.len()
-            )));
-        }
-
-        let indices: Vec<u64> = (0..CELLS_PER_EXT_BLOB as u64).collect();
-        let per_blob_cells =
-            cells.chunks_exact(CELLS_PER_EXT_BLOB).map(|chunk| chunk.to_vec()).collect::<Vec<_>>();
-        let reconstructed = Self::try_from_sparse_cells_with_settings(
-            commitments,
-            &indices,
-            &per_blob_cells,
-            settings,
-        )?;
-
-        if reconstructed.cell_proofs != cell_proofs {
-            return Err(c_kzg::Error::InvalidKzgProof(
-                "supplied cell proofs do not match the recovered proofs".into(),
-            ));
-        }
-
-        Ok(reconstructed)
-    }
-
-    /// Tries to create a new sidecar by reconstructing blobs from sparse EIP-7594 cell sets.
+    /// Recovery authenticates each reconstructed blob by recomputing and comparing its
+    /// commitment. It does not verify proofs for the input cells; callers accepting untrusted
+    /// cells and proofs should batch-verify them before recovery when early rejection is useful.
     ///
-    /// `cell_indices` must be strictly ascending and describe the cells in every inner vector of
-    /// `cells`. The vectors are blob-major and must have the same length as `commitments`. At
-    /// least 64 cells are required for each blob. The recovered sidecar contains the complete blob
-    /// data and all 128 cell proofs. This uses the default KZG settings.
+    /// This uses the default KZG settings.
     #[cfg(feature = "kzg")]
-    pub fn try_from_sparse_cells(
+    pub fn try_recover_from_cells(
         commitments: Vec<Bytes48>,
-        cell_indices: &[u64],
-        cells: &[Vec<crate::eip7594::Cell>],
-    ) -> Result<Self, c_kzg::Error> {
+        cell_mask: BlobCellMask,
+        cells: &[crate::eip7594::Cell],
+    ) -> Result<Self, BlobCellRecoveryError> {
         use crate::eip4844::env_settings::EnvKzgSettings;
 
-        Self::try_from_sparse_cells_with_settings(
+        Self::try_recover_from_cells_with_settings(
             commitments,
-            cell_indices,
+            cell_mask,
             cells,
             EnvKzgSettings::Default.get(),
         )
     }
 
-    /// Tries to create a new sidecar by reconstructing blobs from sparse EIP-7594 cell sets with
-    /// custom KZG settings.
+    /// Recovers a sidecar from EIP-7594 cells using custom KZG settings.
+    ///
+    /// See [`Self::try_recover_from_cells`] for the expected cell layout and verification
+    /// boundary.
     #[cfg(feature = "kzg")]
-    pub fn try_from_sparse_cells_with_settings(
+    pub fn try_recover_from_cells_with_settings(
         commitments: Vec<Bytes48>,
-        cell_indices: &[u64],
-        cells: &[Vec<crate::eip7594::Cell>],
+        cell_mask: BlobCellMask,
+        cells: &[crate::eip7594::Cell],
         settings: &c_kzg::KzgSettings,
-    ) -> Result<Self, c_kzg::Error> {
-        if commitments.len() != cells.len() {
-            return Err(c_kzg::Error::MismatchLength(format!(
-                "expected one cell vector per commitment, got {} commitments and {} cell vectors",
-                commitments.len(),
-                cells.len()
-            )));
+    ) -> Result<Self, BlobCellRecoveryError> {
+        let cells_per_blob = cell_mask.count();
+        if !commitments.is_empty() && cells_per_blob < CELLS_PER_EXT_BLOB / 2 {
+            return Err(BlobCellRecoveryError::InsufficientCells {
+                provided: cells_per_blob,
+                required: CELLS_PER_EXT_BLOB / 2,
+            });
         }
 
-        // An empty sidecar has no blob to recover and is valid without cell indices.
+        let expected_cells = commitments
+            .len()
+            .checked_mul(cells_per_blob)
+            .ok_or(BlobCellRecoveryError::CellCountOverflow)?;
+        if cells.len() != expected_cells {
+            return Err(BlobCellRecoveryError::CellCountMismatch {
+                provided: cells.len(),
+                expected: expected_cells,
+            });
+        }
         if commitments.is_empty() {
             return Ok(Self::new(Vec::new(), commitments, Vec::new()));
         }
 
-        if cell_indices.len() < CELLS_PER_EXT_BLOB / 2 {
-            return Err(c_kzg::Error::MismatchLength(format!(
-                "need at least {} cells for recovery, got {}",
-                CELLS_PER_EXT_BLOB / 2,
-                cell_indices.len()
-            )));
-        }
-        if cell_indices.len() > CELLS_PER_EXT_BLOB {
-            return Err(c_kzg::Error::MismatchLength(format!(
-                "got {} cells, maximum is {}",
-                cell_indices.len(),
-                CELLS_PER_EXT_BLOB
-            )));
-        }
-        if cell_indices.iter().any(|&index| index >= CELLS_PER_EXT_BLOB as u64)
-            || cell_indices.windows(2).any(|window| window[0] >= window[1])
-        {
-            return Err(c_kzg::Error::CError(c_kzg::CkzgError::C_KZG_BADARGS));
-        }
-
+        let cell_indices =
+            cell_mask.selected_indices().map(|index| index as u64).collect::<Vec<_>>();
         let mut blobs = Vec::with_capacity(commitments.len());
-        let mut cell_proofs = Vec::with_capacity(commitments.len() * CELLS_PER_EXT_BLOB);
-        for (blob_index, blob_cells) in cells.iter().enumerate() {
-            if blob_cells.len() != cell_indices.len() {
-                return Err(c_kzg::Error::MismatchLength(format!(
-                    "blob {blob_index} has {} cells, expected {}",
-                    blob_cells.len(),
-                    cell_indices.len()
-                )));
-            }
+        let cell_proof_capacity = commitments
+            .len()
+            .checked_mul(CELLS_PER_EXT_BLOB)
+            .ok_or(BlobCellRecoveryError::CellCountOverflow)?;
+        let mut cell_proofs = Vec::with_capacity(cell_proof_capacity);
 
-            let ckzg_cells = blob_cells
-                .iter()
-                .map(|cell| {
-                    c_kzg::Cell::new(
-                        cell.as_slice()
-                            .try_into()
-                            .expect("EIP-7594 cells have a fixed byte length"),
-                    )
-                })
-                .collect::<Vec<_>>();
+        for (blob_index, (blob_cells, expected_commitment)) in
+            cells.chunks_exact(cells_per_blob).zip(&commitments).enumerate()
+        {
+            let ckzg_cells = <crate::eip7594::Cell as AsCkzg>::slice_as_ckzg(blob_cells);
             let (recovered_cells, recovered_proofs) =
-                settings.recover_cells_and_kzg_proofs(cell_indices, &ckzg_cells)?;
-            let blob = reconstruct_blob(recovered_cells.as_ref())?;
+                settings.recover_cells_and_kzg_proofs(&cell_indices, ckzg_cells)?;
+            let blob = reconstruct_blob(recovered_cells.as_ref());
 
             let commitment = settings.blob_to_kzg_commitment(AsCkzg::as_ckzg(&blob))?;
             let commitment = <Bytes48 as AsCkzg>::from_ckzg(commitment.to_bytes());
-            if commitment != commitments[blob_index] {
-                return Err(c_kzg::Error::InvalidKzgCommitment(format!(
-                    "reconstructed blob {blob_index} does not match its commitment"
-                )));
-            }
-
-            let cell_indices = (0..CELLS_PER_EXT_BLOB as u64).collect::<Vec<_>>();
-            let commitments =
-                core::iter::repeat_n(commitment, CELLS_PER_EXT_BLOB).collect::<Vec<_>>();
-            let recovered_proofs_bytes =
-                recovered_proofs.iter().map(|proof| proof.to_bytes()).collect::<Vec<_>>();
-            let valid = settings.verify_cell_kzg_proof_batch(
-                <Bytes48 as AsCkzg>::slice_as_ckzg(&commitments),
-                &cell_indices,
-                recovered_cells.as_ref(),
-                &recovered_proofs_bytes,
-            )?;
-            if !valid {
-                return Err(c_kzg::Error::InvalidKzgProof(format!(
-                    "recovered proofs for blob {blob_index} are invalid"
-                )));
+            if commitment != *expected_commitment {
+                return Err(BlobCellRecoveryError::CommitmentMismatch { blob_index });
             }
 
             blobs.push(blob);
@@ -1321,26 +1239,18 @@ impl BlobTransactionSidecarEip7594 {
 }
 
 #[cfg(feature = "kzg")]
-fn reconstruct_blob(recovered_cells: &[c_kzg::Cell]) -> Result<Blob, c_kzg::Error> {
+fn reconstruct_blob(recovered_cells: &[c_kzg::Cell; CELLS_PER_EXT_BLOB]) -> Blob {
     // `RecoverCells` returns cells in the canonical EIP-7594 order. The first half is the
     // original blob data; the remaining cells are the extension used for sampling and proofs.
     // This is the same boundary used by Geth's `kzg4844.RecoverBlobs`: the KZG backend performs
     // the recovery, while the wrapper only materializes the first `DataPerBlob` cells.
-    if recovered_cells.len() < CELLS_PER_EXT_BLOB / 2 {
-        return Err(c_kzg::Error::MismatchLength(format!(
-            "expected at least {} recovered cells, got {}",
-            CELLS_PER_EXT_BLOB / 2,
-            recovered_cells.len()
-        )));
-    }
-
     let mut blob = [0u8; BYTES_PER_BLOB];
     for (cell_index, cell) in recovered_cells.iter().take(CELLS_PER_EXT_BLOB / 2).enumerate() {
         let start = cell_index * crate::eip7594::BYTES_PER_CELL;
         let end = start + crate::eip7594::BYTES_PER_CELL;
         blob[start..end].copy_from_slice(&cell.to_bytes());
     }
-    Ok(Blob::new(blob))
+    Blob::new(blob)
 }
 
 impl Encodable for BlobTransactionSidecarEip7594 {
@@ -1762,67 +1672,56 @@ mod tests {
     }
 
     #[cfg(feature = "kzg")]
-    fn sparse_cells_for_indices(
+    fn sparse_cells_for_mask(
         sidecar: &BlobTransactionSidecarEip7594,
-        cell_indices: &[u64],
+        cell_mask: BlobCellMask,
         settings: &c_kzg::KzgSettings,
-    ) -> Vec<Vec<crate::eip7594::Cell>> {
-        sidecar
-            .compute_cells_with_settings(settings)
-            .unwrap()
-            .chunks_exact(CELLS_PER_EXT_BLOB)
-            .map(|blob_cells| {
-                cell_indices.iter().map(|&index| blob_cells[index as usize]).collect()
-            })
-            .collect()
+    ) -> Vec<crate::eip7594::Cell> {
+        let cells = sidecar.compute_cells_with_settings(settings).unwrap();
+        cell_mask.matching_cells_from_computed_cells(&cells).unwrap()
     }
 
     #[test]
     #[cfg(feature = "kzg")]
-    fn reconstruct_sidecar_from_cells() {
+    fn recover_sidecar_from_complete_cells() {
         let settings = EnvKzgSettings::Default.get();
+        assert_eq!(
+            BlobTransactionSidecarEip7594::try_recover_from_cells_with_settings(
+                Vec::new(),
+                BlobCellMask::default(),
+                &[],
+                settings,
+            )
+            .unwrap(),
+            BlobTransactionSidecarEip7594::default()
+        );
+
         let sidecar = BlobTransactionSidecarEip7594::try_from_blobs_with_settings(
             vec![Blob::repeat_byte(0x01), Blob::repeat_byte(0x02)],
             settings,
         )
         .unwrap();
         let cells = sidecar.compute_cells_with_settings(settings).unwrap();
+        let cell_mask = BlobCellMask::from_bits(u128::MAX);
 
-        let reconstructed = BlobTransactionSidecarEip7594::try_from_cells_with_settings(
-            cells.clone(),
+        let recovered = BlobTransactionSidecarEip7594::try_recover_from_cells_with_settings(
             sidecar.commitments.clone(),
-            sidecar.cell_proofs.clone(),
+            cell_mask,
+            &cells,
             settings,
         )
         .unwrap();
-        assert_eq!(reconstructed.blobs, sidecar.blobs);
+        assert_eq!(recovered, sidecar);
+
         assert_eq!(
-            BlobTransactionSidecarEip7594::try_from_cells(
-                cells,
-                reconstructed.commitments.clone(),
-                reconstructed.cell_proofs.clone(),
+            BlobTransactionSidecarEip7594::try_recover_from_cells(
+                recovered.commitments.clone(),
+                cell_mask,
+                &cells,
             )
             .unwrap(),
-            reconstructed
+            recovered
         );
-
-        let cell_indices = (0..CELLS_PER_EXT_BLOB as u64 / 2).collect::<Vec<_>>();
-        let sparse_cells = sidecar
-            .compute_cells_with_settings(settings)
-            .unwrap()
-            .chunks_exact(CELLS_PER_EXT_BLOB)
-            .map(|blob_cells| {
-                cell_indices.iter().map(|&index| blob_cells[index as usize]).collect::<Vec<_>>()
-            })
-            .collect::<Vec<_>>();
-        let reconstructed = BlobTransactionSidecarVariant::try_from_sparse_cells_with_settings(
-            sidecar.commitments.clone(),
-            &cell_indices,
-            &sparse_cells,
-            settings,
-        )
-        .unwrap();
-        assert_eq!(reconstructed.blobs(), sidecar.blobs.as_slice());
     }
 
     /// Mirrors Geth's `RecoverBlobs` coverage: multiple blobs are recovered from a shared,
@@ -1837,14 +1736,15 @@ mod tests {
         )
         .unwrap();
 
-        let cell_indices =
-            (0..CELLS_PER_EXT_BLOB as u64).filter(|index| index % 2 == 0).collect::<Vec<_>>();
-        assert_eq!(cell_indices.len(), CELLS_PER_EXT_BLOB / 2);
-        let sparse_cells = sparse_cells_for_indices(&sidecar, &cell_indices, settings);
+        let cell_mask = BlobCellMask::from_bits(
+            (0..CELLS_PER_EXT_BLOB).step_by(2).fold(0, |mask, index| mask | (1u128 << index)),
+        );
+        assert_eq!(cell_mask.count(), CELLS_PER_EXT_BLOB / 2);
+        let sparse_cells = sparse_cells_for_mask(&sidecar, cell_mask, settings);
 
-        let recovered = BlobTransactionSidecarEip7594::try_from_sparse_cells_with_settings(
+        let recovered = BlobTransactionSidecarEip7594::try_recover_from_cells_with_settings(
             sidecar.commitments.clone(),
-            &cell_indices,
+            cell_mask,
             &sparse_cells,
             settings,
         )
@@ -1867,15 +1767,15 @@ mod tests {
         )
         .unwrap();
 
-        let cell_indices = (0..CELLS_PER_EXT_BLOB as u64 / 2)
-            .chain(core::iter::once(CELLS_PER_EXT_BLOB as u64 - 1))
-            .collect::<Vec<_>>();
-        assert_eq!(cell_indices.len(), CELLS_PER_EXT_BLOB / 2 + 1);
-        let sparse_cells = sparse_cells_for_indices(&sidecar, &cell_indices, settings);
+        let cell_mask = BlobCellMask::from_bits(
+            ((1u128 << (CELLS_PER_EXT_BLOB / 2)) - 1) | (1u128 << (CELLS_PER_EXT_BLOB - 1)),
+        );
+        assert_eq!(cell_mask.count(), CELLS_PER_EXT_BLOB / 2 + 1);
+        let sparse_cells = sparse_cells_for_mask(&sidecar, cell_mask, settings);
 
-        let recovered = BlobTransactionSidecarEip7594::try_from_sparse_cells_with_settings(
+        let recovered = BlobTransactionSidecarEip7594::try_recover_from_cells_with_settings(
             sidecar.commitments.clone(),
-            &cell_indices,
+            cell_mask,
             &sparse_cells,
             settings,
         )
@@ -1889,48 +1789,69 @@ mod tests {
     #[cfg(feature = "kzg")]
     fn recover_sparse_blobs_rejects_insufficient_cells() {
         let settings = EnvKzgSettings::Default.get();
-        let cell_indices = (0..CELLS_PER_EXT_BLOB as u64 / 2 - 1).collect::<Vec<_>>();
-        let cells = vec![(0..cell_indices.len())
-            .map(|_| crate::eip7594::Cell::repeat_byte(0))
-            .collect::<Vec<_>>()];
+        let cell_mask = BlobCellMask::from_bits((1u128 << (CELLS_PER_EXT_BLOB / 2 - 1)) - 1);
+        let cells = vec![crate::eip7594::Cell::repeat_byte(0); cell_mask.count()];
 
-        assert!(BlobTransactionSidecarEip7594::try_from_sparse_cells_with_settings(
+        let err = BlobTransactionSidecarEip7594::try_recover_from_cells_with_settings(
             vec![Bytes48::ZERO],
-            &cell_indices,
+            cell_mask,
             &cells,
             settings,
         )
-        .is_err());
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            BlobCellRecoveryError::InsufficientCells {
+                provided,
+                required,
+            } if provided == CELLS_PER_EXT_BLOB / 2 - 1
+                && required == CELLS_PER_EXT_BLOB / 2
+        ));
     }
 
     #[test]
     #[cfg(feature = "kzg")]
-    fn recover_sparse_blobs_rejects_invalid_indices() {
+    fn recover_sparse_blobs_rejects_mismatched_cell_count() {
         let settings = EnvKzgSettings::Default.get();
-        let cells = vec![(0..CELLS_PER_EXT_BLOB / 2)
-            .map(|_| crate::eip7594::Cell::repeat_byte(0))
-            .collect::<Vec<_>>()];
+        let cell_mask = BlobCellMask::from_bits((1u128 << (CELLS_PER_EXT_BLOB / 2)) - 1);
+        let cells = vec![crate::eip7594::Cell::repeat_byte(0); cell_mask.count() - 1];
 
-        let mut duplicate_indices = (0..CELLS_PER_EXT_BLOB as u64 / 2).collect::<Vec<_>>();
-        duplicate_indices[CELLS_PER_EXT_BLOB / 2 - 1] =
-            duplicate_indices[CELLS_PER_EXT_BLOB / 2 - 2];
-        assert!(BlobTransactionSidecarEip7594::try_from_sparse_cells_with_settings(
-            vec![Bytes48::ZERO],
-            &duplicate_indices,
+        let err = BlobTransactionSidecarEip7594::try_recover_from_cells_with_settings(
+            vec![Bytes48::ZERO, Bytes48::ZERO],
+            cell_mask,
             &cells,
             settings,
         )
-        .is_err());
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            BlobCellRecoveryError::CellCountMismatch {
+                provided,
+                expected,
+            } if provided == CELLS_PER_EXT_BLOB / 2 - 1 && expected == CELLS_PER_EXT_BLOB
+        ));
+    }
 
-        let mut out_of_range_indices = (0..CELLS_PER_EXT_BLOB as u64 / 2).collect::<Vec<_>>();
-        out_of_range_indices[CELLS_PER_EXT_BLOB / 2 - 1] = CELLS_PER_EXT_BLOB as u64;
-        assert!(BlobTransactionSidecarEip7594::try_from_sparse_cells_with_settings(
-            vec![Bytes48::ZERO],
-            &out_of_range_indices,
-            &cells,
+    #[test]
+    #[cfg(feature = "kzg")]
+    fn recover_sparse_blobs_rejects_commitment_mismatch() {
+        let settings = EnvKzgSettings::Default.get();
+        let sidecar = BlobTransactionSidecarEip7594::try_from_blobs_with_settings(
+            vec![Blob::repeat_byte(0x01)],
             settings,
         )
-        .is_err());
+        .unwrap();
+        let cell_mask = BlobCellMask::from_bits((1u128 << (CELLS_PER_EXT_BLOB / 2)) - 1);
+        let sparse_cells = sparse_cells_for_mask(&sidecar, cell_mask, settings);
+
+        let err = BlobTransactionSidecarEip7594::try_recover_from_cells_with_settings(
+            vec![Bytes48::ZERO],
+            cell_mask,
+            &sparse_cells,
+            settings,
+        )
+        .unwrap_err();
+        assert!(matches!(err, BlobCellRecoveryError::CommitmentMismatch { blob_index: 0 }));
     }
 
     /// Mirrors Geth's corrupted-cell recovery coverage. A cell that no longer matches the
@@ -1944,13 +1865,13 @@ mod tests {
             settings,
         )
         .unwrap();
-        let cell_indices = (0..CELLS_PER_EXT_BLOB as u64 / 2).collect::<Vec<_>>();
-        let mut sparse_cells = sparse_cells_for_indices(&sidecar, &cell_indices, settings);
-        sparse_cells[0][0][0] ^= 0xff;
+        let cell_mask = BlobCellMask::from_bits((1u128 << (CELLS_PER_EXT_BLOB / 2)) - 1);
+        let mut sparse_cells = sparse_cells_for_mask(&sidecar, cell_mask, settings);
+        sparse_cells[0][0] ^= 0xff;
 
-        assert!(BlobTransactionSidecarEip7594::try_from_sparse_cells_with_settings(
+        assert!(BlobTransactionSidecarEip7594::try_recover_from_cells_with_settings(
             sidecar.commitments,
-            &cell_indices,
+            cell_mask,
             &sparse_cells,
             settings,
         )

--- a/crates/eips/src/eip7594/sidecar.rs
+++ b/crates/eips/src/eip7594/sidecar.rs
@@ -594,7 +594,7 @@ impl BlobTransactionSidecarEip7594 {
     ) -> Self {
         Self { blobs, commitments, cell_proofs }
     }
-  
+
     /// Tries to create a new sidecar by reconstructing blobs from complete EIP-7594 cell sets.
     ///
     /// The cells must be laid out in blob-major order, with exactly
@@ -628,7 +628,7 @@ impl BlobTransactionSidecarEip7594 {
         cell_proofs: Vec<Bytes48>,
         settings: &c_kzg::KzgSettings,
     ) -> Result<Self, c_kzg::Error> {
-        if cells.len() % CELLS_PER_EXT_BLOB != 0 {
+        if !cells.len().is_multiple_of(CELLS_PER_EXT_BLOB) {
             return Err(c_kzg::Error::MismatchLength(format!(
                 "invalid cell count {}; expected a multiple of {CELLS_PER_EXT_BLOB}",
                 cells.len()


### PR DESCRIPTION
EIP-7594 allows nodes to store and exchange only subsets of a blob’s 128 cells. However, transaction validation, execution APIs, RPC responses, and existing blobpool code still require a complete BlobTransactionSidecar. This change provides the missing bridge: once 64+ cells are available, Alloy reconstructs the original blob and all cell proofs using c-kzg, verifies them against the transaction commitments, and returns the normal complete sidecar type.