### PR TITLE
fix(signer): reject BIP32 indices that already set the harden bit

### DIFF
--- a/crates/signer-ledger/src/signer.rs
+++ b/crates/signer-ledger/src/signer.rs
@@ -387,10 +387,17 @@ impl LedgerSigner {
         let mut bytes = vec![depth as u8];
         for derivation_index in elements {
             let hardened = derivation_index.contains('\'');
-            let mut index = derivation_index.replace('\'', "").parse::<u32>()?;
-            if hardened {
-                index |= 0x80000000;
+            let index = derivation_index.replace('\'', "").parse::<u32>().map_err(|e| {
+                LedgerError::InvalidDerivationPath(e.to_string())
+            })?;
+            // Reject raw indices that already set the harden bit (e.g. 2147483648 ≡ 0').
+            // Otherwise Other("m/2147483648") silently selects a hardened child.
+            if index >= 0x8000_0000 {
+                return Err(LedgerError::InvalidDerivationPath(format!(
+                    "index {index} is out of range (use \' for hardened segments)"
+                )));
             }
+            let index = if hardened { index | 0x8000_0000 } else { index };
 
             bytes.extend(index.to_be_bytes());
         }
@@ -447,6 +454,20 @@ mod tests {
         let err = LedgerSigner::path_to_bytes(&DerivationType::Other("m/44'/invalid/0".into()))
             .unwrap_err();
         assert!(matches!(err, LedgerError::InvalidDerivationPath(_)));
+    }
+
+    #[test]
+    fn rejects_raw_hardened_index_without_marker() {
+        let err = LedgerSigner::path_to_bytes(&DerivationType::Other("m/2147483648".into()))
+            .unwrap_err();
+        assert!(matches!(err, LedgerError::InvalidDerivationPath(_)));
+
+        let err = LedgerSigner::path_to_bytes(&DerivationType::Other("m/2147483648'".into()))
+            .unwrap_err();
+        assert!(matches!(err, LedgerError::InvalidDerivationPath(_)));
+
+        let ok = LedgerSigner::path_to_bytes(&DerivationType::Other("m/0'".into())).unwrap();
+        assert_eq!(ok, vec![1, 0x80, 0x00, 0x00, 0x00]);
     }
 
     #[tokio::test]

--- a/crates/signer-ledger/src/signer.rs
+++ b/crates/signer-ledger/src/signer.rs
@@ -387,9 +387,10 @@ impl LedgerSigner {
         let mut bytes = vec![depth as u8];
         for derivation_index in elements {
             let hardened = derivation_index.contains('\'');
-            let index = derivation_index.replace('\'', "").parse::<u32>().map_err(|e| {
-                LedgerError::InvalidDerivationPath(e.to_string())
-            })?;
+            let index = derivation_index
+                .replace('\'', "")
+                .parse::<u32>()
+                .map_err(|e| LedgerError::InvalidDerivationPath(e.to_string()))?;
             // Reject raw indices that already set the harden bit (e.g. 2147483648 ≡ 0').
             // Otherwise Other("m/2147483648") silently selects a hardened child.
             if index >= 0x8000_0000 {
@@ -458,8 +459,8 @@ mod tests {
 
     #[test]
     fn rejects_raw_hardened_index_without_marker() {
-        let err = LedgerSigner::path_to_bytes(&DerivationType::Other("m/2147483648".into()))
-            .unwrap_err();
+        let err =
+            LedgerSigner::path_to_bytes(&DerivationType::Other("m/2147483648".into())).unwrap_err();
         assert!(matches!(err, LedgerError::InvalidDerivationPath(_)));
 
         let err = LedgerSigner::path_to_bytes(&DerivationType::Other("m/2147483648'".into()))

--- a/crates/signer-ledger/src/types.rs
+++ b/crates/signer-ledger/src/types.rs
@@ -45,8 +45,8 @@ pub enum LedgerError {
     #[error(transparent)]
     SemVerError(#[from] semver::Error),
     /// Invalid derivation path.
-    #[error("invalid derivation path")]
-    InvalidDerivationPath(#[from] std::num::ParseIntError),
+    #[error("invalid derivation path: {0}")]
+    InvalidDerivationPath(String),
     /// Signature Error
     #[error(transparent)]
     SignatureError(#[from] alloy_primitives::SignatureError),

--- a/crates/signer-trezor/src/signer.rs
+++ b/crates/signer-trezor/src/signer.rs
@@ -156,7 +156,7 @@ impl TrezorSigner {
         derivation: &DerivationType,
     ) -> Result<Address, TrezorError> {
         let mut client = self.get_client()?;
-        let address_str = client.ethereum_get_address(Self::convert_path(derivation))?;
+        let address_str = client.ethereum_get_address(Self::convert_path(derivation)?)?;
         Ok(address_str.parse()?)
     }
 
@@ -169,7 +169,7 @@ impl TrezorSigner {
         tx: &dyn SignableTransaction<Signature>,
     ) -> Result<Signature, TrezorError> {
         let mut client = self.get_client()?;
-        let path = Self::convert_path(&self.derivation);
+        let path = Self::convert_path(&self.derivation)?;
         let request = build_sign_request(tx)?;
 
         let signature = match request {
@@ -202,27 +202,48 @@ impl TrezorSigner {
     #[instrument(skip(message), fields(message=hex::encode(message)), ret)]
     async fn sign_message_inner(&self, message: &[u8]) -> Result<Signature, TrezorError> {
         let mut client = self.get_client()?;
-        let apath = Self::convert_path(&self.derivation);
+        let apath = Self::convert_path(&self.derivation)?;
         let signature = client.ethereum_sign_message(message.into(), apath)?;
         signature_from_trezor(signature)
     }
 
     // helper which converts a derivation path to [u32]
-    fn convert_path(derivation: &DerivationType) -> Vec<u32> {
+    fn convert_path(derivation: &DerivationType) -> Result<Vec<u32>, TrezorError> {
         let derivation = derivation.to_string();
         let elements = derivation.split('/').skip(1).collect::<Vec<_>>();
 
         let mut path = vec![];
         for derivation_index in elements {
             let hardened = derivation_index.contains('\'');
-            let mut index = derivation_index.replace('\'', "").parse::<u32>().unwrap();
-            if hardened {
-                index |= 0x80000000;
+            let index = derivation_index.replace('\'', "").parse::<u32>().map_err(|e| {
+                TrezorError::InvalidDerivationPath(e.to_string())
+            })?;
+            // Reject raw indices that already set the harden bit (e.g. 2147483648 ≡ 0').
+            if index >= 0x8000_0000 {
+                return Err(TrezorError::InvalidDerivationPath(format!(
+                    "index {index} is out of range (use \' for hardened segments)"
+                )));
             }
+            let index = if hardened { index | 0x8000_0000 } else { index };
             path.push(index);
         }
 
-        path
+        Ok(path)
+    }
+}
+
+#[cfg(test)]
+mod convert_path_tests {
+    use super::*;
+
+    #[test]
+    fn rejects_raw_hardened_index_without_marker() {
+        let err = TrezorSigner::convert_path(&DerivationType::Other("m/2147483648".into()))
+            .unwrap_err();
+        assert!(matches!(err, TrezorError::InvalidDerivationPath(_)));
+
+        let ok = TrezorSigner::convert_path(&DerivationType::Other("m/0'".into())).unwrap();
+        assert_eq!(ok, vec![0x8000_0000]);
     }
 }
 

--- a/crates/signer-trezor/src/signer.rs
+++ b/crates/signer-trezor/src/signer.rs
@@ -215,9 +215,10 @@ impl TrezorSigner {
         let mut path = vec![];
         for derivation_index in elements {
             let hardened = derivation_index.contains('\'');
-            let index = derivation_index.replace('\'', "").parse::<u32>().map_err(|e| {
-                TrezorError::InvalidDerivationPath(e.to_string())
-            })?;
+            let index = derivation_index
+                .replace('\'', "")
+                .parse::<u32>()
+                .map_err(|e| TrezorError::InvalidDerivationPath(e.to_string()))?;
             // Reject raw indices that already set the harden bit (e.g. 2147483648 ≡ 0').
             if index >= 0x8000_0000 {
                 return Err(TrezorError::InvalidDerivationPath(format!(
@@ -238,8 +239,8 @@ mod convert_path_tests {
 
     #[test]
     fn rejects_raw_hardened_index_without_marker() {
-        let err = TrezorSigner::convert_path(&DerivationType::Other("m/2147483648".into()))
-            .unwrap_err();
+        let err =
+            TrezorSigner::convert_path(&DerivationType::Other("m/2147483648".into())).unwrap_err();
         assert!(matches!(err, TrezorError::InvalidDerivationPath(_)));
 
         let ok = TrezorSigner::convert_path(&DerivationType::Other("m/0'".into())).unwrap();

--- a/crates/signer-trezor/src/types.rs
+++ b/crates/signer-trezor/src/types.rs
@@ -57,6 +57,9 @@ pub enum TrezorError {
     /// Could not retrieve device features.
     #[error("could not retrieve device features")]
     Features,
+    /// Invalid derivation path.
+    #[error("invalid derivation path: {0}")]
+    InvalidDerivationPath(String),
 }
 
 impl From<TrezorError> for alloy_signer::Error {


### PR DESCRIPTION
## Summary
- Ledger `path_to_bytes` and Trezor `convert_path` parsed BIP32 segments with `parse::<u32>()` then optionally applied `0x80000000`.
- Raw index `2147483648` (no `'`) already equals the harden bit, so `Other(\"m/2147483648\")` silently selected the same child as `m/0'`.
- Reject `index >= 0x80000000` before applying the harden marker. Trezor path conversion now returns `Result` instead of unwrapping parse errors.

## Test plan
- [x] `cargo test -p alloy-signer-ledger --lib rejects_raw_hardened`
- [x] `cargo test -p alloy-signer-trezor --lib rejects_raw_hardened`
- [x] `cargo test -p alloy-signer-ledger --lib invalid_derivation_path`

Made with [Cursor](https://cursor.com)