### PR TITLE
chore(eips): remove redundant format import

### DIFF
--- a/crates/eips/src/eip7594/sidecar.rs
+++ b/crates/eips/src/eip7594/sidecar.rs
@@ -5,7 +5,7 @@ use crate::{
     },
     eip7594::{CELLS_PER_EXT_BLOB, EIP_7594_WRAPPER_VERSION},
 };
-use alloc::{boxed::Box, format, vec::Vec};
+use alloc::{boxed::Box, vec::Vec};
 use alloy_primitives::{B128, B256};
 use alloy_rlp::{BufMut, Decodable, Encodable, Header};
 


### PR DESCRIPTION
The `format` import in `eip7594/sidecar.rs` (added in #4120) is redundant since the crate already has `#[macro_use] extern crate alloc`, which resolves the `format!` invocations in `validate`.