### PR TITLE
feat(genesis): add account code helpers

### DIFF
--- a/crates/genesis/src/lib.rs
+++ b/crates/genesis/src/lib.rs
@@ -255,6 +255,16 @@ impl GenesisAccount {
         self
     }
 
+    /// Returns the account bytecode if it is non-empty.
+    pub fn non_empty_code(&self) -> Option<&Bytes> {
+        self.code.as_ref().filter(|code| !code.is_empty())
+    }
+
+    /// Returns the hash of the account bytecode if it is non-empty.
+    pub fn code_hash(&self) -> Option<B256> {
+        self.non_empty_code().map(keccak256)
+    }
+
     /// Set the storage.
     pub fn with_storage(mut self, storage: Option<BTreeMap<B256, B256>>) -> Self {
         self.storage = storage;
@@ -277,6 +287,7 @@ impl GenesisAccount {
 
 impl From<GenesisAccount> for TrieAccount {
     fn from(account: GenesisAccount) -> Self {
+        let code_hash = account.code_hash().unwrap_or(KECCAK_EMPTY);
         let storage_root = account
             .storage
             .map(|storage| {
@@ -293,7 +304,7 @@ impl From<GenesisAccount> for TrieAccount {
             nonce: account.nonce.unwrap_or_default(),
             balance: account.balance,
             storage_root,
-            code_hash: account.code.map_or(KECCAK_EMPTY, keccak256),
+            code_hash,
         }
     }
 }
@@ -2290,6 +2301,22 @@ mod tests {
 
         let result: Result<GenesisAccount, _> = serde_json::from_value(json_data);
         assert!(result.is_err()); // The deserialization should fail due to an empty string
+    }
+
+    #[test]
+    fn genesis_account_code_helpers() {
+        let account = GenesisAccount::default();
+        assert_eq!(account.non_empty_code(), None);
+        assert_eq!(account.code_hash(), None);
+
+        let account = GenesisAccount::default().with_code(Some(Bytes::new()));
+        assert_eq!(account.non_empty_code(), None);
+        assert_eq!(account.code_hash(), None);
+
+        let code = Bytes::from(vec![0x60, 0x61]);
+        let account = GenesisAccount::default().with_code(Some(code.clone()));
+        assert_eq!(account.non_empty_code(), Some(&code));
+        assert_eq!(account.code_hash(), Some(keccak256(&code)));
     }
 
     #[test]


### PR DESCRIPTION
## Motivation

Genesis files can encode empty bytecode as either an absent `code` field or `code: "0x"`. Consumers currently have to repeat this distinction, and treating every present value as deployed code can persist `KECCAK_EMPTY` as a present bytecode hash, as seen in [reth #26645](https://github.com/paradigmxyz/reth/pull/26645).

## Solution

Add `GenesisAccount::non_empty_code` and `GenesisAccount::code_hash`, both of which canonicalize absent and empty bytecode to `None`. Use the helper in the `TrieAccount` conversion and cover absent, empty, and non-empty code with unit tests.

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
