### PR TITLE
Fix/4085 ws json rpc batch

### DIFF
--- a/crates/json-rpc/src/lib.rs
+++ b/crates/json-rpc/src/lib.rs
@@ -86,7 +86,7 @@ mod error;
 pub use error::RpcError;
 
 mod notification;
-pub use notification::{EthNotification, PubSubItem, SubId};
+pub use notification::{EthNotification, PubSubItem, PubSubItems, PubSubItemsIter, SubId};
 
 mod packet;
 pub use packet::{BorrowedResponsePacket, RequestPacket, ResponsePacket};

--- a/crates/json-rpc/src/notification.rs
+++ b/crates/json-rpc/src/notification.rs
@@ -1,7 +1,7 @@
 use crate::{Response, ResponsePayload};
 use alloy_primitives::U256;
 use serde::{
-    de::{MapAccess, Visitor},
+    de::{self, MapAccess, SeqAccess, Visitor},
     Deserialize, Serialize,
 };
 
@@ -145,6 +145,105 @@ impl<'de> Deserialize<'de> for PubSubItem {
         }
 
         deserializer.deserialize_any(PubSubItemVisitor)
+    }
+}
+
+/// One or more [`PubSubItem`]s received in a single pubsub transport message.
+///
+/// A pubsub server normally sends one JSON object per message. However, a
+/// server answering a JSON-RPC batch request may reply with a single JSON array
+/// containing several responses. This type deserializes either shape so batch
+/// responses received over a pubsub transport are not dropped.
+///
+/// Each contained [`PubSubItem`] is dispatched and routed to its waiter
+/// independently by JSON-RPC ID, so the order of items within a batch does not
+/// matter.
+#[derive(Clone, Debug)]
+pub enum PubSubItems {
+    /// A single item, received as a JSON object.
+    Single(PubSubItem),
+    /// Multiple items, received as one JSON array (a JSON-RPC batch response).
+    Batch(Vec<PubSubItem>),
+}
+
+impl From<PubSubItem> for PubSubItems {
+    fn from(item: PubSubItem) -> Self {
+        Self::Single(item)
+    }
+}
+
+impl IntoIterator for PubSubItems {
+    type Item = PubSubItem;
+    type IntoIter = PubSubItemsIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        match self {
+            Self::Single(item) => PubSubItemsIter::Single(Some(item)),
+            Self::Batch(items) => PubSubItemsIter::Batch(items.into_iter()),
+        }
+    }
+}
+
+/// Owning iterator over the [`PubSubItem`]s in a [`PubSubItems`].
+///
+/// The single case does not allocate, keeping the common (non-batch) path cheap.
+#[derive(Debug)]
+pub enum PubSubItemsIter {
+    /// Yields the single contained item once.
+    Single(Option<PubSubItem>),
+    /// Yields each item of a batch in order.
+    Batch(std::vec::IntoIter<PubSubItem>),
+}
+
+impl Iterator for PubSubItemsIter {
+    type Item = PubSubItem;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::Single(item) => item.take(),
+            Self::Batch(iter) => iter.next(),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for PubSubItems {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct PubSubItemsVisitor;
+
+        impl<'de> Visitor<'de> for PubSubItemsVisitor {
+            type Value = PubSubItems;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str(
+                    "a JSON-RPC response, an Ethereum-style notification, or a batch array of them",
+                )
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                let mut items = Vec::new();
+                while let Some(item) = seq.next_element()? {
+                    items.push(item);
+                }
+                Ok(PubSubItems::Batch(items))
+            }
+
+            fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+            where
+                A: MapAccess<'de>,
+            {
+                // Reuse the single-item map deserialization.
+                PubSubItem::deserialize(de::value::MapAccessDeserializer::new(map))
+                    .map(PubSubItems::Single)
+            }
+        }
+
+        deserializer.deserialize_any(PubSubItemsVisitor)
     }
 }
 
