### PR TITLE
feat(rpc-types-engine): add FOCIL response types

### DIFF
--- a/crates/rpc-types-engine/src/forkchoice.rs
+++ b/crates/rpc-types-engine/src/forkchoice.rs
@@ -1,4 +1,4 @@
-use super::{PayloadStatus, PayloadStatusEnum};
+use super::{PayloadStatus, PayloadStatusEnum, PayloadStatusV2};
 use crate::PayloadId;
 use alloy_primitives::B256;
 
@@ -209,6 +209,80 @@ impl ssz::Decode for ForkchoiceUpdated {
     }
 }
 
+/// Represents a successfully processed forkchoice update in the Bogota Engine API.
+///
+/// See also <https://github.com/ethereum/execution-apis/blob/main/src/engine/bogota.md#engine_forkchoiceupdatedv5>
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+pub struct ForkchoiceUpdatedResponseV2 {
+    /// Represents the outcome of payload validation.
+    ///
+    /// The Engine API restricts the status to `VALID`, `INVALID`, and `SYNCING` for this response.
+    pub payload_status: PayloadStatusV2,
+    /// The identifier of the payload build process that was successfully initiated.
+    pub payload_id: Option<PayloadId>,
+}
+
+impl ForkchoiceUpdatedResponseV2 {
+    /// Creates a new forkchoice update response.
+    pub const fn new(payload_status: PayloadStatusV2) -> Self {
+        Self { payload_status, payload_id: None }
+    }
+
+    /// Creates a new response from a common payload status.
+    pub const fn from_status(status: PayloadStatusEnum) -> Self {
+        Self::new(PayloadStatusV2::new(PayloadStatus::from_status(status), None))
+    }
+
+    /// Sets the latest valid hash of the payload status.
+    pub const fn with_latest_valid_hash(mut self, hash: B256) -> Self {
+        self.payload_status.payload_inner.latest_valid_hash = Some(hash);
+        self
+    }
+
+    /// Sets whether the payload satisfied the inclusion-list constraints.
+    pub const fn with_inclusion_list_satisfied(mut self, satisfied: bool) -> Self {
+        self.payload_status.inclusion_list_satisfied = Some(satisfied);
+        self
+    }
+
+    /// Sets the payload id of the created payload job.
+    pub const fn with_payload_id(mut self, id: PayloadId) -> Self {
+        self.payload_id = Some(id);
+        self
+    }
+
+    /// Returns true if the payload status is syncing.
+    pub const fn is_syncing(&self) -> bool {
+        self.payload_status.is_syncing()
+    }
+
+    /// Returns true if the payload status is valid.
+    pub const fn is_valid(&self) -> bool {
+        self.payload_status.is_valid()
+    }
+
+    /// Returns true if the payload status is invalid.
+    pub const fn is_invalid(&self) -> bool {
+        self.payload_status.is_invalid()
+    }
+}
+
+impl From<ForkchoiceUpdated> for ForkchoiceUpdatedResponseV2 {
+    fn from(response: ForkchoiceUpdated) -> Self {
+        Self { payload_status: response.payload_status.into(), payload_id: response.payload_id }
+    }
+}
+
+/// Downgrades a V2 forkchoice response, discarding its inclusion-list validation result.
+impl From<ForkchoiceUpdatedResponseV2> for ForkchoiceUpdated {
+    fn from(response: ForkchoiceUpdatedResponseV2) -> Self {
+        Self { payload_status: response.payload_status.into(), payload_id: response.payload_id }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -259,5 +333,33 @@ mod tests {
         let encoded = updated.as_ssz_bytes();
         let decoded = ForkchoiceUpdated::from_ssz_bytes(&encoded).unwrap();
         assert_eq!(decoded, updated);
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn serde_forkchoice_updated_response_v2() {
+        let updated = ForkchoiceUpdatedResponseV2::from_status(PayloadStatusEnum::Valid)
+            .with_inclusion_list_satisfied(true);
+        let value = serde_json::to_value(&updated).unwrap();
+        assert_eq!(value["payloadStatus"]["status"], "VALID");
+        assert_eq!(value["payloadStatus"]["inclusionListSatisfied"], true);
+
+        let decoded: ForkchoiceUpdatedResponseV2 = serde_json::from_value(value).unwrap();
+        assert_eq!(decoded, updated);
+    }
+
+    #[test]
+    fn forkchoice_updated_response_v2_conversions() {
+        let v1 = ForkchoiceUpdated::from_status(PayloadStatusEnum::Valid)
+            .with_latest_valid_hash(B256::with_last_byte(1))
+            .with_payload_id(PayloadId(alloy_primitives::B64::with_last_byte(2)));
+
+        let v2: ForkchoiceUpdatedResponseV2 = v1.clone().into();
+        assert_eq!(v2.payload_status.payload_inner, v1.payload_status);
+        assert_eq!(v2.payload_id, v1.payload_id);
+        assert_eq!(v2.payload_status.inclusion_list_satisfied, None);
+
+        let downgraded: ForkchoiceUpdated = v2.with_inclusion_list_satisfied(true).into();
+        assert_eq!(downgraded, v1);
     }
 }

--- a/crates/rpc-types-engine/src/payload.rs
+++ b/crates/rpc-types-engine/src/payload.rs
@@ -3965,6 +3965,85 @@ impl core::fmt::Display for PayloadStatusEnum {
     }
 }
 
+/// This structure contains the result of processing a payload in the Bogota Engine API.
+///
+/// It extends [`PayloadStatus`] with the EIP-7805 inclusion-list validation result.
+///
+/// See also <https://github.com/ethereum/execution-apis/blob/main/src/engine/bogota.md#payloadstatusv2>
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+pub struct PayloadStatusV2 {
+    /// The common payload status fields.
+    #[cfg_attr(feature = "serde", serde(flatten))]
+    pub payload_inner: PayloadStatus,
+    /// Whether the payload satisfied the inclusion-list constraints if it was deemed valid.
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub inclusion_list_satisfied: Option<bool>,
+}
+
+impl PayloadStatusV2 {
+    /// Creates a new payload status.
+    pub const fn new(
+        payload_status: PayloadStatus,
+        inclusion_list_satisfied: Option<bool>,
+    ) -> Self {
+        Self { payload_inner: payload_status, inclusion_list_satisfied }
+    }
+
+    /// Sets whether the payload satisfied the inclusion-list constraints.
+    pub const fn with_inclusion_list_satisfied(mut self, satisfied: bool) -> Self {
+        self.inclusion_list_satisfied = Some(satisfied);
+        self
+    }
+
+    /// Returns true if the payload status is syncing.
+    pub const fn is_syncing(&self) -> bool {
+        self.payload_inner.is_syncing()
+    }
+
+    /// Returns true if the payload status is valid.
+    pub const fn is_valid(&self) -> bool {
+        self.payload_inner.is_valid()
+    }
+
+    /// Returns true if the payload status is invalid.
+    pub const fn is_invalid(&self) -> bool {
+        self.payload_inner.is_invalid()
+    }
+}
+
+impl From<PayloadStatus> for PayloadStatusV2 {
+    fn from(payload_status: PayloadStatus) -> Self {
+        Self::new(payload_status, None)
+    }
+}
+
+/// Downgrades a V2 payload status, discarding its inclusion-list validation result.
+impl From<PayloadStatusV2> for PayloadStatus {
+    fn from(payload_status: PayloadStatusV2) -> Self {
+        payload_status.payload_inner
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for PayloadStatusV2 {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeMap;
+
+        let mut map = serializer.serialize_map(Some(4))?;
+        map.serialize_entry("status", self.payload_inner.status.as_str())?;
+        map.serialize_entry("latestValidHash", &self.payload_inner.latest_valid_hash)?;
+        map.serialize_entry("validationError", &self.payload_inner.status.validation_error())?;
+        map.serialize_entry("inclusionListSatisfied", &self.inclusion_list_satisfied)?;
+        map.end()
+    }
+}
+
 /// Struct aggregating [`ExecutionPayload`] and [`ExecutionPayloadSidecar`] and encapsulating
 /// complete payload supplied for execution.
 #[derive(Debug, Clone)]
@@ -4462,6 +4541,36 @@ mod tests {
         assert!(status.latest_valid_hash.is_none());
         assert!(status.status.validation_error().is_none());
         assert_eq!(serde_json::to_string(&status).unwrap(), full);
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn serde_payload_status_v2() {
+        let json = r#"{"status":"VALID","latestValidHash":null,"validationError":null,"inclusionListSatisfied":true}"#;
+        let status: PayloadStatusV2 = serde_json::from_str(json).unwrap();
+        assert!(status.is_valid());
+        assert!(status.payload_inner.latest_valid_hash.is_none());
+        assert_eq!(status.inclusion_list_satisfied, Some(true));
+        assert_eq!(serde_json::to_string(&status).unwrap(), json);
+
+        let json = r#"{"status":"SYNCING","latestValidHash":null,"validationError":null,"inclusionListSatisfied":null}"#;
+        let status: PayloadStatusV2 = serde_json::from_str(json).unwrap();
+        assert!(status.is_syncing());
+        assert_eq!(status.inclusion_list_satisfied, None);
+        assert_eq!(serde_json::to_string(&status).unwrap(), json);
+    }
+
+    #[test]
+    fn payload_status_v2_conversions() {
+        let v1 = PayloadStatus::from_status(PayloadStatusEnum::Valid)
+            .with_latest_valid_hash(B256::with_last_byte(1));
+
+        let v2: PayloadStatusV2 = v1.clone().into();
+        assert_eq!(v2.payload_inner, v1);
+        assert_eq!(v2.inclusion_list_satisfied, None);
+
+        let downgraded: PayloadStatus = v2.with_inclusion_list_satisfied(true).into();
+        assert_eq!(downgraded, v1);
     }
 
     #[test]


### PR DESCRIPTION
Adds standalone `PayloadStatusV2` and `ForkchoiceUpdatedResponseV2` definitions from the Bogota Engine API for EIP-7805.

This extracts the stable response shapes from #4086 so follow-up work can add payload attributes, RPC methods, and existing-type integrations independently. `ExecutionPayloadV4` already exists in Alloy, so this deliberately does not duplicate it or modify the existing payload enums.

`PayloadStatusV2` composes the existing payload status fields with `inclusionListSatisfied`, while `ForkchoiceUpdatedResponseV2` exposes the corresponding versioned forkchoice response and convenience methods.
