### PR TITLE
fix(signer-local): add fallible YubiHSM constructors

### DIFF
--- a/crates/signer-local/Cargo.toml
+++ b/crates/signer-local/Cargo.toml
@@ -47,7 +47,6 @@ coins-bip39 = { version = "0.12", default-features = false, features = [
 ], optional = true }
 
 # yubi
-elliptic-curve = { workspace = true, optional = true }
 yubihsm = { version = "0.42", features = [
     "secp256k1",
     "http",
@@ -81,7 +80,7 @@ keystore = ["dep:eth-keystore"]
 keystore-geth-compat = ["keystore", "eth-keystore?/geth-compat"]
 mnemonic = ["dep:coins-bip32", "dep:coins-bip39", "zeroize"]
 mnemonic-all-languages = ["mnemonic", "coins-bip39?/all-langs"]
-yubihsm = ["dep:yubihsm", "dep:elliptic-curve"]
+yubihsm = ["dep:yubihsm"]
 secp256k1 = [
 	"dep:secp256k1",
 	"alloy-consensus/secp256k1",

--- a/crates/signer-local/src/error.rs
+++ b/crates/signer-local/src/error.rs
@@ -15,6 +15,11 @@ pub enum LocalSignerError {
     #[error(transparent)]
     IoError(#[from] std::io::Error),
 
+    /// [`yubihsm`] client error.
+    #[cfg(feature = "yubihsm")]
+    #[error(transparent)]
+    YubiHsmError(#[from] yubihsm::client::Error),
+
     /// [`secp256k1`] error.
     #[error(transparent)]
     #[cfg(feature = "secp256k1")]

--- a/crates/signer-local/src/yubi.rs
+++ b/crates/signer-local/src/yubi.rs
@@ -1,6 +1,6 @@
 //! [YubiHSM2](yubihsm) signer implementation.
 
-use super::LocalSigner;
+use super::{LocalSigner, LocalSignerError};
 use alloy_signer::utils::raw_public_key_to_address;
 use elliptic_curve::sec1::{FromEncodedPoint, ToEncodedPoint};
 use k256::{PublicKey, Secp256k1};
@@ -10,14 +10,33 @@ use yubihsm::{
 };
 
 impl LocalSigner<YubiSigner<Secp256k1>> {
-    /// Connects to a yubi key's ECDSA account at the provided id
+    /// Connects to a YubiHSM ECDSA key at the provided ID.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the HSM connection cannot be opened or the key cannot be loaded. Use
+    /// [`try_connect`](Self::try_connect) to handle these errors.
     pub fn connect(connector: Connector, credentials: Credentials, id: object::Id) -> Self {
-        let client = Client::open(connector, credentials, true).unwrap();
-        let signer = YubiSigner::create(client, id).unwrap();
-        signer.into()
+        Self::try_connect(connector, credentials, id).expect("failed to connect to YubiHSM signer")
     }
 
-    /// Creates a new random ECDSA keypair on the yubi at the provided id
+    /// Attempts to connect to a YubiHSM ECDSA key at the provided ID.
+    pub fn try_connect(
+        connector: Connector,
+        credentials: Credentials,
+        id: object::Id,
+    ) -> Result<Self, LocalSignerError> {
+        let client = Client::open(connector, credentials, true)?;
+        let signer = YubiSigner::create(client, id)?;
+        Ok(signer.into())
+    }
+
+    /// Creates a new random ECDSA keypair on the YubiHSM at the provided ID.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the HSM connection cannot be opened or the key cannot be generated or loaded. Use
+    /// [`try_new`](Self::try_new) to handle these errors.
     pub fn new(
         connector: Connector,
         credentials: Credentials,
@@ -25,15 +44,31 @@ impl LocalSigner<YubiSigner<Secp256k1>> {
         label: Label,
         domain: Domain,
     ) -> Self {
-        let client = Client::open(connector, credentials, true).unwrap();
-        let id = client
-            .generate_asymmetric_key(id, label, domain, Capability::SIGN_ECDSA, EcK256)
-            .unwrap();
-        let signer = YubiSigner::create(client, id).unwrap();
-        signer.into()
+        Self::try_new(connector, credentials, id, label, domain)
+            .expect("failed to create YubiHSM signer")
     }
 
-    /// Uploads the provided keypair on the yubi at the provided id
+    /// Attempts to create a new random ECDSA keypair on the YubiHSM at the provided ID.
+    pub fn try_new(
+        connector: Connector,
+        credentials: Credentials,
+        id: object::Id,
+        label: Label,
+        domain: Domain,
+    ) -> Result<Self, LocalSignerError> {
+        let client = Client::open(connector, credentials, true)?;
+        let id =
+            client.generate_asymmetric_key(id, label, domain, Capability::SIGN_ECDSA, EcK256)?;
+        let signer = YubiSigner::create(client, id)?;
+        Ok(signer.into())
+    }
+
+    /// Uploads the provided keypair to the YubiHSM at the provided ID.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the HSM connection cannot be opened or the key cannot be imported or loaded. Use
+    /// [`try_from_key`](Self::try_from_key) to handle these errors.
     pub fn from_key(
         connector: Connector,
         credentials: Credentials,
@@ -42,19 +77,32 @@ impl LocalSigner<YubiSigner<Secp256k1>> {
         domain: Domain,
         key: impl Into<Vec<u8>>,
     ) -> Self {
-        let client = Client::open(connector, credentials, true).unwrap();
-        let id = client
-            .put_asymmetric_key(id, label, domain, Capability::SIGN_ECDSA, EcK256, key)
-            .unwrap();
-        let signer = YubiSigner::create(client, id).unwrap();
-        signer.into()
+        Self::try_from_key(connector, credentials, id, label, domain, key)
+            .expect("failed to import YubiHSM signer")
+    }
+
+    /// Attempts to upload the provided keypair to the YubiHSM at the provided ID.
+    pub fn try_from_key(
+        connector: Connector,
+        credentials: Credentials,
+        id: object::Id,
+        label: Label,
+        domain: Domain,
+        key: impl Into<Vec<u8>>,
+    ) -> Result<Self, LocalSignerError> {
+        let client = Client::open(connector, credentials, true)?;
+        let id =
+            client.put_asymmetric_key(id, label, domain, Capability::SIGN_ECDSA, EcK256, key)?;
+        let signer = YubiSigner::create(client, id)?;
+        Ok(signer.into())
     }
 }
 
 impl From<YubiSigner<Secp256k1>> for LocalSigner<YubiSigner<Secp256k1>> {
     fn from(credential: YubiSigner<Secp256k1>) -> Self {
-        // Uncompress the public key.
-        let pubkey = PublicKey::from_encoded_point(credential.public_key()).unwrap();
+        // Uncompress the public key. `YubiSigner::create` already validated this point.
+        let pubkey = PublicKey::from_encoded_point(credential.public_key())
+            .expect("YubiSigner contains a validated public key");
         let pubkey = pubkey.to_encoded_point(false);
         let bytes = pubkey.as_bytes();
         debug_assert_eq!(bytes[0], 0x04);
@@ -75,14 +123,15 @@ mod tests {
             .unwrap();
 
         let connector = yubihsm::Connector::mockhsm();
-        let signer = LocalSigner::from_key(
+        let signer = LocalSigner::try_from_key(
             connector,
             Credentials::default(),
             0,
             Label::from_bytes(&[]).unwrap(),
             Domain::at(1).unwrap(),
             key,
-        );
+        )
+        .unwrap();
 
         let msg = "Some data";
         let sig = signer.sign_message_sync(msg.as_bytes()).unwrap();
@@ -93,16 +142,42 @@ mod tests {
     #[test]
     fn new_key() {
         let connector = yubihsm::Connector::mockhsm();
-        let signer = LocalSigner::<YubiSigner<Secp256k1>>::new(
+        let signer = LocalSigner::<YubiSigner<Secp256k1>>::try_new(
             connector,
             Credentials::default(),
             0,
             Label::from_bytes(&[]).unwrap(),
             Domain::at(1).unwrap(),
-        );
+        )
+        .unwrap();
 
         let msg = "Some data";
         let sig = signer.sign_message_sync(msg.as_bytes()).unwrap();
         assert_eq!(sig.recover_address_from_msg(msg).unwrap(), signer.address());
+    }
+
+    #[test]
+    fn missing_key_returns_error() {
+        let result = LocalSigner::<YubiSigner<Secp256k1>>::try_connect(
+            yubihsm::Connector::mockhsm(),
+            Credentials::default(),
+            0x1234,
+        );
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn invalid_key_returns_error() {
+        let result = LocalSigner::<YubiSigner<Secp256k1>>::try_from_key(
+            yubihsm::Connector::mockhsm(),
+            Credentials::default(),
+            1,
+            Label::from_bytes(&[]).unwrap(),
+            Domain::at(1).unwrap(),
+            [0; 31],
+        );
+
+        assert!(matches!(result, Err(LocalSignerError::YubiHsmError(_))));
     }
 }

--- a/crates/signer-local/src/yubi.rs
+++ b/crates/signer-local/src/yubi.rs
@@ -2,8 +2,7 @@
 
 use super::{LocalSigner, LocalSignerError};
 use alloy_signer::utils::raw_public_key_to_address;
-use elliptic_curve::sec1::{FromEncodedPoint, ToEncodedPoint};
-use k256::{PublicKey, Secp256k1};
+use k256::Secp256k1;
 use yubihsm::{
     asymmetric::Algorithm::EcK256, ecdsa::Signer as YubiSigner, object, object::Label, Capability,
     Client, Connector, Credentials, Domain,
@@ -100,10 +99,7 @@ impl LocalSigner<YubiSigner<Secp256k1>> {
 
 impl From<YubiSigner<Secp256k1>> for LocalSigner<YubiSigner<Secp256k1>> {
     fn from(credential: YubiSigner<Secp256k1>) -> Self {
-        // Uncompress the public key. `YubiSigner::create` already validated this point.
-        let pubkey = PublicKey::from_encoded_point(credential.public_key())
-            .expect("YubiSigner contains a validated public key");
-        let pubkey = pubkey.to_encoded_point(false);
+        let pubkey = credential.as_ref().to_encoded_point(false);
         let bytes = pubkey.as_bytes();
         debug_assert_eq!(bytes[0], 0x04);
         let address = raw_public_key_to_address(&bytes[1..]);


### PR DESCRIPTION
## Summary

- add `try_connect`, `try_new`, and `try_from_key` for YubiHSM signers
- propagate YubiHSM client and ECDSA signer creation failures through `LocalSignerError`
- preserve the existing infallible constructors and document their panic behavior
- cover missing-object and invalid-key failures with regression tests

## Motivation

YubiHSM connector, authentication, object, policy, and device errors are expected runtime conditions. The existing constructors unwrap each fallible operation, turning those conditions into process panics.

This addresses the fallible-constructor portion of #4127. Moving synchronous YubiHSM signing off async executor threads remains intentionally out of scope for this PR.