@@ -292,6 +391,46 @@ mod tests {
 
         let deser = serde_json::from_str::<PubSubItem>(invalid_notification);
         assert!(deser.is_err());
+    }
+
+    #[test]
+    fn pubsub_items_single_object() {
+        // A single JSON object deserializes into `Single`.
+        let single = r#"{"jsonrpc":"2.0","id":1,"result":"0x1"}"#;
+        let items = serde_json::from_str::<PubSubItems>(single).unwrap();
+        match items {
+            PubSubItems::Single(PubSubItem::Response(resp)) => assert_eq!(resp.id, 1.into()),
+            _ => panic!("expected a single response"),
+        }
+    }
+
+    #[test]
+    fn pubsub_items_batch_array() {
+        // A JSON array (a batch response) deserializes into `Batch`, preserving
+        // every element so each can be routed by its own id.
+        let batch = r#"[
+            {"jsonrpc":"2.0","id":1,"result":22},
+            {"jsonrpc":"2.0","id":0,"result":11}
+        ]"#;
+        let items = serde_json::from_str::<PubSubItems>(batch).unwrap();
+        let collected: Vec<_> = items.into_iter().collect();
+        assert_eq!(collected.len(), 2);
+        let ids: Vec<_> = collected
+            .iter()
+            .map(|item| match item {
+                PubSubItem::Response(resp) => resp.id.clone(),
+                _ => panic!("expected responses"),
+            })
+            .collect();
+        assert_eq!(ids, vec![1.into(), 0.into()]);
+    }
+
+    #[test]
+    fn pubsub_items_single_notification() {
+        // Subscription notifications still parse via the single path.
+        let notification = r#"{ "jsonrpc": "2.0", "method": "eth_subscription", "params": {"subscription": "0x1", "result": {}} }"#;
+        let items = serde_json::from_str::<PubSubItems>(notification).unwrap();
+        assert!(matches!(items, PubSubItems::Single(PubSubItem::Notification(_))));
     }
 
     #[test]

--- a/crates/pubsub/src/frontend.rs
+++ b/crates/pubsub/src/frontend.rs
@@ -81,15 +81,79 @@ impl PubSubFrontend {
         .instrument(debug_span!("request", %method_name))
     }
 
-    /// Send a packet of requests, by breaking it up into individual requests.
+    /// Send a packet of JSON-RPC requests.
     ///
-    /// Once all responses are received, we return a single response packet.
+    /// Single requests continue to use the existing request path.
+    ///
+    /// Batch requests are kept grouped when they are sent to the pubsub
+    /// service. Each request still gets its own [`InFlight`] entry and response
+    /// receiver so responses can be routed independently by JSON-RPC ID.
+    ///
+    /// The pubsub service is responsible for serializing the batch into one
+    /// JSON array and dispatching it as one backend message.
     pub fn send_packet(&self, req: RequestPacket) -> TransportFut<'static> {
         match req {
             RequestPacket::Single(req) => self.send(req).map_ok(ResponsePacket::Single).boxed(),
-            RequestPacket::Batch(reqs) => try_join_all(reqs.into_iter().map(|req| self.send(req)))
-                .map_ok(ResponsePacket::Batch)
-                .boxed(),
+
+            RequestPacket::Batch(reqs) => {
+                let tx = self.tx.clone();
+                let channel_size = self.channel_size.load(Ordering::Relaxed);
+
+                async move {
+                    // Preserve the previous behavior for an empty batch:
+                    // there is nothing to send to the backend and there are no
+                    // responses to wait for.
+                    if reqs.is_empty() {
+                        return Ok(ResponsePacket::Batch(Vec::new()));
+                    }
+
+                    debug!(request_count = reqs.len(), "sending request batch to backend");
+
+                    // We need two collections:
+                    //
+                    // 1. `in_flights` These are sent together to the pubsub service so the service
+                    //    can serialize them as one JSON-RPC batch.
+                    //
+                    // 2. `receivers` Each request still has an independent oneshot receiver because
+                    //    JSON-RPC responses are matched by request ID.
+                    let mut in_flights = Vec::with_capacity(reqs.len());
+                    let mut receivers = Vec::with_capacity(reqs.len());
+
+                    for req in reqs {
+                        let (in_flight, rx) = InFlight::new(req, channel_size);
+
+                        in_flights.push(in_flight);
+                        receivers.push(rx);
+                    }
+
+                    // IMPORTANT:
+                    //
+                    // Previously this function called `self.send(req)` for
+                    // every element, producing N `Request` instructions.
+                    //
+                    // Sending one `Batch` instruction preserves the grouping
+                    // until the pubsub service, where the requests can be
+                    // serialized into one JSON array / one WebSocket message.
+                    tx.send(PubSubInstruction::Batch(in_flights))
+                        .map_err(|_| TransportErrorKind::backend_gone())?;
+
+                    // The server is allowed to respond to the requests
+                    // independently and even in a different order.
+                    //
+                    // RequestManager routes each response to the correct
+                    // oneshot sender using its JSON-RPC ID. Here we only wait
+                    // until all those individual responses have arrived.
+                    let responses = try_join_all(receivers.into_iter().map(|rx| async move {
+                        rx.await.map_err(|_| TransportErrorKind::backend_gone())?
+                    }))
+                    .await?;
+
+                    // Keep the Transport API unchanged: callers of
+                    // `send_packet()` still receive one ResponsePacket::Batch.
+                    Ok(ResponsePacket::Batch(responses))
+                }
+                .boxed()
+            }
         }
     }
 

