### PR TITLE
feat(provider): add raw transaction sync future

### DIFF
--- a/crates/provider/src/provider/mod.rs
+++ b/crates/provider/src/provider/mod.rs
@@ -32,6 +32,9 @@ pub use root::{builder, RootProvider};
 mod sendable;
 pub use sendable::{SendableTx, SendableTxErr};
 
+mod send_raw_transaction_sync;
+pub use send_raw_transaction_sync::SendRawTransactionSync;
+
 mod r#trait;
 pub use r#trait::{FilterPollerBuilder, Provider};
 

--- a/crates/provider/src/provider/send_raw_transaction_sync.rs
+++ b/crates/provider/src/provider/send_raw_transaction_sync.rs
@@ -1,0 +1,170 @@
+use alloy_network::Network;
+use alloy_rpc_client::{ClientRef, RpcCall};
+use alloy_transport::TransportResult;
+use serde::ser::{Error as _, SerializeSeq};
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+    time::Duration,
+};
+
+#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+use tokio::time::{timeout as timeout_future, Timeout};
+
+#[cfg(all(target_family = "wasm", target_os = "unknown"))]
+use wasmtimer::tokio::{timeout as timeout_future, Timeout};
+
+/// Parameters for an `eth_sendRawTransactionSync` request.
+#[derive(Clone, Debug)]
+struct SendRawTransactionSyncParams {
+    encoded_tx: String,
+    server_timeout: Option<Duration>,
+}
+
+impl serde::Serialize for SendRawTransactionSyncParams {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut seq =
+            serializer.serialize_seq(Some(1 + usize::from(self.server_timeout.is_some())))?;
+        seq.serialize_element(&self.encoded_tx)?;
+
+        if let Some(server_timeout) = self.server_timeout {
+            let timeout_ms = u64::try_from(server_timeout.as_millis())
+                .map_err(|_| S::Error::custom("server timeout exceeds u64 milliseconds"))?;
+            if timeout_ms == 0 {
+                return Err(S::Error::custom("server timeout must be at least one millisecond"));
+            }
+            seq.serialize_element(&timeout_ms)?;
+        }
+
+        seq.end()
+    }
+}
+
+/// Future for an `eth_sendRawTransactionSync` request.
+///
+/// This type is returned by [`Provider::send_raw_transaction_sync`]. Use [`Self::timeout`] to
+/// limit how long the client waits for the response, and [`Self::server_timeout`] to configure the
+/// optional server-side timeout parameter defined by [EIP-7966].
+///
+/// [EIP-7966]: https://eips.ethereum.org/EIPS/eip-7966
+/// [`Provider::send_raw_transaction_sync`]: crate::Provider::send_raw_transaction_sync
+#[must_use = "futures do nothing unless you `.await` or poll them"]
+#[pin_project::pin_project]
+pub struct SendRawTransactionSync<N: Network> {
+    #[pin]
+    inner: RpcCall<SendRawTransactionSyncParams, N::ReceiptResponse>,
+}
+
+impl<N: Network> SendRawTransactionSync<N> {
+    pub(crate) fn new(client: ClientRef<'_>, encoded_tx: &[u8]) -> Self {
+        let params = SendRawTransactionSyncParams {
+            encoded_tx: alloy_primitives::hex::encode_prefixed(encoded_tx),
+            server_timeout: None,
+        };
+        Self { inner: client.request("eth_sendRawTransactionSync", params) }
+    }
+
+    /// Wraps this future in a client-side timeout.
+    ///
+    /// The timeout only stops waiting for the response. The transaction may still have been
+    /// submitted to the network, so it may be unsafe to retry it without checking its status.
+    /// Awaiting the returned future produces a timeout result around the existing transport result,
+    /// so the two error cases can be handled separately.
+    ///
+    /// # Panics
+    ///
+    /// On Tokio-backed targets, including WASI, the returned future panics when polled if there
+    /// is no current Tokio timer, for example when polled outside of a Tokio runtime.
+    pub fn timeout(self, duration: Duration) -> Timeout<Self> {
+        timeout_future(duration, self)
+    }
+
+    /// Sets the optional server-side timeout for transaction inclusion.
+    ///
+    /// The timeout is serialized in milliseconds as the optional second
+    /// `eth_sendRawTransactionSync` parameter defined by [EIP-7966]. Unlike [`Self::timeout`], this
+    /// is enforced by the RPC server and is returned as a regular RPC error if it elapses.
+    ///
+    /// Durations shorter than one millisecond or longer than [`u64::MAX`] milliseconds fail to
+    /// serialize and are returned as transport serialization errors.
+    ///
+    /// [EIP-7966]: https://eips.ethereum.org/EIPS/eip-7966
+    pub fn server_timeout(mut self, server_timeout: Option<Duration>) -> Self {
+        self.inner.params().server_timeout = server_timeout;
+        self
+    }
+}
+
+impl<N: Network> std::fmt::Debug for SendRawTransactionSync<N> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SendRawTransactionSync").field("inner", &self.inner).finish()
+    }
+}
+
+impl<N: Network> Future for SendRawTransactionSync<N> {
+    type Output = TransportResult<N::ReceiptResponse>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.project().inner.poll(cx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_json_rpc::ResponsePacket;
+    use alloy_network::Ethereum;
+    use alloy_rpc_client::RpcClient;
+    use alloy_transport::TransportFut;
+    use serde_json::json;
+
+    #[test]
+    fn serializes_optional_server_timeout() {
+        let params =
+            SendRawTransactionSyncParams { encoded_tx: "0x1234".into(), server_timeout: None };
+        assert_eq!(serde_json::to_value(&params).unwrap(), json!(["0x1234"]));
+
+        let params =
+            SendRawTransactionSyncParams { server_timeout: Some(Duration::from_secs(5)), ..params };
+        assert_eq!(serde_json::to_value(&params).unwrap(), json!(["0x1234", 5000]));
+    }
+
+    #[test]
+    fn rejects_invalid_server_timeout() {
+        let params = SendRawTransactionSyncParams {
+            encoded_tx: "0x1234".into(),
+            server_timeout: Some(Duration::from_nanos(1)),
+        };
+        assert!(serde_json::to_value(&params).is_err());
+
+        let params = SendRawTransactionSyncParams { server_timeout: Some(Duration::MAX), ..params };
+        assert!(serde_json::to_value(&params).is_err());
+    }
+
+    #[tokio::test]
+    async fn client_timeout() {
+        let transport = tower::service_fn(|_| -> TransportFut<'static, ResponsePacket> {
+            Box::pin(std::future::pending())
+        });
+        let client = RpcClient::builder().transport(transport, true);
+        let call = SendRawTransactionSync::<Ethereum>::new(client.inner().as_ref(), &[0x12, 0x34]);
+
+        assert!(call.timeout(Duration::ZERO).await.is_err());
+    }
+
+    #[test]
+    fn helper_updates_server_timeout() {
+        let transport = tower::service_fn(|_| -> TransportFut<'static, ResponsePacket> {
+            Box::pin(std::future::pending())
+        });
+        let client = RpcClient::builder().transport(transport, true);
+        let call = SendRawTransactionSync::<Ethereum>::new(client.inner().as_ref(), &[0x12, 0x34])
+            .server_timeout(Some(Duration::from_secs(5)));
+
+        assert_eq!(
+            serde_json::to_value(&call.inner.request().params).unwrap(),
+            json!(["0x1234", 5000])
+        );
+    }
+}

