### PR TITLE
chore(deps): bump lru to 0.18.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,7 +154,7 @@ either = { version = "1.15", default-features = false }
 http = "1.1.0"
 itertools = { version = ">=0.13, <=0.14", default-features = false }
 jsonwebtoken = "10.3.0"
-lru = "0.16"
+lru = "0.18.2"
 once_cell = { version = "1.21", default-features = false }
 parking_lot = "0.12.3"
 pin-project = "1.1"


### PR DESCRIPTION
## Summary

- bump `lru` to 0.18.2, which fixes RUSTSEC-2026-0253
- unblock the Cargo Deny check failing on `lru` 0.16.4

## Testing

- `cargo check -p alloy-provider --all-features`
- `cargo deny --all-features check all`

Prompted by: @onbjerg