--- a/crates/pubsub/src/ix.rs
+++ b/crates/pubsub/src/ix.rs
@@ -11,6 +11,12 @@ pub enum PubSubInstruction {
     GetSub(B256, oneshot::Sender<Option<RawSubscription>>),
     /// Unsubscribe from a subscription.
     Unsubscribe(B256),
+    /// Send multiple JSON-RPC requests as one wire-level batch.
+    ///
+    /// Each request remains an independent `InFlight` entry for response
+    /// routing, but the service should serialize all entries into a single
+    /// JSON-RPC array before dispatching them to the transport backend.
+    Batch(Vec<InFlight>),
 }
 
 impl fmt::Debug for PubSubInstruction {
@@ -19,6 +25,7 @@ impl fmt::Debug for PubSubInstruction {
             Self::Request(arg0) => f.debug_tuple("Request").field(arg0).finish(),
             Self::GetSub(arg0, _) => f.debug_tuple("GetSub").field(arg0).finish(),
             Self::Unsubscribe(arg0) => f.debug_tuple("Unsubscribe").field(arg0).finish(),
+            Self::Batch(arg0) => f.debug_tuple("Batch").field(arg0).finish(),
         }
     }
 }

--- a/crates/pubsub/src/service.rs
+++ b/crates/pubsub/src/service.rs
@@ -4,11 +4,13 @@ use crate::{
     managers::{InFlight, RequestManager, SubscriptionManager},
     PubSubConnect, PubSubFrontend, RawSubscription,
 };
-use alloy_json_rpc::{Id, PubSubItem, Request, Response, ResponsePayload, RpcError, SubId};
+use alloy_json_rpc::{
+    Id, PubSubItem, Request, RequestPacket, Response, ResponsePayload, RpcError, SubId,
+};
 use alloy_primitives::B256;
 use alloy_transport::{
     utils::{to_json_raw_value, Spawnable},
-    TransportErrorKind, TransportResult,
+    TransportError, TransportErrorKind, TransportResult,
 };
 use serde_json::value::RawValue;
 use std::time::Duration;
@@ -123,6 +125,32 @@ impl<T: PubSubConnect> PubSubService<T> {
         Ok(())
     }
 
