### PR TITLE
docs: clarify public API behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,19 +17,29 @@ We also have a [book](https://alloy.rs/) on all things Alloy and many [examples]
 
 Alloy consists of a number of crates that provide a range of functionality essential for interfacing with any Ethereum-based blockchain.
 
-The easiest way to get started is to add the `alloy` crate with the `full` feature flag from the command-line using Cargo:
+The easiest way to get started is to add the `alloy` crate from the command line using Cargo:
 
 ```sh
-cargo add alloy --features full
+cargo add alloy
 ```
 
 Alternatively, you can add the following to your `Cargo.toml` file:
 
 ```toml
-alloy = { version = "2", features = ["full"] }
+alloy = "2"
 ```
 
-For a more fine-grained control over the features you wish to include, you can add the individual crates to your `Cargo.toml` file, or use the `alloy` crate with the features you need.
+The default features include contracts, an HTTP provider, Ethereum RPC types, and a local signer.
+For WebSocket and IPC transports plus commonly used extended RPC APIs, enable the `full`
+feature:
+
+```sh
+cargo add alloy --features full
+```
+
+`full` is a convenience bundle, not every optional integration. Node process bindings, ENS,
+genesis and trie support, and cloud or hardware signers remain opt-in. For finer control, enable
+only the features you need or depend on the individual crates directly.
 
 A comprehensive list of available features can be found on [docs.rs](https://docs.rs/crate/alloy/latest/features) or in the [`alloy` crate's `Cargo.toml`](https://github.com/alloy-rs/alloy/blob/main/crates/alloy/Cargo.toml).
 
@@ -136,6 +146,7 @@ This repository contains the following crates:
   - [`alloy-signer-gcp`] - [GCP KMS] signer implementation
   - [`alloy-signer-ledger`] - [Ledger] signer implementation
   - [`alloy-signer-local`] - Local (private key, keystore, mnemonic, YubiHSM) signer implementations
+  - [`alloy-signer-tempo`] - Read-only [Tempo] wallet keystore lookup that materializes local signers
   - [`alloy-signer-trezor`] - [Trezor] signer implementation
   - [`alloy-signer-turnkey`] - [Turnkey] signer implementation
 - [`alloy-transport`] - Low-level Ethereum JSON-RPC transport abstraction
@@ -178,6 +189,7 @@ This repository contains the following crates:
 [`alloy-signer-gcp`]: https://github.com/alloy-rs/alloy/tree/main/crates/signer-gcp
 [`alloy-signer-ledger`]: https://github.com/alloy-rs/alloy/tree/main/crates/signer-ledger
 [`alloy-signer-local`]: https://github.com/alloy-rs/alloy/tree/main/crates/signer-local
+[`alloy-signer-tempo`]: https://github.com/alloy-rs/alloy/tree/main/crates/signer-tempo
 [`alloy-signer-trezor`]: https://github.com/alloy-rs/alloy/tree/main/crates/signer-trezor
 [`alloy-signer-turnkey`]: https://github.com/alloy-rs/alloy/tree/main/crates/signer-turnkey
 [`alloy-transport`]: https://github.com/alloy-rs/alloy/tree/main/crates/transport
@@ -190,6 +202,7 @@ This repository contains the following crates:
 [AWS KMS]: https://aws.amazon.com/kms
 [GCP KMS]: https://cloud.google.com/kms
 [Ledger]: https://www.ledger.com
+[Tempo]: https://tempo.xyz
 [Trezor]: https://trezor.io
 [Turnkey]: https://www.turnkey.com
 [Serde]: https://serde.rs
@@ -208,8 +221,7 @@ When updating this, also update:
 The current MSRV (minimum supported rust version) is 1.94.1.
 
 Alloy will keep a rolling MSRV policy of **at least** two versions behind the
-latest stable release (so if the latest stable release is 1.58, we would
-support 1.56).
+latest stable release.
 
 Note that the MSRV is not increased automatically, and only as part of a patch
 (pre-1.0) or minor (post-1.0) release.

--- a/crates/consensus-any/src/receipt/envelope.rs
+++ b/crates/consensus-any/src/receipt/envelope.rs
@@ -10,10 +10,8 @@ use core::fmt;
 
 /// Receipt envelope, as defined in [EIP-2718].
 ///
-/// This enum distinguishes between tagged and untagged legacy receipts, as the
-/// in-protocol Merkle tree may commit to EITHER 0-prefixed or raw. Therefore
-/// we must ensure that encoding returns the precise byte-array that was
-/// decoded, preserving the presence or absence of the `TransactionType` flag.
+/// Represents legacy and typed EIP-2718 receipts. Type ID 0 is encoded as untagged legacy; this
+/// type does not preserve a literal `0x00` prefix.
 ///
 /// Transaction receipt payloads are specified in their respective EIPs.
 ///

--- a/crates/consensus/src/block/mod.rs
+++ b/crates/consensus/src/block/mod.rs
@@ -187,6 +187,9 @@ impl<T: Encodable2718> Block<T, Header> {
     ///
     /// Computes and sets the `transactions_root` on the header automatically.
     /// `ommers_hash` is set to [`EMPTY_OMMER_ROOT_HASH`](crate::EMPTY_OMMER_ROOT_HASH).
+    ///
+    /// This updates no other header fields, creates a body without withdrawals, and does not
+    /// calculate the receipts root, validate transactions, or seal the header.
     pub fn from_transactions(
         mut header: Header,
         transactions: impl IntoIterator<Item = T>,

--- a/crates/consensus/src/receipt/envelope.rs
+++ b/crates/consensus/src/receipt/envelope.rs
@@ -13,10 +13,9 @@ use core::fmt;
 
 /// Receipt envelope, as defined in [EIP-2718].
 ///
-/// This enum distinguishes between tagged and untagged legacy receipts, as the
-/// in-protocol Merkle tree may commit to EITHER 0-prefixed or raw. Therefore
-/// we must ensure that encoding returns the precise byte-array that was
-/// decoded, preserving the presence or absence of the `TransactionType` flag.
+/// Represents untagged legacy receipts and typed EIP-2718 variants. Binary decoding rejects a
+/// literal `0x00` type prefix; legacy receipts use the untagged fallback encoding. JSON `type: 0x0`
+/// is accepted as legacy.
 ///
 /// Transaction receipt payloads are specified in their respective EIPs.
 ///

--- a/crates/consensus/src/receipt/receipts.rs
+++ b/crates/consensus/src/receipt/receipts.rs
@@ -250,12 +250,11 @@ impl<T> Default for Receipts<T> {
     }
 }
 
-/// [`Receipt`] with calculated bloom filter.
+/// A receipt paired with a precomputed logs bloom.
 ///
-/// This convenience type allows us to lazily calculate the bloom filter for a
-/// receipt, similar to [`Sealed`].
-///
-/// [`Sealed`]: crate::Sealed
+/// Consistency is not verified or automatically maintained. Prefer [`Receipt::with_bloom`] or
+/// [`From<R>`](From) to calculate it, and recompute it after changing bloom-relevant log addresses
+/// or topics.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
@@ -318,15 +317,13 @@ where
 }
 
 impl<R> ReceiptWithBloom<R> {
-    /// Converts the receipt type by applying the given closure to it.
-    ///
-    /// Returns the type with the new receipt type.
+    /// Converts the receipt type while reusing the existing bloom without validation.
     pub fn map_receipt<U>(self, f: impl FnOnce(R) -> U) -> ReceiptWithBloom<U> {
         let Self { receipt, logs_bloom } = self;
         ReceiptWithBloom { receipt: f(receipt), logs_bloom }
     }
 
-    /// Create new [ReceiptWithBloom]
+    /// Creates a receipt with a caller-supplied bloom without verifying consistency.
     pub const fn new(receipt: R, logs_bloom: Bloom) -> Self {
         Self { receipt, logs_bloom }
     }
@@ -343,9 +340,9 @@ impl<R> ReceiptWithBloom<R> {
 }
 
 impl<L> ReceiptWithBloom<Receipt<L>> {
-    /// Converts the receipt's log type by applying a function to each log.
+    /// Converts the receipt's log type while reusing the existing bloom.
     ///
-    /// Returns the receipt with the new log type.
+    /// Use this only when the mapping preserves bloom-relevant log addresses and topics.
     pub fn map_logs<U>(self, f: impl FnMut(L) -> U) -> ReceiptWithBloom<Receipt<U>> {
         let Self { receipt, logs_bloom } = self;
         ReceiptWithBloom { receipt: receipt.map_logs(f), logs_bloom }

--- a/crates/consensus/src/signed.rs
+++ b/crates/consensus/src/signed.rs
@@ -21,7 +21,10 @@ use once_cell::race::OnceBox as OnceLock;
 #[cfg(feature = "std")]
 use std::sync::OnceLock;
 
-/// A transaction with a signature and hash seal.
+/// A transaction paired with a signature and a lazily cached or caller-supplied hash.
+///
+/// The cached hash is not a live view of the transaction. Mapping or mutating the inner value is
+/// valid only when the signed payload and signature preimage remain unchanged.
 #[derive(Debug, Clone)]
 pub struct Signed<T, Sig = Signature> {
     #[doc(alias = "transaction")]
@@ -32,7 +35,9 @@ pub struct Signed<T, Sig = Signature> {
 }
 
 impl<T, Sig> Signed<T, Sig> {
-    /// Instantiate from a transaction and signature. Does not verify the signature.
+    /// Instantiates a signed transaction with a caller-supplied hash.
+    ///
+    /// Neither the signature nor the supplied hash is verified against `tx`.
     pub fn new_unchecked(tx: T, signature: Sig, hash: B256) -> Self {
         let value = OnceLock::new();
         #[allow(clippy::useless_conversion)]
@@ -55,7 +60,8 @@ impl<T, Sig> Signed<T, Sig> {
     ///
     /// # Warning
     ///
-    /// Modifying the transaction structurally invalidates the signature and hash.
+    /// Modifying the transaction structurally invalidates the signature and any cached hash. The
+    /// cache is not automatically cleared.
     #[doc(hidden)]
     pub const fn tx_mut(&mut self) -> &mut T {
         &mut self.tx
@@ -97,8 +103,8 @@ impl<T, Sig> Signed<T, Sig> {
 
     /// Applies the given closure to the inner transaction type.
     ///
-    /// Caution: This is only intended for converting transaction types that are structurally
-    /// equivalent (produce the same hash).
+    /// The signature and cached hash are retained without recomputation. Use this only for
+    /// encoding-preserving conversions that produce the same signature preimage and hash.
     pub fn map<Tx>(self, f: impl FnOnce(T) -> Tx) -> Signed<Tx, Sig> {
         let Self { tx, signature, hash } = self;
         Signed { tx: f(tx), signature, hash }
@@ -106,8 +112,8 @@ impl<T, Sig> Signed<T, Sig> {
 
     /// Applies the given fallible closure to the inner transactions.
     ///
-    /// Caution: This is only intended for converting transaction types that are structurally
-    /// equivalent (produce the same hash).
+    /// The signature and cached hash are retained without recomputation. Use this only for
+    /// encoding-preserving conversions that produce the same signature preimage and hash.
     pub fn try_map<Tx, E>(self, f: impl FnOnce(T) -> Result<Tx, E>) -> Result<Signed<Tx, Sig>, E> {
         let Self { tx, signature, hash } = self;
         Ok(Signed { tx: f(tx)?, signature, hash })

--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -10,17 +10,7 @@ use crate::{
 use alloy_eips::{eip2718::Encodable2718, eip7594::Encodable7594};
 use alloy_primitives::{Bytes, Signature, B256};
 
-/// The Ethereum [EIP-2718] Transaction Envelope.
-///
-/// # Note:
-///
-/// This enum distinguishes between tagged and untagged legacy transactions, as
-/// the in-protocol merkle tree may commit to EITHER 0-prefixed or raw.
-/// Therefore we must ensure that encoding returns the precise byte-array that
-/// was decoded, preserving the presence or absence of the `TransactionType`
-/// flag.
-///
-/// [EIP-2718]: https://eips.ethereum.org/EIPS/eip-2718
+/// The standard Ethereum transaction envelope, using [`TxEip4844Variant`] for blob transactions.
 pub type TxEnvelope = EthereumTxEnvelope<TxEip4844Variant>;
 
 impl<T: Encodable7594> EthereumTxEnvelope<TxEip4844Variant<T>> {
@@ -466,13 +456,8 @@ impl TryFrom<EthereumTxEnvelope<TxEip4844Variant<alloy_eips::eip4844::BlobTransa
 
 /// The Ethereum [EIP-2718] Transaction Envelope.
 ///
-/// # Note:
-///
-/// This enum distinguishes between tagged and untagged legacy transactions, as
-/// the in-protocol merkle tree may commit to EITHER 0-prefixed or raw.
-/// Therefore we must ensure that encoding returns the precise byte-array that
-/// was decoded, preserving the presence or absence of the `TransactionType`
-/// flag.
+/// Represents untagged legacy transactions and typed EIP-2718 variants. Type ID 0 is normalized to
+/// the untagged legacy encoding; this type does not preserve a literal `0x00` prefix.
 ///
 /// [EIP-2718]: https://eips.ethereum.org/EIPS/eip-2718
 #[derive(Clone, Debug, TransactionEnvelope)]

--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -10,7 +10,17 @@ use crate::{
 use alloy_eips::{eip2718::Encodable2718, eip7594::Encodable7594};
 use alloy_primitives::{Bytes, Signature, B256};
 
-/// The standard Ethereum transaction envelope, using [`TxEip4844Variant`] for blob transactions.
+/// The Ethereum [EIP-2718] Transaction Envelope.
+///
+/// # Note:
+///
+/// This enum distinguishes between tagged and untagged legacy transactions, as
+/// the in-protocol merkle tree may commit to EITHER 0-prefixed or raw.
+/// Therefore we must ensure that encoding returns the precise byte-array that
+/// was decoded, preserving the presence or absence of the `TransactionType`
+/// flag.
+///
+/// [EIP-2718]: https://eips.ethereum.org/EIPS/eip-2718
 pub type TxEnvelope = EthereumTxEnvelope<TxEip4844Variant>;
 
 impl<T: Encodable7594> EthereumTxEnvelope<TxEip4844Variant<T>> {
@@ -456,8 +466,13 @@ impl TryFrom<EthereumTxEnvelope<TxEip4844Variant<alloy_eips::eip4844::BlobTransa
 
 /// The Ethereum [EIP-2718] Transaction Envelope.
 ///
-/// Represents untagged legacy transactions and typed EIP-2718 variants. Type ID 0 is normalized to
-/// the untagged legacy encoding; this type does not preserve a literal `0x00` prefix.
+/// # Note:
+///
+/// This enum distinguishes between tagged and untagged legacy transactions, as
+/// the in-protocol merkle tree may commit to EITHER 0-prefixed or raw.
+/// Therefore we must ensure that encoding returns the precise byte-array that
+/// was decoded, preserving the presence or absence of the `TransactionType`
+/// flag.
 ///
 /// [EIP-2718]: https://eips.ethereum.org/EIPS/eip-2718
 #[derive(Clone, Debug, TransactionEnvelope)]

--- a/crates/consensus/src/transaction/pooled.rs
+++ b/crates/consensus/src/transaction/pooled.rs
@@ -5,9 +5,11 @@ use super::EthereumTxEnvelope;
 use crate::{error::ValueError, Signed, TxEip4844, TxEip4844Variant, TxEip4844WithSidecar};
 use alloy_eips::eip7594::{BlobTransactionSidecarEip7594, Encodable7594};
 
-/// All possible transactions that can be included in a response to `GetPooledTransactions`.
-/// A response to `GetPooledTransactions`. This can include either a blob transaction, or a
-/// non-4844 signed transaction.
+/// Pooled transaction format for Osaka and later.
+///
+/// This can contain an EIP-7594 blob transaction with its cell-proof sidecar or any non-blob
+/// signed Ethereum transaction. For cross-fork EIP-4844/EIP-7594 handling, use
+/// `EthereumTxEnvelope<TxEip4844WithSidecar<BlobTransactionSidecarVariant>>` instead.
 ///
 /// The difference between this and the [`EthereumTxEnvelope<TxEip4844Variant<T>>`] is that this
 /// type always requires the [`TxEip4844WithSidecar`] variant, because EIP-4844 transaction can only

--- a/crates/consensus/src/transaction/pooled.rs
+++ b/crates/consensus/src/transaction/pooled.rs
@@ -7,8 +7,8 @@ use alloy_eips::eip7594::{BlobTransactionSidecarEip7594, Encodable7594};
 
 /// Pooled transaction format for Osaka and later.
 ///
-/// This can contain an EIP-7594 blob transaction with its cell-proof sidecar or any non-blob
-/// signed Ethereum transaction. For cross-fork EIP-4844/EIP-7594 handling, use
+/// This can contain an [EIP-7594] blob transaction with its cell-proof sidecar or any non-blob
+/// signed Ethereum transaction. For cross-fork [EIP-4844]/[EIP-7594] handling, use
 /// `EthereumTxEnvelope<TxEip4844WithSidecar<BlobTransactionSidecarVariant>>` instead.
 ///
 /// The difference between this and the [`EthereumTxEnvelope<TxEip4844Variant<T>>`] is that this
@@ -18,6 +18,9 @@ use alloy_eips::eip7594::{BlobTransactionSidecarEip7594, Encodable7594};
 /// After the Osaka upgrade (EIP-7594), the blob sidecar uses
 /// [`BlobTransactionSidecarEip7594`] which replaces single KZG proofs with cell proofs
 /// for PeerDAS data availability sampling.
+///
+/// [EIP-4844]: https://eips.ethereum.org/EIPS/eip-4844
+/// [EIP-7594]: https://eips.ethereum.org/EIPS/eip-7594
 pub type PooledTransaction =
     EthereumTxEnvelope<TxEip4844WithSidecar<BlobTransactionSidecarEip7594>>;
 

--- a/crates/consensus/src/transaction/recovered.rs
+++ b/crates/consensus/src/transaction/recovered.rs
@@ -8,7 +8,10 @@ use alloy_primitives::{bytes, Address, Bytes, Sealed, B256};
 use alloy_rlp::{Decodable, Encodable};
 use derive_more::{AsRef, Deref};
 
-/// Signed object with recovered signer.
+/// A signed object paired with a previously recovered signer.
+///
+/// The signer is cached metadata and is not recomputed. Mapping or mutating the inner value is
+/// valid only when it preserves the signed payload and signature preimage.
 #[derive(Debug, Clone, Copy, PartialEq, Hash, Eq, AsRef, Deref)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -33,12 +36,14 @@ impl<T> Recovered<T> {
         &self.signer
     }
 
-    /// Reference to the inner recovered object.
+    /// Returns a reference to the inner recovered object.
     pub const fn inner(&self) -> &T {
         &self.inner
     }
 
-    /// Reference to the inner recovered object.
+    /// Returns a mutable reference to the inner recovered object.
+    ///
+    /// This does not update or invalidate the cached signer.
     pub const fn inner_mut(&mut self) -> &mut T {
         &mut self.inner
     }
@@ -75,7 +80,7 @@ impl<T> Recovered<T> {
         Self { inner, signer }
     }
 
-    /// Converts the inner signed object to the given alternative that is `From<T>`
+    /// Converts the inner signed object while preserving the signer without validation.
     pub fn convert<Tx>(self) -> Recovered<Tx>
     where
         Tx: From<T>,
@@ -83,7 +88,7 @@ impl<T> Recovered<T> {
         self.map(Tx::from)
     }
 
-    /// Converts the inner signed object to the given alternative that is `TryFrom<T>`
+    /// Fallibly converts the inner signed object while preserving the signer without validation.
     pub fn try_convert<Tx>(self) -> Result<Recovered<Tx>, Tx::Error>
     where
         Tx: TryFrom<T>,
@@ -91,12 +96,12 @@ impl<T> Recovered<T> {
         self.try_map(Tx::try_from)
     }
 
-    /// Applies the given closure to the inner signed object.
+    /// Applies a closure while preserving the signer without validation.
     pub fn map<Tx>(self, f: impl FnOnce(T) -> Tx) -> Recovered<Tx> {
         Recovered::new_unchecked(f(self.inner), self.signer)
     }
 
-    /// Applies the given fallible closure to the inner signed object.
+    /// Applies a fallible closure while preserving the signer without validation.
     pub fn try_map<Tx, E>(self, f: impl FnOnce(T) -> Result<Tx, E>) -> Result<Recovered<Tx>, E> {
         Ok(Recovered::new_unchecked(f(self.inner)?, self.signer))
     }

--- a/crates/contract/README.md
+++ b/crates/contract/README.md
@@ -15,40 +15,37 @@ that returns a `CallBuilder` for that function. See its documentation for more d
 ```rust,no_run
 # async fn test() -> Result<(), Box<dyn std::error::Error>> {
 use alloy_contract::SolCallBuilder;
-use alloy_network::Ethereum;
 use alloy_primitives::{Address, U256};
 use alloy_provider::ProviderBuilder;
+use alloy_signer_local::PrivateKeySigner;
 use alloy_sol_types::sol;
 
 sol! {
     #[sol(rpc)] // <-- Important! Generates the necessary `MyContract` struct and function methods.
-    #[sol(bytecode = "0x1234")] // <-- Generates the `BYTECODE` static and the `deploy` method.
     contract MyContract {
-        constructor(address) {} // The `deploy` method will also include any constructor arguments.
-
         #[derive(Debug)]
         function doStuff(uint a, bool b) public payable returns(address c, bytes32 d);
     }
 }
 
-// Build a provider.
-let provider = ProviderBuilder::new().connect("http://localhost:8545").await?;
+// Configure a funded sender. `PRIVATE_KEY` must belong to an account funded on this node.
+let signer: PrivateKeySigner = std::env::var("PRIVATE_KEY")?.parse()?;
+let sender = signer.address();
+let provider = ProviderBuilder::new()
+    .wallet(signer)
+    .connect("http://localhost:8545")
+    .await?;
 
-// If `#[sol(bytecode = "0x...")]` is provided, the contract can be deployed with `MyContract::deploy`,
-// and a new instance will be created.
-let constructor_arg = Address::ZERO;
-let contract = MyContract::deploy(&provider, constructor_arg).await?;
-
-// Otherwise, or if already deployed, a new contract instance can be created with `MyContract::new`.
-let address = Address::ZERO;
+// Connect to an existing deployment.
+let address: Address = std::env::var("CONTRACT_ADDRESS")?.parse()?;
 let contract = MyContract::new(address, &provider);
 
 // Build a call to the `doStuff` function and configure it.
 let a = U256::from(123);
 let b = true;
-let call_builder = contract.doStuff(a, b).value(U256::from(50e18 as u64));
+let call_builder = contract.doStuff(a, b).from(sender);
 
-// Send the call. Note that this is not broadcasted as a transaction.
+// Simulate the call with `eth_call`. This does not broadcast a transaction.
 let call_return = call_builder.call().await?;
 println!("{call_return:?}"); // doStuffReturn { c: 0x..., d: 0x... }
 
@@ -57,3 +54,7 @@ let _pending_tx = call_builder.send().await?;
 # Ok(())
 # }
 ```
+
+When the `sol!` contract has real creation bytecode through `#[sol(bytecode = "0x...")]`, it also
+generates a `deploy` method. Payable calls can attach wei with `CallBuilder::value`; set a deliberate
+amount only when broadcasting.

--- a/crates/contract/src/call.rs
+++ b/crates/contract/src/call.rs
@@ -33,6 +33,10 @@ pub type RawCallBuilder<P, N = Ethereum> = CallBuilder<P, (), N>;
 /// A builder for sending a transaction via `eth_sendTransaction`, or calling a contract via
 /// `eth_call`.
 ///
+/// The builder can be `.await`ed directly, which is equivalent to invoking [`call`].
+/// Prefer using [`call`] when possible, as `await`ing the builder directly will consume it, and
+/// currently also boxes the future due to type system limitations.
+///
 /// A call builder can currently be instantiated in the following ways:
 /// - by [`sol!`][sol]-generated contract structs' methods (through the `#[sol(rpc)]` attribute)
 ///   ([`SolCallBuilder`]);
@@ -125,7 +129,7 @@ pub type RawCallBuilder<P, N = Ethereum> = CallBuilder<P, (), N>;
 ///
 /// [sol]: alloy_sol_types::sol
 #[derive(Clone)]
-#[must_use = "call builders do nothing unless used to call, estimate, build, or send a transaction"]
+#[must_use = "call builders do nothing unless you `.call`, `.send`, or `.await` them"]
 pub struct CallBuilder<P, D, N: Network = Ethereum> {
     pub(crate) request: N::TransactionRequest,
     block: BlockId,

--- a/crates/contract/src/call.rs
+++ b/crates/contract/src/call.rs
@@ -33,10 +33,6 @@ pub type RawCallBuilder<P, N = Ethereum> = CallBuilder<P, (), N>;
 /// A builder for sending a transaction via `eth_sendTransaction`, or calling a contract via
 /// `eth_call`.
 ///
-/// The builder can be `.await`ed directly, which is equivalent to invoking [`call`].
-/// Prefer using [`call`] when possible, as `await`ing the builder directly will consume it, and
-/// currently also boxes the future due to type system limitations.
-///
 /// A call builder can currently be instantiated in the following ways:
 /// - by [`sol!`][sol]-generated contract structs' methods (through the `#[sol(rpc)]` attribute)
 ///   ([`SolCallBuilder`]);
@@ -49,8 +45,11 @@ pub type RawCallBuilder<P, N = Ethereum> = CallBuilder<P, (), N>;
 ///
 /// # Note
 ///
-/// This will set [state overrides](https://geth.ethereum.org/docs/rpc/ns-eth#3-object---state-override-set)
-/// for `eth_call`, but this is not supported by all clients.
+/// The selected block and
+/// [state overrides](https://geth.ethereum.org/docs/rpc/ns-eth#3-object---state-override-set)
+/// apply only to [`call`](Self::call), [`call_raw`](Self::call_raw), and
+/// [`estimate_gas`](Self::estimate_gas). They do not modify transactions built or submitted from
+/// this builder. State overrides are not supported by all clients.
 ///
 /// # Examples
 ///
@@ -126,7 +125,7 @@ pub type RawCallBuilder<P, N = Ethereum> = CallBuilder<P, (), N>;
 ///
 /// [sol]: alloy_sol_types::sol
 #[derive(Clone)]
-#[must_use = "call builders do nothing unless you `.call`, `.send`, or `.await` them"]
+#[must_use = "call builders do nothing unless used to call, estimate, build, or send a transaction"]
 pub struct CallBuilder<P, D, N: Network = Ethereum> {
     pub(crate) request: N::TransactionRequest,
     block: BlockId,
@@ -138,39 +137,50 @@ pub struct CallBuilder<P, D, N: Network = Ethereum> {
 }
 
 impl<P, D, N: Network> CallBuilder<P, D, N> {
-    /// Converts the call builder to the inner transaction request
+    /// Consumes the builder and returns its inner transaction request.
+    ///
+    /// The provider, decoder, selected block, and state overrides are stored separately from the
+    /// transaction request and are discarded.
     pub fn into_transaction_request(self) -> N::TransactionRequest {
         self.request
     }
 
-    /// Builds and returns a RLP-encoded unsigned transaction from the call that can be signed.
+    /// Builds and returns the unsigned transaction's encoded signing preimage.
+    ///
+    /// This does not use the provider or its fillers. The request must already contain every field
+    /// required by the selected transaction type, including gas, nonce, and fee fields.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the transaction request is incomplete or otherwise invalid.
     ///
     /// # Examples
     ///
     /// ```no_run
+    /// # use alloy_primitives::Address;
     /// # use alloy_provider::ProviderBuilder;
     /// # use alloy_sol_types::sol;
     ///
     /// sol! {
-    ///     #[sol(rpc, bytecode = "0x")]
-    ///    contract Counter {
-    ///        uint128 public counter;
-    ///
-    ///        function increment() external {
-    ///            counter += 1;
-    ///        }
-    ///    }
+    ///     #[sol(rpc)]
+    ///     interface Counter {
+    ///         function increment() external;
+    ///     }
     /// }
     ///
-    /// #[tokio::main]
-    /// async fn main() {
-    ///     let provider = ProviderBuilder::new().connect_anvil_with_wallet();
+    /// fn main() {
+    ///     let provider = ProviderBuilder::new().connect_anvil();
+    ///     let counter = Counter::new(Address::ZERO, &provider);
     ///
-    ///     let my_contract = Counter::deploy(provider).await.unwrap();
-    ///
-    ///     let call = my_contract.increment();
-    ///
-    ///     let unsigned_raw_tx: Vec<u8> = call.build_unsigned_raw_transaction().unwrap();
+    ///     let unsigned_raw_tx: Vec<u8> = counter
+    ///         .increment()
+    ///         .chain_id(31_337)
+    ///         .nonce(0)
+    ///         .gas(50_000)
+    ///         .max_fee_per_gas(20_000_000_000)
+    ///         .max_priority_fee_per_gas(1_000_000_000)
+    ///         .build_unsigned_raw_transaction()
+    ///         .unwrap();
     ///
     ///     assert!(!unsigned_raw_tx.is_empty())
     /// }
@@ -183,37 +193,50 @@ impl<P, D, N: Network> CallBuilder<P, D, N> {
         Ok(tx.encoded_for_signing())
     }
 
-    /// Build a RLP-encoded signed raw transaction for the call that can be sent to the network
+    /// Builds an EIP-2718-encoded signed transaction for the call that can be sent to the network
     /// using [`Provider::send_raw_transaction`].
+    ///
+    /// The signer can fill or validate the chain ID according to its [`TxSigner`] implementation.
+    /// This method does not use the provider or its fillers, so the request must already contain
+    /// every other field required by the selected transaction type, including gas, nonce, and fee
+    /// fields.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the transaction request is incomplete or invalid, or if signing fails.
     ///
     /// # Examples
     ///
     /// ```no_run
-    /// # use alloy_provider::{ProviderBuilder, Provider};
-    /// # use alloy_sol_types::sol;
+    /// # use alloy_primitives::Address;
+    /// # use alloy_provider::{Provider, ProviderBuilder};
     /// # use alloy_signer_local::PrivateKeySigner;
+    /// # use alloy_sol_types::sol;
     ///
     /// sol! {
-    ///    #[sol(rpc, bytecode = "0x")]
-    ///   contract Counter {
-    ///      uint128 public counter;
-    ///
-    ///     function increment() external {
-    ///        counter += 1;
-    ///    }
-    ///  }
+    ///     #[sol(rpc)]
+    ///     interface Counter {
+    ///         function increment() external;
+    ///     }
     /// }
     ///
     /// #[tokio::main]
     /// async fn main() {
-    ///     let provider = ProviderBuilder::new().connect_anvil_with_wallet();
+    ///     let provider = ProviderBuilder::new().connect_anvil();
+    ///     let counter = Counter::new(Address::ZERO, &provider);
+    ///     let signer: PrivateKeySigner =
+    ///         "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80".parse().unwrap();
     ///
-    ///     let my_contract = Counter::deploy(&provider).await.unwrap();
-    ///
-    ///     let call = my_contract.increment();
-    ///
-    ///     let pk_signer: PrivateKeySigner = "0x..".parse().unwrap();
-    ///     let signed_raw_tx: Vec<u8> = call.build_raw_transaction(pk_signer).await.unwrap();
+    ///     let signed_raw_tx: Vec<u8> = counter
+    ///         .increment()
+    ///         .chain_id(31_337)
+    ///         .nonce(0)
+    ///         .gas(50_000)
+    ///         .max_fee_per_gas(20_000_000_000)
+    ///         .max_priority_fee_per_gas(1_000_000_000)
+    ///         .build_raw_transaction(signer)
+    ///         .await
+    ///         .unwrap();
     ///
     ///     let tx = provider.send_raw_transaction(&signed_raw_tx).await.unwrap();
     /// }
@@ -494,13 +517,20 @@ impl<P: Provider<N>, D: CallDecoder, N: Network> CallBuilder<P, D, N> {
         self
     }
 
-    /// Sets the `block` field for sending the tx to the chain
+    /// Sets the block used by [`call`](Self::call), [`call_raw`](Self::call_raw), and
+    /// [`estimate_gas`](Self::estimate_gas).
+    ///
+    /// This does not affect transactions built or submitted from this builder.
     pub const fn block(mut self, block: BlockId) -> Self {
         self.block = block;
         self
     }
 
     /// Sets the [state override set](https://geth.ethereum.org/docs/rpc/ns-eth#3-object---state-override-set).
+    ///
+    /// The overrides apply to [`call`](Self::call), [`call_raw`](Self::call_raw), and
+    /// [`estimate_gas`](Self::estimate_gas), but do not affect transactions built or submitted from
+    /// this builder.
     ///
     /// # Note
     ///

--- a/crates/contract/src/interface.rs
+++ b/crates/contract/src/interface.rs
@@ -43,17 +43,40 @@ impl Interface {
         self.get_from_selector(selector)?.abi_encode_input(args).map_err(Into::into)
     }
 
-    /// ABI-decodes the given data according to the function's types.
+    /// ABI-decodes argument data according to the function's input types.
+    ///
+    /// `data` must not include the four-byte function selector. To decode full calldata, pass the
+    /// bytes after the selector.
     ///
     /// # Note
     ///
     /// If the function exists multiple times and you want to use one of the overloaded versions,
     /// consider using [`Self::decode_input_with_selector`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use alloy_contract::Interface;
+    /// use alloy_dyn_abi::DynSolValue;
+    /// use alloy_json_abi::JsonAbi;
+    /// use alloy_primitives::U256;
+    ///
+    /// let interface = Interface::new(JsonAbi::parse(["function setValue(uint256 value)"])?);
+    /// let args = [DynSolValue::Uint(U256::from(42), 256)];
+    /// let calldata = interface.encode_input("setValue", &args)?;
+    ///
+    /// let decoded = interface.decode_input("setValue", &calldata[4..])?;
+    /// assert_eq!(decoded, args);
+    /// # Ok::<_, Box<dyn std::error::Error>>(())
+    /// ```
     pub fn decode_input(&self, name: &str, data: &[u8]) -> Result<Vec<DynSolValue>> {
         self.get_from_name(name)?.abi_decode_input(data).map_err(Into::into)
     }
 
-    /// Decode the provided ABI encoded bytes as the input of the provided function selector.
+    /// Decodes argument data using the function identified by `selector`.
+    ///
+    /// `data` must not include the four-byte function selector. The `selector` argument selects the
+    /// function from the ABI; it is not decoded from or validated against `data`.
     pub fn decode_input_with_selector(
         &self,
         selector: &Selector,

--- a/crates/eip5792/README.md
+++ b/crates/eip5792/README.md
@@ -1,11 +1,12 @@
 # alloy-eip5792
 
-Types for the Wallet Call API.
+Legacy sequencer-specific Wallet Call API types.
 
-- `wallet_getCapabilities` based on [EIP-5792][eip-5792], with the only capability being
-  `delegation`.
-- `wallet_sendTransaction` that can perform sequencer-sponsored [EIP-7702][eip-7702] delegations
-  and send other sequencer-sponsored transactions on behalf of EOAs with delegated code.
+These types model an earlier draft and do **not** implement the Final [EIP-5792] `wallet_sendCalls`
+schema. In particular, `SendCallsRequest` requires `from`, stores a chain ID per call, and has no
+top-level `id`, `chainId`, or `atomicRequired`. `WalletCapabilities` models a custom
+sequencer-sponsored [EIP-7702] delegation capability rather than EIP-5792's built-in `atomic`
+capability. Use this crate only with APIs that expect this legacy shape.
 
-[eip-5792]: https://eips.ethereum.org/EIPS/eip-5792
-[eip-7702]: https://eips.ethereum.org/EIPS/eip-7702
+[EIP-5792]: https://eips.ethereum.org/EIPS/eip-5792
+[EIP-7702]: https://eips.ethereum.org/EIPS/eip-7702

--- a/crates/eip5792/src/call.rs
+++ b/crates/eip5792/src/call.rs
@@ -1,6 +1,12 @@
 use alloy_primitives::{map::HashMap, Address, Bytes, ChainId, U256};
 
-/// Request that a wallet submits a batch of calls in `wallet_sendCalls`
+/// Legacy sequencer-specific request for submitting a batch of wallet calls.
+///
+/// This shape predates and is incompatible with the Final [EIP-5792] `wallet_sendCalls` request:
+/// it requires `from`, stores chain IDs on individual calls, and omits the final schema's
+/// top-level `id`, `chainId`, and `atomicRequired` fields.
+///
+/// [EIP-5792]: https://eips.ethereum.org/EIPS/eip-5792
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SendCallsRequest {
@@ -10,12 +16,12 @@ pub struct SendCallsRequest {
     pub from: Address,
     /// A batch of calls to be submitted
     pub calls: Vec<CallParams>,
-    /// Enabled permissions per chain
+    /// Opaque capability requests keyed by capability name.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub capabilities: Option<HashMap<String, serde_json::Value>>,
 }
 
-/// Call parameters for `wallet_sendCalls`
+/// Call parameters for the legacy sequencer-specific request shape.
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CallParams {
@@ -28,7 +34,9 @@ pub struct CallParams {
     /// Transferred value
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub value: Option<U256>,
-    /// Id of target chain
+    /// ID of the target chain.
+    ///
+    /// Final EIP-5792 instead places one required `chainId` on the enclosing request.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub chain_id: Option<ChainId>,
 }

--- a/crates/eip5792/src/wallet.rs
+++ b/crates/eip5792/src/wallet.rs
@@ -1,7 +1,7 @@
 use alloy_primitives::{map::HashMap, Address, ChainId};
 use serde::{Deserialize, Serialize};
 
-/// The capability to perform [EIP-7702][eip-7702] delegations, sponsored by the sequencer.
+/// A legacy, sequencer-specific capability for sponsored [EIP-7702][eip-7702] delegations.
 ///
 /// The sequencer will only perform delegations, and act on behalf of delegated accounts, if the
 /// account delegates to one of the addresses specified within this capability.
@@ -13,14 +13,16 @@ pub struct DelegationCapability {
     pub addresses: Vec<Address>,
 }
 
-/// Wallet capabilities for a specific chain.
+/// Legacy sequencer-specific wallet capabilities for a chain.
+///
+/// This is not the capability object defined by the Final EIP-5792 schema.
 #[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
 pub struct Capabilities {
     /// The capability to delegate.
     pub delegation: DelegationCapability,
 }
 
-/// A map of wallet capabilities per chain ID.
+/// A legacy map of sequencer-specific wallet capabilities per chain ID.
 #[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
 pub struct WalletCapabilities(
     #[serde(with = "alloy_serde::quantity::hashmap")] pub HashMap<ChainId, Capabilities>,

--- a/crates/eip7547/README.md
+++ b/crates/eip7547/README.md
@@ -1,5 +1,11 @@
 # alloy-eip7547
 
-Includes the EIP-7547 engine types.
+Experimental types for the historical Engine API draft linked below.
 
-Currently based on the [EIP-7547 engine API spec](https://github.com/michaelneuder/execution-apis/pull/1).
+These types do not match the current, stagnant [EIP-7547] text. Notably, this draft uses a
+`2**22` inclusion-list gas limit, `{ address, nonce }` summary entries, and a `parentHash`; the
+published EIP uses `2**21`, `{ address, gas_limit }`, and no `parent_hash`. Use these types only
+with implementations of the [historical Engine API draft].
+
+[EIP-7547]: https://eips.ethereum.org/EIPS/eip-7547
+[historical Engine API draft]: https://github.com/michaelneuder/execution-apis/pull/1

--- a/crates/eip7547/src/constants.rs
+++ b/crates/eip7547/src/constants.rs
@@ -1,8 +1,10 @@
 //! Constants related to EIP-7547.
 
-/// The maximum gas allowed for the inclusion list.
+/// The maximum gas allowed by the historical Engine API draft implemented by this crate.
 ///
-/// Based on the following part of the spec:
+/// This is `2**22`, not the `2**21` value in the currently published EIP-7547 text.
+///
+/// Based on the following part of the historical draft:
 ///
 /// ## Constants
 ///

--- a/crates/eip7547/src/constants.rs
+++ b/crates/eip7547/src/constants.rs
@@ -1,10 +1,8 @@
 //! Constants related to EIP-7547.
 
-/// The maximum gas allowed by the historical Engine API draft implemented by this crate.
+/// The maximum gas allowed for the inclusion list.
 ///
-/// This is `2**22`, not the `2**21` value in the currently published EIP-7547 text.
-///
-/// Based on the following part of the historical draft:
+/// Based on the following part of the spec:
 ///
 /// ## Constants
 ///

--- a/crates/eip7547/src/summary.rs
+++ b/crates/eip7547/src/summary.rs
@@ -65,10 +65,8 @@ impl Serialize for InclusionListStatusV1 {
     }
 }
 
-/// An inclusion-list entry from the historical Engine API draft implemented by this crate.
-///
-/// This `{ address, nonce }` shape is not the `{ address, gas_limit }` entry in the currently
-/// published EIP-7547 text.
+/// This is an individual entry in the inclusion list summary, representing a transaction that
+/// should be included in this block or the next block.
 ///
 /// From the spec:
 ///
@@ -98,9 +96,8 @@ impl fmt::Display for InclusionListSummaryEntryV1 {
     }
 }
 
-/// Inclusion-list summary input for the historical `engine_newInclusionListV1` draft RPC.
-///
-/// The `parent_hash` field and entry shape do not match the currently published EIP-7547 text.
+/// This structure contains the inclusion list summary input to the `engine_newInclusionListV1` RPC
+/// call.
 ///
 /// ### InclusionListSummaryV1
 ///

--- a/crates/eip7547/src/summary.rs
+++ b/crates/eip7547/src/summary.rs
@@ -65,8 +65,10 @@ impl Serialize for InclusionListStatusV1 {
     }
 }
 
-/// This is an individual entry in the inclusion list summary, representing a transaction that
-/// should be included in this block or the next block.
+/// An inclusion-list entry from the historical Engine API draft implemented by this crate.
+///
+/// This `{ address, nonce }` shape is not the `{ address, gas_limit }` entry in the currently
+/// published EIP-7547 text.
 ///
 /// From the spec:
 ///
@@ -96,8 +98,9 @@ impl fmt::Display for InclusionListSummaryEntryV1 {
     }
 }
 
-/// This structure contains the inclusion list summary input to the `engine_newInclusionListV1` RPC
-/// call.
+/// Inclusion-list summary input for the historical `engine_newInclusionListV1` draft RPC.
+///
+/// The `parent_hash` field and entry shape do not match the currently published EIP-7547 text.
 ///
 /// ### InclusionListSummaryV1
 ///

--- a/crates/eips/src/eip2718.rs
+++ b/crates/eips/src/eip2718.rs
@@ -410,7 +410,11 @@ impl<T: Typed2718> Typed2718 for alloy_serde::WithOtherFields<T> {
     }
 }
 
-/// Generic wrapper with encoded Bytes, such as transaction data.
+/// A value paired with bytes presumed to be its exact EIP-2718 encoding.
+///
+/// [`Self::new`] does not verify that the value and bytes correspond. Mapping and transforming
+/// preserve the bytes unchanged and are correct only for encoding-preserving conversions. Prefer
+/// [`Self::from_2718_encodable`] when constructing this wrapper from a value.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WithEncoded<T>(Bytes, pub T);
 
@@ -421,7 +425,7 @@ impl<T> From<(Bytes, T)> for WithEncoded<T> {
 }
 
 impl<T> WithEncoded<T> {
-    /// Wraps the value with the bytes.
+    /// Wraps the value with caller-supplied bytes without verifying that they correspond.
     pub const fn new(bytes: Bytes, value: T) -> Self {
         Self(bytes, value)
     }
@@ -446,7 +450,7 @@ impl<T> WithEncoded<T> {
         self.1
     }
 
-    /// Transform the value
+    /// Transforms the value while retaining the encoded bytes unchanged.
     pub fn transform<F: From<T>>(self) -> WithEncoded<F> {
         WithEncoded(self.0, self.1.into())
     }
@@ -456,7 +460,7 @@ impl<T> WithEncoded<T> {
         (self.0, self.1)
     }
 
-    /// Maps the inner value to a new value using the given function.
+    /// Maps the inner value while retaining the encoded bytes unchanged.
     pub fn map<U, F: FnOnce(T) -> U>(self, op: F) -> WithEncoded<U> {
         WithEncoded(self.0, op(self.1))
     }
@@ -476,7 +480,7 @@ impl<T: Encodable2718> WithEncoded<T> {
 }
 
 impl<T> WithEncoded<Option<T>> {
-    /// returns `None` if the inner value is `None`, otherwise returns `Some(WithEncoded<T>)`.
+    /// Returns `None` if the inner value is `None`; otherwise retains the encoded bytes unchanged.
     pub fn transpose(self) -> Option<WithEncoded<T>> {
         self.1.map(|v| WithEncoded(self.0, v))
     }

--- a/crates/eips/src/eip4844/sidecar.rs
+++ b/crates/eips/src/eip4844/sidecar.rs
@@ -32,7 +32,13 @@ pub struct IndexedBlobHash {
 
 /// This represents a set of blobs, and its corresponding commitments and proofs.
 ///
-/// This type encodes and decodes the fields without an rlp header.
+/// For a well-formed sidecar, all three vectors have equal lengths and describe the same blob at
+/// each index. Public fields and [`Self::new`] do not enforce this invariant. With the `kzg`
+/// feature, prefer `try_from_blobs_with_settings` or call `validate` before use. Consuming
+/// iteration uses `zip`, so malformed unequal vectors are truncated to the shortest vector.
+///
+/// Its [`Encodable`] and [`Decodable`] implementations include an outer RLP list header. The
+/// field-level [`Encodable7594`] and [`Decodable7594`] codecs omit that header.
 #[derive(Clone, Default, PartialEq, Eq, Hash)]
 #[repr(C)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -235,7 +241,7 @@ impl<'a> arbitrary::Arbitrary<'a> for BlobTransactionSidecar {
 }
 
 impl BlobTransactionSidecar {
-    /// Constructs a new [BlobTransactionSidecar] from a set of blobs, commitments, and proofs.
+    /// Constructs a sidecar without validating vector lengths, commitments, or proofs.
     pub const fn new(blobs: Vec<Blob>, commitments: Vec<Bytes48>, proofs: Vec<Bytes48>) -> Self {
         Self { blobs, commitments, proofs }
     }
@@ -481,7 +487,7 @@ impl BlobTransactionSidecar {
 }
 
 impl Encodable for BlobTransactionSidecar {
-    /// Encodes the inner [BlobTransactionSidecar] fields as RLP bytes, without a RLP header.
+    /// Encodes the sidecar as an RLP list, including its outer header.
     fn encode(&self, out: &mut dyn BufMut) {
         self.rlp_encode(out);
     }
@@ -492,7 +498,7 @@ impl Encodable for BlobTransactionSidecar {
 }
 
 impl Decodable for BlobTransactionSidecar {
-    /// Decodes the inner [BlobTransactionSidecar] fields from RLP bytes, without a RLP header.
+    /// Decodes an RLP list, including its outer header.
     fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
         Self::rlp_decode(buf)
     }

--- a/crates/eips/src/eip7594/sidecar.rs
+++ b/crates/eips/src/eip7594/sidecar.rs
@@ -17,7 +17,8 @@ use crate::eip4844::{AsAlloy, AsCkzg, BlobTransactionValidationError};
 /// This represents a set of blobs, and its corresponding commitments and proofs.
 /// Proof type depends on the sidecar variant.
 ///
-/// This type encodes and decodes the fields without an rlp header.
+/// Its [`Encodable`] and [`Decodable`] implementations include an outer RLP list header. The
+/// field-level [`Encodable7594`] and [`Decodable7594`] codecs omit that header.
 #[derive(Clone, PartialEq, Eq, Hash, Debug, derive_more::From)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[cfg_attr(feature = "serde", serde(untagged))]
@@ -361,7 +362,7 @@ impl BlobTransactionSidecarVariant {
 }
 
 impl Encodable for BlobTransactionSidecarVariant {
-    /// Encodes the [BlobTransactionSidecar] fields as RLP bytes, without a RLP header.
+    /// Encodes the selected sidecar as an RLP list, including its outer header.
     fn encode(&self, out: &mut dyn BufMut) {
         match self {
             Self::Eip4844(sidecar) => sidecar.encode(out),
@@ -378,7 +379,7 @@ impl Encodable for BlobTransactionSidecarVariant {
 }
 
 impl Decodable for BlobTransactionSidecarVariant {
-    /// Decodes the inner [BlobTransactionSidecar] fields from RLP bytes, without a RLP header.
+    /// Decodes an RLP list, including its outer header.
     fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
         let header = Header::decode(buf)?;
         if !header.list {
@@ -509,7 +510,13 @@ impl<'de> serde::Deserialize<'de> for BlobTransactionSidecarVariant {
 
 /// This represents a set of blobs, and its corresponding commitments and cell proofs.
 ///
-/// This type encodes and decodes the fields without an rlp header.
+/// A well-formed sidecar has one commitment per blob and `CELLS_PER_EXT_BLOB` cell proofs per
+/// blob. Public fields and [`Self::new`] do not enforce these cardinalities or validate proofs.
+/// With the `kzg` feature, prefer `try_from_blobs_with_settings` or call `validate` before
+/// use.
+///
+/// Its [`Encodable`] and [`Decodable`] implementations include an outer RLP list header. The
+/// field-level [`Encodable7594`] and [`Decodable7594`] codecs omit that header.
 #[derive(Clone, Default, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
@@ -538,8 +545,7 @@ impl core::fmt::Debug for BlobTransactionSidecarEip7594 {
 }
 
 impl BlobTransactionSidecarEip7594 {
-    /// Constructs a new [BlobTransactionSidecarEip7594] from a set of blobs, commitments, and
-    /// cell proofs.
+    /// Constructs a sidecar without validating cardinalities, commitments, or cell proofs.
     pub const fn new(
         blobs: Vec<Blob>,
         commitments: Vec<Bytes48>,
@@ -1065,7 +1071,7 @@ impl BlobTransactionSidecarEip7594 {
 }
 
 impl Encodable for BlobTransactionSidecarEip7594 {
-    /// Encodes the inner [BlobTransactionSidecarEip7594] fields as RLP bytes, without a RLP header.
+    /// Encodes the sidecar as an RLP list, including its outer header.
     fn encode(&self, out: &mut dyn BufMut) {
         self.rlp_encode(out);
     }
@@ -1076,8 +1082,7 @@ impl Encodable for BlobTransactionSidecarEip7594 {
 }
 
 impl Decodable for BlobTransactionSidecarEip7594 {
-    /// Decodes the inner [BlobTransactionSidecarEip7594] fields from RLP bytes, without a RLP
-    /// header.
+    /// Decodes an RLP list, including its outer header.
     fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
         Self::rlp_decode(buf)
     }

--- a/crates/eips/src/eip7685.rs
+++ b/crates/eips/src/eip7685.rs
@@ -16,6 +16,8 @@ pub const EMPTY_REQUESTS_HASH: B256 =
 ///
 /// The container only holds the `requests` as defined by their respective EIPs. The first byte of
 /// each element is the `request_type` and the remaining bytes are the `request_data`.
+/// Construction and mutable access accept short entries and duplicate type bytes. `requests_hash`
+/// filters entries shorter than type plus data and sorts by type, but does not deduplicate them.
 #[derive(Debug, Clone, PartialEq, Eq, Default, Hash, Deref, DerefMut, From, IntoIterator)]
 #[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -56,7 +58,7 @@ impl ssz::Decode for Requests {
 }
 
 impl Requests {
-    /// Create a new [`Requests`] container from an iterator of items convertible to [`Bytes`].
+    /// Creates a raw container without validating request shape or type uniqueness.
     pub fn from_requests<T: Into<Bytes>>(requests: impl IntoIterator<Item = T>) -> Self {
         Self(requests.into_iter().map(Into::into).collect())
     }
@@ -65,7 +67,7 @@ impl Requests {
         Self(Vec::with_capacity(capacity))
     }
 
-    /// Construct a new [`Requests`] container.
+    /// Constructs a raw container without validating request shape or type uniqueness.
     ///
     /// This function assumes that the request type byte is already included as the
     /// first byte in the provided `Bytes` blob.

--- a/crates/ens/README.md
+++ b/crates/ens/README.md
@@ -2,6 +2,7 @@
 
 Ethereum Name Service utilities like namehash, forward & reverse lookups.
 
-Names passed to this crate must already be normalized according to ENSIP-15. The crate does not
-perform complete normalization or validation before hashing, DNS-encoding, or resolving input;
-`namehash` only applies a legacy rewrite that removes `U+FE0F`.
+Names passed to this crate must already be normalized according to
+[ENSIP-15](https://docs.ens.domains/ensip/15/). The crate does not perform complete normalization or
+validation before hashing, DNS-encoding, or resolving input; `namehash` only applies a legacy
+rewrite that removes `U+FE0F`.

--- a/crates/ens/README.md
+++ b/crates/ens/README.md
@@ -1,3 +1,7 @@
 # alloy-ens
 
 Ethereum Name Service utilities like namehash, forward & reverse lookups.
+
+Names passed to this crate must already be normalized according to ENSIP-15. The crate does not
+perform complete normalization or validation before hashing, DNS-encoding, or resolving input;
+`namehash` only applies a legacy rewrite that removes `U+FE0F`.

--- a/crates/ens/src/lib.rs
+++ b/crates/ens/src/lib.rs
@@ -18,6 +18,7 @@ pub const ENS_ADDRESS: Address = address!("0x00000000000C2E074eC69A0dFb2997BA6C7
 /// (`0xeeeeeeee14d718c2b47d9923deab1335e144eeee`)
 ///
 /// The Universal Resolver is the canonical entry point for all ENS resolution.
+/// Resolution may require EIP-3668 CCIP Read, which must be handled outside this crate's helpers.
 pub const UNIVERSAL_RESOLVER_ADDRESS: Address =
     address!("0xeeeeeeee14d718c2b47d9923deab1335e144eeee");
 
@@ -30,17 +31,21 @@ pub use contract::*;
 #[cfg(feature = "provider")]
 pub use provider::*;
 
-/// ENS name or Ethereum Address.
+/// An ENS name or Ethereum address.
+///
+/// [`FromStr`] first attempts to parse an address, then treats a string containing `.` as a name.
+/// This is only a routing heuristic: it rejects dotless names and does not normalize or validate
+/// ENS names. In contrast, converting from [`String`] always creates [`Name`](Self::Name).
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum NameOrAddress {
-    /// An ENS Name (format does not get checked)
+    /// An ENS name. The value must already be ENSIP-15 normalized; its format is not checked.
     Name(String),
     /// An Ethereum Address
     Address(Address),
 }
 
 impl NameOrAddress {
-    /// Resolves the name to an Ethereum Address.
+    /// Resolves a name to an Ethereum address, or returns an address unchanged without an RPC call.
     #[cfg(feature = "provider")]
     pub async fn resolve<N: alloy_provider::Network, P: alloy_provider::Provider<N>>(
         &self,
@@ -119,15 +124,23 @@ mod contract {
 
         /// ENS Universal Resolver contract.
         ///
-        /// The Universal Resolver is the canonical entry point for ENS resolution.
-        /// It handles CCIP-Read (EIP-3668) for offchain/cross-chain names and
-        /// supports all name types including DNS names.
+        /// The `resolve` item models the canonical Universal Resolver entry point.
+        ///
+        /// It may signal EIP-3668 CCIP Read with an `OffchainLookup` revert. This binding does not
+        /// follow that redirect; the caller must provide CCIP-Read handling separately.
+        ///
+        /// The legacy `reverse(bytes)` item below does **not** match the deployed canonical
+        /// resolver's `reverse(bytes,uint256)` ABI and must not be used with
+        /// [`UNIVERSAL_RESOLVER_ADDRESS`](crate::UNIVERSAL_RESOLVER_ADDRESS).
         #[sol(rpc)]
         contract UniversalResolver {
             /// Resolves an ENS name with the given encoded resolver call data.
             function resolve(bytes calldata name, bytes calldata data) external view returns (bytes memory, address);
 
-            /// Performs reverse resolution for an address.
+            /// A legacy reverse-resolution ABI retained for compatibility.
+            ///
+            /// This selector and return shape do not match the deployed canonical Universal
+            /// Resolver. Do not call it at [`UNIVERSAL_RESOLVER_ADDRESS`](crate::UNIVERSAL_RESOLVER_ADDRESS).
             function reverse(bytes calldata reverseName) external view returns (string memory, address, address, address);
         }
 
@@ -175,6 +188,10 @@ mod provider {
     use alloy_sol_types::SolCall;
 
     /// Extension trait for ENS contract calls.
+    ///
+    /// All ENS name strings must already be normalized according to ENSIP-15. These helpers do not
+    /// perform complete normalization or validation before hashing or DNS-encoding them;
+    /// [`namehash`] only removes `U+FE0F`.
     #[cfg_attr(target_family = "wasm", async_trait::async_trait(?Send))]
     #[cfg_attr(not(target_family = "wasm"), async_trait::async_trait)]
     pub trait ProviderEnsExt<N: alloy_provider::Network, P: Provider<N>> {
@@ -188,13 +205,23 @@ mod provider {
         /// Returns the reverse registrar for the specified node.
         async fn get_reverse_registrar(&self) -> Result<ReverseRegistrarInstance<&P, N>, EnsError>;
 
-        /// Performs a forward lookup of an ENS name to an address using the Universal Resolver.
+        /// Performs a forward lookup of an already-normalized ENS name using the Universal
+        /// Resolver.
+        ///
+        /// The name must also satisfy [`dns_encode`]'s non-empty-label and length preconditions.
+        ///
+        /// EIP-3668 CCIP-Read redirects are not followed by this helper and surface as a resolution
+        /// error unless handling is supplied outside it.
         async fn resolve_name(&self, name: &str) -> Result<Address, EnsError>;
 
-        /// Performs a reverse lookup of an address to an ENS name.
+        /// Reads the legacy `{address}.addr.reverse` record through the ENS registry and resolver.
+        ///
+        /// This is not Universal Resolver multichain reverse resolution. The returned name is not
+        /// normalized or forward-verified; normalize it, resolve it, and compare the resulting
+        /// address before treating the name as an authenticated identity.
         async fn lookup_address(&self, address: &Address) -> Result<String, EnsError>;
 
-        /// Performs a txt lookup of an ENS name.
+        /// Looks up a text record for an already-normalized ENS name.
         async fn lookup_txt(&self, name: &str, key: &str) -> Result<String, EnsError>;
     }
 
@@ -273,7 +300,10 @@ mod provider {
     }
 }
 
-/// Returns the ENS namehash as specified in [EIP-137](https://eips.ethereum.org/EIPS/eip-137)
+/// Returns the ENS namehash as specified in [EIP-137](https://eips.ethereum.org/EIPS/eip-137).
+///
+/// `name` must already be ENSIP-15 normalized. Apart from removing the `U+FE0F` variation selector,
+/// this function hashes labels verbatim and does not normalize or validate them.
 pub fn namehash(name: &str) -> B256 {
     if name.is_empty() {
         return B256::ZERO;
@@ -311,6 +341,12 @@ pub fn namehash(name: &str) -> B256 {
 ///
 /// Each label is prefixed with its length byte, and the name is terminated with a
 /// zero-length label (null byte).
+///
+/// This is an unchecked encoder: `name` must already be ENSIP-15 normalized and non-empty, must
+/// not contain empty labels (including leading, trailing, or repeated dots), and each UTF-8 label
+/// length must fit in a `u8`. The caller is also responsible for the applicable ENSIP-10 and DNS
+/// length limits. Invalid input is encoded without an error; an oversized label's length prefix is
+/// truncated.
 ///
 /// # Examples
 ///

--- a/crates/genesis/src/lib.rs
+++ b/crates/genesis/src/lib.rs
@@ -306,6 +306,9 @@ impl From<GenesisAccount> for TrieAccount {
 ///
 /// Encapsulates parameters shaping network evolution and behavior.
 ///
+/// `Default` is a minimally populated configuration with chain ID 1 and every fork activation
+/// unset. It is not Ethereum mainnet's historical chain configuration.
+///
 /// See [geth's `ChainConfig`
 /// struct](https://github.com/ethereum/go-ethereum/blob/v1.14.0/params/config.go#L326)
 /// for the source of each field.
@@ -1061,15 +1064,17 @@ impl ChainConfig {
         self.is_active_at_block(self.gray_glacier_block, block)
     }
 
-    /// Checks if the blockchain is active at or after the Shanghai fork block and the specified
-    /// timestamp.
+    /// Returns whether London is active at `block` and Shanghai is active at `timestamp`.
+    ///
+    /// Returns `false` if either activation is unset.
     pub fn is_shanghai_active_at_block_and_timestamp(&self, block: u64, timestamp: u64) -> bool {
         self.is_london_active_at_block(block)
             && self.is_active_at_timestamp(self.shanghai_time, timestamp)
     }
 
-    /// Checks if the blockchain is active at or after the Cancun fork block and the specified
-    /// timestamp.
+    /// Returns whether London is active at `block` and Cancun is active at `timestamp`.
+    ///
+    /// Returns `false` if either activation is unset.
     pub fn is_cancun_active_at_block_and_timestamp(&self, block: u64, timestamp: u64) -> bool {
         self.is_london_active_at_block(block)
             && self.is_active_at_timestamp(self.cancun_time, timestamp)

--- a/crates/json-rpc/README.md
+++ b/crates/json-rpc/README.md
@@ -5,30 +5,38 @@ Core types for JSON-RPC 2.0 clients.
 This crate includes data types and traits for JSON-RPC 2.0 requests and
 responses, targeted at RPC client usage.
 
-### Core Model
+## Core model
 
-<!-- TODO: More links and real doctests -->
+A JSON-RPC call contains a method, an ID, and optional parameters; protocol
+notifications omit the ID. Alloy's client-oriented `Request` always serializes
+an `id`, with `Id::None` encoded as JSON `null`. Any type that implements
+[`RpcSend`] may be used as parameters. Parameters are omitted when their Rust
+type is zero-sized, such as `()` or `[(); 0]`; an empty `Vec` is still serialized
+as `[]`.
 
-A JSON-RPC 2.0 request is a JSON object containing an ID, a method name, and
-an arbitrary parameters object. The parameters object may be omitted if empty.
+Responses contain either a success value or an [`ErrorPayload`]. Client code
+usually handles them through [`RpcResult<T, E>`], an alias for
+`Result<T, RpcError<E>>`:
 
-Any object that may be Serialized and Cloned may be used as RPC Parameters.
+- `Ok(T)` means the server returned a successful result.
+- `Err(RpcError::ErrorResp(_))` means the server returned a JSON-RPC error.
+- `Err(RpcError::NullResp)` means a method that requires a value received JSON
+  `null`.
+- Other variants include serialization, deserialization, local usage,
+  unsupported-feature, and transport failures.
 
-Requests are sent via transports (see [alloy-transport]). This results in 1 of
-3 outcomes, captured in the `RpcResult<E>` enum:
+The borrowed response aliases, such as [`BorrowedResponse`] and
+[`BorrowedResponsePacket`], support inspecting payloads without first copying
+them. The client-oriented [`RpcRecv`] trait requires owned response types.
 
-- `Ok(Response)` - The request was successful, and the server returned a
-  response.
-- `ErrResp(ErrorPayload)` - The request was received by the server. Server-side
-  handling was unsuccessful, and the server returned an error response. This
-  indicates a server-side error.
-- `Err(E)` - Some client-side error prevented the request from being received
-  by the server, or prevented the response from being processed. This indicates a client-side or transport-related error.
+Most applications should use [`alloy-rpc-client`] or [`alloy-provider`]
+instead of constructing these protocol types directly.
 
-[alloy-transport]: ../transport
-
-### Limitations
-
-- This library does not support borrowing response data from the deserializer.
-  This is intended to simplify client implementations, but makes the library
-  poorly suited for use in a high-performance server.
+[`alloy-provider`]: https://docs.rs/alloy-provider/
+[`alloy-rpc-client`]: https://docs.rs/alloy-rpc-client/
+[`BorrowedResponse`]: https://docs.rs/alloy-json-rpc/latest/alloy_json_rpc/type.BorrowedResponse.html
+[`BorrowedResponsePacket`]: https://docs.rs/alloy-json-rpc/latest/alloy_json_rpc/type.BorrowedResponsePacket.html
+[`ErrorPayload`]: https://docs.rs/alloy-json-rpc/latest/alloy_json_rpc/struct.ErrorPayload.html
+[`RpcRecv`]: https://docs.rs/alloy-json-rpc/latest/alloy_json_rpc/trait.RpcRecv.html
+[`RpcResult<T, E>`]: https://docs.rs/alloy-json-rpc/latest/alloy_json_rpc/type.RpcResult.html
+[`RpcSend`]: https://docs.rs/alloy-json-rpc/latest/alloy_json_rpc/trait.RpcSend.html

--- a/crates/json-rpc/src/lib.rs
+++ b/crates/json-rpc/src/lib.rs
@@ -6,10 +6,11 @@
 //!
 //! If you find yourself importing this crate, and you are not implementing a
 //! JSON-RPC client or transport, you are likely at the wrong layer of
-//! abstraction. If you want to _use_ a JSON-RPC client, consider using the
-//! [`alloy-transport`] crate.
+//! abstraction. To _use_ a JSON-RPC client, consider [`alloy-rpc-client`] or
+//! the higher-level [`alloy-provider`] crate.
 //!
-//! [`alloy-transport`]: https://docs.rs/alloy-transport/latest/alloy_transport/
+//! [`alloy-provider`]: https://docs.rs/alloy-provider/latest/alloy_provider/
+//! [`alloy-rpc-client`]: https://docs.rs/alloy-rpc-client/latest/alloy_rpc_client/
 //!
 //! ## Usage
 //!

--- a/crates/json-rpc/src/packet.rs
+++ b/crates/json-rpc/src/packet.rs
@@ -133,8 +133,11 @@ impl RequestPacket {
         self.requests().iter().map(|req| req.method())
     }
 
-    /// Retrieves the combined headers from all requests in the packet. If
-    /// multiple requests contain the same header, the last one wins.
+    /// Retrieves the combined HTTP headers from all requests in the packet.
+    ///
+    /// Headers are appended in request order, retaining every value for a repeated name. An HTTP
+    /// batch is sent as one request, so these headers apply to the whole packet rather than to
+    /// individual JSON-RPC calls.
     pub fn headers(&self) -> HeaderMap {
         self.requests().iter().fold(HeaderMap::new(), |mut acc, req| {
             if let Some(http_header_extension) = req.meta().extensions().get::<HeaderMap>() {

--- a/crates/json-rpc/src/request.rs
+++ b/crates/json-rpc/src/request.rs
@@ -337,6 +337,13 @@ where
 /// This struct is used to represent a request that has been serialized, but
 /// not yet sent. It is used by RPC clients to build batch requests and manage
 /// in-flight requests.
+///
+/// The metadata is stored separately from the serialized JSON. Mutating the
+/// metadata's ID or method after serialization does not rewrite the JSON that
+/// will be sent, and can make routing metadata disagree with the wire request.
+/// To change a wire field, modify the original [`Request`] and serialize it
+/// again. Extensions, headers, and subscription status are intentionally
+/// metadata-only.
 #[derive(Clone, Debug)]
 pub struct SerializedRequest {
     meta: RequestMeta,
@@ -360,7 +367,9 @@ impl SerializedRequest {
         &self.meta
     }
 
-    /// Returns a mutable reference to the request metadata (ID and Method).
+    /// Returns a mutable reference to the request metadata (ID and method).
+    ///
+    /// Changing the ID or method does not rewrite [`Self::serialized`].
     pub const fn meta_mut(&mut self) -> &mut RequestMeta {
         &mut self.meta
     }

--- a/crates/json-rpc/src/result.rs
+++ b/crates/json-rpc/src/result.rs
@@ -10,10 +10,11 @@ use std::{any::TypeId, borrow::Borrow};
 ///
 /// The common cases are:
 /// - `Ok(T)` - The server returned a successful response.
-/// - `Err(RpcError::ErrorResponse(ErrResp))` - The server returned an error response.
-/// - `Err(RpcError::SerError(E))` - A serialization error occurred.
-/// - `Err(RpcError::DeserError { err: E, text: String })` - A deserialization error occurred.
-/// - `Err(RpcError::TransportError(E))` - Some client-side or communication error occurred.
+/// - `Err(RpcError::ErrorResp(ErrorPayload<ErrResp>))` - The server returned an error response.
+/// - `Err(RpcError::SerError(serde_json::Error))` - A serialization error occurred.
+/// - `Err(RpcError::DeserError { err: serde_json::Error, text: String })` - A deserialization error
+///   occurred.
+/// - `Err(RpcError::Transport(E))` - Some client-side or communication error occurred.
 pub type RpcResult<T, E, ErrResp = Box<RawValue>> = Result<T, RpcError<E, ErrResp>>;
 
 /// A partially deserialized [`RpcResult`], borrowing from the deserializer.

--- a/crates/network-primitives/README.md
+++ b/crates/network-primitives/README.md
@@ -1,3 +1,19 @@
 # alloy-network-primitives
 
-Primitive types for Alloy network abstraction.
+Response traits and shared types for Alloy's network abstraction.
+
+The response traits (`BlockResponse`, `HeaderResponse`, `TransactionResponse`, and
+`ReceiptResponse`) let generic code inspect network-specific RPC values. `BlockTransactions`
+represents full transactions, hashes only, or the omitted transaction field used by uncle
+responses. Because its JSON representation is untagged, an empty `[]` deserializes as `Full([])`
+and cannot preserve whether a hashes-only request produced it. Builder capability traits describe
+optional transaction fields without choosing a concrete network.
+
+```rust
+use alloy_network_primitives::BlockResponse;
+use alloy_primitives::TxHash;
+
+fn transaction_hashes<B: BlockResponse>(block: &B) -> Vec<TxHash> {
+    block.transactions().hashes().collect()
+}
+```

--- a/crates/network-primitives/src/block.rs
+++ b/crates/network-primitives/src/block.rs
@@ -6,8 +6,14 @@ use alloy_consensus::error::ValueError;
 use alloy_eips::Encodable2718;
 use core::slice;
 
-/// Block Transactions depending on the boolean attribute of `eth_getBlockBy*`,
-/// or if used by `eth_getUncle*`
+/// Representation of the `transactions` field in block JSON-RPC responses.
+///
+/// [`Full`](Self::Full) corresponds to a block requested with full transactions,
+/// [`Hashes`](Self::Hashes) to a block requested with transaction hashes, and
+/// [`Uncle`](Self::Uncle) to the omitted transaction field in uncle responses. `Default` is an
+/// empty `Hashes` value, not an empty `Full` value. With Serde, the representation is untagged and
+/// an empty JSON array deserializes as `Full([])`, so that ambiguous case does not preserve which
+/// request form produced it.
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(untagged))]
@@ -54,7 +60,8 @@ impl<T> BlockTransactions<T> {
 
     /// Converts the transaction type by applying a function to each transaction.
     ///
-    /// Returns the block with the new transaction type.
+    /// The function is called only for [`Self::Full`]; hash and uncle representations pass through
+    /// unchanged.
     pub fn map<U>(self, f: impl FnMut(T) -> U) -> BlockTransactions<U> {
         match self {
             Self::Full(txs) => BlockTransactions::Full(txs.into_iter().map(f).collect()),
@@ -65,7 +72,8 @@ impl<T> BlockTransactions<T> {
 
     /// Converts the transaction type by applying a fallible function to each transaction.
     ///
-    /// Returns the block with the new transaction type if all transactions were successfully.
+    /// The function is called only for [`Self::Full`]; hash and uncle representations pass through
+    /// unchanged.
     pub fn try_map<U, E>(
         self,
         f: impl FnMut(T) -> Result<U, E>,
@@ -89,9 +97,10 @@ impl<T> BlockTransactions<T> {
         }
     }
 
-    /// Calculate the transaction root for the full transactions.
+    /// Calculates a transaction root from the ordered EIP-2718 encodings of full transactions.
     ///
-    /// Returns `None` if this is not the [`BlockTransactions::Full`] variant
+    /// Returns `None` for other representations. This does not compare the result against a block
+    /// header.
     pub fn calculate_transactions_root(&self) -> Option<B256>
     where
         T: Encodable2718,
@@ -108,6 +117,9 @@ impl<T> BlockTransactions<T> {
     /// Returns an iterator over the transactions (if any). This will be empty
     /// if the block is an uncle or if the transaction list contains only
     /// hashes.
+    ///
+    /// Use [`Self::try_into_transactions`] when those representations should be treated as an
+    /// error instead of an empty collection.
     #[doc(alias = "transactions")]
     pub fn txns(&self) -> impl Iterator<Item = &T> {
         self.as_transactions().map(|txs| txs.iter()).unwrap_or_else(|| [].iter())
@@ -115,6 +127,9 @@ impl<T> BlockTransactions<T> {
 
     /// Returns an iterator over the transactions (if any). This will be empty if the block is not
     /// full.
+    ///
+    /// Use [`Self::try_into_transactions`] to preserve the distinction between a full empty block
+    /// and a non-full representation.
     pub fn into_transactions(self) -> vec::IntoIter<T> {
         match self {
             Self::Full(txs) => txs.into_iter(),
@@ -124,7 +139,8 @@ impl<T> BlockTransactions<T> {
 
     /// Consumes the type and returns the transactions as a vector.
     ///
-    /// Note: if this is an uncle or hashes, this will return an empty vector.
+    /// Hash and uncle representations are collapsed to an empty vector. Use
+    /// [`Self::try_into_transactions`] when that distinction matters.
     pub fn into_transactions_vec(self) -> Vec<T> {
         match self {
             Self::Full(txs) => txs,
@@ -134,7 +150,7 @@ impl<T> BlockTransactions<T> {
 
     /// Attempts to unwrap the [`Self::Full`] variant.
     ///
-    /// Returns an error if the type is different variant.
+    /// Returns an error retaining the original representation for hash and uncle variants.
     pub fn try_into_transactions(self) -> Result<Vec<T>, ValueError<Self>> {
         match self {
             Self::Full(txs) => Ok(txs),
@@ -172,7 +188,10 @@ impl<T: TransactionResponse> BlockTransactions<T> {
         Self::Hashes(txs.into_iter().map(|tx| tx.as_ref().tx_hash()).collect())
     }
 
-    /// Converts `self` into `Hashes`.
+    /// Converts full transactions to same-order hashes.
+    ///
+    /// Existing hashes are unchanged. [`Self::Uncle`] is normalized to an empty hash list, losing
+    /// the omitted-field representation.
     #[inline]
     pub fn convert_to_hashes(&mut self) {
         if !self.is_hashes() {
@@ -189,7 +208,10 @@ impl<T: TransactionResponse> BlockTransactions<T> {
         self.convert_to_hashes();
     }
 
-    /// Converts `self` into `Hashes`.
+    /// Converts full transactions to same-order hashes.
+    ///
+    /// Existing hashes are unchanged. [`Self::Uncle`] is normalized to an empty hash list, losing
+    /// the omitted-field representation.
     #[inline]
     pub fn into_hashes(mut self) -> Self {
         self.convert_to_hashes();
@@ -205,7 +227,10 @@ impl<T: TransactionResponse> BlockTransactions<T> {
         self.into_hashes()
     }
 
-    /// Returns an iterator over references to the transaction hashes.
+    /// Returns transaction hashes by value.
+    ///
+    /// Stored hashes are copied, full transactions use [`TransactionResponse::tx_hash`], and
+    /// [`Self::Uncle`] yields an empty iterator.
     #[inline]
     pub fn hashes(&self) -> BlockTransactionHashes<'_, T> {
         BlockTransactionHashes::new(self)
@@ -234,7 +259,7 @@ impl<T: TransactionResponse> From<Vec<T>> for BlockTransactions<T> {
     }
 }
 
-/// An iterator over the transaction hashes of a block.
+/// An iterator over transaction hashes by value.
 ///
 /// See [`BlockTransactions::hashes`].
 #[derive(Clone, Debug)]

--- a/crates/network-primitives/src/traits.rs
+++ b/crates/network-primitives/src/traits.rs
@@ -32,6 +32,8 @@ pub trait ReceiptResponse {
     /// receipts, as it may not accurately reflect the status of the
     /// transaction. The transaction status is not knowable from the receipt
     /// for transactions before [EIP-658].
+    ///
+    /// [EIP-658]: https://eips.ethereum.org/EIPS/eip-658
     fn status(&self) -> bool;
 
     /// Hash of the block this transaction was included within.
@@ -42,7 +44,8 @@ pub trait ReceiptResponse {
 
     /// Returns the [`BlockNumHash`] of the block this transaction was mined in.
     ///
-    /// Returns `None` if this transaction is still pending.
+    /// Returns `None` if either component is absent, as is normally the case for a pending
+    /// transaction.
     fn block_hash_num(&self) -> Option<BlockNumHash> {
         Some(BlockNumHash::new(self.block_number()?, self.block_hash()?))
     }
@@ -59,7 +62,11 @@ pub trait ReceiptResponse {
     /// Effective gas price.
     fn effective_gas_price(&self) -> u128;
 
-    /// Total cost of this transaction = gas_used * effective_gas_price.
+    /// Returns the execution-gas cost in wei: `gas_used * effective_gas_price`.
+    ///
+    /// This excludes blob-gas charges, transferred value, and network-specific fee components;
+    /// it is not the sender's total balance change. The ordinary `u128` multiplication can
+    /// overflow, panicking when overflow checks are enabled or wrapping otherwise.
     fn cost(&self) -> u128 {
         self.gas_used() as u128 * self.effective_gas_price()
     }
@@ -73,18 +80,24 @@ pub trait ReceiptResponse {
     /// Address of the sender.
     fn from(&self) -> Address;
 
-    /// Address of the receiver.
+    /// Address of the receiver, or `None` for contract creation.
     fn to(&self) -> Option<Address>;
 
-    /// Returns the cumulative gas used at this receipt.
+    /// Returns the gas used in the block up to and including this transaction.
     fn cumulative_gas_used(&self) -> u64;
 
-    /// The post-transaction state root (pre Byzantium)
+    /// Returns the post-transaction state root carried by pre-[EIP-658] receipts.
     ///
-    /// EIP98 makes this field optional.
+    /// [EIP-658] replaced this value with a status code, so post-Byzantium receipts normally
+    /// return `None`.
+    ///
+    /// [EIP-658]: https://eips.ethereum.org/EIPS/eip-658
     fn state_root(&self) -> Option<B256>;
 
-    /// Ensures the transaction was successful, returning an error if it failed.
+    /// Ensures the transaction was successful, returning its hash in the error if it failed.
+    ///
+    /// This does not recover revert data and has the same pre-EIP-658 limitation as
+    /// [`Self::status`].
     fn ensure_success(&self) -> Result<(), TransactionFailedError> {
         if self.status() {
             Ok(())
@@ -95,6 +108,10 @@ pub trait ReceiptResponse {
 }
 
 /// Transaction JSON-RPC response. Aggregates transaction data with its block and signer context.
+///
+/// The optional fee accessors split fixed-price and dynamic-fee consensus caps by transaction type
+/// and share names with differently typed methods on [`Transaction`]. Use trait-qualified calls
+/// such as `TransactionResponse::max_fee_per_gas(tx)` when the distinction matters.
 pub trait TransactionResponse: Transaction {
     /// Hash of the transaction
     #[doc(alias = "transaction_hash")]
@@ -102,17 +119,18 @@ pub trait TransactionResponse: Transaction {
 
     /// Returns the hash of the block this transaction was mined in.
     ///
-    /// Returns `None` if this transaction is still pending.
+    /// Returns `None` when absent from the response, normally for a pending transaction.
     fn block_hash(&self) -> Option<BlockHash>;
 
     /// Returns the number of the block this transaction was mined in.
     ///
-    /// Returns `None` if this transaction is still pending.
+    /// Returns `None` when absent from the response, normally for a pending transaction.
     fn block_number(&self) -> Option<u64>;
 
     /// Returns the [`BlockNumHash`] of the block this transaction was mined in.
     ///
-    /// Returns `None` if this transaction is still pending.
+    /// Returns `None` if either component is absent, as is normally the case for a pending
+    /// transaction.
     fn block_hash_num(&self) -> Option<BlockNumHash> {
         Some(BlockNumHash::new(self.block_number()?, self.block_hash()?))
     }
@@ -123,7 +141,11 @@ pub trait TransactionResponse: Transaction {
     /// Sender of the transaction
     fn from(&self) -> Address;
 
-    /// Gas Price, this is the RPC format for `max_fee_per_gas`, pre-eip-1559.
+    /// Returns the fixed gas price for standard Ethereum transaction type IDs 0 and 1.
+    ///
+    /// The default returns the consensus fee cap for those type IDs and `None` for IDs 2 and
+    /// above. Networks with different type numbering or RPC `gasPrice` semantics must override
+    /// this method.
     fn gas_price(&self) -> Option<u128> {
         if self.ty() < 2 {
             return Some(Transaction::max_fee_per_gas(self));
@@ -131,8 +153,10 @@ pub trait TransactionResponse: Transaction {
         None
     }
 
-    /// Max BaseFeePerGas the user is willing to pay. For pre-eip-1559 transactions, the field
-    /// label `gas_price` is used instead.
+    /// Returns the maximum fee per gas for standard Ethereum transaction type IDs 2 and above.
+    ///
+    /// The default returns `None` for type IDs 0 and 1 and the consensus fee cap for later IDs.
+    /// Networks with different type numbering must override this method.
     fn max_fee_per_gas(&self) -> Option<u128> {
         if self.ty() < 2 {
             return None;
@@ -173,9 +197,9 @@ pub trait HeaderResponse: BlockHeader {
 
 /// Block JSON-RPC response.
 pub trait BlockResponse {
-    /// Header type
+    /// Concrete RPC header representation.
     type Header;
-    /// Transaction type
+    /// Full-transaction representation used by [`BlockTransactions::Full`].
     type Transaction: TransactionResponse;
 
     /// Block header
@@ -184,10 +208,16 @@ pub trait BlockResponse {
     /// Block transactions
     fn transactions(&self) -> &BlockTransactions<Self::Transaction>;
 
-    /// Mutable reference to block transactions
+    /// Returns a mutable reference to the block transactions.
+    ///
+    /// Mutating transactions does not recompute or validate header fields such as the transaction
+    /// root.
     fn transactions_mut(&mut self) -> &mut BlockTransactions<Self::Transaction>;
 
-    /// Returns the `other` field from `WithOtherFields` type.
+    /// Returns flattened chain- or client-specific RPC fields when they were retained.
+    ///
+    /// The default is `None`. A [`WithOtherFields`] response returns `Some` even when its map is
+    /// empty.
     fn other_fields(&self) -> Option<&alloy_serde::OtherFields> {
         None
     }

--- a/crates/network-primitives/src/tx_builders.rs
+++ b/crates/network-primitives/src/tx_builders.rs
@@ -26,6 +26,10 @@ pub trait TransactionBuilder4844: Default + Sized + Send + Sync + 'static {
     fn blob_sidecar(&self) -> Option<&BlobTransactionSidecarVariant>;
 
     /// Sets the blob sidecar (either EIP-4844 or EIP-7594 variant) of the transaction.
+    ///
+    /// Implementations that also store blob versioned hashes must replace them with the hashes
+    /// derived from `sidecar` so that the transaction payload remains consistent. The
+    /// variant-specific setters delegate to this method.
     fn set_blob_sidecar(&mut self, sidecar: BlobTransactionSidecarVariant);
 
     /// Builder-pattern method for setting the blob sidecar of the transaction.
@@ -39,10 +43,9 @@ pub trait TransactionBuilder4844: Default + Sized + Send + Sync + 'static {
         self.blob_sidecar().and_then(|s| s.as_eip4844())
     }
 
-    /// Returns true if the transaction contains any blob sidecar data.
+    /// Returns whether the transaction contains an EIP-4844 or EIP-7594 sidecar.
     ///
-    /// By default this checks only the EIP-4844 sidecar accessor. Types that can also carry
-    /// alternate blob sidecar formats, such as EIP-7594, should override this method.
+    /// The default is equivalent to `self.blob_sidecar().is_some()`.
     fn has_blob_sidecar(&self) -> bool {
         self.blob_sidecar().is_some()
     }

--- a/crates/network-primitives/src/tx_meta.rs
+++ b/crates/network-primitives/src/tx_meta.rs
@@ -1,6 +1,10 @@
 use alloy_primitives::B256;
 
-/// Additional fields in the context of a block that contains an included transaction.
+/// Metadata locating an included transaction within a block.
+///
+/// [`crate::TransactionResponse::inclusion_info`] constructs this only when the block hash, block
+/// number, and transaction index are all present. The derived `Default` is an all-zero location;
+/// it is not a pending sentinel.
 #[derive(Debug, Clone, Default, Eq, PartialEq)]
 pub struct InclusionInfo {
     /// The hash of the block.

--- a/crates/network/README.md
+++ b/crates/network/README.md
@@ -1,4 +1,4 @@
-# alloy-networks
+# alloy-network
 
 Ethereum blockchain RPC behavior abstraction.
 
@@ -14,11 +14,10 @@ networking. The core model is as follows:
 
 - `Transaction` - A trait that defines an abstract interface for EVM-like
   transactions.
-- `Network` - A trait that defines the RPC types for a given blockchain.
-  Providers are parameterized by a `Network` type, and use the associated
-  types to define the input and output types of the RPC methods.
-- `TransactionBuilder` - A trait for constructing and validating network-specific transaction requests. Used to build typed transactions for signing and submission. See [`TransactionBuilder`](./src/transaction/builder.rs).
-- `NetworkWallet` - A trait for wallets that can sign transactions for a given network. Used to abstract over different signing backends. See [`NetworkWallet`](./src/transaction/signer.rs).
+- `Network` - A type-level mapping between a blockchain's consensus types and JSON-RPC request and
+  response types. Providers use its associated types to define RPC inputs and outputs.
+- `TransactionBuilder` - A trait for constructing and validating network-specific transaction requests. Used to build typed transactions for signing and submission. See [`TransactionBuilder`](https://docs.rs/alloy-network/latest/alloy_network/trait.TransactionBuilder.html).
+- `NetworkWallet` - A trait for wallets that can sign transactions for a given network. Used to abstract over different signing backends. See [`NetworkWallet`](https://docs.rs/alloy-network/latest/alloy_network/trait.NetworkWallet.html).
 - `BlockResponse`, `TransactionResponse`, `ReceiptResponse`, `HeaderResponse` - Traits (from `alloy-network-primitives`) that define the structure of block, transaction, receipt, and header types used in RPC responses. These are associated types in the `Network` trait and are implemented by network-specific types. See [`alloy-network-primitives`](https://docs.rs/alloy-network-primitives/).
 
 ## Usage
@@ -34,7 +33,8 @@ and then parameterizing the `Provider` type with the new network type.
 For example, to add a new network called `Foo`:
 
 ```rust,ignore
-// Foo must be a ZST. It is a compile error to use a non-ZST type.
+// A ZST is conventional because Network is a type-level marker, but it is not required.
+#[derive(Clone, Copy, Debug)]
 struct Foo;
 
 impl Network for Foo {
@@ -55,17 +55,20 @@ The user may then instantiate a `Provider<Foo>` and use it as normal. This
 allows the user to use the same API for all networks, regardless of the
 underlying RPC types.
 
-**Note:** If you need to also add custom _methods_ to your network, you should
-make an extension trait for `Provider<N>` as follows:
+If the network also needs custom RPC methods, define an extension trait with default method
+implementations and add a blanket implementation for every matching provider:
 
 ```rust,ignore
-#[async_trait]
-trait FooProviderExt: Provider<Foo> {
-    async fn custom_foo_method(&self) -> RpcResult<Something, TransportError>;
+use alloy_provider::Provider;
+use alloy_transport::TransportResult;
 
-    async fn another_custom_method(&self) -> RpcResult<Something, TransportError>;
+trait FooProviderExt: Provider<Foo> {
+    async fn custom_foo_method(&self) -> TransportResult<Something> {
+        self.client().request("foo_customMethod", ()).await
+    }
 }
+
+impl<P: Provider<Foo>> FooProviderExt for P {}
 ```
 
-[alloy-provider]: ../provider
-
+[alloy-provider]: https://docs.rs/alloy-provider/

--- a/crates/node-bindings/README.md
+++ b/crates/node-bindings/README.md
@@ -1,3 +1,31 @@
 # alloy-node-bindings
 
-Ethereum execution-layer client bindings.
+Builders for launching local [Anvil], [Geth], and [Reth] child processes.
+
+The node binaries are not bundled: install them on `PATH`, or select an executable explicitly with
+the builder's `at` or `path` method. Prefer `try_spawn` when startup failures should be returned;
+`spawn` unwraps the result and therefore panics on any startup error. `try_spawn` waits until the
+node's startup output reports its RPC service ready before returning an instance handle.
+Readiness output is consumed synchronously, so a live child that emits no newline can delay a
+configured startup timeout.
+
+```no_run
+use alloy_node_bindings::Anvil;
+
+# fn main() -> Result<(), alloy_node_bindings::NodeError> {
+let anvil = Anvil::new().try_spawn()?;
+println!("Anvil is listening at {}", anvil.endpoint());
+
+// Dropping the handle shuts down the child process.
+drop(anvil);
+# Ok(())
+# }
+```
+
+Keep the returned instance alive for as long as the node is needed. Anvil and Geth default their
+HTTP port to zero; use the returned instance's `port` or `endpoint` method to read the OS-assigned
+port.
+
+[Anvil]: https://docs.rs/alloy-node-bindings/latest/alloy_node_bindings/struct.Anvil.html
+[Geth]: https://docs.rs/alloy-node-bindings/latest/alloy_node_bindings/struct.Geth.html
+[Reth]: https://docs.rs/alloy-node-bindings/latest/alloy_node_bindings/struct.Reth.html

--- a/crates/node-bindings/src/nodes/anvil.rs
+++ b/crates/node-bindings/src/nodes/anvil.rs
@@ -130,24 +130,22 @@ impl Drop for AnvilInstance {
 
 /// Builder for launching `anvil`.
 ///
-/// # Panics
-///
-/// If `spawn` is called without `anvil` being available in the user's $PATH
+/// [`Anvil::spawn`] panics on any startup failure; use [`Anvil::try_spawn`] to handle errors.
 ///
 /// # Example
 ///
 /// ```no_run
 /// use alloy_node_bindings::Anvil;
 ///
-/// let port = 8545u16;
-/// let url = format!("http://localhost:{}", port).to_string();
-///
+/// # fn main() -> Result<(), alloy_node_bindings::NodeError> {
 /// let anvil = Anvil::new()
-///     .port(port)
 ///     .mnemonic("abstract vacuum mammal awkward pudding scene penalty purchase dinner depart evoke puzzle")
-///     .spawn();
+///     .try_spawn()?;
+/// println!("Anvil is listening at {}", anvil.endpoint());
 ///
 /// drop(anvil); // this will kill the instance
+/// # Ok(())
+/// # }
 /// ```
 #[derive(Clone, Debug, Default)]
 #[must_use = "This Builder struct does nothing unless it is `spawn`ed"]
@@ -170,8 +168,10 @@ pub struct Anvil {
 }
 
 impl Anvil {
-    /// Creates an empty Anvil builder.
-    /// The default port and the mnemonic are chosen randomly.
+    /// Creates an Anvil builder.
+    ///
+    /// Unless configured, port zero is passed so the OS chooses an available port, while account
+    /// and mnemonic defaults are left to Anvil.
     ///
     /// # Example
     ///
@@ -191,12 +191,15 @@ impl Anvil {
     ///
     /// # Example
     ///
-    /// ```
-    /// # use alloy_node_bindings::Anvil;
-    /// fn a() {
-    ///  let anvil = Anvil::at("~/.foundry/bin/anvil").spawn();
+    /// Paths are passed directly to [`Command`], so shell expansions such as `~` are not performed.
     ///
-    ///  println!("Anvil running at `{}`", anvil.endpoint());
+    /// ```no_run
+    /// # use alloy_node_bindings::Anvil;
+    /// # fn main() -> Result<(), alloy_node_bindings::NodeError> {
+    /// let anvil = Anvil::at("/path/to/anvil").try_spawn()?;
+    ///
+    /// println!("Anvil running at `{}`", anvil.endpoint());
+    /// # Ok(())
     /// # }
     /// ```
     pub fn at(path: impl Into<PathBuf>) -> Self {
@@ -219,6 +222,9 @@ impl Anvil {
     }
 
     /// Sets the port which will be used when the `anvil` instance is launched.
+    ///
+    /// Port zero asks the OS to choose an available port. Read [`AnvilInstance::port`] or
+    /// [`AnvilInstance::endpoint`] after spawning to obtain the selected value.
     pub fn port<T: Into<u16>>(mut self, port: T) -> Self {
         self.port = Some(port.into());
         self
@@ -398,7 +404,11 @@ impl Anvil {
         self.try_spawn().unwrap()
     }
 
-    /// Consumes the builder and spawns `anvil`. If spawning fails, returns an error.
+    /// Consumes the builder, spawns `anvil`, and waits for it to report its listening address.
+    ///
+    /// Returns an error if the process cannot be started or does not become ready before the
+    /// configured [`Self::timeout`] is observed. The deadline is checked between complete stdout
+    /// lines; a live process that emits no newline can block this call past the deadline.
     pub fn try_spawn(self) -> Result<AnvilInstance, NodeError> {
         let mut cmd = self.program.as_ref().map_or_else(|| Command::new("anvil"), Command::new);
         cmd.stdout(std::process::Stdio::piped()).stderr(std::process::Stdio::inherit());

--- a/crates/node-bindings/src/nodes/geth.rs
+++ b/crates/node-bindings/src/nodes/geth.rs
@@ -144,15 +144,17 @@ impl GethInstance {
 
     /// Takes the stderr contained in the child process.
     ///
-    /// This leaves a `None` in its place, so calling methods that require a stderr to be present
-    /// will fail if called after this.
+    /// Stderr is available only when [`Geth::keep_stderr`] was set. This leaves `None` in its
+    /// place, so later calls that require stderr return [`NodeError::NoStderr`].
     pub fn stderr(&mut self) -> Result<ChildStderr, NodeError> {
         self.pid.stderr.take().ok_or(NodeError::NoStderr)
     }
 
-    /// Blocks until geth adds the specified peer, using 20s as the timeout.
+    /// Blocks until geth adds the specified peer, using a 20-second deadline checked between
+    /// complete stderr lines. A live process that emits no newline can block past the deadline.
     ///
-    /// Requires the stderr to be present in the `GethInstance`.
+    /// Requires [`Geth::keep_stderr`] to have been set and [`Self::stderr`] not to have taken the
+    /// handle.
     pub fn wait_to_add_peer(&mut self, id: &str) -> Result<(), NodeError> {
         let mut stderr = self.pid.stderr.as_mut().ok_or(NodeError::NoStderr)?;
         let mut err_reader = BufReader::new(&mut stderr);
@@ -181,21 +183,23 @@ impl Drop for GethInstance {
 
 /// Builder for launching `geth`.
 ///
-/// # Panics
-///
-/// If `spawn` is called without `geth` being available in the user's $PATH
+/// The default mode is an isolated development chain. [`Geth::p2p_port`] and
+/// [`Geth::disable_discovery`] switch to non-dev mode; [`Geth::dev`] and [`Geth::block_time`]
+/// switch back to dev mode. [`Geth::spawn`] panics on any startup failure; use
+/// [`Geth::try_spawn`] to handle errors.
 ///
 /// # Example
 ///
 /// ```no_run
 /// use alloy_node_bindings::Geth;
 ///
-/// let port = 8545u16;
-/// let url = format!("http://localhost:{}", port).to_string();
-///
-/// let geth = Geth::new().port(port).block_time(5000u64).spawn();
+/// # fn main() -> Result<(), alloy_node_bindings::NodeError> {
+/// let geth = Geth::new().block_time(1).try_spawn()?;
+/// println!("Geth is listening at {}", geth.endpoint());
 ///
 /// drop(geth); // this will kill the instance
+/// # Ok(())
+/// # }
 /// ```
 #[derive(Clone, Debug, Default)]
 #[must_use = "This Builder struct does nothing unless it is `spawn`ed"]
@@ -217,7 +221,7 @@ pub struct Geth {
 }
 
 impl Geth {
-    /// Creates an empty Geth builder.
+    /// Creates a Geth builder in dev mode.
     pub fn new() -> Self {
         Self::default()
     }
@@ -308,7 +312,7 @@ impl Geth {
         self
     }
 
-    /// Sets the block-time which will be used when the `geth-cli` instance is launched.
+    /// Sets the dev-chain block interval in seconds.
     ///
     /// This will put the geth instance in `dev` mode, discarding any previously set options that
     /// cannot be used in dev mode.
@@ -388,7 +392,8 @@ impl Geth {
 
     /// Keep the handle to geth's stderr in order to read from it.
     ///
-    /// Caution: if the stderr handle isn't used, this can end up blocking.
+    /// This is required by [`GethInstance::stderr`] and [`GethInstance::wait_to_add_peer`].
+    /// Caution: if the stderr handle is not continuously consumed, the child process can block.
     pub const fn keep_stderr(mut self) -> Self {
         self.keep_err = true;
         self
@@ -442,7 +447,13 @@ impl Geth {
         self.try_spawn().unwrap()
     }
 
-    /// Consumes the builder and spawns `geth`. If spawning fails, returns an error.
+    /// Consumes the builder, spawns `geth`, and waits for its HTTP and active networking services
+    /// to report ready.
+    ///
+    /// Returns an error if the process cannot be started, reports a fatal startup error, or does
+    /// not become ready before [`NODE_STARTUP_TIMEOUT`] is observed. The deadline is checked
+    /// between complete stderr lines; a live process that emits no newline can block this call
+    /// past the deadline.
     pub fn try_spawn(mut self) -> Result<GethInstance, NodeError> {
         let bin_path = self
             .program

--- a/crates/node-bindings/src/nodes/reth.rs
+++ b/crates/node-bindings/src/nodes/reth.rs
@@ -1,4 +1,4 @@
-//! Utilities for launching a Reth dev-mode instance.
+//! Utilities for configuring and launching a Reth node.
 
 use crate::{
     utils::{extract_endpoint, GracefulShutdown},
@@ -122,8 +122,8 @@ impl RethInstance {
 
     /// Takes the stdout contained in the child process.
     ///
-    /// This leaves a `None` in its place, so calling methods that require a stdout to be present
-    /// will fail if called after this.
+    /// Stdout is available only when [`Reth::keep_stdout`] was set. This leaves `None` in its
+    /// place, so a second call returns [`NodeError::NoStdout`].
     pub fn stdout(&mut self) -> Result<ChildStdout, NodeError> {
         self.pid.stdout.take().ok_or(NodeError::NoStdout)
     }
@@ -137,21 +137,21 @@ impl Drop for RethInstance {
 
 /// Builder for launching `reth`.
 ///
-/// # Panics
-///
-/// If `spawn` is called without `reth` being available in the user's $PATH
+/// [`Reth::new`] configures a regular node. Call [`Reth::dev`] for an isolated development chain.
+/// [`Reth::spawn`] panics on any startup failure; use [`Reth::try_spawn`] to handle errors.
 ///
 /// # Example
 ///
 /// ```no_run
 /// use alloy_node_bindings::Reth;
 ///
-/// let port = 8545u16;
-/// let url = format!("http://localhost:{}", port).to_string();
-///
-/// let reth = Reth::new().instance(1).block_time("12sec").spawn();
+/// # fn main() -> Result<(), alloy_node_bindings::NodeError> {
+/// let reth = Reth::new().dev().block_time("12s").try_spawn()?;
+/// println!("Reth is listening at {}", reth.endpoint());
 ///
 /// drop(reth); // this will kill the instance
+/// # Ok(())
+/// # }
 /// ```
 #[derive(Clone, Debug)]
 #[must_use = "This Builder struct does nothing unless it is `spawn`ed"]
@@ -182,11 +182,11 @@ impl Default for Reth {
 }
 
 impl Reth {
-    /// Creates an empty Reth builder.
+    /// Creates a Reth builder in regular (non-dev) mode.
     ///
-    /// The instance number is set to a random number between 1 and 200 by default to reduce the
-    /// odds of port conflicts. This can be changed with [`Reth::instance`]. Set to 0 to use the
-    /// default ports. 200 is the maximum number of instances that can be run set by Reth.
+    /// The instance number is chosen from `1..=199` to reduce the odds of port conflicts. Change it
+    /// with [`Reth::instance`], or set it to zero to use Reth's base default ports. Reth permits
+    /// instance numbers up to 200.
     pub fn new() -> Self {
         Self {
             dev: false,
@@ -213,12 +213,13 @@ impl Reth {
     ///
     /// # Example
     ///
-    /// ```
+    /// ```no_run
     /// use alloy_node_bindings::Reth;
-    /// # fn a() {
-    /// let reth = Reth::at("../reth/target/release/reth").spawn();
+    /// # fn main() -> Result<(), alloy_node_bindings::NodeError> {
+    /// let reth = Reth::at("/path/to/reth").dev().try_spawn()?;
     ///
     /// println!("Reth running at `{}`", reth.endpoint());
+    /// # Ok(())
     /// # }
     /// ```
     pub fn at(path: impl Into<PathBuf>) -> Self {
@@ -280,9 +281,10 @@ impl Reth {
         self
     }
 
-    /// Sets the block time for the Reth instance.
-    /// Parses strings using <https://docs.rs/humantime/latest/humantime/fn.parse_duration.html>
-    /// This is only used if `dev` mode is enabled.
+    /// Sets the block time for a dev-mode Reth instance.
+    ///
+    /// Reth parses this with `humantime` syntax, such as `"12s"`. The setting is ignored unless
+    /// [`Self::dev`] is also enabled.
     pub fn block_time(mut self, block_time: &str) -> Self {
         self.block_time = Some(block_time.to_string());
         self
@@ -309,8 +311,9 @@ impl Reth {
         self
     }
 
-    /// Sets the instance number for the Reth instance. Set to 0 to use the default ports.
-    /// By default, a random number between 1 and 200 is used.
+    /// Sets the Reth instance number. Set to zero to use the base default ports.
+    ///
+    /// By default, a random number in `1..=199` is used; Reth permits values up to 200.
     pub const fn instance(mut self, instance: u16) -> Self {
         self.instance = instance;
         self
@@ -382,7 +385,12 @@ impl Reth {
         self.try_spawn().unwrap()
     }
 
-    /// Consumes the builder and spawns `reth`. If spawning fails, returns an error.
+    /// Consumes the builder, spawns `reth`, and waits for its services to report ready.
+    ///
+    /// Returns an error if the process cannot be started, reports a fatal startup error, or does
+    /// not become ready before [`NODE_STARTUP_TIMEOUT`] is observed. The deadline is checked
+    /// between complete stdout lines; a live process that emits no newline can block this call
+    /// past the deadline.
     pub fn try_spawn(self) -> Result<RethInstance, NodeError> {
         let bin_path = self
             .program

--- a/crates/provider/src/builder.rs
+++ b/crates/provider/src/builder.rs
@@ -114,6 +114,33 @@ where
 /// enabled, whereas `ProviderBuilder::default()` will instantiate it in its vanilla
 /// [`ProviderBuilder`] form i.e with no fillers enabled.
 ///
+/// # Filler ordering
+///
+/// For Ethereum, `new()` already includes gas, blob-gas, cached-nonce, and chain-ID fillers.
+/// Methods such as [`with_gas_estimation`](Self::with_gas_estimation) append another filler; they
+/// do not replace one from the recommended set. Start with
+/// [`disable_recommended_fillers`](Self::disable_recommended_fillers) (or `default()`) when
+/// assembling those fillers explicitly.
+///
+/// [`network`](Self::network) replaces the entire filler stack with the target network's
+/// recommended fillers, so select the network before adding custom fillers or a wallet. Fillers
+/// that modify a transaction request should be added before [`wallet`](Self::wallet), which signs
+/// the request and turns it into an envelope.
+///
+/// ```
+/// use alloy_provider::ProviderBuilder;
+///
+/// // Use the complete recommended set as-is.
+/// let _recommended = ProviderBuilder::new();
+///
+/// // Or opt out before assembling an explicit set; these calls append in order.
+/// let _custom = ProviderBuilder::new()
+///     .disable_recommended_fillers()
+///     .with_gas_estimation()
+///     .with_cached_nonce_management()
+///     .fetch_chain_id();
+/// ```
+///
 /// [`tower::ServiceBuilder`]: https://docs.rs/tower/latest/tower/struct.ServiceBuilder.html
 #[derive(Debug)]
 pub struct ProviderBuilder<L, F, N = Ethereum> {
@@ -131,8 +158,8 @@ impl
 {
     /// Create a new [`ProviderBuilder`] with the recommended filler enabled.
     ///
-    /// Recommended fillers are preconfigured set of fillers that handle gas estimation, nonce
-    /// management, and chain-id fetching.
+    /// For Ethereum, the recommended set handles gas and blob-gas estimation, cached nonce
+    /// management, and chain-ID fetching.
     ///
     /// Building a provider with this setting enabled will return a [`crate::fillers::FillProvider`]
     /// with [`crate::utils::JoinedRecommendedFillers`].
@@ -171,8 +198,7 @@ impl ProviderBuilder<Identity, Identity, Ethereum> {
 }
 
 impl<L, N: Network> ProviderBuilder<L, Identity, N> {
-    /// Add preconfigured set of layers handling gas estimation, nonce
-    /// management, and chain-id fetching.
+    /// Add the network's preconfigured set of transaction fillers.
     pub fn with_recommended_fillers(
         self,
     ) -> ProviderBuilder<L, JoinFill<Identity, N::RecommendedFillers>, N>

--- a/crates/provider/src/fillers/mod.rs
+++ b/crates/provider/src/fillers/mod.rs
@@ -371,19 +371,26 @@ where
     ///
     /// ```rust
     /// # use alloy_consensus::{TypedTransaction, SignableTransaction};
-    /// # use alloy_primitives::{address, U256};
-    /// # use alloy_provider::ProviderBuilder;
+    /// # use alloy_primitives::{Address, U256};
+    /// # use alloy_provider::{Provider, ProviderBuilder};
     /// # use alloy_rpc_types_eth::TransactionRequest;
     /// # use alloy_network::{NetworkTransactionBuilder, TransactionBuilder};
     ///
     /// # #[cfg(feature = "anvil-node")]
     /// async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    ///     // Create transaction request
-    ///     let tx_request = TransactionRequest::default()
-    ///         .with_from(address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045"))
-    ///         .with_value(U256::from(1000));
+    ///     // Do not add a wallet: this example needs the filled request, not a signed envelope.
+    ///     let provider = ProviderBuilder::new().connect_anvil();
+    ///     let from = provider
+    ///         .get_accounts()
+    ///         .await?
+    ///         .into_iter()
+    ///         .next()
+    ///         .expect("Anvil provides funded accounts");
     ///
-    ///     let provider = ProviderBuilder::new().connect_anvil_with_wallet();
+    ///     let tx_request = TransactionRequest::default()
+    ///         .with_from(from)
+    ///         .with_to(Address::ZERO)
+    ///         .with_value(U256::from(1000));
     ///
     ///     // Fill transaction with provider data
     ///     let filled_tx = provider.fill(tx_request).await?;

--- a/crates/provider/src/fillers/nonce.rs
+++ b/crates/provider/src/fillers/nonce.rs
@@ -22,12 +22,10 @@ pub trait NonceManager: Clone + Send + Sync + std::fmt::Debug {
         N: Network;
 }
 
-/// This [`NonceManager`] implementation will fetch the transaction count for any new account it
-/// sees.
-///
-/// Unlike [`CachedNonceManager`], this implementation does not store the transaction count locally,
-/// which results in more frequent calls to the provider, but it is more resilient to chain
-/// reorganizations.
+/// This [`NonceManager`] fetches the pending transaction count on every request and does not
+/// reserve nonces locally. It makes more RPC calls than [`CachedNonceManager`] and is more
+/// resilient to chain reorganizations, but concurrent transactions from the same address can
+/// receive the same nonce.
 #[derive(Clone, Debug, Default)]
 #[non_exhaustive]
 pub struct SimpleNonceManager;
@@ -46,9 +44,13 @@ impl NonceManager for SimpleNonceManager {
 
 /// Cached nonce manager
 ///
-/// This [`NonceManager`] implementation will fetch the transaction count for any new account it
-/// sees, store it locally and increment the locally stored nonce as transactions are sent via
-/// [`Provider::send_transaction`].
+/// This [`NonceManager`] fetches the pending transaction count the first time it sees an account,
+/// then reserves subsequent nonces locally as transactions are filled. Clones share the same
+/// per-address state, so they can allocate distinct nonces to concurrent requests.
+///
+/// The local nonce advances before broadcast. A failed submission, a chain reorganization, or a
+/// transaction sent through another manager can therefore leave it out of sync with the node; it
+/// does not resynchronize automatically.
 ///
 /// There is also an alternative implementation [`SimpleNonceManager`] that does not store the
 /// transaction count locally.
@@ -95,9 +97,10 @@ impl NonceManager for CachedNonceManager {
 /// # Note
 ///
 /// - If the transaction request does not have a sender set, this layer will not fill nonces.
-/// - Using two providers with their own nonce layer can potentially fill invalid nonces if
-///   transactions are sent from the same address, as the next nonce to be used is cached internally
-///   in the layer.
+/// - An explicit nonce is preserved and does not consult the manager.
+/// - For concurrent sends from one address, reuse a provider or cloned [`CachedNonceManager`]. Two
+///   independent cached managers can allocate conflicting nonces, while [`SimpleNonceManager`] does
+///   not reserve nonces between concurrent requests.
 ///
 /// # Example
 ///
@@ -134,8 +137,8 @@ impl<M: NonceManager> NonceFiller<M> {
 
     /// Creates a new [`NonceFiller`] with the [`SimpleNonceManager`].
     ///
-    /// [`SimpleNonceManager`] will fetch the transaction count for any new account it sees,
-    /// resulting in frequent RPC calls.
+    /// [`SimpleNonceManager`] fetches the pending transaction count for every request, resulting in
+    /// frequent RPC calls and no local nonce reservation.
     pub const fn simple() -> NonceFiller<SimpleNonceManager> {
         NonceFiller { nonce_manager: SimpleNonceManager }
     }
@@ -143,8 +146,9 @@ impl<M: NonceManager> NonceFiller<M> {
     /// Creates a new [`NonceFiller`] with the [`CachedNonceManager`].
     ///
     /// [`CachedNonceManager`] will fetch the transaction count for any new account it sees,
-    /// store it locally and increment the locally stored nonce as transactions are sent via
-    /// [`Provider::send_transaction`], reducing the number of RPC calls.
+    /// store it locally, and increment the locally stored nonce as transactions are filled,
+    /// reducing the number of RPC calls. Reservation happens before broadcast and also applies to
+    /// direct [`FillProvider::fill`](crate::fillers::FillProvider::fill) calls.
     pub fn cached() -> NonceFiller<CachedNonceManager> {
         NonceFiller { nonce_manager: CachedNonceManager::default() }
     }

--- a/crates/provider/src/layers/cache.rs
+++ b/crates/provider/src/layers/cache.rs
@@ -19,11 +19,15 @@ use serde::{Deserialize, Serialize};
 use std::{io::BufReader, marker::PhantomData, num::NonZero, path::PathBuf, sync::Arc};
 /// A provider layer that caches RPC responses and serves them on subsequent requests.
 ///
-/// In order to initialize the caching layer, the path to the cache file is provided along with the
-/// max number of items that are stored in the in-memory LRU cache.
+/// The cache is an in-memory LRU with a fixed maximum item count. Block-sensitive methods are
+/// cached only for explicit block numbers or hashes; dynamic tags such as `latest` and `pending`
+/// bypass the cache. Log queries are cached only when pinned to a block hash or a fixed numeric
+/// range. It also caches block receipts, included transactions, raw transactions, and transaction
+/// receipts; other [`Provider`] methods pass through to the inner provider.
 ///
-/// One can load the cache from the file system by calling `load_cache` and save the cache to the
-/// file system by calling `save_cache`.
+/// Persistence is opt-in. Obtain a [`SharedCache`] with [`CacheLayer::cache`] before applying the
+/// layer, retain that handle, and use [`SharedCache::load_cache`] or [`SharedCache::save_cache`].
+/// There is no automatic persistence or invalidation.
 #[derive(Debug, Clone)]
 pub struct CacheLayer {
     /// In-memory LRU cache, mapping requests to responses.
@@ -64,9 +68,8 @@ where
 /// from the [`Provider`] trait. It attempts to fetch from the cache and fallbacks to
 /// the RPC in case of a cache miss.
 ///
-/// Most importantly, the [`CacheProvider`] adds `save_cache` and `load_cache` methods
-/// to the provider interface, allowing users to save the cache to disk and load it
-/// from there on demand.
+/// Access to persistence remains on the shared [`SharedCache`] handle obtained from
+/// [`CacheLayer::cache`].
 #[derive(Debug, Clone)]
 pub struct CacheProvider<P, N> {
     /// Inner provider.
@@ -532,7 +535,7 @@ impl SharedCache {
         self.max_items.get() as u32
     }
 
-    /// Puts a value into the cache, and returns the old value if it existed.
+    /// Puts a value into the cache and returns whether an existing value was replaced.
     pub fn put(&self, key: B256, value: String) -> TransportResult<bool> {
         Ok(self.inner.write().put(key, value).is_some())
     }
@@ -569,8 +572,10 @@ impl SharedCache {
         Ok(())
     }
 
-    /// Loads the cache from a file specified by the path.
-    /// If the file does not exist, it returns without error.
+    /// Loads entries from a file and merges them into the existing cache.
+    ///
+    /// Existing keys may be replaced, and entries beyond the configured capacity are evicted
+    /// according to the LRU policy. If the file does not exist, this returns without error.
     pub fn load_cache(&self, path: PathBuf) -> TransportResult<()> {
         if !path.exists() {
             return Ok(());

--- a/crates/provider/src/provider/eth_call/mod.rs
+++ b/crates/provider/src/provider/eth_call/mod.rs
@@ -141,6 +141,11 @@ where
 /// A builder for an `"eth_call"` request. This type is returned by the
 /// [`Provider::call`] method.
 ///
+/// Builders returned by the default [`Provider::call`] and estimation paths retain only a weak
+/// client handle. Keep the provider alive until such a call is awaited, or awaiting it returns a
+/// backend-gone transport error. Provider layers may supply a custom caller that retains additional
+/// state, as the batching layer does.
+///
 /// [`Provider::call`]: crate::Provider::call
 #[must_use = "EthCall must be awaited to execute the call"]
 #[derive(Clone)]

--- a/crates/provider/src/provider/root.rs
+++ b/crates/provider/src/provider/root.rs
@@ -17,6 +17,14 @@ use alloy_pubsub::{PubSubFrontend, Subscription};
 
 /// The root provider manages the RPC client and the heartbeat. It is at the
 /// base of every provider stack.
+///
+/// Cloning a root provider is cheap: clones share the client and heartbeat. Some deferred APIs,
+/// including default call builders, filter pollers, block or log watch builders, and subscription
+/// request builders, keep only a weak client handle. Keep at least one provider clone alive until
+/// those builders are awaited or their streams are consumed, or they may report that the backend
+/// was dropped or end early. A [`PendingTransactionBuilder`](crate::PendingTransactionBuilder)
+/// instead owns a root-provider clone. Layers can also retain additional state; for example,
+/// batched calls keep their batching backend alive.
 pub struct RootProvider<N: Network = Ethereum> {
     /// The inner state of the root provider.
     pub(crate) inner: Arc<RootProviderInner<N>>,

--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -174,16 +174,10 @@ pub trait Provider<N: Network = Ethereum>: Send + Sync {
     ///
     /// ```no_run
     /// # use alloy_provider::Provider;
-    /// # use alloy_eips::BlockId;
-    /// # use alloy_rpc_types_eth::state::StateOverride;
-    /// # use alloy_transport::BoxTransport;
-    /// # async fn example<P: Provider>(
-    /// #    provider: P,
-    /// #    my_overrides: StateOverride
-    /// # ) -> Result<(), Box<dyn std::error::Error>> {
+    /// # async fn example<P: Provider>(provider: P) -> Result<(), Box<dyn std::error::Error>> {
     /// # let tx = alloy_rpc_types_eth::transaction::TransactionRequest::default();
     /// // Execute a call on the latest block, with no state overrides
-    /// let output = provider.call(tx).await?;
+    /// let output = provider.call(tx).latest().await?;
     /// # Ok(())
     /// # }
     /// ```
@@ -1346,22 +1340,29 @@ pub trait Provider<N: Network = Ethereum>: Send + Sync {
         Ok(PendingTransactionBuilder::new(self.root().clone(), tx_hash))
     }
 
-    /// Broadcasts a transaction to the network.
+    /// Runs any configured transaction fillers and broadcasts a transaction to the network.
+    ///
+    /// The resulting [`SendableTx`] determines submission. An envelope is submitted with
+    /// `eth_sendRawTransaction`; a request builder uses `eth_sendTransaction`, so the node must be
+    /// able to sign for its `from` account. A [`WalletFiller`](crate::fillers::WalletFiller)
+    /// normally transforms a builder into a locally signed envelope, and custom fillers may do the
+    /// same.
     ///
     /// Returns a [`PendingTransactionBuilder`] which can be used to configure
-    /// how and when to await the transaction's confirmation.
+    /// how and when to await the transaction's confirmation. The default is one confirmation with
+    /// no timeout. [`PendingTransactionBuilder::watch`] waits and returns the transaction hash;
+    /// [`PendingTransactionBuilder::get_receipt`] waits and then fetches the receipt.
     ///
     /// # Examples
     ///
     /// See [`PendingTransactionBuilder`] for more examples.
     ///
     /// ```no_run
-    /// # async fn example<N: alloy_network::Network>(provider: impl alloy_provider::Provider, tx: alloy_rpc_types_eth::transaction::TransactionRequest) -> Result<(), Box<dyn std::error::Error>> {
-    /// let tx_hash = provider.send_transaction(tx)
+    /// # async fn example<N: alloy_network::Network>(provider: impl alloy_provider::Provider<N>, tx: N::TransactionRequest) -> Result<(), Box<dyn std::error::Error>> {
+    /// let receipt = provider.send_transaction(tx)
     ///     .await?
     ///     .with_required_confirmations(2)
-    ///     .with_timeout(Some(std::time::Duration::from_secs(60)))
-    ///     .watch()
+    ///     .get_receipt()
     ///     .await?;
     /// # Ok(())
     /// # }

--- a/crates/pubsub/README.md
+++ b/crates/pubsub/README.md
@@ -23,7 +23,7 @@ The PubSub system here consists of 3 logical parts:
 - The **backend** is an actively running connection to the server. Users
   should NEVER instantiate a backend directly. Instead, they should use
   [`PubSubConnect::into_service`] for some connection object. Backends
-  are responsible for managing the connection to the server,accepting user
+  are responsible for managing the connection to the server, accepting user
   requests from the **service** and forwarding server responses to the
   **service**.
 
@@ -53,9 +53,8 @@ This crate provides the following:
   into the expected type, and allows the user to accept or discard unexpected
   responses.
 - [`SubscriptionItem`]: An item in a typed [`Subscription`]. This type is
-  yielded by the subscription via the `recv_any()` API a notification is
-  received and contains the deserialized item. If deserialization fails, it
-  contains the raw JSON value.
+  yielded by the subscription via the `recv_any()` API. It contains the
+  deserialized item, or the raw JSON value if deserialization fails.
 
 ## On Handling Subscriptions
 
@@ -63,25 +62,44 @@ For a normal request, the user sends a request to the **frontend**, and
 later receives a response via a tokio oneshot channel. This is straightforward
 and easy to reason about. Subscriptions, however, are side-effects of other
 requests, and are long-lived. They are managed by the **service** and
-identified by a `U256` id. The **service** uses this id to manage the
-subscription lifecycle, and to dispatch notifications to the correct
-subscribers.
+identified locally by a `B256`. This value is a params-derived alias: it is the
+Keccak-256 hash of the serialized parameters and does not include the method.
+Requests with identical parameters therefore share an alias, including custom
+subscription methods with different names. The service uses this ID to manage
+the subscription lifecycle and dispatch notifications to receivers.
 
 ### Server & Local IDs
 
 When a user issues a subscription request, the **frontend** sends a
 subscription request to the **service**. The **service** dispatches it to the
 RPC server via the **backend**. The **service** then intercepts the RPC server
-response containing the serve id, and assigns a `local_id` to the subscription.
-This `local_id` is used to identify the subscription in the **service** and in
-tasks consuming the subscription, while the `server_id` is used to identify the
-subscription to the RPC server, and to associate notifications with specific
-active subscriptions.
+response containing the server ID and assigns a stable `B256` `local_id` to
+the subscription. Server IDs are represented by [`alloy_json_rpc::SubId`] and
+may be numeric or strings. The `local_id` identifies the subscription in the
+**service** and consumer tasks, while the current `server_id` associates
+notifications with the server-side subscription.
 
-This allows us to use long-lived `local_id` values to manage subscriptions over
-multiple reconnections, without having to notify frontend users of the ID change
-when the server connection is lost. It also prevents race conditions when
-unsubscribing during or immediately after a reconnection.
+This allows the service to keep the consumer-facing `local_id` stable while the
+server ID changes across reconnections.
+
+### Reconnection, replay, and cancellation
+
+After a retryable established-backend failure, the service attempts reconnection under its
+configured retry policy; non-retryable failures terminate it immediately. Following a successful
+reconnect, it re-sends every
+request still awaiting a response and re-creates active subscriptions. If the
+server processed a request but its response was lost, that request may execute
+more than once. Do not rely on at-most-once execution for non-idempotent methods.
+
+Dropping a request future stops waiting locally, but does not cancel a request
+already accepted by the service. Likewise, dropping a [`RawSubscription`] or
+[`Subscription`] only drops that receiver; it does not send
+`eth_unsubscribe`. Call [`PubSubFrontend::unsubscribe`] with the local ID when
+the server-side subscription is no longer needed. `unsubscribe` only queues
+the instruction and does not wait for the server's response. It is best effort:
+an unsubscribe processed while reconnection is re-creating the subscription can
+race with the replacement response, so it is not confirmation of server-side
+teardown.
 
 ### What is a subscription request?
 
@@ -94,8 +112,8 @@ on unknown methods, the `Request`, `SerializedRequest` and `RpcCall` expose
 subscription.
 
 When marking a request as a subscription, the **service** will intercept the
-RPC response, which MUST be a `U256` value. Subscription requests that return
-anything other than a `U256` value will not function.
+RPC response, which must deserialize as an [`alloy_json_rpc::SubId`] (a numeric
+or string ID). Other response types will fail deserialization.
 
 ### Subscription Lifecycle
 
@@ -119,7 +137,7 @@ Subscription Request Lifecycle:
 1. The **service** stores the oneshot channel in its `RequestManager`.
 1. The **service** sends the request to the **backend**.
 1. The **backend** sends the request to the RPC server.
-1. The RPC server responds with a `U256` value (the `server_id`).
+1. The RPC server responds with a numeric or string `server_id`.
 1. The **backend** sends the response to the **service**.
 1. The **service** assigns a `local_id` to the subscription, creates a
    subscription broadcast channel, and stores the relevant information in its
@@ -131,6 +149,7 @@ Subscription Notification Lifecycle
 
 1. The RPC server sends a notification to the **backend**.
 1. The **backend** sends the notification to the **service**.
-1. The **service** looks up the `local_id` in its `SubscriptionManager`.
+1. The **service** maps the notification's `server_id` to its stable
+   `local_id`.
 1. If present, the **service** sends the notification to the relevant channel.
    1. Otherwise, the **service** ignores the notification.

--- a/crates/pubsub/src/frontend.rs
+++ b/crates/pubsub/src/frontend.rs
@@ -49,7 +49,15 @@ impl PubSubFrontend {
         }
     }
 
-    /// Unsubscribe from a subscription.
+    /// Queue an unsubscribe instruction for a local subscription ID.
+    ///
+    /// A successful return means the instruction was sent to the pubsub
+    /// service. It does not wait for the server's `eth_unsubscribe` response.
+    /// Dropping a [`RawSubscription`] does not call this automatically. This is
+    /// best effort: during reconnection it can race with a replacement
+    /// subscription response, so success does not confirm server-side teardown.
+    ///
+    /// [`RawSubscription`]: crate::RawSubscription
     pub fn unsubscribe(&self, id: B256) -> TransportResult<()> {
         self.tx
             .send(PubSubInstruction::Unsubscribe(id))

--- a/crates/pubsub/src/sub.rs
+++ b/crates/pubsub/src/sub.rs
@@ -10,7 +10,10 @@ use tokio_stream::wrappers::{errors::BroadcastStreamRecvError, BroadcastStream};
 /// local ID.
 ///
 /// This type is mostly a wrapper around [`broadcast::Receiver`], and exposes
-/// the same methods.
+/// the same methods. Dropping it removes this receiver but does not unsubscribe
+/// from the server; use [`PubSubFrontend::unsubscribe`] for that.
+///
+/// [`PubSubFrontend::unsubscribe`]: crate::PubSubFrontend::unsubscribe
 #[derive(Debug)]
 pub struct RawSubscription {
     /// The channel via which notifications are received.
@@ -52,8 +55,11 @@ impl RawSubscription {
         self.rx.recv().await
     }
 
-    /// Wrapper for [`resubscribe`]. Create a new Subscription, starting from
-    /// the current tail element.
+    /// Wrapper for [`resubscribe`]. Create a new subscription at the current
+    /// channel tail.
+    ///
+    /// The new receiver gets messages sent after this call, not this
+    /// receiver's unread backlog.
     ///
     /// [`resubscribe`]: broadcast::Receiver::resubscribe
     pub fn resubscribe(&self) -> Self {
@@ -87,8 +93,8 @@ impl RawSubscription {
     }
 }
 
-/// An item in a typed [`Subscription`]. This is either the expected type, or
-/// some serialized value of another type.
+/// An item in a typed [`Subscription`]. This is either the expected type, or a
+/// raw value that could not be deserialized as that type.
 #[derive(Debug)]
 pub enum SubscriptionItem<T> {
     /// The expected item.
@@ -119,6 +125,17 @@ impl<T: DeserializeOwned> From<Box<RawValue>> for SubscriptionItem<T> {
 ///   [`SubscriptionItem::Other`].
 /// - The [`Subscription::recv_result`] and its variants will attempt to deserialize the
 ///   notifications and yield the `serde_json::Result` of the deserialization.
+///
+/// The receiver methods propagate broadcast lag errors. The typed stream
+/// adapters log and skip lag errors; [`SubscriptionStream`] also skips values
+/// that fail to deserialize, while [`SubResultStream`] yields those
+/// deserialization errors.
+///
+/// Dropping this receiver does not unsubscribe from the server. Use
+/// [`PubSubFrontend::unsubscribe`] with [`Subscription::local_id`] when the
+/// subscription is no longer needed.
+///
+/// [`PubSubFrontend::unsubscribe`]: crate::PubSubFrontend::unsubscribe
 #[derive(Debug)]
 #[must_use]
 pub struct Subscription<T> {
@@ -168,16 +185,16 @@ impl<T> Subscription<T> {
         self.inner.len()
     }
 
-    /// Wrapper for [`resubscribe`]. Create a new [`RawSubscription`], starting
-    /// from the current tail element.
+    /// Wrapper for [`resubscribe`]. Create a new [`RawSubscription`] at the
+    /// current channel tail, without copying unread messages.
     ///
     /// [`resubscribe`]: broadcast::Receiver::resubscribe
     pub fn resubscribe_inner(&self) -> RawSubscription {
         self.inner.resubscribe()
     }
 
-    /// Wrapper for [`resubscribe`]. Create a new `Subscription`, starting from
-    /// the current tail element.
+    /// Wrapper for [`resubscribe`]. Create a new `Subscription` at the current
+    /// channel tail, without copying unread messages.
     ///
     /// [`resubscribe`]: broadcast::Receiver::resubscribe
     pub fn resubscribe(&self) -> Self {
@@ -222,7 +239,7 @@ impl<T: DeserializeOwned> Subscription<T> {
 
     /// Convert the subscription into a stream.
     ///
-    /// Errors are logged and ignored.
+    /// Broadcast lag and deserialization errors are logged and skipped.
     pub fn into_stream(self) -> SubscriptionStream<T> {
         SubscriptionStream {
             id: self.inner.local_id,
@@ -232,6 +249,8 @@ impl<T: DeserializeOwned> Subscription<T> {
     }
 
     /// Convert the subscription into a stream that returns deserialization results.
+    ///
+    /// Broadcast lag errors are logged and skipped.
     pub fn into_result_stream(self) -> SubResultStream<T> {
         SubResultStream {
             id: self.inner.local_id,
@@ -240,7 +259,10 @@ impl<T: DeserializeOwned> Subscription<T> {
         }
     }
 
-    /// Convert the subscription into a stream that may yield unexpected types.
+    /// Convert the subscription into a stream that preserves values which do
+    /// not deserialize as `T`.
+    ///
+    /// Broadcast lag errors are logged and skipped.
     pub fn into_any_stream(self) -> SubAnyStream<T> {
         SubAnyStream {
             id: self.inner.local_id,
@@ -320,7 +342,8 @@ impl<T: DeserializeOwned> Subscription<T> {
 }
 
 /// A stream of notifications from the server, identified by a local ID. This
-/// stream may yield unexpected types.
+/// stream preserves values that do not deserialize as `T`, but logs and skips
+/// broadcast lag errors.
 #[derive(Debug)]
 pub struct SubAnyStream<T> {
     id: B256,
@@ -357,8 +380,8 @@ impl<T: DeserializeOwned> Stream for SubAnyStream<T> {
 }
 
 /// A stream of notifications from the server, identified by a local ID. This
-/// stream will yield only the expected type, discarding any notifications of
-/// unexpected types.
+/// stream yields only the expected type, discarding values that fail to
+/// deserialize. Broadcast lag errors are also logged and skipped.
 #[derive(Debug)]
 pub struct SubscriptionStream<T> {
     id: B256,
@@ -403,7 +426,7 @@ impl<T: DeserializeOwned> Stream for SubscriptionStream<T> {
 /// A stream of notifications from the server, identified by a local ID.
 ///
 /// This stream will attempt to deserialize the notifications and yield the [`serde_json::Result`]
-/// of the deserialization.
+/// of the deserialization. Broadcast lag errors are logged and skipped.
 #[derive(Debug)]
 pub struct SubResultStream<T> {
     id: B256,

--- a/crates/rpc-client/src/batch.rs
+++ b/crates/rpc-client/src/batch.rs
@@ -28,8 +28,16 @@ pub(crate) type ChannelMap = HashMap<Id, Channel>;
 
 /// A batch JSON-RPC request, used to bundle requests into a single transport
 /// call.
+///
+/// Calls are serialized when they are added. Sending the batch is still lazy:
+/// [`Self::send`] returns a future, and the transport is not called until that
+/// future is polled. Await the batch before awaiting its [`Waiter`]s.
+///
+/// Responses are matched to waiters by JSON-RPC ID, not response order.
+/// Missing IDs produce a per-waiter error; responses with unknown IDs are
+/// ignored.
 #[derive(Debug)]
-#[must_use = "A BatchRequest does nothing unless sent via `send_batch` and `.await`"]
+#[must_use = "a BatchRequest does nothing unless it is awaited or `send()` is awaited"]
 pub struct BatchRequest<'a> {
     /// The transport via which the batch will be sent.
     transport: ClientRef<'a>,
@@ -42,7 +50,10 @@ pub struct BatchRequest<'a> {
 }
 
 /// Awaits a single response for a request that has been included in a batch.
-#[must_use = "A Waiter does nothing unless the corresponding BatchRequest is sent via `send_batch` and `.await`, AND the Waiter is awaited."]
+///
+/// Await the corresponding [`BatchRequest`] first so transport-level failures
+/// are observed and the response channels are populated.
+#[must_use = "a Waiter requires its BatchRequest to be sent and the Waiter to be awaited"]
 #[pin_project]
 #[derive(Debug)]
 pub struct Waiter<Resp, Output = Resp, Map = fn(Resp) -> Output> {
@@ -144,6 +155,9 @@ impl<'a> BatchRequest<'a> {
 
     /// Add a call to the batch.
     ///
+    /// Unlike [`RpcCall`](crate::RpcCall), this serializes the parameters
+    /// immediately so calls with different parameter types can share a batch.
+    ///
     /// ### Errors
     ///
     /// If the request cannot be serialized, this will return an error.
@@ -156,7 +170,9 @@ impl<'a> BatchRequest<'a> {
         self.push(request)
     }
 
-    /// Send the batch future via its connection.
+    /// Return a future that sends the batch when polled.
+    ///
+    /// This method alone does not dispatch anything; await the returned future.
     pub fn send(self) -> BatchFuture {
         BatchFuture::Prepared {
             transport: self.transport.transport.clone(),

--- a/crates/rpc-client/src/call.rs
+++ b/crates/rpc-client/src/call.rs
@@ -137,6 +137,17 @@ where
 /// [`crate::BatchRequest`], which serializes greedily. This is because the
 /// batch request must immediately erase the `Param` type to allow batching of
 /// requests with different `Param` types, while the `RpcCall` may do so lazily.
+///
+/// ### Cloning and cancellation
+///
+/// A call can be cloned only while it is still prepared, normally before its
+/// first poll. Each clone keeps the same JSON-RPC ID, and polling multiple
+/// clones sends the request multiple times with that ID. Cloning after
+/// dispatch panics.
+///
+/// Dropping an unpolled call leaves it unsent. Dropping a dispatched call stops
+/// waiting locally, but does not guarantee that the remote operation is
+/// cancelled.
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 #[pin_project::pin_project]
 #[derive(Clone)]

--- a/crates/rpc-client/src/poller.rs
+++ b/crates/rpc-client/src/poller.rs
@@ -30,8 +30,20 @@ use tokio::time::{sleep, Sleep};
 /// channel size of 16, and no limit on the number of successful polls. This is all configurable.
 ///
 /// The builder is consumed using the [`spawn`](Self::spawn) method, which returns a channel to
-/// receive the responses. The task will continue to poll until either the client or the channel is
-/// dropped.
+/// receive the responses. A spawned task normally stops when it observes that the client or every
+/// receiving channel has been dropped, or when another configured terminal condition is reached.
+///
+/// The configured interval is a delay after each request finishes, not a
+/// fixed-rate schedule. The limit counts successful responses. Request,
+/// response, and transport errors are logged rather than yielded, then retried
+/// after the interval unless a configured terminal error is received. With no
+/// configured terminal codes, a JSON-RPC error response whose message contains
+/// `filter not found` also terminates the poller.
+///
+/// Pollers hold a [`WeakClient`] between attempts. Each in-flight request temporarily upgrades it
+/// and keeps the client alive until that request completes. Receiver closure is observed when a
+/// successful response is sent, so repeated failures or a request that never completes can delay
+/// task shutdown after all channels are dropped.
 ///
 /// The channel can be converted into a stream using the [`into_stream`](PollChannel::into_stream)
 /// method.
@@ -137,6 +149,8 @@ where
     }
 
     /// Sets the error codes this poller will terminate on.
+    ///
+    /// A non-empty set replaces the default `filter not found` message check.
     pub fn set_terminal_error_codes<I>(&mut self, error_codes: I)
     where
         I: IntoIterator<Item = i64>,
@@ -145,6 +159,8 @@ where
     }
 
     /// Sets the error codes this poller will terminate on.
+    ///
+    /// A non-empty set replaces the default `filter not found` message check.
     pub fn with_terminal_error_codes<I>(mut self, error_codes: I) -> Self
     where
         I: IntoIterator<Item = i64>,
@@ -229,7 +245,9 @@ enum PollState<Resp> {
 
 /// A stream of responses from polling an RPC method.
 ///
-/// This stream polls the given RPC method at the specified interval and yields the responses.
+/// This stream polls the given RPC method and yields successful responses. It
+/// waits for the configured interval after each attempt completes; errors are
+/// logged and not yielded.
 ///
 /// # Examples
 ///
@@ -452,13 +470,10 @@ where
 
 /// A channel yielding responses from a poller task.
 ///
-/// This stream is backed by a coroutine, and will continue to produce responses
-/// until the poller task is dropped. The poller task is dropped when all
-/// [`RpcClient`] instances are dropped, or when all listening `PollChannel` are
-/// dropped.
-///
-/// The poller task also ignores errors from the server and deserialization
-/// errors, and will continue to poll until the client is dropped.
+/// The background task stops when it observes that the client or all listening `PollChannel`s have
+/// been dropped, the success limit is reached, or a terminal error is received. Channel closure is
+/// checked while forwarding a successful response; repeated failures or a request that never
+/// completes can delay shutdown. Other errors are logged and retried after the configured interval.
 ///
 /// [`RpcClient`]: crate::RpcClient
 #[derive(Debug)]
@@ -495,7 +510,10 @@ where
         Self { rx: self.rx.resubscribe() }
     }
 
-    /// Converts the poll channel into a stream.
+    /// Converts the poll channel into a stream, skipping broadcast lag errors.
+    ///
+    /// Use [`Self::into_stream_raw`] to observe when a slow receiver loses
+    /// responses.
     pub fn into_stream(self) -> impl Stream<Item = Resp> + Unpin {
         self.into_stream_raw().filter_map(|r| futures::future::ready(r.ok()))
     }

--- a/crates/rpc-types-any/src/transaction/receipt.rs
+++ b/crates/rpc-types-any/src/transaction/receipt.rs
@@ -7,6 +7,11 @@ use core::ops::{Deref, DerefMut};
 use serde::{Deserialize, Serialize};
 
 /// A catch-all receipt type for handling receipts on multiple networks.
+///
+/// Unknown top-level, network-specific RPC fields are retained in [`OtherFields`]. Inspect them
+/// through [`Self::other_fields`] or [`Self::deserialize_other`]. Methods that return only a
+/// [`TransactionReceipt`], including [`Self::into_inner`], mapping, and conversion methods,
+/// discard those fields; use [`Self::into_parts`] to retain both components.
 #[doc(alias = "AnyTxReceipt")]
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AnyTransactionReceipt(pub WithOtherFields<TransactionReceipt<AnyReceiptEnvelope<Log>>>);
@@ -23,7 +28,7 @@ impl AnyTransactionReceipt {
         (inner, other)
     }
 
-    /// Consumes the type and returns the wrapped receipt.
+    /// Consumes the type and returns the wrapped receipt, discarding unknown fields.
     pub fn into_inner(self) -> TransactionReceipt<AnyReceiptEnvelope<Log>> {
         self.0.into_inner()
     }

--- a/crates/rpc-types-engine/src/payload.rs
+++ b/crates/rpc-types-engine/src/payload.rs
@@ -765,7 +765,10 @@ impl ExecutionPayloadV1 {
         BlockNumHash::new(self.block_number, self.block_hash)
     }
 
-    /// Converts [`ExecutionPayloadV1`] to [`Block`]
+    /// Converts [`ExecutionPayloadV1`] to an unsealed [`Block`].
+    ///
+    /// This does not recompute or compare the payload's advertised [`Self::block_hash`]. Callers
+    /// performing Engine API validation must hash the returned block and compare it separately.
     pub fn try_into_block<T: Decodable2718>(self) -> Result<Block<T>, PayloadError> {
         self.try_into_block_with(|tx| {
             T::decode_2718_exact(tx.as_ref())
@@ -872,6 +875,8 @@ impl ExecutionPayloadV1 {
     }
 
     /// Converts [`alloy_consensus::Block`] to [`ExecutionPayloadV1`] using the given block hash.
+    ///
+    /// The supplied hash is stored verbatim without checking it against the block.
     pub fn from_block_unchecked<T, H>(block_hash: B256, block: &Block<T, H>) -> Self
     where
         T: Encodable2718,
@@ -2288,6 +2293,10 @@ impl TryFrom<BlobsBundleV2> for BlobsBundleV1 {
 
 /// An execution payload, which can be either [ExecutionPayloadV1], [ExecutionPayloadV2],
 /// [ExecutionPayloadV3], or [ExecutionPayloadV4].
+///
+/// Payload-to-block conversions return an unsealed block and do not recompute or compare the
+/// advertised `block_hash`. Callers performing Engine API validation must hash the returned block
+/// and compare it separately.
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[cfg_attr(feature = "serde", serde(untagged))]
@@ -2375,6 +2384,10 @@ impl ExecutionPayload {
     ///
     /// See also [`ExecutionPayloadV3::from_block_unchecked`].
     /// See also [`ExecutionPayloadSidecar::from_block`].
+    ///
+    /// The supplied hash is stored verbatim without checking it against the block. The payload
+    /// version is inferred from the block access-list hash, parent beacon block root, and
+    /// withdrawals.
     pub fn from_block_unchecked<T, H>(
         block_hash: B256,
         block: &Block<T, H>,
@@ -2468,6 +2481,7 @@ impl ExecutionPayload {
     /// Tries to create a new unsealed block from the given payload and payload sidecar.
     ///
     /// Performs additional validation of `extra_data` and `base_fee_per_gas` fields.
+    /// The payload's advertised `block_hash` is not recomputed or compared.
     ///
     /// # Note
     ///
@@ -2517,6 +2531,9 @@ impl ExecutionPayload {
     }
 
     /// Converts [`ExecutionPayload`] to [`Block`].
+    ///
+    /// The returned block is unsealed, and the payload's advertised `block_hash` is not recomputed
+    /// or compared.
     ///
     /// Caution: This does not set fields that are not part of the payload and only part of the
     /// [`ExecutionPayloadSidecar`]:
@@ -4020,6 +4037,7 @@ impl ExecutionData {
     /// Tries to create a new unsealed block from the given payload and payload sidecar.
     ///
     /// Performs additional validation of `extra_data` and `base_fee_per_gas` fields.
+    /// The payload's advertised `block_hash` is not recomputed or compared.
     ///
     /// # Note
     ///

--- a/crates/rpc-types-eth/README.md
+++ b/crates/rpc-types-eth/README.md
@@ -1,3 +1,21 @@
 # alloy-rpc-types-eth
 
 Types for the `eth` Ethereum JSON-RPC namespace.
+
+Common entry points are `TransactionRequest` for calls and transaction construction, `Filter` and
+`Log` for log queries, `Block` and `Header` for block responses, `TransactionReceipt` for execution
+results, and `StateOverride` for temporary call state.
+
+Transaction type inference is driven by populated fields, while event filters require the complete
+canonical event signature:
+
+```rust
+use alloy_consensus::TxType;
+use alloy_rpc_types_eth::{Filter, TransactionRequest};
+
+let request = TransactionRequest::default();
+assert_eq!(request.preferred_type(), TxType::Eip1559);
+
+let filter = Filter::new().event("Transfer(address,address,uint256)");
+assert!(filter.has_topics());
+```

--- a/crates/rpc-types-eth/src/block.rs
+++ b/crates/rpc-types-eth/src/block.rs
@@ -275,7 +275,10 @@ impl<T, H> Block<T, H> {
 }
 
 impl<T: TransactionResponse, H> Block<T, H> {
-    /// Converts a block with Tx hashes into a full block.
+    /// Converts a block with transaction hashes into a full block.
+    ///
+    /// This replaces the transaction representation without validating the supplied transaction
+    /// hashes, count, or order against the original block or its transactions root.
     pub fn into_full_block(self, txs: Vec<T>) -> Self {
         Self { transactions: txs.into(), ..self }
     }
@@ -304,7 +307,7 @@ impl<T> Block<T> {
         self.header.hash
     }
 
-    /// Returns a sealed reference of the header: `Sealed<&alloy_consensus::Header>`
+    /// Returns a sealed reference of the header using its stored RPC hash without verification.
     pub const fn sealed_header(&self) -> Sealed<&alloy_consensus::Header> {
         Sealed::new_unchecked(&self.header.inner, self.header.hash)
     }
@@ -356,7 +359,8 @@ impl<T> Block<T> {
         .into_block(header.into_consensus())
     }
 
-    /// Same as [`Self::into_consensus`] but returns the block as [`Sealed`] with the block's hash.
+    /// Same as [`Self::into_consensus`] but returns the block as [`Sealed`] with its stored RPC
+    /// hash, without verification or recomputation.
     pub fn into_consensus_sealed(self) -> Sealed<alloy_consensus::Block<T>> {
         let hash = self.header.hash;
         Sealed::new_unchecked(self.into_consensus(), hash)
@@ -375,12 +379,16 @@ where
 /// RPC representation of block header, wrapping a consensus header.
 ///
 /// This wraps the consensus header and adds additional fields for RPC.
+///
+/// The block hash is trusted metadata received from RPC or a seal, not a live view of `inner`.
+/// Mutating or mapping the inner header does not recompute the hash and can make the two
+/// inconsistent. Use [`Self::new`] or reseal the inner header when a recomputed hash is required.
 #[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct Header<H = alloy_consensus::Header> {
-    /// Hash of the block
+    /// Hash of the block as received from RPC or a trusted seal.
     pub hash: BlockHash,
     /// Inner consensus header.
     #[cfg_attr(feature = "serde", serde(flatten))]
@@ -415,6 +423,8 @@ impl<H> Header<H> {
     }
 
     /// Consumes the type and returns the [`Sealed`] header.
+    ///
+    /// This uses the stored hash without verification or recomputation.
     pub fn into_sealed(self) -> Sealed<H> {
         Sealed::new_unchecked(self.inner, self.hash)
     }
@@ -447,6 +457,8 @@ impl<H> Header<H> {
     }
 
     /// Applies the given closure to the inner header.
+    ///
+    /// The stored hash is preserved without checking that the mapped header has the same hash.
     #[expect(clippy::use_self)]
     pub fn map<H1>(self, f: impl FnOnce(H) -> H1) -> Header<H1> {
         let Header { hash, inner, total_difficulty, size } = self;
@@ -455,6 +467,8 @@ impl<H> Header<H> {
     }
 
     /// Applies the given fallible closure to the inner header.
+    ///
+    /// The stored hash is preserved without checking that the mapped header has the same hash.
     #[expect(clippy::use_self)]
     pub fn try_map<H1, E>(self, f: impl FnOnce(H) -> Result<H1, E>) -> Result<Header<H1>, E> {
         let Header { hash, inner, total_difficulty, size } = self;

--- a/crates/rpc-types-eth/src/fee.rs
+++ b/crates/rpc-types-eth/src/fee.rs
@@ -6,7 +6,7 @@ use alloc::vec::Vec;
 pub struct TxGasAndReward {
     /// Gas used by the transaction
     pub gas_used: u64,
-    /// The effective gas tip by the transaction
+    /// The effective gas tip paid by the transaction, in wei per gas.
     pub reward: u128,
 }
 
@@ -25,12 +25,18 @@ impl Ord for TxGasAndReward {
     }
 }
 
-/// Response type for `eth_feeHistory`
+/// Response type for `eth_feeHistory`.
+///
+/// For a response covering N blocks, each populated base-fee array contains N+1 entries: one for
+/// every returned block plus a final prediction for the next block. Populated gas-used ratio
+/// arrays contain N entries. When present, `reward` contains one row per block, with columns in the
+/// same order as the requested percentiles. Execution fee and reward values are in wei per gas;
+/// blob base fees are in wei per blob gas.
 #[derive(Clone, Debug, Default, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct FeeHistory {
-    /// An array of block base fees per gas.
+    /// An array of block base fees, in wei per gas.
     /// This includes the next block after the newest of the returned range,
     /// because this value can be derived from the newest block. Zeroes are
     /// returned for pre-EIP-1559 blocks.
@@ -47,9 +53,9 @@ pub struct FeeHistory {
     /// of `gasUsed` and `gasLimit`.
     #[cfg_attr(feature = "serde", serde(deserialize_with = "alloy_serde::null_as_default"))]
     pub gas_used_ratio: Vec<f64>,
-    /// An array of block base fees per blob gas. This includes the next block after the newest
-    /// of the returned range, because this value can be derived from the newest block. Zeroes
-    /// are returned for pre-EIP-4844 blocks.
+    /// An array of block base fees per blob gas, in wei per blob gas. This includes the next block
+    /// after the newest of the returned range, because this value can be derived from the newest
+    /// block. Zeroes are returned for pre-EIP-4844 blocks.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Vec::is_empty", with = "alloy_serde::quantity::vec")
@@ -62,8 +68,9 @@ pub struct FeeHistory {
     /// Lowest number block of the returned range.
     #[cfg_attr(feature = "serde", serde(default, with = "alloy_serde::quantity"))]
     pub oldest_block: u64,
-    /// An (optional) array of effective priority fee per gas data points from a single
-    /// block. All zeroes are returned if the block is empty.
+    /// An optional array of effective priority fees, in wei per gas, grouped by block.
+    ///
+    /// Columns follow the requested percentile order. All zeroes are returned if a block is empty.
     #[cfg_attr(
         feature = "serde",
         serde(
@@ -100,7 +107,7 @@ impl FeeHistory {
 
     /// Returns the blob fee of the latest block in the `eth_feeHistory` request.
     ///
-    /// If the next block is pre-EIP-4844, this will return `None`.
+    /// If the latest requested block is pre-EIP-4844, this will return `None`.
     pub fn latest_block_blob_base_fee(&self) -> Option<u128> {
         // The blob fee requested block is the second last element in the list.
         self.base_fee_per_blob_gas

--- a/crates/rpc-types-eth/src/filter.rs
+++ b/crates/rpc-types-eth/src/filter.rs
@@ -406,9 +406,9 @@ impl Default for FilterBlockOption {
 
 /// Filter for logs.
 ///
-/// Addresses are ORed. Values within one topic position are ORed, while populated topic positions
-/// are ANDed. Empty address and topic sets are wildcards. Block ranges are inclusive, and a block
-/// hash is mutually exclusive with `fromBlock` and `toBlock`.
+/// Addresses use OR semantics. Values within one topic position use OR semantics, while populated
+/// topic positions use AND semantics. Empty address and topic sets are wildcards. Block ranges are
+/// inclusive, and a block hash is mutually exclusive with `fromBlock` and `toBlock`.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
 pub struct Filter {
     /// Filter block options, specifying on which blocks the filter should match.
@@ -421,8 +421,8 @@ pub struct Filter {
     pub address: FilterSet<Address>,
     /// Topic filters, with at most four positions.
     ///
-    /// Values within a position are ORed; populated positions are ANDed. An empty position is a
-    /// wildcard and serializes as `null` when followed by a populated position.
+    /// Values within a position use OR semantics; populated positions use AND semantics. An empty
+    /// position is a wildcard and serializes as `null` when followed by a populated position.
     pub topics: [Topic; 4],
 }
 

--- a/crates/rpc-types-eth/src/filter.rs
+++ b/crates/rpc-types-eth/src/filter.rs
@@ -15,7 +15,13 @@ use itertools::{
     Itertools,
 };
 
-/// FilterSet is a set of values that will be used to filter logs.
+/// A set of values used to filter logs.
+///
+/// Values in the set are ORed. An empty set is a wildcard and matches every value. When used in a
+/// [`Filter`], an empty address set is omitted. An empty topic position before a later populated
+/// position is serialized as `null`; trailing empty positions are omitted. The [`Filter`]
+/// deserializer normalizes `null`, an empty array, or a topic array containing `null` to this
+/// wildcard representation.
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(from = "HashSet<T>"))]
@@ -399,23 +405,24 @@ impl Default for FilterBlockOption {
 }
 
 /// Filter for logs.
+///
+/// Addresses are ORed. Values within one topic position are ORed, while populated topic positions
+/// are ANDed. Empty address and topic sets are wildcards. Block ranges are inclusive, and a block
+/// hash is mutually exclusive with `fromBlock` and `toBlock`.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
 pub struct Filter {
     /// Filter block options, specifying on which blocks the filter should match.
     // https://eips.ethereum.org/EIPS/eip-234
     pub block_option: FilterBlockOption,
-    /// A filter set for matching contract addresses in log queries.
+    /// Contract addresses to match.
     ///
-    /// This field determines which contract addresses the filter applies to. It supports:
-    /// - A single address to match logs from that address only.
-    /// - Multiple addresses to match logs from any of them.
-    ///
-    /// ## Notes:
-    /// - An empty array (`[]`) may result in no logs being returned.
-    /// - Some RPC providers handle empty arrays differently than `None`.
-    /// - Large address lists may affect performance or hit provider limits.
+    /// Multiple addresses are ORed. An empty set is a wildcard and is omitted during
+    /// serialization.
     pub address: FilterSet<Address>,
-    /// Topics (maximum of 4)
+    /// Topic filters, with at most four positions.
+    ///
+    /// Values within a position are ORed; populated positions are ANDed. An empty position is a
+    /// wildcard and serializes as `null` when followed by a populated position.
     pub topics: [Topic; 4],
 }
 
@@ -576,14 +583,19 @@ impl Filter {
         self
     }
 
-    /// Given the event signature in string form, it hashes it and adds it to the topics to monitor
+    /// Hashes a canonical event signature and sets it as topic 0.
+    ///
+    /// Pass the complete signature, for example `Transfer(address,address,uint256)`, rather than
+    /// only the event name. The exact UTF-8 bytes are hashed with Keccak-256.
     #[must_use]
     pub fn event(self, event_name: &str) -> Self {
         let hash = keccak256(event_name.as_bytes());
         self.event_signature(hash)
     }
 
-    /// Hashes all event signatures and sets them as array to event_signature(topic0)
+    /// Hashes canonical event signatures and sets them as alternatives for topic 0.
+    ///
+    /// Each item must include the event name and canonical parameter types.
     #[must_use]
     pub fn events(self, events: impl IntoIterator<Item = impl AsRef<[u8]>>) -> Self {
         let events = events.into_iter().map(|e| keccak256(e.as_ref())).collect::<Vec<_>>();
@@ -677,7 +689,10 @@ impl Filter {
         self.address.matches(&address)
     }
 
-    /// Returns `true` if the block matches the filter.
+    /// Returns `true` if the block number matches the locally evaluable range.
+    ///
+    /// Numeric bounds are inclusive. Dynamic tags such as `latest`, `safe`, and `pending` are not
+    /// resolved here and therefore do not impose a numeric bound.
     pub const fn matches_block_range(&self, block_number: u64) -> bool {
         let mut res = true;
 

--- a/crates/rpc-types-eth/src/log.rs
+++ b/crates/rpc-types-eth/src/log.rs
@@ -16,7 +16,7 @@ pub struct Log<T = LogData> {
     /// Number of the block the transaction that emitted this log was mined in
     #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity::opt"))]
     pub block_number: Option<u64>,
-    /// The timestamp of the block as proposed in:
+    /// The block timestamp in Unix seconds, as proposed in:
     /// <https://ethereum-magicians.org/t/proposal-for-adding-blocktimestamp-to-logs-object-returned-by-eth-getlogs-and-related-requests>
     /// <https://github.com/ethereum/execution-apis/issues/295>
     #[cfg_attr(
@@ -38,7 +38,9 @@ pub struct Log<T = LogData> {
     /// Log Index in Block
     #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity::opt"))]
     pub log_index: Option<u64>,
-    /// Geth Compatibility Field: whether this log was removed
+    /// Whether a previously emitted log was removed from the canonical chain by a reorganization.
+    ///
+    /// Subscription consumers should reverse any effects previously attributed to a removed log.
     #[cfg_attr(feature = "serde", serde(default))]
     pub removed: bool,
 }

--- a/crates/rpc-types-eth/src/simulate.rs
+++ b/crates/rpc-types-eth/src/simulate.rs
@@ -122,6 +122,8 @@ pub struct SimCallResult {
 ///
 /// This struct configures how simulations are executed, including whether to trace token transfers,
 /// validate transaction sequences, and whether to return full transaction objects.
+/// The RPC accepts at most [`MAX_SIMULATE_BLOCKS`] blocks; this type and its builder methods do not
+/// enforce that limit.
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(

--- a/crates/rpc-types-eth/src/state.rs
+++ b/crates/rpc-types-eth/src/state.rs
@@ -123,7 +123,7 @@ impl FromIterator<(Address, AccountOverride)> for StateOverridesBuilder {
     }
 }
 
-/// A set of account overrides
+/// Account overrides keyed by the address whose state should be changed for the call.
 pub type StateOverride = AddressHashMap<AccountOverride>;
 
 /// Allows converting `StateOverridesBuilder` directly into `StateOverride`.
@@ -132,12 +132,17 @@ impl From<StateOverridesBuilder> for StateOverride {
         builder.overrides
     }
 }
-/// Custom account override used in call
+/// Overrides one account while executing a call.
+///
+/// `state` and `state_diff` are alternative request fields; callers should set at most one, though
+/// this type does not enforce that constraint. `state` replaces the complete storage map, so
+/// unspecified slots read as zero, while `state_diff` changes only the listed slots. Storage keys
+/// and values are raw 32-byte EVM slot and value words.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(default, rename_all = "camelCase", deny_unknown_fields))]
 pub struct AccountOverride {
-    /// Fake balance to set for the account before executing the call.
+    /// Fake balance to set for the account before executing the call, in wei.
     #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
     pub balance: Option<U256>,
     /// Fake nonce to set for the account before executing the call.

--- a/crates/rpc-types-eth/src/transaction/receipt.rs
+++ b/crates/rpc-types-eth/src/transaction/receipt.rs
@@ -33,12 +33,15 @@ pub struct TransactionReceipt<T = ReceiptEnvelope<Log>> {
     /// Gas used by this transaction alone.
     #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
     pub gas_used: u64,
-    /// The price paid post-execution by the transaction (i.e. base fee + priority fee). Both
-    /// fields in 1559-style transactions are maximums (max fee + max priority fee), the amount
-    /// that's actually paid by users can only be determined post-execution
+    /// The price paid post-execution by the transaction, in wei per gas (base fee plus priority
+    /// fee). Both fee fields in EIP-1559 transactions are maximums; the amount actually paid can
+    /// only be determined post-execution.
+    ///
+    /// Deserialization also accepts the legacy `gasPrice` name and defaults to zero if neither
+    /// name is present.
     #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
     pub effective_gas_price: u128,
-    /// Blob gas used by the eip-4844 transaction
+    /// Blob gas used by the EIP-4844 transaction, in blob gas units.
     ///
     /// This is None for non eip-4844 transactions
     #[cfg_attr(
@@ -50,7 +53,7 @@ pub struct TransactionReceipt<T = ReceiptEnvelope<Log>> {
         )
     )]
     pub blob_gas_used: Option<u64>,
-    /// The price paid by the eip-4844 transaction per blob gas.
+    /// The price paid by the EIP-4844 transaction, in wei per blob gas.
     #[cfg_attr(
         feature = "serde",
         serde(
@@ -185,6 +188,8 @@ impl<T> TransactionReceipt<T> {
     }
 
     /// Calculates the address that will be created by the transaction, if any.
+    ///
+    /// `nonce` is the sender nonce used by the contract-creation transaction.
     ///
     /// Returns `None` if the transaction is not a contract creation (the `to` field is set).
     pub fn calculate_create_address(&self, nonce: u64) -> Option<Address> {

--- a/crates/rpc-types-eth/src/transaction/request.rs
+++ b/crates/rpc-types-eth/src/transaction/request.rs
@@ -17,6 +17,11 @@ use alloy_primitives::{Address, Bytes, ChainId, Signature, TxKind, B256, U256};
 use core::{hash::Hash, str::FromStr};
 
 /// Represents _all_ transaction requests to/from RPC.
+///
+/// Transaction type selection is field-driven. The [`Self::transaction_type`] field is retained
+/// for RPC serialization, but is not consulted by [`Self::minimal_tx_type`],
+/// [`Self::preferred_type`], or the transaction build methods. Typed transaction builders use
+/// mainnet chain ID `1` when [`Self::chain_id`] is absent.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
 #[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -108,7 +113,10 @@ pub struct TransactionRequest {
     /// An EIP-2930 access list, which lowers cost for accessing accounts and storages in the list. See [EIP-2930](https://eips.ethereum.org/EIPS/eip-2930) for more information.
     #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
     pub access_list: Option<AccessList>,
-    /// The EIP-2718 transaction type. See [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718) for more information.
+    /// The EIP-2718 transaction type reported to or received from RPC.
+    ///
+    /// This is wire metadata and does not select the type used by the transaction build methods.
+    /// See [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718) for more information.
     #[cfg_attr(
         feature = "serde",
         serde(
@@ -429,7 +437,7 @@ impl TransactionRequest {
     /// Build an EIP-1559 transaction.
     ///
     /// Returns an error if required fields are missing. Use `complete_1559` to check if the
-    /// request can be built.
+    /// request can be built. If `chain_id` is absent, this uses mainnet chain ID `1`.
     pub fn build_1559(self) -> Result<TxEip1559, ValueError<Self>> {
         let Some(to) = self.to else {
             return Err(ValueError::new(self, "Missing 'to' field for Eip1559 transaction."));
@@ -472,7 +480,7 @@ impl TransactionRequest {
     /// Build an EIP-2930 transaction.
     ///
     /// Returns an error if required fields are missing. Use `complete_2930` to check if the
-    /// request can be built.
+    /// request can be built. If `chain_id` is absent, this uses mainnet chain ID `1`.
     pub fn build_2930(self) -> Result<TxEip2930, ValueError<Self>> {
         let Some(to) = self.to else {
             return Err(ValueError::new(self, "Missing 'to' field for Eip2930 transaction."));
@@ -519,8 +527,9 @@ impl TransactionRequest {
 
     /// Build an EIP-4844 transaction without sidecar.
     ///
-    /// Returns an error if required fields are missing. Use `complete_4844` to check if the
-    /// request can be built.
+    /// Returns an error if required consensus fields are missing. Unlike [`Self::complete_4844`],
+    /// this does not require the sidecar needed for a network-submittable transaction. If
+    /// `chain_id` is absent, this uses mainnet chain ID `1`.
     pub fn build_4844_without_sidecar(self) -> Result<TxEip4844, ValueError<Self>> {
         // First check 'to' field and type
         let Some(to) = self.to else {
@@ -608,7 +617,7 @@ impl TransactionRequest {
     /// Build an EIP-7702 transaction.
     ///
     /// Returns an error if required fields are missing. Use `complete_7702` to
-    /// check if the request can be built.
+    /// check if the request can be built. If `chain_id` is absent, this uses mainnet chain ID `1`.
     pub fn build_7702(self) -> Result<TxEip7702, ValueError<Self>> {
         let Some(to) = self.to else {
             return Err(ValueError::new(self, "Missing 'to' field for Eip7702 transaction."));
@@ -1642,8 +1651,9 @@ impl FromStr for TransactionInputKind {
 /// This is done for compatibility reasons where older implementations used `data` instead of the
 /// newer, recommended `input` field.
 ///
-/// If both fields are set, it is expected that they contain the same value, otherwise an error is
-/// returned.
+/// Serde accepts either spelling or both and does not validate that both values are equal.
+/// [`Self::input`] and [`Self::into_input`] prefer `input` when both fields are present. Use
+/// [`Self::unique_input`] or [`Self::try_into_unique_input`] to reject conflicting values.
 #[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -1683,6 +1693,8 @@ impl TransactionInput {
     }
 
     /// Consumes the type and returns the optional input data.
+    ///
+    /// If both fields are present, this returns `input` without checking whether `data` differs.
     #[inline]
     pub fn into_input(self) -> Option<Bytes> {
         self.input.or(self.data)
@@ -1690,7 +1702,8 @@ impl TransactionInput {
 
     /// Ensures that if either `input` or `data` is set, the `input` field contains the value.
     ///
-    /// This removes `data` the data field.
+    /// This removes `data`. If both fields are present, the existing `input` value is retained
+    /// without checking whether `data` differs.
     pub fn normalize_input(&mut self) {
         let data = self.data.take();
         // If input is None but data has a value, copy data to input
@@ -1707,7 +1720,8 @@ impl TransactionInput {
 
     /// Ensures that if either `data` or `input` is set, the `data` field contains the value.
     ///
-    /// This removes `input` the data field.
+    /// This removes `input`. If both fields are present, the existing `data` value is retained
+    /// without checking whether `input` differs.
     pub fn normalize_data(&mut self) {
         let input = self.input.take();
         if self.data.is_none() {
@@ -1748,6 +1762,8 @@ impl TransactionInput {
     }
 
     /// Returns the optional input data.
+    ///
+    /// If both fields are present, this returns `input` without checking whether `data` differs.
     #[inline]
     pub fn input(&self) -> Option<&Bytes> {
         self.input.as_ref().or(self.data.as_ref())

--- a/crates/rpc-types-trace/src/geth/call.rs
+++ b/crates/rpc-types-trace/src/geth/call.rs
@@ -77,7 +77,7 @@ impl CallFrame {
         CallFrameIter::new(self)
     }
 
-    /// Error selector is the first 4 bytes of calldata
+    /// Returns the first four bytes of calldata, or `None` if the input is shorter.
     pub fn selector(&self) -> Option<Selector> {
         if self.input.len() < 4 {
             return None;

--- a/crates/rpc-types-trace/src/geth/mod.rs
+++ b/crates/rpc-types-trace/src/geth/mod.rs
@@ -535,8 +535,11 @@ pub struct GethDebugTracingOptions {
     /// This could be [CallConfig] or [PreStateConfig] depending on the tracer.
     #[serde(default, skip_serializing_if = "GethDebugTracerConfig::is_null")]
     pub tracer_config: GethDebugTracerConfig,
-    /// A string of decimal integers that overrides the JavaScript-based tracing calls default
-    /// timeout of 5 seconds.
+    /// A Go duration string, such as `5s`, that overrides the default five-second timeout for
+    /// JavaScript-based tracing calls.
+    ///
+    /// [`Self::with_timeout`] represents the supplied duration as integer milliseconds, for
+    /// example `2500ms`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub timeout: Option<String>,
 }

--- a/crates/rpc-types-trace/src/geth/pre_state.rs
+++ b/crates/rpc-types-trace/src/geth/pre_state.rs
@@ -31,8 +31,8 @@ impl PreStateFrame {
         matches!(self, Self::Diff(_))
     }
 
-    /// Returns the account states after the transaction is executed if this trace was requested
-    /// without diffmode.
+    /// Returns the pre-state accounts needed to execute the transaction if this trace was
+    /// requested without diff mode.
     pub const fn as_default(&self) -> Option<&PreStateMode> {
         match self {
             Self::Default(mode) => Some(mode),

--- a/crates/rpc-types-txpool/src/txpool.rs
+++ b/crates/rpc-types-txpool/src/txpool.rs
@@ -9,21 +9,28 @@ use serde::{
 };
 use std::{collections::BTreeMap, fmt, str::FromStr};
 
-/// Transaction summary as found in the Txpool Inspection property.
+/// Transaction summary as found in the txpool inspection response.
+///
+/// Its Geth wire representation is a string of the form
+/// `<to>: <value> wei + <gas> gas × <gas_price> wei`; contract creation uses
+/// `contract creation` in place of the recipient.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct TxpoolInspectSummary {
     /// Recipient (None when contract creation)
     pub to: Option<Address>,
-    /// Transferred value
+    /// Transferred value, in wei.
     pub value: U256,
     /// Gas amount
     pub gas: u64,
-    /// Gas Price
+    /// Gas price or fee cap, in wei per gas.
     pub gas_price: u128,
 }
 
 impl TxpoolInspectSummary {
     /// Extracts the [`TxpoolInspectSummary`] from a transaction.
+    ///
+    /// For a dynamic-fee transaction, `gas_price` is its maximum fee per gas, not an effective
+    /// price paid in a mined block.
     pub fn from_tx<T: TransactionTrait>(tx: T) -> Self {
         Self {
             to: tx.to(),
@@ -122,14 +129,19 @@ impl Serialize for TxpoolInspectSummary {
 /// the transactions currently pending for inclusion in the next block(s), as well
 /// as the ones that are being scheduled for future execution only.
 ///
+/// The wire shape is sender address to decimal nonce string to transaction. `pending` entries are
+/// executable, while `queued` entries are held for future execution, commonly because of nonce
+/// gaps. Iterators follow [`BTreeMap`] key order: senders are ordered by address, but nonce strings
+/// are lexicographic rather than numeric. Parse nonce keys before relying on numeric order.
+///
 /// See [here](https://geth.ethereum.org/docs/rpc/ns-txpool#txpool_content) for more details
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(bound(serialize = "T: Serialize"))]
 pub struct TxpoolContent<T = Transaction> {
-    /// pending tx
+    /// Transactions currently executable by sender and decimal nonce string.
     #[serde(serialize_with = "serialize_checksum_address_map")]
     pub pending: BTreeMap<Address, BTreeMap<String, T>>,
-    /// queued tx
+    /// Transactions queued for future execution by sender and decimal nonce string.
     #[serde(serialize_with = "serialize_checksum_address_map")]
     pub queued: BTreeMap<Address, BTreeMap<String, T>>,
 }

--- a/crates/serde/README.md
+++ b/crates/serde/README.md
@@ -1,3 +1,42 @@
 # alloy-serde
 
-Serde related helpers for Alloy.
+Serde helpers for Ethereum JSON-RPC formats that differ from Serde's defaults.
+
+- [`quantity`] encodes primitive integers as canonical RPC quantities such as
+  `"0x2a"`. Its `opt`, `vec`, `hashmap`, and `btreemap` modules cover common containers.
+- [`ttd`] handles geth's mixed number/string representation of terminal total
+  difficulty.
+- [`storage`] handles storage keys and zero-padding cropped storage values.
+- [`WithOtherFields`] preserves unknown object fields for forwarding or
+  round-tripping RPC payloads.
+
+```rust
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+struct Request {
+    #[serde(with = "alloy_serde::quantity")]
+    block: u64,
+    // `default` is required if an omitted field should become `None`.
+    #[serde(default, with = "alloy_serde::quantity::opt")]
+    limit: Option<u64>,
+}
+
+let request: Request = serde_json::from_str(r#"{"block":"0x2a"}"#)?;
+assert_eq!(request, Request { block: 42, limit: None });
+assert_eq!(
+    serde_json::to_string(&Request { block: 42, limit: Some(16) })?,
+    r#"{"block":"0x2a","limit":"0x10"}"#,
+);
+# Ok::<(), serde_json::Error>(())
+```
+
+For deserialization-only helpers such as [`null_as_default`], use
+`deserialize_with` and pair it with `#[serde(default)]` when missing fields should also use the
+default. The no-prefix hex helpers are serialization-only and therefore use `serialize_with`.
+
+[`null_as_default`]: https://docs.rs/alloy-serde/latest/alloy_serde/fn.null_as_default.html
+[`quantity`]: https://docs.rs/alloy-serde/latest/alloy_serde/quantity/index.html
+[`storage`]: https://docs.rs/alloy-serde/latest/alloy_serde/storage/index.html
+[`ttd`]: https://docs.rs/alloy-serde/latest/alloy_serde/ttd/index.html
+[`WithOtherFields`]: https://docs.rs/alloy-serde/latest/alloy_serde/struct.WithOtherFields.html

--- a/crates/serde/src/lib.rs
+++ b/crates/serde/src/lib.rs
@@ -31,9 +31,10 @@ pub use ttd::*;
 mod other;
 pub use other::{OtherFields, WithOtherFields};
 
-/// Serialize a byte vec as a hex string _without_ the "0x" prefix.
+/// Serialize bytes as a hex string _without_ the "0x" prefix.
 ///
-/// This behaves the same as [`hex::encode`].
+/// This behaves the same as [`hex::encode`] and is intended for Serde's `serialize_with`
+/// attribute. It has no matching deserializer.
 pub fn serialize_hex_string_no_prefix<S, T>(x: T, s: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
@@ -42,7 +43,9 @@ where
     s.serialize_str(&hex::encode(x.as_ref()))
 }
 
-/// Serialize a [B256] as a hex string _without_ the "0x" prefix.
+/// Serialize a [`B256`] as a hex string _without_ the "0x" prefix.
+///
+/// This is intended for Serde's `serialize_with` attribute and has no matching deserializer.
 pub fn serialize_b256_hex_string_no_prefix<S>(x: &B256, s: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,

--- a/crates/serde/src/optional.rs
+++ b/crates/serde/src/optional.rs
@@ -2,8 +2,10 @@
 
 use serde::{Deserialize, Deserializer};
 
-/// For use with serde's `deserialize_with` on a sequence that must be
-/// deserialized as a single but optional (i.e. possibly `null`) value.
+/// Deserializes an explicit `null` as [`Default::default`] and any other value as `T`.
+///
+/// Use with Serde's `deserialize_with`. Add `#[serde(default)]` separately if a missing field
+/// should also use its default.
 pub fn null_as_default<'de, T, D>(deserializer: D) -> Result<T, D::Error>
 where
     T: Deserialize<'de> + Default,
@@ -12,7 +14,10 @@ where
     Option::<T>::deserialize(deserializer).map(Option::unwrap_or_default)
 }
 
-/// For use with serde's `deserialize_with` on a field that must be missing.
+/// Deserializes an explicit `null` as [`None`] and rejects a non-null value.
+///
+/// Use with Serde's `deserialize_with`. Add `#[serde(default)]` to accept a missing field as
+/// [`None`]; Serde handles that case without calling this function.
 pub fn reject_if_some<'de, T, D>(deserializer: D) -> Result<Option<T>, D::Error>
 where
     T: Deserialize<'de>,

--- a/crates/serde/src/quantity.rs
+++ b/crates/serde/src/quantity.rs
@@ -1,8 +1,13 @@
 //! Serde functions for encoding primitive numbers using the Ethereum JSON-RPC "quantity" format.
 //!
-//! This is defined as a "hex encoded unsigned integer", with a special case of 0 being `0x0`.
+//! Serializers emit a "hex encoded unsigned integer", with the special case of zero being `0x0`.
+//! Deserializers also accept decimal strings for compatibility with existing RPC payloads.
 //!
 //! A regex for this format is: `^0x([1-9a-f]+[0-9a-f]*|0)$`.
+//!
+//! The helpers support [`bool`], `u8` through `u128`, and their [`core::num::NonZeroU8`] through
+//! [`core::num::NonZeroU128`] counterparts. Booleans are encoded as the quantities `0x0` and
+//! `0x1`.
 //!
 //! This is only valid for human-readable [`serde`] implementations.
 //! For non-human-readable implementations, the format is unspecified.
@@ -75,7 +80,7 @@ pub mod vec {
         Deserializer, Serializer,
     };
 
-    /// Serializes a vector of primitive numbers as a "quantity" hex string.
+    /// Serializes each primitive number in a vector as a "quantity" hex string.
     pub fn serialize<T, S>(value: &[T], serializer: S) -> Result<S::Ok, S::Error>
     where
         T: ConvertRuint,
@@ -88,7 +93,7 @@ pub mod vec {
         seq.end()
     }
 
-    /// Deserializes a vector of primitive numbers from a "quantity" hex string.
+    /// Deserializes a vector of primitive numbers from "quantity" hex strings.
     pub fn deserialize<'de, T, D>(deserializer: D) -> Result<Vec<T>, D::Error>
     where
         T: ConvertRuint,
@@ -182,7 +187,7 @@ pub mod hashmap {
         Deserialize, Deserializer, Serialize, Serializer,
     };
 
-    /// Serializes a `HashMap` of primitive numbers as a "quantity" hex string.
+    /// Serializes each primitive-number key in a `HashMap` as a "quantity" hex string.
     pub fn serialize<K, V, S, H>(map: &HashMap<K, V, H>, serializer: S) -> Result<S::Ok, S::Error>
     where
         K: ConvertRuint,
@@ -197,7 +202,7 @@ pub mod hashmap {
         map_ser.end()
     }
 
-    /// Deserializes a `HashMap` of primitive numbers from a "quantity" hex string.
+    /// Deserializes a `HashMap` whose primitive-number keys are "quantity" hex strings.
     pub fn deserialize<'de, K, V, D, H>(deserializer: D) -> Result<HashMap<K, V, H>, D::Error>
     where
         K: ConvertRuint + Eq + core::hash::Hash,

--- a/crates/serde/src/storage.rs
+++ b/crates/serde/src/storage.rs
@@ -6,26 +6,16 @@ use alloy_primitives::{
 use core::{fmt, str::FromStr};
 use serde::{Deserialize, Deserializer, Serialize};
 
-/// A storage key type that can be serialized to and from a hex string up to 32 bytes. Used for
-/// `eth_getStorageAt` and `eth_getProof` RPCs.
+/// A storage key that accepts hex strings up to 32 bytes for `eth_getStorageAt` and `eth_getProof`.
 ///
-/// This is a wrapper type meant to mirror geth's serialization and deserialization behavior for
-/// storage keys.
+/// A full-width, 32-byte input is stored as [`Hash`](Self::Hash) and serializes at full width.
+/// Shorter inputs are stored as [`Number`](Self::Number) and serialize as canonical quantities, so
+/// their original prefix, letter case, and leading zeroes are not preserved. [`Self::as_b256`]
+/// returns either representation left-padded to 32 bytes.
 ///
-/// In `eth_getStorageAt`, this is used for deserialization of the `index` field. Internally, the
-/// index is a [B256], but in `eth_getStorageAt` requests, its serialization can be _up to_ 32
-/// bytes. To support this, the storage key is deserialized first as a U256, and converted to a
-/// B256 for use internally.
-///
-/// `eth_getProof` also takes storage keys up to 32 bytes as input, so the `keys` field is
-/// similarly deserialized. However, geth populates the storage proof `key` fields in the response
-/// by mirroring the `key` field used in the input.
-///
-/// See how `storageKey`s (the input) are populated in the `StorageResult` (the output):
+/// This distinction mirrors geth's treatment of `eth_getProof` storage keys. See how input
+/// `storageKey`s populate the returned `StorageResult`:
 /// <https://github.com/ethereum/go-ethereum/blob/00a73fbcce3250b87fc4160f3deddc44390848f4/internal/ethapi/api.go#L658-L690>
-///
-/// The contained [B256] and From implementation for String are used to preserve the input and
-/// implement this behavior from geth.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum JsonStorageKey {
@@ -93,8 +83,7 @@ impl fmt::Display for JsonStorageKey {
     }
 }
 
-/// Converts a Bytes value into a B256, accepting inputs that are less than 32 bytes long. These
-/// inputs will be left padded with zeros.
+/// Converts a [`Bytes`] value of at most 32 bytes into a [`B256`], left-padding it with zeroes.
 pub fn from_bytes_to_b256<'de, D>(bytes: Bytes) -> Result<B256, D::Error>
 where
     D: Deserializer<'de>,
@@ -111,8 +100,8 @@ where
     Ok(B256::from_slice(&padded))
 }
 
-/// Deserializes the input into a storage map, using [from_bytes_to_b256] which allows cropped
-/// values:
+/// Deserializes an optional storage map, accepting keys and values shorter than 32 bytes and
+/// left-padding them with zeroes:
 ///
 /// ```json
 /// {

--- a/crates/serde/src/ttd.rs
+++ b/crates/serde/src/ttd.rs
@@ -1,14 +1,16 @@
-//! Serde functions for encoding the TTD using a Geth compatible format.
+//! Serde functions for encoding terminal total difficulty (TTD) using a geth-compatible format.
 //!
-//! In Go `big.Int` is marshalled as a JSON number without quotes. Numbers are arbitrary
-//! precision in JSON, so this is valid JSON.
+//! Human-readable serializers emit values that fit in [`u128`] as unquoted decimal numbers. Larger
+//! values use [`U256`]'s standard human-readable representation, a quoted hex string.
+//! Most values above [`u64::MAX`] through [`u128::MAX`] therefore do not round-trip through this
+//! helper: serialization emits an unquoted number that deserialization rejects. Use a quoted
+//! decimal or hex representation at the wire boundary when those values must round-trip.
 //!
-//! These functions serialize the TTD as a JSON number, if the value fits within `u128`.
-//!
-//! The TTD is parsed from:
-//!   - JSON numbers: direct `u64` values, or the specific Ethereum mainnet TTD (e.g., `5.875e22` if
-//!     represented as a float). Other floats or negative numbers will error.
-//!   - JSON strings: these are parsed as `U256` (allowing hex or decimal strings).
+//! Human-readable deserializers accept `null`, hex or decimal strings parsed as [`U256`], JSON
+//! integers up to [`u64::MAX`], and geth's unquoted Ethereum mainnet TTD
+//! (`58750000000000000000000`). `serde_json` represents larger JSON numbers as `f64`, so nearby
+//! integer literals that round to the same float are also normalized to that mainnet value; other
+//! numbers outside the `u64` range are rejected.
 //!
 //! For non-human-readable formats, the default `serde` behavior for `Option<U256>` is used.
 
@@ -16,9 +18,7 @@ use alloy_primitives::U256;
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value;
 
-/// Serializes an optional TTD as a JSON number.
-///
-/// It returns an error, if the TTD value is larger than 128-bit.
+/// Serializes an optional TTD using the format described in the [module documentation](self).
 pub fn serialize<S>(value: &Option<U256>, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
@@ -39,7 +39,7 @@ where
     }
 }
 
-/// Deserializes an optional TTD value from JSON number or string.
+/// Deserializes an optional TTD using the formats described in the [module documentation](self).
 pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<U256>, D::Error>
 where
     D: Deserializer<'de>,
@@ -52,8 +52,7 @@ where
     }
 }
 
-/// Supports parsing the TTD as an `Option<u64>`, or `Option<f64>` specifically for the mainnet TTD
-/// (5.875e22).
+/// Compatibility alias for [`deserialize`].
 pub fn deserialize_json_ttd_opt<'de, D>(deserializer: D) -> Result<Option<U256>, D::Error>
 where
     D: Deserializer<'de>,

--- a/crates/signer-aws/README.md
+++ b/crates/signer-aws/README.md
@@ -2,4 +2,15 @@
 
 Ethereum [AWS KMS] signer.
 
+The KMS key must be an asymmetric `ECC_SECG_P256K1` key with `SIGN_VERIFY`
+usage. Constructing a signer requires `kms:GetPublicKey`; signing requires
+`kms:Sign`.
+
+This crate disables the default features of `aws-config` and `aws-sdk-kms`.
+Applications that construct the standard AWS client must enable a runtime and
+HTTPS client (for example, `rt-tokio` and `default-https-client`) in their own
+AWS SDK dependencies, or supply an otherwise configured client.
+
+Enable this crate's `eip712` feature to sign EIP-712 typed data.
+
 [AWS KMS]: https://aws.amazon.com/kms

--- a/crates/signer-aws/src/signer.rs
+++ b/crates/signer-aws/src/signer.rs
@@ -17,33 +17,29 @@ use std::fmt;
 
 /// Amazon Web Services Key Management Service (AWS KMS) Ethereum signer.
 ///
-/// The AWS Signer passes signing requests to the cloud service. AWS KMS keys are identified by a
-/// UUID, the `key_id`.
+/// Signing requests are sent to AWS KMS. The key must be an asymmetric `ECC_SECG_P256K1` key with
+/// `SIGN_VERIFY` usage. `key_id` may be a key ID, key ARN, alias name, or alias ARN.
 ///
-/// Because the public key is unknown, we retrieve it on instantiation of the signer. This means
-/// that the new function is `async` and must be called within some runtime.
+/// [`Self::new`] retrieves and caches the public key and derived Ethereum address. Signing performs
+/// network I/O and must be awaited; this type does not implement [`alloy_signer::SignerSync`].
 ///
-/// Note that this signer only supports asynchronous operations. Calling a non-asynchronous method
-/// will always return an error.
+/// Constructing a signer requires `kms:GetPublicKey`; signing requires `kms:Sign`.
 ///
 /// # Examples
 ///
 /// ```no_run
 /// use alloy_signer::Signer;
-/// use alloy_signer_aws::AwsSigner;
-/// use aws_config::BehaviorVersion;
+/// use alloy_signer_aws::{aws_config, aws_sdk_kms, AwsSigner};
 ///
 /// # async fn test() {
-/// let config = aws_config::load_defaults(BehaviorVersion::latest()).await;
+/// let config = aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
 /// let client = aws_sdk_kms::Client::new(&config);
 ///
-/// let key_id = "...".to_string();
-/// let chain_id = Some(1);
-/// let signer = AwsSigner::new(client, key_id, chain_id).await.unwrap();
+/// let key_id = std::env::var("AWS_KMS_KEY_ID").expect("AWS_KMS_KEY_ID");
+/// let signer = AwsSigner::new(client, key_id, None).await.unwrap();
 ///
-/// let message = vec![0, 1, 2, 3];
-///
-/// let sig = signer.sign_message(&message).await.unwrap();
+/// let message = b"hello from Alloy";
+/// let sig = signer.sign_message(message).await.unwrap();
 /// assert_eq!(sig.recover_address_from_msg(message).unwrap(), signer.address());
 /// # }
 /// ```
@@ -143,7 +139,14 @@ alloy_network::impl_into_wallet!(AwsSigner);
 impl AwsSigner {
     /// Instantiate a new signer from an existing `Client` and key ID.
     ///
-    /// Retrieves the public key from AWS and calculates the Ethereum address.
+    /// `key_id` may be a key ID, key ARN, alias name, or alias ARN. This makes a
+    /// `GetPublicKey` request, then caches the verifying key and derived Ethereum address.
+    /// Prefer a stable key ID or ARN: retargeting an alias does not update the cached key or
+    /// address, so signatures from the new target will fail parity recovery.
+    ///
+    /// `chain_id` affects transaction signing only. `Some(id)` fills an unset transaction chain ID
+    /// and rejects a conflicting one before signing. It does not affect hash, message, or
+    /// typed-data signing; `None` disables this signer-side check.
     #[instrument(skip(kms), err)]
     pub async fn new(
         kms: Client,
@@ -157,17 +160,26 @@ impl AwsSigner {
         Ok(Self { kms, chain_id, key_id, pubkey, address })
     }
 
-    /// Fetch the pubkey associated with a key ID.
+    /// Fetch the public key associated with a key ID.
+    ///
+    /// This makes a `GetPublicKey` request but does not change this signer's cached key or address.
     pub async fn get_pubkey_for_key(&self, key_id: String) -> Result<VerifyingKey, AwsSignerError> {
         request_get_pubkey(&self.kms, key_id).await.and_then(decode_pubkey)
     }
 
-    /// Fetch the pubkey associated with this signer's key ID.
+    /// Fetch the public key currently associated with this signer's key ID.
+    ///
+    /// This makes a `GetPublicKey` request but does not replace the key and address cached by
+    /// [`Self::new`].
     pub async fn get_pubkey(&self) -> Result<VerifyingKey, AwsSignerError> {
         self.get_pubkey_for_key(self.key_id.clone()).await
     }
 
-    /// Sign a digest with the key associated with a key ID.
+    /// Sign a precomputed 32-byte digest with the key associated with a key ID.
+    ///
+    /// The digest is sent to KMS as [`MessageType::Digest`] and is not hashed or prefixed again.
+    /// The returned `(r, s)` signature is low-s normalized and has no recovery parity. Use
+    /// [`Signer::sign_hash`] when an Alloy [`Signature`] with y-parity is required.
     pub async fn sign_digest_with_key(
         &self,
         key_id: String,
@@ -176,12 +188,17 @@ impl AwsSigner {
         request_sign_digest(&self.kms, key_id, digest).await.and_then(decode_signature)
     }
 
-    /// Sign a digest with this signer's key
+    /// Sign a precomputed 32-byte digest with this signer's key.
+    ///
+    /// See [`Self::sign_digest_with_key`] for prehash and return-value semantics.
     pub async fn sign_digest(&self, digest: &B256) -> Result<ecdsa::Signature, AwsSignerError> {
         self.sign_digest_with_key(self.key_id.clone(), digest).await
     }
 
-    /// Sign a digest with this signer's key and applies EIP-155.
+    /// Sign a digest with this signer's key and recover the correct y-parity.
+    ///
+    /// This does not apply EIP-155 itself. Transaction signing supplies a signature hash that
+    /// already reflects the transaction's chain ID.
     #[instrument(err, skip(digest), fields(digest = %hex::encode(digest)))]
     async fn sign_digest_inner(&self, digest: &B256) -> Result<Signature, AwsSignerError> {
         let sig = self.sign_digest(digest).await?;

--- a/crates/signer-gcp/README.md
+++ b/crates/signer-gcp/README.md
@@ -2,4 +2,12 @@
 
 Ethereum [GCP KMS] signer.
 
+The key must have purpose `ASYMMETRIC_SIGN` and algorithm
+`EC_SIGN_SECP256K1_SHA256`; GCP supports secp256k1 only with HSM protection.
+The client identity needs `cloudkms.cryptoKeyVersions.viewPublicKey` to
+construct a signer and `cloudkms.cryptoKeyVersions.useToSign` to sign.
+
+The example client uses Google Application Default Credentials. Enable this
+crate's `eip712` feature to sign EIP-712 typed data.
+
 [GCP KMS]: https://cloud.google.com/kms/docs/

--- a/crates/signer-gcp/src/signer.rs
+++ b/crates/signer-gcp/src/signer.rs
@@ -42,7 +42,10 @@ impl GcpKeyRingRef {
     }
 }
 
-/// Identifies a specific key version in the key ring.
+/// Identifies a fixed key version in the key ring.
+///
+/// A specifier does not follow primary-key rotation; construct a new signer with the new version
+/// when rotating keys.
 #[derive(Debug)]
 pub struct KeySpecifier(String);
 
@@ -60,22 +63,22 @@ impl KeySpecifier {
 ///
 /// The GCP Signer passes signing requests to the cloud service. GCP KMS keys belong to a key ring,
 /// which is identified by a project ID, location, and key ring name. The key ring contains keys,
-/// which are identified by a key ID and version.
+/// which are identified by a key ID and version. The selected key must use purpose
+/// `ASYMMETRIC_SIGN` and algorithm `EC_SIGN_SECP256K1_SHA256`.
 ///
-/// Because the public key is unknown, we retrieve it on instantiation of the signer. This means
-/// that the new function is `async` and must be called within some runtime.
-///
-/// Note that this wallet only supports asynchronous operations. Calling a non-asynchronous method
-/// will always return an error.
+/// [`Self::new`] retrieves and caches the public key and derived Ethereum address. Signing performs
+/// network I/O and must be awaited; this type does not implement [`alloy_signer::SignerSync`].
 ///
 /// # Examples
 ///
 /// ```no_run
 /// use alloy_signer::Signer;
-/// use alloy_signer_gcp::{GcpKeyRingRef, GcpSigner, KeySpecifier};
-/// use gcloud_sdk::{
-///     google::cloud::kms::v1::key_management_service_client::KeyManagementServiceClient,
-///     GoogleApi,
+/// use alloy_signer_gcp::{
+///     gcloud_sdk::{
+///         google::cloud::kms::v1::key_management_service_client::KeyManagementServiceClient,
+///         GoogleApi,
+///     },
+///     GcpKeyRingRef, GcpSigner, KeySpecifier,
 /// };
 ///
 /// # async fn test() {
@@ -93,15 +96,13 @@ impl KeySpecifier {
 /// .await
 /// .expect("Failed to create GCP KMS Client");
 ///
-/// let key_name = "...";
+/// let key_name = std::env::var("GOOGLE_KEY_NAME").expect("GOOGLE_KEY_NAME");
 /// let key_version = 1;
-/// let key_specifier = KeySpecifier::new(keyring, key_name, key_version);
-/// let chain_id = Some(1);
-/// let signer = GcpSigner::new(client, key_specifier, chain_id).await.unwrap();
+/// let key_specifier = KeySpecifier::new(keyring, &key_name, key_version);
+/// let signer = GcpSigner::new(client, key_specifier, None).await.unwrap();
 ///
-/// let message = vec![0, 1, 2, 3];
-///
-/// let sig = signer.sign_message(&message).await.unwrap();
+/// let message = b"hello from Alloy";
+/// let sig = signer.sign_message(message).await.unwrap();
 /// assert_eq!(sig.recover_address_from_msg(message).unwrap(), signer.address());
 /// # }
 /// ```
@@ -194,9 +195,16 @@ impl Signer for GcpSigner {
 alloy_network::impl_into_wallet!(GcpSigner);
 
 impl GcpSigner {
-    /// Instantiate a new signer from an existing `Client`, keyring reference, key ID, and version.
+    /// Instantiate a new signer from a configured GCP KMS client and fixed key-version specifier.
     ///
-    /// Retrieves the public key from GCP and calculates the Ethereum address.
+    /// This makes a `GetPublicKey` request, then caches the verifying key and derived Ethereum
+    /// address. The client identity therefore needs
+    /// `cloudkms.cryptoKeyVersions.viewPublicKey`; signing additionally needs
+    /// `cloudkms.cryptoKeyVersions.useToSign`.
+    ///
+    /// `chain_id` affects transaction signing only. `Some(id)` fills an unset transaction chain ID
+    /// and rejects a conflicting one before signing. It does not affect hash, message, or
+    /// typed-data signing; `None` disables this signer-side check.
     #[instrument(skip(client), err)]
     pub async fn new(
         client: Client,
@@ -211,12 +219,19 @@ impl GcpSigner {
         Ok(Self { client, key_name, chain_id, pubkey, address })
     }
 
-    /// Fetch the pubkey associated with this signer's key.
+    /// Return the public key cached by [`Self::new`].
+    ///
+    /// This method does not make a GCP KMS request.
     pub async fn get_pubkey(&self) -> Result<VerifyingKey, GcpSignerError> {
         Ok(self.pubkey)
     }
 
-    /// Sign a digest with this signer's key
+    /// Sign a precomputed 32-byte digest with this signer's key.
+    ///
+    /// The digest is passed to KMS unchanged and is not hashed or prefixed again. GCP permits an
+    /// equal-length non-SHA digest, such as Keccak-256, in the SHA-256 digest field. The returned
+    /// `(r, s)` signature is low-s normalized and has no recovery parity. Use [`Signer::sign_hash`]
+    /// when an Alloy [`Signature`] with y-parity is required.
     pub async fn sign_digest(&self, digest: &B256) -> Result<ecdsa::Signature, GcpSignerError> {
         request_sign_digest(&self.client, &self.key_name, digest).await.and_then(decode_signature)
     }
@@ -224,8 +239,8 @@ impl GcpSigner {
     /// Sign a digest with this signer's key and recover a `Signature` with the
     /// correct y-parity for the given public key.
     ///
-    /// The digest is expected to already include any EIP-155 chain ID encoding
-    /// via the transaction's signature hash.
+    /// This does not apply EIP-155 itself. Transaction signing supplies a signature hash that
+    /// already reflects the transaction's chain ID.
     #[instrument(err, skip(digest), fields(digest = %hex::encode(digest)))]
     async fn sign_digest_inner(&self, digest: &B256) -> Result<Signature, GcpSignerError> {
         let sig = self.sign_digest(digest).await?;

--- a/crates/signer-ledger/README.md
+++ b/crates/signer-ledger/README.md
@@ -1,5 +1,49 @@
 # alloy-signer-ledger
 
-Ethereum [Ledger] signer.
+Asynchronous Ethereum signer for [Ledger] devices.
+
+## Device setup
+
+Unlock the device and open its Ethereum app before constructing a signer. On native targets,
+`LedgerSigner::new` connects to the first compatible device and keeps an exclusive transport open;
+share that transport through `LedgerSigner::new_with_transport` when using multiple derivation
+paths. Signing requests wait for approval on the device. Address queries do not request on-device
+confirmation.
+
+## Supported operations
+
+- Ethereum transactions through `TxSigner`, including legacy, EIP-2930, and EIP-1559 signing
+  payloads.
+- EIP-191 personal messages through `Signer::sign_message`.
+- EIP-712 typed data with the `eip712` feature and Ledger Ethereum app version 1.6.0 or newer. The
+  device receives the domain separator and struct hash.
+- EIP-7702 authorizations with the `eip7702` feature.
+
+Raw digest signing through `Signer::sign_hash` is not supported. Passing a 32-byte digest to
+`sign_message` signs those bytes as an EIP-191 message; it does not sign the digest directly.
+
+## Chain IDs
+
+Set each transaction's chain ID explicitly before signing. The optional chain ID passed to
+`LedgerSigner::new` applies only to transaction signing: `Some(id)` rejects a transaction carrying
+a different ID, but must not be relied on to supply a missing ID. `None` leaves the transaction
+unchanged. The signer setting does not constrain messages, EIP-712 domains, or EIP-7702
+authorizations.
+
+## Example
+
+```no_run
+use alloy_signer::Signer;
+use alloy_signer_ledger::{HDPath, LedgerSigner};
+
+# async fn example() -> Result<(), Box<dyn std::error::Error>> {
+let signer = LedgerSigner::new(HDPath::LedgerLive(0), Some(1)).await?;
+let message = b"hello";
+let signature = signer.sign_message(message).await?;
+
+assert_eq!(signature.recover_address_from_msg(message)?, signer.address());
+# Ok(())
+# }
+```
 
 [Ledger]: https://www.ledger.com

--- a/crates/signer-ledger/src/signer.rs
+++ b/crates/signer-ledger/src/signer.rs
@@ -22,8 +22,10 @@ use alloy_sol_types::{Eip712Domain, SolStruct};
 ///
 /// This is a simple wrapper around the [Ledger transport](Ledger).
 ///
-/// Note that this wallet only supports asynchronous operations. Calling a non-asynchronous method
-/// will always return an error.
+/// Device operations are available through the asynchronous [`Signer`] and
+/// [`alloy_network::TxSigner`] traits; [`alloy_signer::SignerSync`] is not implemented. Raw digest
+/// signing is unsupported, while [`Signer::sign_message`] performs EIP-191 personal-message
+/// signing and requires confirmation on the device.
 #[derive(Debug)]
 pub struct LedgerSigner {
     transport: Arc<Mutex<Ledger>>,
@@ -148,11 +150,15 @@ impl Signer for LedgerSigner {
 alloy_network::impl_into_wallet!(LedgerSigner);
 
 impl LedgerSigner {
-    /// Instantiate the application by acquiring a lock on the ledger device.
+    /// Connects to the first compatible Ledger device and reads the derived address.
+    ///
+    /// The device must be unlocked with its Ethereum app open. Set the transaction's chain ID
+    /// explicitly before signing. `chain_id` applies only to transaction signing and rejects a
+    /// conflicting transaction ID; do not rely on it to supply a missing ID.
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```no_run
     /// # async fn foo() -> Result<(), Box<dyn std::error::Error>> {
     /// use alloy_signer_ledger::{HDPath, LedgerSigner};
     ///
@@ -171,7 +177,11 @@ impl LedgerSigner {
         Ok(Self { transport: Mutex::new(transport).into(), derivation, chain_id, address })
     }
 
-    /// Instantiate the application using a existing transport.
+    /// Creates a signer using an existing shared transport.
+    ///
+    /// The transport mutex serializes device operations and can be shared by signers using
+    /// different derivation paths. `chain_id` has the same transaction-only validation behavior
+    /// as in [`Self::new`].
     pub async fn new_with_transport(
         derivation: DerivationType,
         chain_id: Option<ChainId>,
@@ -186,12 +196,15 @@ impl LedgerSigner {
         Ok(Self { transport, derivation, chain_id, address })
     }
 
-    /// Get the account which corresponds to our derivation path
+    /// Re-queries the address for this signer's derivation path.
+    ///
+    /// This does not request on-device display confirmation. [`Signer::address`] returns the
+    /// address cached when this signer was constructed.
     pub async fn get_address(&self) -> Result<Address, LedgerError> {
         self.get_address_with_path(&self.derivation).await
     }
 
-    /// Gets the account which corresponds to the provided derivation path
+    /// Queries the address for `derivation` without requesting on-device display confirmation.
     pub async fn get_address_with_path(
         &self,
         derivation: &DerivationType,
@@ -232,7 +245,7 @@ impl LedgerSigner {
         Ok(address)
     }
 
-    /// Returns the semver of the Ethereum ledger app
+    /// Returns the semantic version of the Ledger Ethereum app.
     pub async fn version(&self) -> Result<semver::Version, LedgerError> {
         let transport = self.transport.lock().await;
 
@@ -256,9 +269,12 @@ impl LedgerSigner {
         Ok(version)
     }
 
-    /// Signs an Ethereum transaction's RLP bytes (requires confirmation on the ledger).
+    /// Signs an encoded transaction signing payload and requires confirmation on the Ledger.
     ///
-    /// Note that this does not apply EIP-155.
+    /// The payload must be legacy RLP or an EIP-2718 transaction type byte followed by its encoded
+    /// payload. This method does not encode a transaction, inject or check a chain ID, or accept a
+    /// transaction hash. Prefer [`alloy_network::TxSigner::sign_transaction`] when a
+    /// [`SignableTransaction`] is available.
     #[doc(alias = "sign_transaction_rlp")]
     pub async fn sign_tx_rlp(&self, tx_rlp: &[u8]) -> Result<Signature, LedgerError> {
         let mut payload = Self::path_to_bytes(&self.derivation)?;

--- a/crates/signer-ledger/src/types.rs
+++ b/crates/signer-ledger/src/types.rs
@@ -8,14 +8,14 @@ use alloy_primitives::hex;
 use std::fmt;
 use thiserror::Error;
 
+/// A Ledger derivation-path preset.
 #[derive(Clone, Debug)]
-/// Ledger wallet type
 pub enum DerivationType {
-    /// Ledger Live-generated HD path
+    /// Ledger Live path `m/44'/60'/<account>'/0/0`.
     LedgerLive(usize),
-    /// Legacy generated HD Path
+    /// Legacy path `m/44'/60'/0'/<index>`.
     Legacy(usize),
-    /// Any other path
+    /// A custom derivation path.
     Other(String),
 }
 

--- a/crates/signer-local/src/lib.rs
+++ b/crates/signer-local/src/lib.rs
@@ -49,7 +49,12 @@ pub type Secp256k1Signer = LocalSigner<Secp256k1Credential>;
 #[cfg(feature = "yubihsm")]
 pub type YubiSigner = LocalSigner<yubihsm::ecdsa::Signer<k256::Secp256k1>>;
 
-/// An Ethereum private-public key pair which can be used for signing messages.
+/// An Ethereum signer backed by a synchronous [`PrehashSigner`] credential.
+///
+/// [`PrivateKeySigner`] and `Secp256k1Signer` keep private-key material in process memory, while
+/// credentials such as `YubiSigner` can delegate signing to external hardware. The asynchronous
+/// [`Signer`] implementation calls the credential synchronously and does not move blocking work to
+/// another thread; custom or hardware credentials may therefore block an async executor.
 ///
 /// # Examples
 ///
@@ -65,10 +70,6 @@ pub type YubiSigner = LocalSigner<yubihsm::ecdsa::Signer<k256::Secp256k1>>;
 /// use alloy_signer_local::PrivateKeySigner;
 ///
 /// let signer = PrivateKeySigner::random();
-///
-/// // Optionally, the signer's chain id can be set, in order to use EIP-155
-/// // replay protection with different chains
-/// let signer = signer.with_chain_id(Some(1337));
 ///
 /// // The signer can be used to sign messages
 /// let message = b"hello";
@@ -128,7 +129,11 @@ impl<C: PrehashSigner<(ecdsa::Signature, RecoveryId)>> SignerSync for LocalSigne
 }
 
 impl<C: PrehashSigner<(ecdsa::Signature, RecoveryId)>> LocalSigner<C> {
-    /// Construct a new credential with an external [`PrehashSigner`].
+    /// Constructs a signer from an external [`PrehashSigner`] credential.
+    ///
+    /// `address` is trusted and is not derived from or checked against `credential`. The caller
+    /// must ensure it is the address recovered from signatures produced by the credential.
+    /// `chain_id` affects transaction signing only.
     #[inline]
     pub const fn new_with_credential(
         credential: C,
@@ -139,12 +144,18 @@ impl<C: PrehashSigner<(ecdsa::Signature, RecoveryId)>> LocalSigner<C> {
     }
 
     /// Returns this signer's credential.
+    ///
+    /// Depending on `C`, the returned value may expose private-key material. Do not log or
+    /// otherwise disclose it.
     #[inline]
     pub const fn credential(&self) -> &C {
         &self.credential
     }
 
     /// Consumes this signer and returns its credential.
+    ///
+    /// Depending on `C`, the returned value may expose private-key material. Do not log or
+    /// otherwise disclose it.
     #[inline]
     pub fn into_credential(self) -> C {
         self.credential

--- a/crates/signer-local/src/mnemonic.rs
+++ b/crates/signer-local/src/mnemonic.rs
@@ -62,7 +62,7 @@ impl MnemonicBuilder<English> {
         Self::default()
     }
 
-    /// Creates a new  [`MnemonicBuilder`] with the [`English`] wordlist and the given phrase
+    /// Creates a new [`MnemonicBuilder`] with the [`English`] wordlist and the given phrase.
     pub fn from_phrase<P: Into<String>>(phrase: P) -> Self {
         Self::english().phrase(phrase)
     }
@@ -106,39 +106,39 @@ impl MnemonicBuilder<English> {
 }
 
 impl<W: Wordlist> MnemonicBuilder<W> {
-    /// Sets the phrase in the mnemonic builder. The phrase can either be a string or a path to
-    /// the file that contains the phrase. Once a phrase is provided, the key will be generated
-    /// deterministically by calling the `build` method.
+    /// Sets the space-separated mnemonic phrase.
+    ///
+    /// The value is parsed as phrase words, not as a file path. Once supplied,
+    /// [`build`](Self::build) derives the signer deterministically.
     ///
     /// # Examples
     ///
     /// ```
-    /// # async fn foo() -> Result<(), Box<dyn std::error::Error>> {
     /// use alloy_signer_local::{MnemonicBuilder, coins_bip39::English};
     ///
     /// let signer = MnemonicBuilder::<English>::default()
     ///     .phrase("abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about")
     ///     .build()?;
-    /// # Ok(())
-    /// # }
+    /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
     pub fn phrase<P: Into<String>>(mut self, phrase: P) -> Self {
         self.phrase = Some(phrase.into());
         self
     }
 
-    /// Sets the word count of a mnemonic phrase to be generated at random. If the `phrase` field
-    /// is set, then `word_count` will be ignored.
+    /// Sets the word count of a mnemonic phrase to generate with
+    /// [`build_random`](Self::build_random).
+    ///
+    /// Valid BIP-39 word counts are 12, 15, 18, 21, and 24. Random generation returns an error if
+    /// a phrase was also supplied.
     ///
     /// # Examples
     ///
-    /// ```no_run
-    /// # async fn foo() -> Result<(), Box<dyn std::error::Error>> {
+    /// ```
     /// use alloy_signer_local::{coins_bip39::English, MnemonicBuilder};
     ///
-    /// let signer = MnemonicBuilder::<English>::default().word_count(24).build()?;
-    /// # Ok(())
-    /// # }
+    /// let signer = MnemonicBuilder::<English>::default().word_count(24).build_random()?;
+    /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
     pub const fn word_count(mut self, count: usize) -> Self {
         self.word_count = count;
@@ -162,14 +162,25 @@ impl<W: Wordlist> MnemonicBuilder<W> {
         &self.derivation_path
     }
 
-    /// Sets the password used to construct the seed from the mnemonic phrase.
+    /// Sets the optional BIP-39 passphrase used to derive the seed.
+    ///
+    /// This is not encryption: the same mnemonic with a different passphrase silently derives a
+    /// different wallet. The passphrase is required to recover the same keys later.
     pub fn password<T: Into<String>>(mut self, password: T) -> Self {
         self.password = Some(password.into());
         self
     }
 
-    /// Sets the path to which the randomly generated phrase will be written to. This field is
-    /// ignored when building a wallet from the provided mnemonic phrase.
+    /// Sets the directory where a randomly generated phrase will be written.
+    ///
+    /// [`build_random`](Self::build_random) writes the phrase in plaintext to a file named after
+    /// the derived signer address. The directory must already exist. This setting is ignored by
+    /// [`build`](Self::build) when deriving from a supplied phrase.
+    ///
+    /// # Security
+    ///
+    /// The file contains the wallet recovery secret in plaintext. Restrict its permissions and do
+    /// not use this option unless plaintext storage is intended.
     pub fn write_to<P: Into<PathBuf>>(mut self, path: P) -> Self {
         self.write_to = Some(path.into());
         self

--- a/crates/signer-local/src/private_key.rs
+++ b/crates/signer-local/src/private_key.rs
@@ -77,13 +77,23 @@ impl LocalSigner<SigningKey> {
         self.credential.as_nonzero_scalar()
     }
 
-    /// Serialize this [`LocalSigner`]'s [`SigningKey`] as a [`B256`] byte array.
+    /// Serializes this [`LocalSigner`]'s [`SigningKey`] as a [`B256`] byte array.
+    ///
+    /// # Security
+    ///
+    /// The returned bytes are unencrypted private-key material. Do not log or disclose them, and
+    /// clear copies as soon as practical.
     #[inline]
     pub fn to_bytes(&self) -> B256 {
         B256::new(<[u8; 32]>::from(self.to_field_bytes()))
     }
 
-    /// Serialize this [`LocalSigner`]'s [`SigningKey`] as a [`FieldBytes`] byte array.
+    /// Serializes this [`LocalSigner`]'s [`SigningKey`] as a [`FieldBytes`] byte array.
+    ///
+    /// # Security
+    ///
+    /// The returned bytes are unencrypted private-key material. Do not log or disclose them, and
+    /// clear copies as soon as practical.
     #[inline]
     pub fn to_field_bytes(&self) -> FieldBytes {
         self.credential.to_bytes()

--- a/crates/signer-local/src/secp256k1.rs
+++ b/crates/signer-local/src/secp256k1.rs
@@ -32,12 +32,16 @@ impl Secp256k1Credential {
     }
 
     /// Returns a reference to the inner [`SecretKey`].
+    ///
+    /// This exposes private-key material. Do not log or disclose it.
     #[inline]
     pub const fn inner(&self) -> &SecretKey {
         &self.0
     }
 
     /// Consumes this credential and returns the inner [`SecretKey`].
+    ///
+    /// This exposes private-key material. Do not log or disclose it.
     #[inline]
     pub const fn into_inner(self) -> SecretKey {
         self.0
@@ -139,7 +143,12 @@ impl LocalSigner<Secp256k1Credential> {
         Self::from_secp256k1(secret_key)
     }
 
-    /// Serialize this [`LocalSigner`]'s [`SecretKey`] as a [`B256`] byte array.
+    /// Serializes this [`LocalSigner`]'s [`SecretKey`] as a [`B256`] byte array.
+    ///
+    /// # Security
+    ///
+    /// The returned bytes are unencrypted private-key material. Do not log or disclose them, and
+    /// clear copies as soon as practical.
     #[inline]
     pub fn to_bytes(&self) -> B256 {
         B256::from_slice(&self.credential.0.secret_bytes())

--- a/crates/signer-tempo/README.md
+++ b/crates/signer-tempo/README.md
@@ -7,7 +7,12 @@ materialized signer plus optional Keychain-mode metadata. No network I/O.
 ## On-disk path
 
 `$TEMPO_HOME/wallet/keys.toml`, falling back to `~/.tempo/wallet/keys.toml`
-(Unix mode `0600`). Matches the Tempo CLI exactly.
+(matches the Tempo CLI). The CLI normally creates this file with Unix mode
+`0600`; this crate reads the file without inspecting or enforcing its permissions.
+
+If the file is valid TOML but individual `[[keys]]` entries do not match the
+expected schema, those entries are skipped and a warning is emitted through
+`tracing`.
 
 ## Example
 
@@ -38,3 +43,9 @@ metadata, foundry-compatible env vars (`TEMPO_PRIVATE_KEY`,
 
 Out: writing/rotating keys, decoding `key_authorization` to a typed value
 (the RLP bytes are exposed opaquely), any network I/O.
+
+Lookup is metadata extraction, not authorization enforcement. It filters for
+available secp256k1 key material and checks expiry at lookup time, but it does
+not enforce the recorded chain ID, spending limits, authorization, or expiry
+when the signer is later used. Returned signers have no chain ID configured;
+configure transaction chain IDs separately.

--- a/crates/signer-tempo/src/keystore.rs
+++ b/crates/signer-tempo/src/keystore.rs
@@ -60,6 +60,10 @@ impl TempoKeystore {
     }
 
     /// Load the keystore from an explicit path.
+    ///
+    /// If the file is valid TOML but individual `[[keys]]` entries are malformed, those entries
+    /// are skipped and a warning is emitted through [`tracing`]. Completely invalid TOML returns
+    /// [`TempoSignerError::BadToml`].
     pub fn load_from(path: impl AsRef<Path>) -> Result<Self, TempoSignerError> {
         let path = path.as_ref().to_path_buf();
         let contents = match std::fs::read_to_string(&path) {
@@ -104,14 +108,20 @@ impl TempoKeystore {
         })
     }
 
-    /// Find a usable key by wallet/EOA address (`from`).
+    /// Find available key material by wallet/EOA address (`from`).
+    ///
+    /// This checks key type, key presence, and expiry at lookup time; it does not enforce chain ID,
+    /// limits, or authorization metadata. The returned signer's chain ID is not configured.
     pub fn find_by_from(&self, from: Address) -> Result<TempoLookup, TempoSignerError> {
         let candidates: Vec<&RawKeyEntry> =
             self.entries.iter().filter(|e| e.wallet_address == from).collect();
         select_one(candidates, from)
     }
 
-    /// Find a usable key by access-key address.
+    /// Find available key material by the recorded access-key address.
+    ///
+    /// This has the same validation scope as [`Self::find_by_from`], and the returned signer's
+    /// chain ID is not configured.
     pub fn find_by_key(&self, key_address: Address) -> Result<TempoLookup, TempoSignerError> {
         let candidates: Vec<&RawKeyEntry> =
             self.entries.iter().filter(|e| e.key_address == Some(key_address)).collect();

--- a/crates/signer-tempo/src/lookup.rs
+++ b/crates/signer-tempo/src/lookup.rs
@@ -14,7 +14,10 @@ pub struct TempoAccessKey {
     pub key_address: Address,
     /// RLP-encoded `SignedKeyAuthorization`.
     pub key_authorization: Option<Bytes>,
-    /// Chain ID the access key was authorized on.
+    /// Chain ID recorded for the access key.
+    ///
+    /// This is metadata and is not applied to the signer. Environment-derived Keychain lookups use
+    /// `0` when the chain ID is unknown.
     pub chain_id: u64,
     /// Expiry as a unix timestamp, if any.
     pub expiry: Option<u64>,
@@ -36,7 +39,8 @@ impl fmt::Debug for TempoAccessKey {
 ///
 /// In [`Self::Direct`] the signer is the wallet itself; in [`Self::Keychain`]
 /// the signer is an access key and the transaction `from` lives in the
-/// accompanying [`TempoAccessKey`].
+/// accompanying [`TempoAccessKey`]. Lookup does not enforce the metadata, and the underlying
+/// signer's chain ID is not configured.
 #[non_exhaustive]
 pub enum TempoLookup {
     /// EOA mode: the signer is the wallet.
@@ -54,6 +58,10 @@ impl TempoLookup {
     }
 
     /// Consume the lookup and return the underlying signer.
+    ///
+    /// For [`Self::Keychain`], this returns the access-key signer and discards the wallet address,
+    /// authorization, chain ID, and expiry metadata. Retain the lookup when that metadata is needed
+    /// to construct a transaction.
     pub fn into_signer(self) -> PrivateKeySigner {
         match self {
             Self::Direct(s) | Self::Keychain(s, _) => s,

--- a/crates/signer-trezor/README.md
+++ b/crates/signer-trezor/README.md
@@ -1,5 +1,46 @@
 # alloy-signer-trezor
 
-Ethereum [Trezor] signer.
+Asynchronous Ethereum signer for [Trezor] devices.
+
+## Device setup
+
+Exactly one Trezor device or emulator must be discoverable. The signer reconnects to that unique
+device for each request, so device operations should not be run concurrently. Unlock the device and
+complete signing prompts on it. Construction requires firmware 1.11.1 or newer for firmware major
+version 1, or 2.5.1 or newer for firmware major version 2.
+
+Although the public signing API is asynchronous, the underlying USB calls are blocking and can
+block an executor thread. Address queries do not request on-device display confirmation.
+
+## Supported operations
+
+- EIP-191 personal messages through `Signer::sign_message`.
+- Legacy and EIP-1559 transactions, including EIP-1559 access lists, through `TxSigner`.
+
+Raw digest and EIP-712 typed-data signing are not supported. EIP-2930, EIP-4844, EIP-7702, and
+other transaction types return an unsupported-transaction error. Passing a 32-byte digest to
+`sign_message` signs those bytes as an EIP-191 message; it does not sign the digest directly.
+
+## Chain IDs
+
+The optional chain ID passed to `TrezorSigner::new` applies only to transaction signing. `Some(id)`
+fills a transaction that has no chain ID and rejects a different transaction chain ID before the
+device is prompted. `None` leaves the transaction unchanged. It does not affect message signatures.
+
+## Example
+
+```no_run
+use alloy_signer::Signer;
+use alloy_signer_trezor::{HDPath, TrezorSigner};
+
+# async fn example() -> Result<(), Box<dyn std::error::Error>> {
+let signer = TrezorSigner::new(HDPath::TrezorLive(0), Some(1)).await?;
+let message = b"hello";
+let signature = signer.sign_message(message).await?;
+
+assert_eq!(signature.recover_address_from_msg(message)?, signer.address());
+# Ok(())
+# }
+```
 
 [Trezor]: https://trezor.io

--- a/crates/signer-trezor/src/signer.rs
+++ b/crates/signer-trezor/src/signer.rs
@@ -8,7 +8,7 @@ use async_trait::async_trait;
 use std::fmt;
 use trezor_client::client::Trezor;
 
-// we need firmware that supports EIP-1559 and EIP-712
+// We require firmware that supports EIP-1559 transaction signing.
 const FIRMWARE_1_MIN_VERSION: &str = ">=1.11.1";
 const FIRMWARE_2_MIN_VERSION: &str = ">=2.5.1";
 
@@ -16,8 +16,11 @@ const FIRMWARE_2_MIN_VERSION: &str = ">=2.5.1";
 ///
 /// This is a simple wrapper around the [Trezor transport](Trezor).
 ///
-/// Note that this wallet only supports asynchronous operations. Calling a non-asynchronous method
-/// will always return an error.
+/// Device operations are available through the asynchronous [`Signer`] and
+/// [`alloy_network::TxSigner`] traits; [`alloy_signer::SignerSync`] is not implemented. The
+/// underlying USB operations are blocking. Raw digest signing is unsupported, while
+/// [`Signer::sign_message`] performs EIP-191 personal-message signing and requires confirmation on
+/// the device.
 pub struct TrezorSigner {
     derivation: DerivationType,
     session_id: Vec<u8>,
@@ -86,7 +89,12 @@ impl alloy_network::TxSigner<Signature> for TrezorSigner {
 alloy_network::impl_into_wallet!(TrezorSigner);
 
 impl TrezorSigner {
-    /// Instantiates a new Trezor signer.
+    /// Connects to the unique available Trezor device and reads the derived address.
+    ///
+    /// Exactly one device or emulator must be discoverable. Firmware major version 1 requires
+    /// version 1.11.1 or newer, and major version 2 requires 2.5.1 or newer. `chain_id` applies
+    /// only to transaction signing: it fills a missing transaction chain ID and rejects a
+    /// different one.
     #[instrument(ret)]
     pub async fn new(
         derivation: DerivationType,
@@ -108,7 +116,7 @@ impl TrezorSigner {
             1 => FIRMWARE_1_MIN_VERSION,
             2 => FIRMWARE_2_MIN_VERSION,
             // unknown major version, possibly newer models that we don't know about yet
-            // it's probably safe to assume they support EIP-1559 and EIP-712
+            // It's probably safe to assume they support EIP-1559.
             _ => return Ok(()),
         };
 
@@ -144,12 +152,15 @@ impl TrezorSigner {
         Ok(client)
     }
 
-    /// Get the account which corresponds to our derivation path
+    /// Re-queries the address for this signer's derivation path.
+    ///
+    /// This does not request on-device display confirmation. [`Signer::address`] returns the
+    /// address cached when this signer was constructed.
     pub async fn get_address(&self) -> Result<Address, TrezorError> {
         self.get_address_with_path(&self.derivation).await
     }
 
-    /// Gets the account which corresponds to the provided derivation path
+    /// Queries the address for `derivation` without requesting on-device display confirmation.
     #[instrument(ret)]
     pub async fn get_address_with_path(
         &self,
@@ -160,9 +171,7 @@ impl TrezorSigner {
         Ok(address_str.parse()?)
     }
 
-    /// Signs an Ethereum transaction (requires confirmation on the Trezor).
-    ///
-    /// Does not apply EIP-155.
+    /// Signs a legacy or EIP-1559 transaction and requires confirmation on the Trezor.
     #[doc(alias = "sign_transaction_inner")]
     async fn sign_tx_inner(
         &self,

--- a/crates/signer-trezor/src/types.rs
+++ b/crates/signer-trezor/src/types.rs
@@ -6,10 +6,10 @@ use alloy_primitives::hex;
 use std::fmt;
 use thiserror::Error;
 
-/// Trezor wallet type.
+/// A Trezor derivation-path preset.
 #[derive(Clone, Debug)]
 pub enum DerivationType {
-    /// Trezor Live-generated HD path
+    /// Standard path `m/44'/60'/0'/0/<index>`.
     TrezorLive(usize),
     /// Any other path.
     ///
@@ -42,8 +42,7 @@ pub enum TrezorError {
     /// Signature Error
     #[error(transparent)]
     SignatureError(#[from] alloy_primitives::SignatureError),
-    /// Thrown when trying to sign an EIP-712 struct with an incompatible Trezor Ethereum app
-    /// version.
+    /// Device firmware is older than the minimum accepted during signer construction.
     #[error("Trezor Ethereum app requires at least version {0:?}")]
     UnsupportedFirmwareVersion(String),
     /// Need to provide a chain ID for EIP-155 signing.

--- a/crates/signer-turnkey/README.md
+++ b/crates/signer-turnkey/README.md
@@ -2,4 +2,11 @@
 
 Ethereum [Turnkey] signer.
 
+The P-256 API key authenticates and stamps Turnkey requests; it is not the
+secp256k1 key that signs Ethereum payloads. The Ethereum key remains in
+Turnkey and is selected by its address. The API key must be authorized to sign
+with that address in the supplied organization.
+
+Enable this crate's `eip712` feature to sign EIP-712 typed data.
+
 [Turnkey]: https://docs.turnkey.com/getting-started/quickstart

--- a/crates/signer-turnkey/src/signer.rs
+++ b/crates/signer-turnkey/src/signer.rs
@@ -14,32 +14,37 @@ use crate::{TurnkeyClient, TurnkeyClientError, TurnkeyP256ApiKey};
 /// Turnkey signer implementation for Alloy.
 ///
 /// The Turnkey Signer passes signing requests to the Turnkey secure key management infrastructure.
-/// This implementation uses Turnkey's sign_raw_payload API with HASH_FUNCTION_NO_OP for simplicity.
+/// It uses `sign_raw_payload` with `HASH_FUNCTION_NO_OP`, so [`Signer::sign_hash`] sends the
+/// supplied 32-byte prehash without hashing it again.
 ///
-/// The signer is initialized with a user-provided address that corresponds to a key in your Turnkey
-/// organization. This follows the Turnkey team's recommendation for an MVP implementation.
+/// The user-provided address selects a Turnkey-managed Ethereum key. Construction does not contact
+/// Turnkey or verify that the address belongs to the organization; [`Signer::address`] returns the
+/// supplied value. Organization, address, API-key authorization, and policy errors surface on the
+/// first signing request.
 ///
-/// Note that this signer only supports asynchronous operations. Calling a non-asynchronous method
-/// will always return an error.
+/// Signing performs network I/O and must be awaited; this type does not implement
+/// [`alloy_signer::SignerSync`].
 ///
 /// # Examples
 ///
 /// ```no_run
-/// use alloy_primitives::Address;
 /// use alloy_signer::Signer;
-/// use alloy_signer_turnkey::{TurnkeyClient, TurnkeyP256ApiKey, TurnkeySigner};
+/// use alloy_signer_turnkey::TurnkeySigner;
 ///
 /// # async fn test() {
-/// let api_key =
-///     TurnkeyP256ApiKey::from_strings("private_key_hex", None).expect("api key creation failed");
-/// let client = TurnkeyClient::builder().api_key(api_key).build().expect("client builder failed");
-/// let org_id = "your-org-id".to_string();
-/// let address = alloy_primitives::address!("0x1234567890123456789012345678901234567890");
-/// let chain_id = Some(1);
-/// let signer = TurnkeySigner::new(client, org_id, address, chain_id);
+/// let api_private_key =
+///     std::env::var("TURNKEY_API_PRIVATE_KEY").expect("TURNKEY_API_PRIVATE_KEY");
+/// let organization_id =
+///     std::env::var("TURNKEY_ORGANIZATION_ID").expect("TURNKEY_ORGANIZATION_ID");
+/// let address = std::env::var("TURNKEY_ADDRESS")
+///     .expect("TURNKEY_ADDRESS")
+///     .parse()
+///     .expect("valid TURNKEY_ADDRESS");
+/// let signer =
+///     TurnkeySigner::from_api_key(&api_private_key, organization_id, address, None).unwrap();
 ///
-/// let message = vec![0, 1, 2, 3];
-/// let sig = signer.sign_message(&message).await.unwrap();
+/// let message = b"hello from Alloy";
+/// let sig = signer.sign_message(message).await.unwrap();
 /// assert_eq!(sig.recover_address_from_msg(message).unwrap(), signer.address());
 /// # }
 /// ```
@@ -97,6 +102,11 @@ impl alloy_network::TxSigner<Signature> for TurnkeySigner {
 #[cfg_attr(target_family = "wasm", async_trait(?Send))]
 #[cfg_attr(not(target_family = "wasm"), async_trait)]
 impl Signer for TurnkeySigner {
+    /// Sign a precomputed 32-byte digest.
+    ///
+    /// The digest is sent to Turnkey with `HASH_FUNCTION_NO_OP` and is not hashed or prefixed
+    /// again. [`Signer::sign_message`] and the EIP-712 helpers compute their respective signing
+    /// hashes before calling this method.
     #[instrument(err)]
     async fn sign_hash(&self, hash: &B256) -> Result<Signature> {
         let response = self
@@ -160,6 +170,14 @@ alloy_network::impl_into_wallet!(TurnkeySigner);
 
 impl TurnkeySigner {
     /// Instantiate a new signer from an existing client, organization ID, and address.
+    ///
+    /// Construction performs no network request and does not verify that `address` belongs to the
+    /// organization. The address is sent to Turnkey as `sign_with` and is also returned by
+    /// [`Signer::address`].
+    ///
+    /// `chain_id` affects transaction signing only. `Some(id)` fills an unset transaction chain ID
+    /// and rejects a conflicting one before signing. It does not affect hash, message, or
+    /// typed-data signing; `None` disables this signer-side check.
     pub const fn new(
         client: TurnkeyClient,
         organization_id: String,
@@ -169,10 +187,15 @@ impl TurnkeySigner {
         Self { client, organization_id, address, chain_id }
     }
 
-    /// Instantiate a new signer from API credentials, organization ID, and address.
+    /// Instantiate a new signer from a P-256 API key, organization ID, and Ethereum address.
     ///
-    /// This is a convenience constructor that builds the Turnkey client from
-    /// an API private key string.
+    /// `api_private_key` must be the hex-encoded P-256 key used to authenticate and stamp Turnkey
+    /// API requests. It is not the secp256k1 key that signs Ethereum payloads. This constructor
+    /// uses the default Turnkey client settings; use [`Self::new`] with
+    /// [`TurnkeyClient::builder`] for custom endpoint, retry, or timeout configuration.
+    ///
+    /// Construction performs no Turnkey request. See [`Self::new`] for address trust and `chain_id`
+    /// semantics.
     pub fn from_api_key(
         api_private_key: &str,
         organization_id: String,

--- a/crates/signer/README.md
+++ b/crates/signer/README.md
@@ -6,6 +6,7 @@ You can implement the [`Signer`][Signer] trait to extend functionality to other 
 such as Hardware Security Modules, KMS etc. See [its documentation][Signer] for more.
 
 Signer implementations in Alloy:
+
 - [K256 private key](https://docs.rs/alloy-signer-local)
 - [YubiHSM2](https://docs.rs/alloy-signer-local)
 - [Ledger](https://docs.rs/alloy-signer-ledger)
@@ -13,15 +14,30 @@ Signer implementations in Alloy:
 - [AWS KMS](https://docs.rs/alloy-signer-aws)
 - [GCP KMS](https://docs.rs/alloy-signer-gcp)
 - [Turnkey](https://docs.rs/alloy-signer-turnkey)
+- [Tempo wallet keystore](https://docs.rs/alloy-signer-tempo)
 
 [Signer]: https://docs.rs/alloy-signer/latest/alloy_signer/trait.Signer.html
 
+## Signing inputs
+
+The signing methods differ in what they hash before producing a signature:
+
+| Method | Input |
+| --- | --- |
+| `sign_hash` | A 32-byte prehash, signed exactly as supplied |
+| `sign_message` | Arbitrary bytes, prefixed and hashed according to EIP-191 |
+| `sign_typed_data` | A value and domain, encoded and hashed according to EIP-712 |
+| `TxSigner::sign_transaction` | A mutable signable transaction; the implementation may fill or validate its chain ID, then signs its signing payload or hash |
+
+A signer's configured chain ID applies only to transaction signing. It does not change raw-hash,
+message, or typed-data signatures; an EIP-712 chain ID belongs in the typed-data domain.
+
 ## Examples
 
-Sign an Ethereum prefixed message ([EIP-712](https://eips.ethereum.org/EIPS/eip-712)):
+Sign an Ethereum-prefixed message ([EIP-191](https://eips.ethereum.org/EIPS/eip-191)):
 
 ```rust,ignore
-use alloy_signer::{Signer, SignerSync};
+use alloy_signer::SignerSync;
 use alloy_signer_local::PrivateKeySigner;
 
 // Instantiate a signer.
@@ -42,7 +58,6 @@ Sign a transaction:
 ```rust,ignore
 use alloy_consensus::TxLegacy;
 use alloy_primitives::{U256, address, bytes};
-use alloy_signer::{Signer, SignerSync};
 use alloy_signer_local::PrivateKeySigner;
 use alloy_network::TxSignerSync;
 

--- a/crates/signer/src/lib.rs
+++ b/crates/signer/src/lib.rs
@@ -17,8 +17,12 @@ pub mod utils;
 pub use alloy_primitives::Signature;
 pub use k256;
 
-/// Utility to get and set the chain ID on a transaction and the resulting signature within a
-/// signer's `sign_transaction`.
+/// Implements chain-ID validation for a signer's `sign_transaction` method.
+///
+/// When the signer has a chain ID, this fills an unset transaction chain ID or returns
+/// [`Error::TransactionChainIdMismatch`] before the signing expression is evaluated. A signer
+/// without a chain ID leaves the transaction unchanged. Errors from the signing expression are
+/// wrapped with [`Error::other`].
 #[macro_export]
 macro_rules! sign_transaction_with_chain_id {
     // async (

--- a/crates/signer/src/signer.rs
+++ b/crates/signer/src/signer.rs
@@ -23,10 +23,15 @@ use alloy_sol_types::{Eip712Domain, SolStruct};
 #[cfg_attr(not(target_family = "wasm"), async_trait)]
 #[auto_impl(&mut, Box)]
 pub trait Signer<Sig = Signature> {
-    /// Signs the given hash.
+    /// Signs the given 32-byte prehash exactly as supplied.
+    ///
+    /// This method does not hash, prefix, or domain-separate the input. Use
+    /// [`sign_message`](Self::sign_message) for EIP-191 messages or `sign_typed_data` for EIP-712
+    /// typed data when the `eip712` feature is enabled.
     async fn sign_hash(&self, hash: &B256) -> Result<Sig>;
 
     /// Signs the hash of the provided message after prefixing it, as specified in [EIP-191].
+    /// The signer's configured chain ID is not included.
     ///
     /// [EIP-191]: https://eips.ethereum.org/EIPS/eip-191
     #[inline]
@@ -35,6 +40,9 @@ pub trait Signer<Sig = Signature> {
     }
 
     /// Encodes and signs the typed data according to [EIP-712].
+    ///
+    /// Any chain ID is taken from `domain`; the signer's configured chain ID is not applied or
+    /// checked.
     ///
     /// [EIP-712]: https://eips.ethereum.org/EIPS/eip-712
     #[cfg(feature = "eip712")]
@@ -55,6 +63,7 @@ pub trait Signer<Sig = Signature> {
     ///
     /// Unlike [`Signer::sign_typed_data`], this method works with unsized Signers (trait objects
     /// like `Box<dyn Signer>`).
+    /// The signer's configured chain ID is not applied or checked.
     ///
     /// [EIP-712]: https://eips.ethereum.org/EIPS/eip-712
     #[cfg(feature = "eip712")]
@@ -63,16 +72,23 @@ pub trait Signer<Sig = Signature> {
         self.sign_hash(&payload.eip712_signing_hash()?).await
     }
 
-    /// Returns the signer's Ethereum Address.
+    /// Returns the signer's Ethereum address.
     fn address(&self) -> Address;
 
-    /// Returns the signer's chain ID.
+    /// Returns the chain ID used to fill or validate transactions before signing.
+    ///
+    /// This value does not affect hash, message, or typed-data signing.
     fn chain_id(&self) -> Option<ChainId>;
 
-    /// Sets the signer's chain ID.
+    /// Sets the chain ID used to fill or validate transactions before signing.
+    ///
+    /// Passing `None` disables signer-side transaction chain-ID validation. This setting does not
+    /// affect hash, message, or typed-data signing.
     fn set_chain_id(&mut self, chain_id: Option<ChainId>);
 
-    /// Sets the signer's chain ID and returns `self`.
+    /// Sets the transaction chain ID and returns `self`.
+    ///
+    /// Passing `None` clears the setting. See [`Signer::set_chain_id`] for its scope.
     #[inline]
     #[must_use]
     #[auto_impl(keep_default_for(&mut, Box))]
@@ -98,10 +114,15 @@ pub trait Signer<Sig = Signature> {
 /// [EIP-155]: https://eips.ethereum.org/EIPS/eip-155
 #[auto_impl(&, &mut, Box, Rc, Arc)]
 pub trait SignerSync<Sig = Signature> {
-    /// Signs the given hash.
+    /// Signs the given 32-byte prehash exactly as supplied.
+    ///
+    /// This method does not hash, prefix, or domain-separate the input. Use
+    /// [`sign_message_sync`](Self::sign_message_sync) for EIP-191 messages or
+    /// `sign_typed_data_sync` for EIP-712 typed data when the `eip712` feature is enabled.
     fn sign_hash_sync(&self, hash: &B256) -> Result<Sig>;
 
     /// Signs the hash of the provided message after prefixing it, as specified in [EIP-191].
+    /// The signer's configured chain ID is not included.
     ///
     /// [EIP-191]: https://eips.ethereum.org/EIPS/eip-191
     #[inline]
@@ -110,6 +131,9 @@ pub trait SignerSync<Sig = Signature> {
     }
 
     /// Encodes and signs the typed data according to [EIP-712].
+    ///
+    /// Any chain ID is taken from `domain`; the signer's configured chain ID is not applied or
+    /// checked.
     ///
     /// [EIP-712]: https://eips.ethereum.org/EIPS/eip-712
     #[cfg(feature = "eip712")]
@@ -126,6 +150,7 @@ pub trait SignerSync<Sig = Signature> {
     ///
     /// Unlike [`SignerSync::sign_typed_data_sync`], this method works with unsized Signers (trait
     /// objects like `Box<dyn SignerSync>`).
+    /// The signer's configured chain ID is not applied or checked.
     ///
     /// [EIP-712]: https://eips.ethereum.org/EIPS/eip-712
     #[cfg(feature = "eip712")]
@@ -135,7 +160,9 @@ pub trait SignerSync<Sig = Signature> {
         self.sign_hash_sync(&hash)
     }
 
-    /// Returns the signer's chain ID.
+    /// Returns the chain ID used to fill or validate transactions before signing.
+    ///
+    /// This value does not affect hash, message, or typed-data signing.
     fn chain_id_sync(&self) -> Option<ChainId>;
 }
 

--- a/crates/transport-http/README.md
+++ b/crates/transport-http/README.md
@@ -2,5 +2,11 @@
 
 HTTP transport implementation.
 
-## Providing HTTP Headers
-The HTTP request headers will be extended if a `http::HeaderMap` is present in the request metadata. This extension functionality is only available for single requests and is not supported for batch requests.
+## Providing HTTP headers
+
+The HTTP request headers are extended when a `http::HeaderMap` is present in
+the request metadata. For a batch, header maps are appended in request order;
+repeated names retain every value rather than replacing earlier ones. Because a
+batch is sent as one HTTP request, headers are packet-wide. Avoid duplicate
+authorization or tenant headers, and do not batch calls that require different
+values.

--- a/crates/transport/README.md
+++ b/crates/transport/README.md
@@ -9,6 +9,8 @@ use alloy_transport::mock::{Asserter, MockTransport};
 use alloy_json_rpc as j;
 use tower::Service;
 
+# async fn example() {
+
 // Prepare a mock response and a serialized request
 let asserter = Asserter::new();
 asserter.push_success(&12345u64);
@@ -20,10 +22,7 @@ let packet = j::RequestPacket::from(req);
 
 // Drive the service and assert the response
 let mut transport = MockTransport::new(asserter.clone());
-let resp = tokio::runtime::Runtime::new()
-    .unwrap()
-    .block_on(async move { transport.call(packet).await })
-    .unwrap();
+let resp = transport.call(packet).await.unwrap();
 
 if let j::ResponsePacket::Single(r) = resp {
     let n: u64 = match r.payload {
@@ -32,6 +31,7 @@ if let j::ResponsePacket::Single(r) = resp {
     };
     assert_eq!(n, 12345);
 }
+# }
 ```
 
 Low-level Ethereum JSON-RPC transport abstraction.

--- a/crates/transport/src/layers/fallback.rs
+++ b/crates/transport/src/layers/fallback.rs
@@ -26,6 +26,21 @@ const DEFAULT_ACTIVE_TRANSPORT_COUNT: usize = 3;
 ///
 /// The service ranks transports based on latency and stability metrics,
 /// and will attempt to always use the best available transports.
+///
+/// # Parallel execution and side effects
+///
+/// Unless a method is in `sequential_methods`, the request is sent to up to
+/// `active_transport_count` transports concurrently. Dropping the remaining
+/// futures after one completes does not undo remote side effects. Add every
+/// non-idempotent method to the sequential set. Sequential mode avoids
+/// concurrent submission, but can still try another transport after an error,
+/// so it does not guarantee at-most-once execution.
+///
+/// "Successful" means that the transport returned `Ok(ResponsePacket)`; a
+/// packet containing a JSON-RPC error still wins the race. Responses are not
+/// compared for equality or consensus. Sequential mode tries only the top
+/// `active_transport_count` transports, and a batch is sequential when any of
+/// its methods is in the sequential set.
 #[derive(Debug, Clone)]
 pub struct FallbackService<S> {
     /// The list of transports to use
@@ -300,6 +315,8 @@ where
 /// transports in parallel, and return the first successful response.
 ///
 /// If all transports fail, the fallback service will return an error.
+/// Parallel execution can submit the same operation to several remote nodes;
+/// see [`FallbackService`] for replay-safety and JSON-RPC error semantics.
 ///
 /// # Automatic Transport Ranking
 ///

--- a/crates/transport/src/layers/retry.rs
+++ b/crates/transport/src/layers/retry.rs
@@ -27,7 +27,8 @@ const DEFAULT_AVG_COST: u64 = 20u64;
 /// A Transport Layer that is responsible for retrying requests based on the
 /// error type. See [`TransportError`].
 ///
-/// TransportError: crate::error::TransportError
+/// A retry re-sends the complete [`RequestPacket`], including every member of
+/// a batch. See [`RetryBackoffService`] for replay-safety details.
 #[derive(Debug, Clone)]
 pub struct RetryBackoffLayer<P: RetryPolicy = RateLimitRetryPolicy> {
     /// The maximum number of retries for rate limit errors.
@@ -44,6 +45,11 @@ pub struct RetryBackoffLayer<P: RetryPolicy = RateLimitRetryPolicy> {
 
 impl RetryBackoffLayer {
     /// Creates a new retry layer with the given parameters and the default [RateLimitRetryPolicy].
+    ///
+    /// `max_rate_limit_retries` is the number of attempts after the initial
+    /// request. `initial_backoff` is a fixed base component in milliseconds unless the retry
+    /// policy supplies a hint; a compute-budget queue offset can add to the actual delay. It is not
+    /// an exponential base.
     pub const fn new(
         max_rate_limit_retries: u32,
         initial_backoff: u64,
@@ -190,6 +196,17 @@ impl<S, P: RetryPolicy + Clone> Layer<S> for RetryBackoffLayer<P> {
 
 /// A Tower Service used by the RetryBackoffLayer that is responsible for retrying requests based
 /// on the error type. See [TransportError] and [RateLimitRetryPolicy].
+///
+/// # Replay safety
+///
+/// Each retry sends the complete [`RequestPacket`] again with the same IDs.
+/// When the policy retries a batch response, successful members are replayed
+/// along with the failed member. Only the first error in response order decides
+/// whether a batch is retried; later retryable errors are ignored when an
+/// earlier error is not retryable. The remote server may also have processed a
+/// request whose response was lost. Use this service only for operations that
+/// are safe to execute more than once, or route non-idempotent methods around
+/// this layer.
 #[derive(Debug, Clone)]
 pub struct RetryBackoffService<S, P: RetryPolicy = RateLimitRetryPolicy> {
     /// The inner service

--- a/crates/tx-macros/README.md
+++ b/crates/tx-macros/README.md
@@ -1,1 +1,32 @@
 # alloy-tx-macros
+
+Derive support for composing EIP-2718 transaction-envelope enums. This crate is normally consumed
+through [`alloy-consensus`](https://docs.rs/alloy-consensus), which re-exports
+`TransactionEnvelope` and forwards its `serde` and `arbitrary` features.
+
+```rust,ignore
+use alloy_consensus::{Signed, TransactionEnvelope, TxEip1559};
+
+#[derive(Clone, Debug, TransactionEnvelope)]
+#[envelope(tx_type_name = MyTxType, typed = MyTypedTransaction)]
+pub enum MyEnvelope {
+    #[envelope(ty = 2)]
+    Eip1559(Signed<TxEip1559>),
+}
+```
+
+The numeric attribute is a dispatch declaration, not an encoding override: the inner type's
+`Typed2718`, encoder, and decoder must already use the same ID. Valid EIP-2718 type bytes are at
+most `0x7f`; although the macro and generated RLP codec accept any `u8`, larger IDs are invalid and
+not interoperable with standard raw EIP-2718 decoding.
+
+When the derive is imported through the `alloy` meta crate rather than a direct
+`alloy-consensus` dependency, point generated paths at the re-export:
+
+```rust,ignore
+#[derive(Clone, Debug, alloy::consensus::TransactionEnvelope)]
+#[envelope(alloy_consensus = alloy::consensus, tx_type_name = MyTxType)]
+enum MyEnvelope {
+    // ...
+}
+```

--- a/crates/tx-macros/src/lib.rs
+++ b/crates/tx-macros/src/lib.rs
@@ -17,33 +17,68 @@ use proc_macro::TokenStream;
 use quote::quote;
 use syn::{parse_macro_input, parse_quote, DeriveInput, Error, Ident};
 
-/// Derive macro for creating transaction envelope types.
+/// Derives an EIP-2718 transaction envelope and its transaction-type enum.
 ///
-/// This macro generates a transaction envelope implementation that supports
-/// multiple transaction types following the EIP-2718 standard.
+/// # Input requirements
 ///
-/// # Container Attributes
+/// The target must be an enum, and every variant must contain exactly one unnamed field. Annotate
+/// each variant with either `#[envelope(ty = N)]` or `#[envelope(flatten)]`.
 ///
-/// - `#[envelope(tx_type_name = MyTxType)]` - Custom name for the generated transaction type enum
-/// - `#[envelope(alloy_consensus = path::to::alloy)]` - Custom path to alloy_consensus crate
-/// - `#[envelope(typed = MyTypedTransaction)]` - Generate a corresponding TypedTransaction enum
-///   (optional)
+/// For `ty = N`, the inner type must implement the transaction, `Typed2718`, `Encodable2718`, and
+/// `Decodable2718` contracts used by the generated implementations. `N` controls the generated
+/// type enum and decode dispatch; it does **not** override the inner value's reported type or
+/// encoded prefix. The inner implementation must therefore already report, encode, and decode the
+/// same ID. Untagged fallback decoding tries each variant's inner `fallback_decode` in declaration
+/// order, so non-legacy variants must reject legacy input and fallback acceptance must not overlap.
+/// `ty = 0` receives the macro's legacy JSON handling and should be used only for the legacy
+/// transaction representation.
 ///
-/// # Variant Attributes
-/// - Each variant must be annotated with `envelope` attribute with one of the following options:
-///   - `#[envelope(ty = N)]` - Specify the transaction type ID (0-255)
-///   - `#[envelope(ty = N, typed = CustomType)]` - Use a custom transaction type for this variant
-///     in the generated TypedTransaction (optional)
-///   - `#[envelope(flatten)]` - Flatten this variant to delegate to inner envelope type
+/// EIP-2718 type bytes are in `0x00..=0x7f`. The attribute parser currently accepts any `u8`, but
+/// values above `0x7f` are not valid EIP-2718 envelope types and are not interoperable with
+/// standard raw EIP-2718 decoding, even though generated RLP methods may round-trip them.
 ///
-/// # Generated Code
+/// A `flatten` variant delegates to an inner `TransactionEnvelope`. Its type IDs must not overlap
+/// any other direct or flattened variant, because overlapping IDs make dispatch order-dependent.
 ///
-/// The macro generates:
-/// - A `MyTxType` enum with transaction type variants
-/// - Implementations of `Transaction`, `Typed2718`, `Encodable2718`, `Decodable2718`
-/// - Serde serialization/deserialization support (if `serde` feature is enabled)
-/// - Arbitrary implementations (if `arbitrary` feature is enabled)
-/// - Optionally, a TypedTransaction enum (if `typed` attribute is specified)
+/// The derive itself generates `PartialEq`, `Eq`, and `Hash` for the envelope, so do not also list
+/// those traits in `#[derive(...)]`. Derive `Clone` and `Debug` as needed by the generated trait
+/// bounds.
+///
+/// # Container attributes
+///
+/// - `#[envelope(tx_type_name = MyTxType)]` names the generated public type enum. It defaults to
+///   `{EnvelopeName}Type`.
+/// - `#[envelope(alloy_consensus = path::to::consensus)]` changes the path used by generated code.
+///   The default is `::alloy_consensus`. When using only the `alloy` meta crate, set this to
+///   `alloy::consensus`.
+/// - `#[envelope(typed = MyTypedTransaction)]` also generates a corresponding typed-transaction
+///   enum. Syntactic `Signed<T>` and `Sealed<T>` fields are unwrapped; other field types remain as
+///   declared, so the result is not necessarily unsigned.
+/// - `#[envelope(serde_cfg(feature = "serde"))]` gates generated Serde implementations with the
+///   supplied `cfg` predicate.
+/// - `#[envelope(arbitrary_cfg(feature = "arbitrary"))]` similarly gates generated `Arbitrary`
+///   implementations.
+///
+/// Serde or `Arbitrary` code is emitted only when the corresponding `alloy-tx-macros` feature is
+/// enabled; `alloy-consensus` forwards its features. Without a `*_cfg` attribute, emitted
+/// implementations are unconditional in the consuming crate.
+///
+/// # Variant attributes
+///
+/// - `#[envelope(ty = N)]` declares a directly supported type ID.
+/// - `#[envelope(flatten)]` delegates type identification and codec behavior to an inner envelope.
+/// - `#[envelope(ty = N, typed = CustomType)]` selects the field type used for that variant in a
+///   generated typed-transaction enum. By default, the macro syntactically unwraps `Signed<T>` and
+///   `Sealed<T>` to `T`; other field types are reused unchanged.
+/// - A variant's `#[serde(...)]` options are forwarded to the macro's internal representation when
+///   Serde generation is enabled.
+///
+/// # Generated API
+///
+/// In addition to the named transaction-type enum, the macro implements `Transaction`,
+/// `TransactionEnvelope`, `Typed2718`, `IsTyped2718`, `Encodable2718`, `Decodable2718`, and RLP
+/// encoding and decoding for the envelope. Supplying `typed = ...` creates the corresponding enum
+/// and its transaction/type implementations; see the crate-level example.
 #[proc_macro_derive(TransactionEnvelope, attributes(envelope, serde))]
 pub fn derive_transaction_envelope(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);


### PR DESCRIPTION
## Summary

- clarify behavioral contracts and invariants across providers, RPC types, transports, signers, consensus, ENS, and serde
- replace stale or misleading examples with concise, compile-checked guidance
- mark historical EIP schemas and document lifecycle, replay, trust, ordering, and preservation boundaries

## Why

Several public comments described intended abstractions rather than the behavior users actually encounter, while important ordering, ownership, serialization, and safety constraints were scattered through implementation details.

## Impact

This is documentation-only. It gives users shorter paths to the right APIs and makes surprising behavior explicit without changing runtime behavior.