--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -15,7 +15,7 @@ use crate::{
     utils::{self, Eip1559Estimation, Eip1559Estimator},
     EthCall, EthGetBlock, Identity, PendingTransaction, PendingTransactionBuilder,
     PendingTransactionConfig, ProviderBuilder, ProviderCall, RootProvider, RpcWithBlock,
-    SendableTx,
+    SendRawTransactionSync, SendableTx,
 };
 use alloy_consensus::BlockHeader;
 use alloy_eips::{eip2718::Encodable2718, eip7928::BlockAccessList};
@@ -1281,7 +1281,7 @@ pub trait Provider<N: Network = Ethereum>: Send + Sync {
     /// Broadcasts a raw transaction RLP bytes to the network and returns the transaction receipt
     /// after it has been mined.
     ///
-    /// Unlike send_raw_transaction which returns immediately with
+    /// Unlike [`send_raw_transaction`](Self::send_raw_transaction), which returns immediately with
     /// a transaction hash, this method waits on the server side until the transaction is included
     /// in a block and returns the receipt directly. This is an optimization that reduces the number
     /// of RPC calls needed to confirm a transaction.
@@ -1289,7 +1289,27 @@ pub trait Provider<N: Network = Ethereum>: Send + Sync {
     /// This method implements the `eth_sendRawTransactionSync` RPC method as defined in
     /// [EIP-7966].
     ///
-    /// [EIP-7966]: https://github.com/ethereum/EIPs/pull/9151
+    /// [EIP-7966]: https://eips.ethereum.org/EIPS/eip-7966
+    ///
+    /// The returned [`SendRawTransactionSync`] future can configure independent client-side and
+    /// server-side timeouts:
+    ///
+    /// ```no_run
+    /// # async fn example<N: alloy_network::Network>(
+    /// #     provider: impl alloy_provider::Provider<N>,
+    /// #     encoded_tx: &[u8],
+    /// # ) -> Result<(), Box<dyn std::error::Error>> {
+    /// use std::time::Duration;
+    ///
+    /// let receipt = provider
+    ///     .send_raw_transaction_sync(encoded_tx)
+    ///     .server_timeout(Some(Duration::from_secs(5)))
+    ///     .timeout(Duration::from_secs(10))
+    ///     .await??;
+    /// # let _ = receipt;
+    /// # Ok(())
+    /// # }
+    /// ```
     ///
     /// # Error Handling
     ///
@@ -1315,12 +1335,8 @@ pub trait Provider<N: Network = Ethereum>: Send + Sync {
     ///
     /// Note: This is only available on certain clients that support the
     /// `eth_sendRawTransactionSync` RPC method, such as Anvil.
-    async fn send_raw_transaction_sync(
-        &self,
-        encoded_tx: &[u8],
-    ) -> TransportResult<N::ReceiptResponse> {
-        let rlp_hex = hex::encode_prefixed(encoded_tx);
-        self.client().request("eth_sendRawTransactionSync", (rlp_hex,)).await
+    fn send_raw_transaction_sync(&self, encoded_tx: &[u8]) -> SendRawTransactionSync<N> {
+        SendRawTransactionSync::new(self.client(), encoded_tx)
     }
 
     /// Broadcasts a raw transaction RLP bytes with a conditional [`TransactionConditional`] to the
@@ -2249,8 +2265,13 @@ mod tests {
         let encoded = tx_envelope.encoded_2718();
 
         // Send using the sync method - this directly returns the receipt
-        let receipt =
-            provider.send_raw_transaction_sync(&encoded).await.expect("failed to send raw tx sync");
+        let receipt = provider
+            .send_raw_transaction_sync(&encoded)
+            .server_timeout(Some(Duration::from_secs(5)))
+            .timeout(Duration::from_secs(10))
+            .await
+            .expect("client timeout elapsed")
+            .expect("failed to send raw tx sync");
 
         // Verify receipt
         assert_eq!(receipt.to(), Some(address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045")));


### PR DESCRIPTION
## Summary

- replace the opaque `async fn Provider::send_raw_transaction_sync` return with a named `SendRawTransactionSync` future
- add a client-side `.timeout(Duration) -> Timeout<Self>`
- add `.server_timeout(Option<Duration>)`, serialized as EIP-7966's optional millisecond parameter
- validate server durations that cannot be represented as a positive `u64` millisecond value

## Motivation

This is an alternative to #4122 that follows the composable future pattern introduced in #4119. Existing call sites can continue to await `send_raw_transaction_sync` directly, while callers that need timeout control can independently bound the local wait and the RPC server's inclusion wait.

The client timeout only stops waiting for the response; the server timeout is sent to the node and surfaces through the normal RPC result. Custom `Provider` implementations that override this method will need to adopt the named return type.