+    /// Service a batch of requests.
+    ///
+    /// The requests are serialized into a single JSON-RPC array and dispatched
+    /// to the backend as one message, but each request is registered with the
+    /// [`RequestManager`] individually. Responses are therefore still routed to
+    /// their waiters by JSON-RPC ID, which is required because a server may
+    /// return the batch responses in any order.
+    fn service_batch(&mut self, in_flights: Vec<InFlight>) -> TransportResult<()> {
+        // Reuse the existing `RequestPacket` batch serialization instead of
+        // hand-writing the JSON array.
+        let packet = RequestPacket::Batch(
+            in_flights.iter().map(|in_flight| in_flight.request().clone()).collect(),
+        );
+        let brv = packet.serialize().map_err(TransportError::ser_err)?;
+
+        // One backend message for the whole batch...
+        self.dispatch_request(brv)?;
+
+        // ...but keep tracking each request by its own ID.
+        for in_flight in in_flights {
+            self.in_flights.insert(in_flight);
+        }
+
+        Ok(())
+    }
+
     /// Service a GetSub instruction.
     ///
     /// If the subscription exists, the waiter is sent `Some` broadcast receiver. If
@@ -149,6 +177,7 @@ impl<T: PubSubConnect> PubSubService<T> {
         trace!(?ix, "servicing instruction");
         match ix {
             PubSubInstruction::Request(in_flight) => self.service_request(in_flight),
+            PubSubInstruction::Batch(in_flights) => self.service_batch(in_flights),
             PubSubInstruction::GetSub(alias, tx) => {
                 self.service_get_sub(alias, tx);
                 Ok(())

--- a/crates/rpc-client/Cargo.toml
+++ b/crates/rpc-client/Cargo.toml
@@ -61,6 +61,8 @@ ci_info.workspace = true
 tempfile = "3"
 futures-util.workspace = true
 similar-asserts.workspace = true
+tokio = { workspace = true, features = ["macros", "net", "rt-multi-thread", "time"] }
+tokio-tungstenite.workspace = true
 
 [features]
 default = ["reqwest"]

--- a/crates/rpc-client/tests/it/ws.rs
+++ b/crates/rpc-client/tests/it/ws.rs
@@ -2,7 +2,14 @@ use alloy_node_bindings::Anvil;
 use alloy_primitives::U64;
 use alloy_rpc_client::{ClientBuilder, RpcCall};
 use alloy_transport_ws::WsConnect;
+use futures_util::{SinkExt, StreamExt};
 use similar_asserts::assert_eq;
+use std::{
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+use tokio::net::TcpListener;
+use tokio_tungstenite::tungstenite::Message;
 
 #[tokio::test]
 async fn it_makes_a_request() {
@@ -14,4 +21,110 @@ async fn it_makes_a_request() {
     let timeout = tokio::time::timeout(std::time::Duration::from_secs(2), req);
     let res = timeout.await.unwrap().unwrap();
     assert_eq!(res.to::<u64>(), 0);
+}
+
+/// Spawns a local WebSocket server that records every inbound text frame in the
+/// returned buffer and replies to each frame with `responder(request_json)`.
+///
+/// Returns the `ws://` URL to connect to and the shared buffer of raw frames.
+async fn spawn_ws_server(
+    responder: impl Fn(serde_json::Value) -> String + Send + 'static,
+) -> (String, Arc<Mutex<Vec<String>>>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let url = format!("ws://{addr}");
+
+    let frames = Arc::new(Mutex::new(Vec::<String>::new()));
+    let server_frames = frames.clone();
+
+    tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.unwrap();
+        let mut ws = tokio_tungstenite::accept_async(stream).await.unwrap();
+        while let Some(Ok(msg)) = ws.next().await {
+            match msg {
+                Message::Text(text) => {
+                    server_frames.lock().unwrap().push(text.to_string());
+                    let request: serde_json::Value = serde_json::from_str(&text).unwrap();
+                    let reply = responder(request);
+                    ws.send(Message::text(reply)).await.unwrap();
+                }
+                Message::Close(_) => break,
+                _ => {}
+            }
+        }
+    });
+
+    (url, frames)
+}
+
+/// Builds a JSON-RPC batch response, mapping each request id `n` to result
+/// `11 * (n + 1)` (id `0` -> `11`, id `1` -> `22`, ...). `reversed` controls
+/// whether the responses are emitted in reversed order relative to the request.
+fn batch_reply(request: &serde_json::Value, reversed: bool) -> String {
+    let requests = request.as_array().expect("expected a JSON-RPC batch array");
+    let mut responses: Vec<serde_json::Value> = requests
+        .iter()
+        .map(|req| {
+            let id = req["id"].as_u64().unwrap();
+            serde_json::json!({ "jsonrpc": "2.0", "id": id, "result": 11 * (id + 1) })
+        })
+        .collect();
+    if reversed {
+        responses.reverse();
+    }
+    serde_json::to_string(&responses).unwrap()
+}
+
+/// A batch created via `new_batch()` must be transmitted as exactly one
+/// WebSocket text frame whose JSON root is an array of the two requests.
+#[tokio::test]
+async fn batch_is_sent_as_one_frame() {
+    let (url, frames) = spawn_ws_server(|req| batch_reply(&req, false)).await;
+
+    let client = ClientBuilder::default().pubsub(WsConnect::new(url)).await.unwrap();
+    let mut batch = client.new_batch();
+    let first = batch.add_call::<_, u64>("first", &()).unwrap();
+    let second = batch.add_call::<_, u64>("second", &()).unwrap();
+    batch.send().await.unwrap();
+
+    // Both individual futures resolve from the single batch response array.
+    assert_eq!(first.await.unwrap(), 11);
+    assert_eq!(second.await.unwrap(), 22);
+
+    let frames = frames.lock().unwrap();
+    assert_eq!(frames.len(), 1, "batch must be sent as exactly one WS frame");
+    let request: serde_json::Value = serde_json::from_str(&frames[0]).unwrap();
+    assert!(request.is_array(), "the wire frame must be a JSON array");
+    assert_eq!(request.as_array().unwrap().len(), 2);
+}
+
+/// Responses are routed by JSON-RPC id, not by array position: a server that
+/// returns the batch responses in reversed order must still resolve each waiter
+/// to its own result.
+#[tokio::test]
+async fn batch_responses_route_by_id() {
+    let (url, _frames) = spawn_ws_server(|req| batch_reply(&req, true)).await;
+
+    let client = ClientBuilder::default().pubsub(WsConnect::new(url)).await.unwrap();
+    let mut batch = client.new_batch();
+    let first = batch.add_call::<_, u64>("first", &()).unwrap();
+    let second = batch.add_call::<_, u64>("second", &()).unwrap();
+    batch.send().await.unwrap();
+
+    assert_eq!(first.await.unwrap(), 11);
+    assert_eq!(second.await.unwrap(), 22);
+}
+
+/// An empty batch must not produce any WebSocket message.
+#[tokio::test]
+async fn empty_batch_sends_no_frame() {
+    let (url, frames) = spawn_ws_server(|req| batch_reply(&req, false)).await;
+
+    let client = ClientBuilder::default().pubsub(WsConnect::new(url)).await.unwrap();
+    let batch = client.new_batch();
+    batch.send().await.unwrap();
+
+    // Give any (erroneous) outbound frame a chance to arrive.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    assert!(frames.lock().unwrap().is_empty(), "an empty batch must not send a frame");
 }

--- a/crates/rpc-types-eth/src/transaction/request.rs
+++ b/crates/rpc-types-eth/src/transaction/request.rs
@@ -27,7 +27,18 @@ pub struct TransactionRequest {
     #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
     pub from: Option<Address>,
     /// The destination address of the transaction.
-    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
+    ///
+    /// A missing `to` field deserializes to `None`, while an explicit `null` deserializes to
+    /// `Some(TxKind::Create)` (contract creation) in human-readable formats. See the
+    /// `deserialize_to` function for details.
+    #[cfg_attr(
+        feature = "serde",
+        serde(
+            default,
+            skip_serializing_if = "Option::is_none",
+            deserialize_with = "deserialize_to"
+        )
+    )]
     pub to: Option<TxKind>,
     /// The legacy gas price.
     #[cfg_attr(
@@ -132,6 +143,41 @@ pub struct TransactionRequest {
     /// Authorization list for EIP-7702 transactions.
     #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
     pub authorization_list: Option<Vec<SignedAuthorization>>,
+}
+
+/// Deserializer for [`TransactionRequest::to`].
+///
+/// This is only invoked when the `to` field is *present* in the input, because the field is also
+/// annotated with `#[serde(default)]`: serde skips `deserialize_with` entirely for a missing field
+/// and uses `Default::default()` (`None`) instead. This is what lets us distinguish the three
+/// cases:
+///
+/// * missing `to`      -> `None` (handled by `#[serde(default)]`, this function is not called)
+/// * explicit `"to": null` -> `Some(TxKind::Create)` (contract creation)
+/// * `"to": "0x..."`   -> `Some(TxKind::Call(address))`
+///
+/// A present value is deserialized directly as [`TxKind`] (whose own `Deserialize` maps `null` to
+/// [`TxKind::Create`] and an address to [`TxKind::Call`]) and wrapped in `Some`. Without this, the
+/// outer `Option<TxKind>` deserializer would swallow `null` as `None`, losing the contract-creation
+/// intent.
+///
+/// For non-human-readable formats (e.g. bincode) the original `Option<TxKind>` behavior is
+/// preserved, since those formats are not self-describing and rely on the field always being
+/// present with its `None`/`Some` encoding intact.
+#[cfg(feature = "serde")]
+fn deserialize_to<'de, D>(deserializer: D) -> Result<Option<TxKind>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::Deserialize;
+
+    if deserializer.is_human_readable() {
+        // Present value: `null` -> `Some(TxKind::Create)`, address -> `Some(TxKind::Call(..))`.
+        TxKind::deserialize(deserializer).map(Some)
+    } else {
+        // Preserve original binary semantics.
+        Option::<TxKind>::deserialize(deserializer)
+    }
 }
 
 impl TransactionRequest {
@@ -2346,5 +2392,69 @@ mod tests {
         let hashes = tx_request.blob_versioned_hashes.unwrap();
         assert_eq!(hashes.len(), 1);
         assert_eq!(hashes[0], expected_hash);
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn serde_tx_request_contract_creation_roundtrip() {
+        let request = TransactionRequest::default().create();
+
+        assert_eq!(request.to, Some(TxKind::Create));
+
+        let json = serde_json::to_value(&request).unwrap();
+
+        assert_eq!(json["to"], serde_json::Value::Null);
+
+        let decoded: TransactionRequest = serde_json::from_value(json).unwrap();
+
+        assert_eq!(decoded.to, Some(TxKind::Create));
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn serde_tx_request_to_missing_is_none() {
+        let request: TransactionRequest = serde_json::from_str("{}").unwrap();
+        assert_eq!(request.to, None);
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn serde_tx_request_to_explicit_null_is_create() {
+        let request: TransactionRequest = serde_json::from_str(r#"{"to":null}"#).unwrap();
+        assert_eq!(request.to, Some(TxKind::Create));
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn serde_tx_request_to_address_is_call() {
+        let address = Address::repeat_byte(0xDE);
+        let json = format!(r#"{{"to":"{address}"}}"#);
+        let request: TransactionRequest = serde_json::from_str(&json).unwrap();
+        assert_eq!(request.to, Some(TxKind::Call(address)));
+    }
+
+    /// Ensures the custom `to` deserializer does not alter binary (non-human-readable) semantics:
+    /// a bincode roundtrip must preserve every `to` variant exactly.
+    #[test]
+    #[cfg(all(feature = "serde", feature = "serde-bincode-compat"))]
+    fn serde_tx_request_to_bincode_roundtrip() {
+        use serde::{Deserialize, Serialize};
+        use serde_with::serde_as;
+
+        #[serde_as]
+        #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+        struct Data {
+            #[serde_as(as = "serde_bincode_compat::TransactionRequest")]
+            request: TransactionRequest,
+        }
+
+        for to in [None, Some(TxKind::Create), Some(TxKind::Call(Address::repeat_byte(0xDE)))] {
+            let data = Data { request: TransactionRequest { to, ..Default::default() } };
+            let encoded = bincode::serde::encode_to_vec(&data, bincode::config::legacy()).unwrap();
+            let (decoded, _) =
+                bincode::serde::decode_from_slice::<Data, _>(&encoded, bincode::config::legacy())
+                    .unwrap();
+            assert_eq!(decoded, data);
+        }
     }
 }

--- a/crates/transport-ipc/src/lib.rs
+++ b/crates/transport-ipc/src/lib.rs
@@ -49,9 +49,12 @@ impl IpcBackend {
     fn spawn(mut self) {
         let fut = async move {
             let (read, mut writer) = self.stream.split();
-            let mut read = ReadJsonStream::new(read).fuse();
+            // Parse each message as one-or-many items so a JSON-RPC batch
+            // response (a single JSON array) is expanded into its individual
+            // responses before being forwarded to the frontend.
+            let mut read = ReadJsonStream::<_, alloy_json_rpc::PubSubItems>::new(read).fuse();
 
-            let err = loop {
+            let err = 'outer: loop {
                 select! {
                     biased;
                     item = self.interface.recv_from_frontend() => {
@@ -73,10 +76,12 @@ impl IpcBackend {
                     // Read from the socket.
                     item = read.next() => {
                         match item {
-                            Some(item) => {
-                                if self.interface.send_to_frontend(item).is_err() {
-                                    debug!("Frontend has gone away");
-                                    break false;
+                            Some(items) => {
+                                for item in items {
+                                    if self.interface.send_to_frontend(item).is_err() {
+                                        debug!("Frontend has gone away");
+                                        break 'outer false;
+                                    }
                                 }
                             }
                             None => {

--- a/crates/transport-ws/Cargo.toml
+++ b/crates/transport-ws/Cargo.toml
@@ -23,6 +23,7 @@ rustdoc-args = [
 workspace = true
 
 [dependencies]
+alloy-json-rpc.workspace = true
 alloy-pubsub.workspace = true
 alloy-transport.workspace = true
 

--- a/crates/transport-ws/src/lib.rs
+++ b/crates/transport-ws/src/lib.rs
@@ -55,16 +55,23 @@ impl<T> WsBackend<T> {
     }
 
     /// Handle inbound text from the websocket.
+    ///
+    /// A message may be a single JSON-RPC response/notification object or, when
+    /// the server answers a JSON-RPC batch request, a single JSON array of
+    /// responses. In the batch case each element is forwarded to the frontend
+    /// individually so it can be routed to its waiter by JSON-RPC ID.
     #[expect(clippy::result_unit_err)]
     pub fn handle_text(&mut self, text: &str) -> Result<(), ()> {
         trace!(%text, "received message from websocket");
 
-        match serde_json::from_str(text) {
-            Ok(item) => {
-                trace!(?item, "deserialized message");
-                if let Err(err) = self.interface.send_to_frontend(item) {
-                    error!(item=?err.0, "failed to send deserialized item to handler");
-                    return Err(());
+        match serde_json::from_str::<alloy_json_rpc::PubSubItems>(text) {
+            Ok(items) => {
+                for item in items {
+                    trace!(?item, "deserialized message");
+                    if let Err(err) = self.interface.send_to_frontend(item) {
+                        error!(item=?err.0, "failed to send deserialized item to handler");
+                        return Err(());
+                    }
                 }
             }
             Err(err) => {


### PR DESCRIPTION
## Summary

Related #4085.

`RpcClient::new_batch()` correctly creates a `RequestPacket::Batch`, but the pubsub frontend was splitting that batch into individual requests before passing them to the transport.

As a result, a batch containing multiple requests was sent as multiple WebSocket messages instead of a single JSON-RPC batch array.

This PR preserves the batch through the pubsub layer so WebSocket and IPC transports send it as one wire-level packet, while still tracking each request independently by JSON-RPC ID.

## Problem

Previously, `PubSubFrontend::send_packet()` handled a batch like this:

```rust
RequestPacket::Batch(reqs) =>
    try_join_all(reqs.into_iter().map(|req| self.send(req)))
        .map_ok(ResponsePacket::Batch)
        .boxed(),
```

Calling `self.send()` for every request created a separate `PubSubInstruction::Request`, so the original batch was lost before reaching the backend.

For a batch containing two requests, the flow was effectively:

```text
RequestPacket::Batch([A, B])
        ↓
send(A) + send(B)
        ↓
two backend messages
        ↓
two WebSocket frames
```

With this change:

```text
RequestPacket::Batch([A, B])
        ↓
one PubSubInstruction::Batch
        ↓
one RequestPacket::Batch
        ↓
one serialized JSON-RPC array
        ↓
one WebSocket frame
```

## Changes

### Preserve batches in the pubsub frontend

`PubSubFrontend::send_packet()` now creates an `InFlight` entry and response receiver for each request, but sends all of the requests to the service using a single batch instruction.

Each request remains independently tracked, so response handling continues to use JSON-RPC IDs rather than array position.

### Dispatch batches as one packet

The pubsub service now handles the batch as a single `RequestPacket::Batch`.

The existing `RequestPacket` serialization is reused, so the batch is serialized as one JSON array and dispatched to the backend once.

Each `InFlight` request is still registered individually with the `RequestManager`.

### Handle batch responses

WebSocket and IPC previously expected each incoming message to deserialize into a single `PubSubItem`.

A new `PubSubItems` helper supports both:

* a single response or subscription notification
* an array of responses

Batch response elements are forwarded individually to the existing frontend handling, where they are matched to pending requests by JSON-RPC ID.

This also means responses can arrive in a different order from the requests without affecting the corresponding futures.

## IPC behavior

Because WebSocket and IPC share the pubsub frontend, IPC now preserves JSON-RPC batches on the wire as well.

Single-request behavior remains unchanged.

## Reconnect behavior

Reconnect behavior is intentionally unchanged.

Pending requests are still reissued individually after reconnect. Preserving the original batch grouping across reconnects would introduce separate retry and idempotency concerns and is outside the scope of this fix.

This PR does not provide transactional batch semantics.

## Empty batches

Existing empty-batch behavior is preserved.

```rust
RequestPacket::Batch(vec![])
```

returns an empty `ResponsePacket::Batch` without sending anything to the backend.

## Tests

Added WebSocket regression tests covering:

* multiple calls from `new_batch()` are sent as one WebSocket text frame containing a JSON array
* batch responses returned in reverse order are routed to the correct futures by request ID
* an empty batch does not send a WebSocket frame

Added JSON-RPC tests covering `PubSubItems` deserialization for:

* a single response object
* a batch response array
* a subscription notification

The original #4085 behavior is also covered by the regression test: restoring the previous split behavior causes the WebSocket batch test to fail because the server receives individual JSON objects instead of one array.

## Files changed

* `crates/json-rpc/src/notification.rs` — add `PubSubItems` support for single items and arrays
* `crates/json-rpc/src/lib.rs` — export `PubSubItems`
* `crates/pubsub/src/ix.rs` — add the internal batch instruction
* `crates/pubsub/src/frontend.rs` — preserve batch grouping and individual response receivers
* `crates/pubsub/src/service.rs` — serialize and dispatch batches once while tracking requests individually
* `crates/transport-ws/src/lib.rs` — handle incoming batch responses
* `crates/transport-ws/Cargo.toml` — add the workspace `alloy-json-rpc` dependency
* `crates/transport-ipc/src/lib.rs` — handle incoming `PubSubItems`
* `crates/rpc-client/tests/it/ws.rs` — add WebSocket batch regression tests
* `crates/rpc-client/Cargo.toml` — add test dependencies required by the local WebSocket server

