### PR TITLE
feat(rpc-types-engine): add Bogota payload sidecar fields

### DIFF
--- a/crates/rpc-types-engine/src/bogota.rs
+++ b/crates/rpc-types-engine/src/bogota.rs
@@ -50,6 +50,11 @@ impl MaybeBogotaPayloadFields {
         Self { fields: None }
     }
 
+    /// Returns `true` if no Bogota fields are present.
+    pub const fn is_none(&self) -> bool {
+        self.fields.is_none()
+    }
+
     /// Consumes `self` and returns the contained [`BogotaPayloadFields`], if present.
     pub fn into_inner(self) -> Option<BogotaPayloadFields> {
         self.fields

--- a/crates/rpc-types-engine/src/sidecar.rs
+++ b/crates/rpc-types-engine/src/sidecar.rs
@@ -1,12 +1,13 @@
 //! Contains helpers for dealing with additional parameters of `newPayload` requests.
 
 use crate::{
-    CancunPayloadFields, MaybeCancunPayloadFields, MaybePraguePayloadFields, PraguePayloadFields,
+    BogotaPayloadFields, CancunPayloadFields, MaybeBogotaPayloadFields, MaybeCancunPayloadFields,
+    MaybePraguePayloadFields, PraguePayloadFields,
 };
 use alloc::vec::Vec;
 use alloy_consensus::{Block, BlockHeader, Transaction};
 use alloy_eips::eip7685::Requests;
-use alloy_primitives::B256;
+use alloy_primitives::{Bytes, B256};
 
 /// Container type for all available additional `newPayload` request parameters that are not present
 /// in the `ExecutionPayload` object itself.
@@ -20,6 +21,13 @@ pub struct ExecutionPayloadSidecar {
     /// The EIP-7685 requests provided as additional request params to `engine_newPayloadV4` that
     /// are not present in the `ExecutionPayload`.
     prague: MaybePraguePayloadFields,
+    /// EIP-7805 inclusion-list transactions provided as an additional request parameter to
+    /// `engine_newPayloadV6` that are not present in the `ExecutionPayload`.
+    #[cfg_attr(
+        feature = "serde",
+        serde(default, skip_serializing_if = "MaybeBogotaPayloadFields::is_none")
+    )]
+    bogota: MaybeBogotaPayloadFields,
 }
 
 impl ExecutionPayloadSidecar {
@@ -30,6 +38,9 @@ impl ExecutionPayloadSidecar {
     ///
     /// Note: This returns [`RequestOrHash::Hash`](alloy_eips::eip7685::RequestsOrHash::Hash) for
     /// the EIP-7685 requests.
+    ///
+    /// Bogota fields cannot be recovered from a block because inclusion-list transactions are not
+    /// committed separately in the execution payload.
     pub fn from_block<T, H>(block: &Block<T, H>) -> Self
     where
         T: Transaction,
@@ -50,19 +61,46 @@ impl ExecutionPayloadSidecar {
         }
     }
 
-    /// Returns a new empty instance (pre-cancun, v1, v2)
+    /// Returns a new empty instance (pre-cancun, v1, v2).
     pub const fn none() -> Self {
-        Self { cancun: MaybeCancunPayloadFields::none(), prague: MaybePraguePayloadFields::none() }
+        Self {
+            cancun: MaybeCancunPayloadFields::none(),
+            prague: MaybePraguePayloadFields::none(),
+            bogota: MaybeBogotaPayloadFields::none(),
+        }
     }
 
-    /// Creates a new instance for cancun with the cancun fields for `engine_newPayloadV3`
+    /// Creates a new instance for cancun with the cancun fields for `engine_newPayloadV3`.
     pub fn v3(cancun: CancunPayloadFields) -> Self {
-        Self { cancun: cancun.into(), prague: MaybePraguePayloadFields::none() }
+        Self {
+            cancun: cancun.into(),
+            prague: MaybePraguePayloadFields::none(),
+            bogota: MaybeBogotaPayloadFields::none(),
+        }
     }
 
-    /// Creates a new instance post prague for `engine_newPayloadV4`
+    /// Creates a new instance post prague for `engine_newPayloadV4`.
     pub fn v4(cancun: CancunPayloadFields, prague: PraguePayloadFields) -> Self {
-        Self { cancun: cancun.into(), prague: prague.into() }
+        Self {
+            cancun: cancun.into(),
+            prague: prague.into(),
+            bogota: MaybeBogotaPayloadFields::none(),
+        }
+    }
+
+    /// Creates a new instance post Bogota for `engine_newPayloadV6`.
+    pub fn v6(
+        cancun: CancunPayloadFields,
+        prague: PraguePayloadFields,
+        bogota: BogotaPayloadFields,
+    ) -> Self {
+        Self { cancun: cancun.into(), prague: prague.into(), bogota: bogota.into() }
+    }
+
+    /// Sets the EIP-7805 inclusion-list transactions.
+    pub fn with_inclusion_list(mut self, inclusion_list_transactions: Vec<Bytes>) -> Self {
+        self.bogota = BogotaPayloadFields::new(inclusion_list_transactions).into();
+        self
     }
 
     /// Returns a reference to the [`CancunPayloadFields`].
@@ -83,6 +121,16 @@ impl ExecutionPayloadSidecar {
     /// Consumes the type and returns the [`PraguePayloadFields`].
     pub fn into_prague(self) -> Option<PraguePayloadFields> {
         self.prague.into_inner()
+    }
+
+    /// Returns a reference to the [`BogotaPayloadFields`].
+    pub const fn bogota(&self) -> Option<&BogotaPayloadFields> {
+        self.bogota.as_ref()
+    }
+
+    /// Consumes the type and returns the [`BogotaPayloadFields`].
+    pub fn into_bogota(self) -> Option<BogotaPayloadFields> {
+        self.bogota.into_inner()
     }
 
     /// Returns the parent beacon block root, if any.
@@ -110,5 +158,53 @@ impl ExecutionPayloadSidecar {
     /// - If it contains a precomputed hash (used for testing), it returns that hash directly.
     pub fn requests_hash(&self) -> Option<B256> {
         self.prague.requests_hash()
+    }
+
+    /// Returns the EIP-7805 inclusion-list transactions, if any.
+    pub fn inclusion_list_transactions(&self) -> Option<&Vec<Bytes>> {
+        self.bogota.inclusion_list_transactions()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn with_inclusion_list() {
+        use alloy_consensus::{BlockBody, Header, TxEnvelope};
+
+        let block: Block<TxEnvelope> = Block::new(Header::default(), BlockBody::default());
+        let transactions = vec![Bytes::from_static(&[0x01, 0x02])];
+        let sidecar =
+            ExecutionPayloadSidecar::from_block(&block).with_inclusion_list(transactions.clone());
+
+        assert_eq!(sidecar.inclusion_list_transactions(), Some(&transactions));
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn serde_sidecar_without_bogota_fields() {
+        let legacy = r#"{"cancun":{"fields":null},"prague":{"fields":null}}"#;
+        let sidecar: ExecutionPayloadSidecar = serde_json::from_str(legacy).unwrap();
+
+        assert!(sidecar.bogota().is_none());
+        assert_eq!(serde_json::to_string(&sidecar).unwrap(), legacy);
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn serde_sidecar_with_bogota_fields() {
+        let transactions = vec![Bytes::from_static(&[0x01, 0x02])];
+        let sidecar = ExecutionPayloadSidecar::v6(
+            CancunPayloadFields::default(),
+            PraguePayloadFields::default(),
+            BogotaPayloadFields::new(transactions.clone()),
+        );
+
+        let encoded = serde_json::to_string(&sidecar).unwrap();
+        let decoded: ExecutionPayloadSidecar = serde_json::from_str(&encoded).unwrap();
+
+        assert_eq!(decoded.inclusion_list_transactions(), Some(&transactions));
     }
 }


### PR DESCRIPTION
## Summary

- extend `ExecutionPayloadSidecar` with optional `MaybeBogotaPayloadFields` for the inclusion-list transactions passed to `engine_newPayloadV6`
- add a V6 constructor, a `with_inclusion_list` builder, and accessors for the Bogota fields and inclusion-list transactions
- preserve the legacy serialized sidecar shape when Bogota fields are absent, while defaulting missing Bogota fields during deserialization

## Motivation

FOCIL inclusion-list transactions are supplied as an additional `engine_newPayloadV6` parameter rather than being part of `ExecutionPayloadV4`, so they belong in the payload sidecar introduced in #4139. The sidecar also documents that these fields cannot be reconstructed from an execution block because the inclusion list is not committed separately in the payload.