### PR TITLE
feat(consensus): add EIP-8070 blob clearing helpers

### DIFF
--- a/crates/consensus/src/transaction/pooled.rs
+++ b/crates/consensus/src/transaction/pooled.rs
@@ -3,7 +3,9 @@
 
 use super::EthereumTxEnvelope;
 use crate::{error::ValueError, Signed, TxEip4844, TxEip4844Variant, TxEip4844WithSidecar};
-use alloy_eips::eip7594::{BlobTransactionSidecarEip7594, Encodable7594};
+use alloy_eips::eip7594::{
+    BlobTransactionSidecarEip7594, BlobTransactionSidecarVariant, Encodable7594,
+};
 
 /// All possible transactions that can be included in a response to `GetPooledTransactions`.
 /// A response to `GetPooledTransactions`. This can include either a blob transaction, or a
@@ -18,6 +20,34 @@ use alloy_eips::eip7594::{BlobTransactionSidecarEip7594, Encodable7594};
 /// for PeerDAS data availability sampling.
 pub type PooledTransaction =
     EthereumTxEnvelope<TxEip4844WithSidecar<BlobTransactionSidecarEip7594>>;
+
+impl EthereumTxEnvelope<TxEip4844WithSidecar<BlobTransactionSidecarEip7594>> {
+    /// Clears EIP-7594 blob payloads while retaining commitments and cell proofs.
+    ///
+    /// This prepares the transaction for inclusion in an eth/72 `PooledTransactions` response as
+    /// specified by [EIP-8070]. This has no effect on non-blob transactions.
+    ///
+    /// [EIP-8070]: https://eips.ethereum.org/EIPS/eip-8070
+    pub fn clear_eip7594_blobs(&mut self) {
+        if let Self::Eip4844(tx) = self {
+            tx.tx_mut().sidecar.clear_eip7594_blobs();
+        }
+    }
+}
+
+impl EthereumTxEnvelope<TxEip4844WithSidecar<BlobTransactionSidecarVariant>> {
+    /// Clears EIP-7594 blob payloads while retaining commitments and cell proofs.
+    ///
+    /// This prepares the transaction for inclusion in an eth/72 `PooledTransactions` response as
+    /// specified by [EIP-8070]. This has no effect on non-blob transactions or EIP-4844 sidecars.
+    ///
+    /// [EIP-8070]: https://eips.ethereum.org/EIPS/eip-8070
+    pub fn clear_eip7594_blobs(&mut self) {
+        if let Self::Eip4844(tx) = self {
+            tx.tx_mut().sidecar.clear_eip7594_blobs();
+        }
+    }
+}
 
 impl<T: Encodable7594> EthereumTxEnvelope<TxEip4844WithSidecar<T>> {
     /// Converts the transaction into [`EthereumTxEnvelope<TxEip4844Variant<T>>`].
@@ -83,10 +113,55 @@ impl<T: Encodable7594> From<EthereumTxEnvelope<TxEip4844WithSidecar<T>>>
 mod tests {
     use super::*;
     use crate::Transaction;
-    use alloy_eips::{Decodable2718, Encodable2718};
-    use alloy_primitives::{address, hex, Bytes};
+    use alloy_eips::{
+        eip4844::{Blob, Bytes48},
+        eip7594::CELLS_PER_EXT_BLOB,
+        Decodable2718, Encodable2718,
+    };
+    use alloy_primitives::{address, hex, Bytes, Signature, U256};
     use alloy_rlp::Decodable;
     use std::path::PathBuf;
+
+    fn eip7594_sidecar() -> BlobTransactionSidecarEip7594 {
+        BlobTransactionSidecarEip7594::new(
+            vec![Blob::repeat_byte(0x01)],
+            vec![Bytes48::repeat_byte(0x02)],
+            vec![Bytes48::repeat_byte(0x03); CELLS_PER_EXT_BLOB],
+        )
+    }
+
+    fn signature() -> Signature {
+        Signature::new(U256::from(1), U256::from(2), false)
+    }
+
+    #[test]
+    fn clear_eip7594_blobs_from_pooled_envelopes() {
+        let sidecar = eip7594_sidecar();
+        let commitments = sidecar.commitments.clone();
+        let cell_proofs = sidecar.cell_proofs.clone();
+        let tx = TxEip4844WithSidecar::from_tx_and_sidecar(TxEip4844::default(), sidecar);
+        let mut pooled: PooledTransaction = Signed::new_unhashed(tx, signature()).into();
+
+        pooled.clear_eip7594_blobs();
+
+        let sidecar = &pooled.as_eip4844().unwrap().tx().sidecar;
+        assert!(sidecar.blobs.is_empty());
+        assert_eq!(sidecar.commitments, commitments);
+        assert_eq!(sidecar.cell_proofs, cell_proofs);
+
+        let tx = TxEip4844WithSidecar::from_tx_and_sidecar(
+            TxEip4844::default(),
+            BlobTransactionSidecarVariant::Eip7594(eip7594_sidecar()),
+        );
+        let mut pooled = EthereumTxEnvelope::Eip4844(Signed::new_unhashed(tx, signature()));
+
+        pooled.clear_eip7594_blobs();
+
+        let sidecar = pooled.as_eip4844().unwrap().tx().sidecar.as_eip7594().unwrap();
+        assert!(sidecar.blobs.is_empty());
+        assert_eq!(sidecar.commitments, commitments);
+        assert_eq!(sidecar.cell_proofs, cell_proofs);
+    }
 
     #[test]
     fn invalid_legacy_pooled_decoding_input_too_short() {

--- a/crates/eips/src/eip7594/sidecar.rs
+++ b/crates/eips/src/eip7594/sidecar.rs
@@ -94,6 +94,18 @@ impl BlobTransactionSidecarVariant {
         }
     }
 
+    /// Clears EIP-7594 blob payloads while retaining commitments and cell proofs.
+    ///
+    /// This prepares the sidecar for inclusion in an eth/72 `PooledTransactions` response as
+    /// specified by [EIP-8070]. This has no effect on EIP-4844 sidecars.
+    ///
+    /// [EIP-8070]: https://eips.ethereum.org/EIPS/eip-8070
+    pub fn clear_eip7594_blobs(&mut self) {
+        if let Self::Eip7594(sidecar) = self {
+            sidecar.clear_eip7594_blobs();
+        }
+    }
+
     /// Calculates a size heuristic for the in-memory size of the [BlobTransactionSidecarVariant].
     #[inline]
     pub const fn size(&self) -> usize {
@@ -546,6 +558,16 @@ impl BlobTransactionSidecarEip7594 {
         cell_proofs: Vec<Bytes48>,
     ) -> Self {
         Self { blobs, commitments, cell_proofs }
+    }
+
+    /// Clears blob payloads while retaining commitments and cell proofs.
+    ///
+    /// This prepares the sidecar for inclusion in an eth/72 `PooledTransactions` response as
+    /// specified by [EIP-8070].
+    ///
+    /// [EIP-8070]: https://eips.ethereum.org/EIPS/eip-8070
+    pub fn clear_eip7594_blobs(&mut self) {
+        self.blobs.clear();
     }
 
     /// Calculates a size heuristic for the in-memory size of the [BlobTransactionSidecarEip7594].
@@ -1305,6 +1327,39 @@ mod tests {
         builder::{SidecarBuilder, SimpleCoder},
         env_settings::EnvKzgSettings,
     };
+
+    #[test]
+    fn clear_eip7594_blobs_preserves_metadata() {
+        let commitments = vec![Bytes48::repeat_byte(0x01)];
+        let cell_proofs = vec![Bytes48::repeat_byte(0x02); CELLS_PER_EXT_BLOB];
+        let sidecar = BlobTransactionSidecarEip7594::new(
+            vec![Blob::repeat_byte(0x03)],
+            commitments.clone(),
+            cell_proofs.clone(),
+        );
+        let mut variant = BlobTransactionSidecarVariant::Eip7594(sidecar);
+
+        variant.clear_eip7594_blobs();
+
+        let sidecar = variant.as_eip7594().unwrap();
+        assert!(sidecar.blobs.is_empty());
+        assert_eq!(sidecar.commitments, commitments);
+        assert_eq!(sidecar.cell_proofs, cell_proofs);
+    }
+
+    #[test]
+    fn clear_eip7594_blobs_ignores_eip4844_variant() {
+        let sidecar = BlobTransactionSidecar::new(
+            vec![Blob::repeat_byte(0x01)],
+            vec![Bytes48::repeat_byte(0x02)],
+            vec![Bytes48::repeat_byte(0x03)],
+        );
+        let mut variant = BlobTransactionSidecarVariant::Eip4844(sidecar.clone());
+
+        variant.clear_eip7594_blobs();
+
+        assert_eq!(variant, BlobTransactionSidecarVariant::Eip4844(sidecar));
+    }
 
     #[test]
     fn sidecar_variant_rlp_roundtrip() {


### PR DESCRIPTION
Adds `clear_eip7594_blobs` helpers to EIP-7594 sidecars, sidecar variants, and pooled Ethereum envelopes.

This lets eth/72 implementations prepare `PooledTransactions` responses as specified by [EIP-8070](https://eips.ethereum.org/EIPS/eip-8070), dropping blob payloads while preserving commitments and cell proofs without reaching through `Signed` internals or rewriting encoded RLP.
