### PR TITLE
fix(signer-local): move YubiHSM signing off async workers

### DIFF
--- a/crates/signer-local/Cargo.toml
+++ b/crates/signer-local/Cargo.toml
@@ -47,6 +47,7 @@ coins-bip39 = { version = "0.12", default-features = false, features = [
 ], optional = true }
 
 # yubi
+tokio = { workspace = true, features = ["rt"], optional = true }
 yubihsm = { version = "0.42", features = [
     "secp256k1",
     "http",
@@ -80,7 +81,7 @@ keystore = ["dep:eth-keystore"]
 keystore-geth-compat = ["keystore", "eth-keystore?/geth-compat"]
 mnemonic = ["dep:coins-bip32", "dep:coins-bip39", "zeroize"]
 mnemonic-all-languages = ["mnemonic", "coins-bip39?/all-langs"]
-yubihsm = ["dep:yubihsm"]
+yubihsm = ["dep:tokio", "dep:yubihsm"]
 secp256k1 = [
 	"dep:secp256k1",
 	"alloy-consensus/secp256k1",

--- a/crates/signer-local/Cargo.toml
+++ b/crates/signer-local/Cargo.toml
@@ -47,7 +47,6 @@ coins-bip39 = { version = "0.12", default-features = false, features = [
 ], optional = true }
 
 # yubi
-elliptic-curve = { workspace = true, optional = true }
 yubihsm = { version = "0.42", features = [
     "secp256k1",
     "http",
@@ -81,7 +80,7 @@ keystore = ["dep:eth-keystore"]
 keystore-geth-compat = ["keystore", "eth-keystore?/geth-compat"]
 mnemonic = ["dep:coins-bip32", "dep:coins-bip39", "zeroize"]
 mnemonic-all-languages = ["mnemonic", "coins-bip39?/all-langs"]
-yubihsm = ["dep:yubihsm", "dep:elliptic-curve"]
+yubihsm = ["dep:yubihsm"]
 secp256k1 = [
 	"dep:secp256k1",
 	"alloy-consensus/secp256k1",

--- a/crates/signer-local/README.md
+++ b/crates/signer-local/README.md
@@ -5,14 +5,14 @@ Local signer implementations:
 - [K256 private key](https://docs.rs/alloy-signer-local/latest/alloy_signer_local/type.PrivateKeySigner.html)
 - [Secp256k1 private key](https://docs.rs/alloy-signer-local/latest/alloy_signer_local/type.Secp256k1Signer.html) (feature-gated)
 - [Mnemonic phrase](https://docs.rs/alloy-signer-local/latest/alloy_signer_local/struct.MnemonicBuilder.html)
-- [YubiHSM2](https://docs.rs/alloy-signer-local/latest/alloy_signer_local/type.YubiSigner.html)
+- [YubiHSM2](https://docs.rs/alloy-signer-local/latest/alloy_signer_local/struct.YubiSigner.html)
 
 ## Features
 
 - `keystore`: enables Ethereum keystore functionality on the `PrivateKeySigner` and `Secp256k1Signer` types.
 - `mnemonic`: enables BIP-39 mnemonic functionality for building `PrivateKeySigner`s.
 - `secp256k1`: enables the `Secp256k1Signer` type, an alternative signer implementation using the [`secp256k1`] crate instead of [`k256`].
-- `yubihsm`: enables `LocalSigner`s with [YubiHSM2] support.
+- `yubihsm`: enables the [YubiHSM2]-backed `YubiSigner`.
 
 ## Secp256k1 vs K256
 

--- a/crates/signer-local/src/error.rs
+++ b/crates/signer-local/src/error.rs
@@ -15,6 +15,11 @@ pub enum LocalSignerError {
     #[error(transparent)]
     IoError(#[from] std::io::Error),
 
+    /// [`yubihsm`] client error.
+    #[cfg(feature = "yubihsm")]
+    #[error(transparent)]
+    YubiHsmError(#[from] yubihsm::client::Error),
+
     /// [`secp256k1`] error.
     #[error(transparent)]
     #[cfg(feature = "secp256k1")]

--- a/crates/signer-local/src/lib.rs
+++ b/crates/signer-local/src/lib.rs
@@ -29,6 +29,8 @@ mod secp256k1;
 
 #[cfg(feature = "yubihsm")]
 mod yubi;
+#[cfg(feature = "yubihsm")]
+pub use yubi::YubiSigner;
 
 #[cfg(feature = "yubihsm")]
 pub use yubihsm;
@@ -45,10 +47,6 @@ pub type PrivateKeySigner = LocalSigner<k256::ecdsa::SigningKey>;
 /// A signer instantiated with a locally stored private key, using the `secp256k1` crate.
 #[cfg(feature = "secp256k1")]
 pub type Secp256k1Signer = LocalSigner<Secp256k1Credential>;
-/// A signer instantiated with a YubiHSM.
-#[cfg(feature = "yubihsm")]
-pub type YubiSigner = LocalSigner<yubihsm::ecdsa::Signer<k256::Secp256k1>>;
-
 /// An Ethereum private-public key pair which can be used for signing messages.
 ///
 /// # Examples

--- a/crates/signer-local/src/yubi.rs
+++ b/crates/signer-local/src/yubi.rs
@@ -1,6 +1,6 @@
 //! [YubiHSM2](yubihsm) signer implementation.
 
-use super::LocalSigner;
+use super::{LocalSigner, LocalSignerError};
 use alloy_signer::utils::raw_public_key_to_address;
 use elliptic_curve::sec1::{FromEncodedPoint, ToEncodedPoint};
 use k256::{PublicKey, Secp256k1};
@@ -10,14 +10,33 @@ use yubihsm::{
 };
 
 impl LocalSigner<YubiSigner<Secp256k1>> {
-    /// Connects to a yubi key's ECDSA account at the provided id
+    /// Connects to a YubiHSM ECDSA key at the provided ID.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the HSM connection cannot be opened or the key cannot be loaded. Use
+    /// [`try_connect`](Self::try_connect) to handle these errors.
     pub fn connect(connector: Connector, credentials: Credentials, id: object::Id) -> Self {
-        let client = Client::open(connector, credentials, true).unwrap();
-        let signer = YubiSigner::create(client, id).unwrap();
-        signer.into()
+        Self::try_connect(connector, credentials, id).expect("failed to connect to YubiHSM signer")
     }
 
-    /// Creates a new random ECDSA keypair on the yubi at the provided id
+    /// Attempts to connect to a YubiHSM ECDSA key at the provided ID.
+    pub fn try_connect(
+        connector: Connector,
+        credentials: Credentials,
+        id: object::Id,
+    ) -> Result<Self, LocalSignerError> {
+        let client = Client::open(connector, credentials, true)?;
+        let signer = YubiSigner::create(client, id)?;
+        Ok(signer.into())
+    }
+
+    /// Creates a new random ECDSA keypair on the YubiHSM at the provided ID.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the HSM connection cannot be opened or the key cannot be generated or loaded. Use
+    /// [`try_new`](Self::try_new) to handle these errors.
     pub fn new(
         connector: Connector,
         credentials: Credentials,
@@ -25,15 +44,31 @@ impl LocalSigner<YubiSigner<Secp256k1>> {
         label: Label,
         domain: Domain,
     ) -> Self {
-        let client = Client::open(connector, credentials, true).unwrap();
-        let id = client
-            .generate_asymmetric_key(id, label, domain, Capability::SIGN_ECDSA, EcK256)
-            .unwrap();
-        let signer = YubiSigner::create(client, id).unwrap();
-        signer.into()
+        Self::try_new(connector, credentials, id, label, domain)
+            .expect("failed to create YubiHSM signer")
     }
 
-    /// Uploads the provided keypair on the yubi at the provided id
+    /// Attempts to create a new random ECDSA keypair on the YubiHSM at the provided ID.
+    pub fn try_new(
+        connector: Connector,
+        credentials: Credentials,
+        id: object::Id,
+        label: Label,
+        domain: Domain,
+    ) -> Result<Self, LocalSignerError> {
+        let client = Client::open(connector, credentials, true)?;
+        let id =
+            client.generate_asymmetric_key(id, label, domain, Capability::SIGN_ECDSA, EcK256)?;
+        let signer = YubiSigner::create(client, id)?;
+        Ok(signer.into())
+    }
+
+    /// Uploads the provided keypair to the YubiHSM at the provided ID.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the HSM connection cannot be opened or the key cannot be imported or loaded. Use
+    /// [`try_from_key`](Self::try_from_key) to handle these errors.
     pub fn from_key(
         connector: Connector,
         credentials: Credentials,
@@ -42,19 +77,32 @@ impl LocalSigner<YubiSigner<Secp256k1>> {
         domain: Domain,
         key: impl Into<Vec<u8>>,
     ) -> Self {
-        let client = Client::open(connector, credentials, true).unwrap();
-        let id = client
-            .put_asymmetric_key(id, label, domain, Capability::SIGN_ECDSA, EcK256, key)
-            .unwrap();
-        let signer = YubiSigner::create(client, id).unwrap();
-        signer.into()
+        Self::try_from_key(connector, credentials, id, label, domain, key)
+            .expect("failed to import YubiHSM signer")
+    }
+
+    /// Attempts to upload the provided keypair to the YubiHSM at the provided ID.
+    pub fn try_from_key(
+        connector: Connector,
+        credentials: Credentials,
+        id: object::Id,
+        label: Label,
+        domain: Domain,
+        key: impl Into<Vec<u8>>,
+    ) -> Result<Self, LocalSignerError> {
+        let client = Client::open(connector, credentials, true)?;
+        let id =
+            client.put_asymmetric_key(id, label, domain, Capability::SIGN_ECDSA, EcK256, key)?;
+        let signer = YubiSigner::create(client, id)?;
+        Ok(signer.into())
     }
 }
 
 impl From<YubiSigner<Secp256k1>> for LocalSigner<YubiSigner<Secp256k1>> {
     fn from(credential: YubiSigner<Secp256k1>) -> Self {
-        // Uncompress the public key.
-        let pubkey = PublicKey::from_encoded_point(credential.public_key()).unwrap();
+        // Uncompress the public key. `YubiSigner::create` already validated this point.
+        let pubkey = PublicKey::from_encoded_point(credential.public_key())
+            .expect("YubiSigner contains a validated public key");
         let pubkey = pubkey.to_encoded_point(false);
         let bytes = pubkey.as_bytes();
         debug_assert_eq!(bytes[0], 0x04);
@@ -75,14 +123,15 @@ mod tests {
             .unwrap();
 
         let connector = yubihsm::Connector::mockhsm();
-        let signer = LocalSigner::from_key(
+        let signer = LocalSigner::try_from_key(
             connector,
             Credentials::default(),
             0,
             Label::from_bytes(&[]).unwrap(),
             Domain::at(1).unwrap(),
             key,
-        );
+        )
+        .unwrap();
 
         let msg = "Some data";
         let sig = signer.sign_message_sync(msg.as_bytes()).unwrap();
@@ -93,16 +142,42 @@ mod tests {
     #[test]
     fn new_key() {
         let connector = yubihsm::Connector::mockhsm();
-        let signer = LocalSigner::<YubiSigner<Secp256k1>>::new(
+        let signer = LocalSigner::<YubiSigner<Secp256k1>>::try_new(
             connector,
             Credentials::default(),
             0,
             Label::from_bytes(&[]).unwrap(),
             Domain::at(1).unwrap(),
-        );
+        )
+        .unwrap();
 
         let msg = "Some data";
         let sig = signer.sign_message_sync(msg.as_bytes()).unwrap();
         assert_eq!(sig.recover_address_from_msg(msg).unwrap(), signer.address());
+    }
+
+    #[test]
+    fn missing_key_returns_error() {
+        let result = LocalSigner::<YubiSigner<Secp256k1>>::try_connect(
+            yubihsm::Connector::mockhsm(),
+            Credentials::default(),
+            0x1234,
+        );
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn invalid_key_returns_error() {
+        let result = LocalSigner::<YubiSigner<Secp256k1>>::try_from_key(
+            yubihsm::Connector::mockhsm(),
+            Credentials::default(),
+            1,
+            Label::from_bytes(&[]).unwrap(),
+            Domain::at(1).unwrap(),
+            [0; 31],
+        );
+
+        assert!(matches!(result, Err(LocalSignerError::YubiHsmError(_))));
     }
 }

--- a/crates/signer-local/src/yubi.rs
+++ b/crates/signer-local/src/yubi.rs
@@ -2,8 +2,7 @@
 
 use super::{LocalSigner, LocalSignerError};
 use alloy_signer::utils::raw_public_key_to_address;
-use elliptic_curve::sec1::{FromEncodedPoint, ToEncodedPoint};
-use k256::{PublicKey, Secp256k1};
+use k256::Secp256k1;
 use yubihsm::{
     asymmetric::Algorithm::EcK256, ecdsa::Signer as YubiSigner, object, object::Label, Capability,
     Client, Connector, Credentials, Domain,
@@ -100,10 +99,7 @@ impl LocalSigner<YubiSigner<Secp256k1>> {
 
 impl From<YubiSigner<Secp256k1>> for LocalSigner<YubiSigner<Secp256k1>> {
     fn from(credential: YubiSigner<Secp256k1>) -> Self {
-        // Uncompress the public key. `YubiSigner::create` already validated this point.
-        let pubkey = PublicKey::from_encoded_point(credential.public_key())
-            .expect("YubiSigner contains a validated public key");
-        let pubkey = pubkey.to_encoded_point(false);
+        let pubkey = credential.as_ref().to_encoded_point(false);
         let bytes = pubkey.as_bytes();
         debug_assert_eq!(bytes[0], 0x04);
         let address = raw_public_key_to_address(&bytes[1..]);

--- a/crates/signer-local/src/yubi.rs
+++ b/crates/signer-local/src/yubi.rs
@@ -1,14 +1,41 @@
 //! [YubiHSM2](yubihsm) signer implementation.
 
 use super::{LocalSigner, LocalSignerError};
-use alloy_signer::utils::raw_public_key_to_address;
-use k256::Secp256k1;
+use alloy_consensus::SignableTransaction;
+use alloy_network::{TxSigner, TxSignerSync};
+use alloy_primitives::{Address, ChainId, Signature, B256};
+use alloy_signer::{
+    sign_transaction_with_chain_id, utils::raw_public_key_to_address, Error, Result, Signer,
+    SignerSync,
+};
+use async_trait::async_trait;
+use k256::{
+    ecdsa::{signature::hazmat::PrehashSigner, RecoveryId, Signature as K256Signature},
+    Secp256k1,
+};
+use std::{fmt, sync::Arc};
 use yubihsm::{
-    asymmetric::Algorithm::EcK256, ecdsa::Signer as YubiSigner, object, object::Label, Capability,
-    Client, Connector, Credentials, Domain,
+    asymmetric::Algorithm::EcK256, ecdsa::Signer as YubiCredential, object, object::Label,
+    Capability, Client, Connector, Credentials, Domain,
 };
 
-impl LocalSigner<YubiSigner<Secp256k1>> {
+type Credential = YubiCredential<Secp256k1>;
+
+/// An Ethereum signer backed by a YubiHSM ECDSA key.
+///
+/// The YubiHSM transports are synchronous. Asynchronous signing moves their blocking I/O to
+/// Tokio's blocking thread pool, while the [`SignerSync`] and [`TxSignerSync`] implementations call
+/// the HSM directly.
+///
+/// Asynchronous signing must run inside a Tokio runtime. Once dispatched, an HSM operation keeps
+/// running even if the future waiting for it is dropped.
+pub struct YubiSigner {
+    credential: Arc<Credential>,
+    address: Address,
+    chain_id: Option<ChainId>,
+}
+
+impl YubiSigner {
     /// Connects to a YubiHSM ECDSA key at the provided ID.
     ///
     /// # Panics
@@ -26,7 +53,7 @@ impl LocalSigner<YubiSigner<Secp256k1>> {
         id: object::Id,
     ) -> Result<Self, LocalSignerError> {
         let client = Client::open(connector, credentials, true)?;
-        let signer = YubiSigner::create(client, id)?;
+        let signer = YubiCredential::create(client, id)?;
         Ok(signer.into())
     }
 
@@ -58,7 +85,7 @@ impl LocalSigner<YubiSigner<Secp256k1>> {
         let client = Client::open(connector, credentials, true)?;
         let id =
             client.generate_asymmetric_key(id, label, domain, Capability::SIGN_ECDSA, EcK256)?;
-        let signer = YubiSigner::create(client, id)?;
+        let signer = YubiCredential::create(client, id)?;
         Ok(signer.into())
     }
 
@@ -92,13 +119,57 @@ impl LocalSigner<YubiSigner<Secp256k1>> {
         let client = Client::open(connector, credentials, true)?;
         let id =
             client.put_asymmetric_key(id, label, domain, Capability::SIGN_ECDSA, EcK256, key)?;
-        let signer = YubiSigner::create(client, id)?;
+        let signer = YubiCredential::create(client, id)?;
         Ok(signer.into())
+    }
+
+    /// Constructs a signer from a YubiHSM credential and its Ethereum address.
+    ///
+    /// `address` is trusted and is not derived from or checked against `credential`.
+    pub fn new_with_credential(
+        credential: Credential,
+        address: Address,
+        chain_id: Option<ChainId>,
+    ) -> Self {
+        Self { credential: Arc::new(credential), address, chain_id }
+    }
+
+    /// Returns this signer's YubiHSM credential.
+    pub fn credential(&self) -> &Credential {
+        &self.credential
+    }
+
+    /// Consumes this signer and returns its YubiHSM credential if no background signing operation
+    /// still holds it.
+    pub fn try_into_credential(self) -> std::result::Result<Credential, Self> {
+        let Self { credential, address, chain_id } = self;
+        Arc::try_unwrap(credential).map_err(|credential| Self { credential, address, chain_id })
+    }
+
+    /// Consumes this signer and returns its YubiHSM credential.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a cancelled asynchronous signing future left its blocking operation running. Use
+    /// [`try_into_credential`](Self::try_into_credential) to handle this case.
+    pub fn into_credential(self) -> Credential {
+        self.try_into_credential()
+            .unwrap_or_else(|_| panic!("YubiHSM signing operation is still running"))
+    }
+
+    /// Returns this signer's address.
+    pub const fn address(&self) -> Address {
+        self.address
+    }
+
+    /// Returns this signer's chain ID.
+    pub const fn chain_id(&self) -> Option<ChainId> {
+        self.chain_id
     }
 }
 
-impl From<YubiSigner<Secp256k1>> for LocalSigner<YubiSigner<Secp256k1>> {
-    fn from(credential: YubiSigner<Secp256k1>) -> Self {
+impl From<Credential> for YubiSigner {
+    fn from(credential: Credential) -> Self {
         let pubkey = credential.as_ref().to_encoded_point(false);
         let bytes = pubkey.as_bytes();
         debug_assert_eq!(bytes[0], 0x04);
@@ -107,11 +178,107 @@ impl From<YubiSigner<Secp256k1>> for LocalSigner<YubiSigner<Secp256k1>> {
     }
 }
 
+impl From<LocalSigner<Credential>> for YubiSigner {
+    fn from(signer: LocalSigner<Credential>) -> Self {
+        let LocalSigner { credential, address, chain_id } = signer;
+        Self::new_with_credential(credential, address, chain_id)
+    }
+}
+
+impl fmt::Debug for YubiSigner {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("YubiSigner")
+            .field("address", &self.address)
+            .field("chain_id", &self.chain_id)
+            .finish()
+    }
+}
+
+async fn run_blocking<T>(operation: impl FnOnce() -> Result<T> + Send + 'static) -> Result<T>
+where
+    T: Send + 'static,
+{
+    let handle = tokio::runtime::Handle::try_current().map_err(Error::other)?;
+    handle.spawn_blocking(operation).await.map_err(Error::other)?
+}
+
+fn sign_hash(credential: &Credential, hash: &B256) -> Result<Signature> {
+    let signature: (K256Signature, RecoveryId) = credential.sign_prehash(hash.as_ref())?;
+    Ok(signature.into())
+}
+
+#[async_trait]
+impl Signer for YubiSigner {
+    async fn sign_hash(&self, hash: &B256) -> Result<Signature> {
+        let credential = Arc::clone(&self.credential);
+        let hash = *hash;
+        run_blocking(move || sign_hash(&credential, &hash)).await
+    }
+
+    fn address(&self) -> Address {
+        self.address
+    }
+
+    fn chain_id(&self) -> Option<ChainId> {
+        self.chain_id
+    }
+
+    fn set_chain_id(&mut self, chain_id: Option<ChainId>) {
+        self.chain_id = chain_id;
+    }
+}
+
+impl SignerSync for YubiSigner {
+    fn sign_hash_sync(&self, hash: &B256) -> Result<Signature> {
+        sign_hash(&self.credential, hash)
+    }
+
+    fn chain_id_sync(&self) -> Option<ChainId> {
+        self.chain_id
+    }
+}
+
+#[async_trait]
+impl TxSigner<Signature> for YubiSigner {
+    fn address(&self) -> Address {
+        self.address
+    }
+
+    async fn sign_transaction(
+        &self,
+        tx: &mut dyn SignableTransaction<Signature>,
+    ) -> Result<Signature> {
+        sign_transaction_with_chain_id!(self, tx, self.sign_hash(&tx.signature_hash()).await)
+    }
+}
+
+impl TxSignerSync<Signature> for YubiSigner {
+    fn address(&self) -> Address {
+        self.address
+    }
+
+    fn sign_transaction_sync(
+        &self,
+        tx: &mut dyn SignableTransaction<Signature>,
+    ) -> Result<Signature> {
+        sign_transaction_with_chain_id!(self, tx, self.sign_hash_sync(&tx.signature_hash()))
+    }
+}
+
+alloy_network::impl_into_wallet!(YubiSigner);
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::SignerSync;
+    use alloy_consensus::TxLegacy;
     use alloy_primitives::{address, hex};
+    use std::{
+        sync::{
+            atomic::{AtomicBool, Ordering},
+            mpsc, Arc,
+        },
+        time::Duration,
+    };
 
     #[test]
     fn from_key() {
@@ -119,7 +286,7 @@ mod tests {
             .unwrap();
 
         let connector = yubihsm::Connector::mockhsm();
-        let signer = LocalSigner::try_from_key(
+        let signer = YubiSigner::try_from_key(
             connector,
             Credentials::default(),
             0,
@@ -138,7 +305,7 @@ mod tests {
     #[test]
     fn new_key() {
         let connector = yubihsm::Connector::mockhsm();
-        let signer = LocalSigner::<YubiSigner<Secp256k1>>::try_new(
+        let signer = YubiSigner::try_new(
             connector,
             Credentials::default(),
             0,
@@ -154,18 +321,15 @@ mod tests {
 
     #[test]
     fn missing_key_returns_error() {
-        let result = LocalSigner::<YubiSigner<Secp256k1>>::try_connect(
-            yubihsm::Connector::mockhsm(),
-            Credentials::default(),
-            0x1234,
-        );
+        let result =
+            YubiSigner::try_connect(yubihsm::Connector::mockhsm(), Credentials::default(), 0x1234);
 
         assert!(result.is_err());
     }
 
     #[test]
     fn invalid_key_returns_error() {
-        let result = LocalSigner::<YubiSigner<Secp256k1>>::try_from_key(
+        let result = YubiSigner::try_from_key(
             yubihsm::Connector::mockhsm(),
             Credentials::default(),
             1,
@@ -175,5 +339,75 @@ mod tests {
         );
 
         assert!(matches!(result, Err(LocalSignerError::YubiHsmError(_))));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn async_signing_matches_sync_signing() {
+        let signer = YubiSigner::try_new(
+            yubihsm::Connector::mockhsm(),
+            Credentials::default(),
+            0,
+            Label::from_bytes(&[]).unwrap(),
+            Domain::at(1).unwrap(),
+        )
+        .unwrap();
+        let message = b"Some data";
+
+        let sync = signer.sign_message_sync(message).unwrap();
+        let asynchronous = signer.sign_message(message).await.unwrap();
+
+        assert_eq!(sync.recover_address_from_msg(message).unwrap(), signer.address());
+        assert_eq!(asynchronous.recover_address_from_msg(message).unwrap(), signer.address());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn async_transaction_signing_applies_chain_id() {
+        let mut signer = YubiSigner::try_new(
+            yubihsm::Connector::mockhsm(),
+            Credentials::default(),
+            0,
+            Label::from_bytes(&[]).unwrap(),
+            Domain::at(1).unwrap(),
+        )
+        .unwrap();
+        signer.set_chain_id(Some(1));
+        let mut tx = TxLegacy::default();
+
+        let signature = signer.sign_transaction(&mut tx).await.unwrap();
+
+        assert_eq!(tx.chain_id, Some(1));
+        assert_eq!(
+            signature.recover_address_from_prehash(&tx.signature_hash()).unwrap(),
+            signer.address()
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn blocking_work_does_not_stall_executor() {
+        let (release_tx, release_rx) = mpsc::channel();
+        let progressed = Arc::new(AtomicBool::new(false));
+        let task_progressed = Arc::clone(&progressed);
+        let unrelated = tokio::spawn(async move {
+            task_progressed.store(true, Ordering::SeqCst);
+        });
+
+        let blocking = run_blocking(move || {
+            release_rx.recv_timeout(Duration::from_secs(2)).map_err(Error::other)?;
+            Ok(())
+        });
+        let release = async move {
+            for _ in 0..100 {
+                if progressed.load(Ordering::SeqCst) {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+            assert!(progressed.load(Ordering::SeqCst));
+            release_tx.send(()).unwrap();
+        };
+
+        let (result, ()) = tokio::join!(blocking, release);
+        result.unwrap();
+        unrelated.await.unwrap();
     }
 }


### PR DESCRIPTION
## Summary

- replace the `YubiSigner` type alias with a concrete signer that can share its synchronous YubiHSM credential with blocking tasks
- dispatch asynchronous hash and transaction signing through Tokio's blocking pool
- retain direct synchronous `SignerSync` and `TxSignerSync` behavior
- return an error when asynchronous signing is polled without a Tokio runtime or when its blocking task fails
- add current-thread executor, signing, and transaction chain-ID regression coverage

## Motivation

The `yubihsm` HTTP and USB connectors perform synchronous network and device I/O. The previous blanket `LocalSigner` async implementations called that synchronous signing path directly, preventing the executor thread from polling unrelated futures until the HSM responded.

The concrete signer owns the credential through an `Arc`, allowing the async implementations to move an owned handle into `spawn_blocking` without applying blocking-task overhead to ordinary in-memory local signers.

## API impact

`YubiSigner` changes from a transparent `LocalSigner<yubihsm::ecdsa::Signer<_>>` alias to a concrete struct. Its constructors, address and chain-ID accessors, credential access, synchronous traits, asynchronous traits, and wallet conversion remain available. Code that explicitly relied on the expanded alias type may need to use `YubiSigner` directly or its `From<LocalSigner<_>>` conversion.

Asynchronous YubiHSM signing now requires a Tokio runtime. Synchronous signing remains runtime-independent.

## Stack

This PR is stacked on #4128 and contains only the non-blocking signing portion of #4127.
