### PR TITLE
feat(provider): expose request metadata and header helpers

### DIFF
--- a/crates/provider/Cargo.toml
+++ b/crates/provider/Cargo.toml
@@ -67,7 +67,7 @@ tokio = { workspace = true, features = ["sync", "macros"] }
 tracing.workspace = true
 url = { workspace = true, optional = true }
 either.workspace = true
-http = { workspace = true, optional = true }
+http.workspace = true
 
 [target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]
 tokio = { workspace = true, features = ["time"] }
@@ -138,5 +138,5 @@ trace-api = ["dep:alloy-rpc-types-trace"]
 rpc-api = ["dep:alloy-rpc-types"]
 txpool-api = ["dep:alloy-rpc-types-txpool"]
 throttle = ["alloy-transport/throttle"]
-mev-api = ["dep:alloy-rpc-types-mev", "dep:http"]
+mev-api = ["dep:alloy-rpc-types-mev"]
 more-tuple-impls = ["alloy-sol-types/more-tuple-impls"]

--- a/crates/provider/src/provider/prov_call.rs
+++ b/crates/provider/src/provider/prov_call.rs
@@ -1,4 +1,4 @@
-use alloy_json_rpc::{RpcRecv, RpcSend};
+use alloy_json_rpc::{RequestMeta, RpcRecv, RpcSend};
 use alloy_rpc_client::{RpcCall, Waiter};
 use alloy_transport::TransportResult;
 use futures::FutureExt;
@@ -157,6 +157,40 @@ where
             _ => Err(self),
         }
     }
+
+    /// Maps the metadata of the underlying RPC request.
+    ///
+    /// This can be used with typed [`Provider`](crate::Provider) methods to
+    /// attach request-scoped metadata such as HTTP headers without falling
+    /// back to a raw RPC call:
+    ///
+    /// ```no_run
+    /// # use alloy_provider::{Provider, ProviderBuilder};
+    /// # use http::{HeaderMap, HeaderValue};
+    /// # async fn example() -> alloy_transport::TransportResult<()> {
+    /// # let provider = ProviderBuilder::new().connect("http://localhost:8545").await?;
+    /// let mut headers = HeaderMap::new();
+    /// headers.insert("x-api-key", HeaderValue::from_static("secret"));
+    ///
+    /// let call = provider.get_block_number().map_meta(|mut meta| {
+    ///     meta.headers_mut().extend(headers);
+    ///     meta
+    /// });
+    /// let Ok(call) = call else { unreachable!("typed provider method should produce an RPC call") };
+    /// let block_number = call.await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// This function fails if the inner future is not an [`RpcCall`], since
+    /// boxed, batched, or ready calls no longer expose an individual request
+    /// whose metadata can be changed.
+    pub fn map_meta(self, f: impl FnOnce(RequestMeta) -> RequestMeta) -> Result<Self, Self> {
+        match self {
+            Self::RpcCall(call) => Ok(Self::RpcCall(call.map_meta(f))),
+            _ => Err(self),
+        }
+    }
 }
 
 impl<Params, Resp, Output, Map> ProviderCall<&Params, Resp, Output, Map>
@@ -256,5 +290,37 @@ where
                 Poll::Ready(output.take().expect("output taken twice"))
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_rpc_client::{ClientBuilder, NoParams};
+    use alloy_transport::mock::{Asserter, MockTransport};
+    use http::HeaderValue;
+
+    #[test]
+    fn map_meta_updates_rpc_call_metadata() {
+        let client = ClientBuilder::default().transport(MockTransport::new(Asserter::new()), true);
+        let call: ProviderCall<NoParams, u64> = client.request_noparams("test_method").into();
+
+        let call = call
+            .map_meta(|mut meta| {
+                meta.headers_mut().insert("x-api-key", HeaderValue::from_static("secret"));
+                meta
+            })
+            .expect("call is an RPC call");
+
+        assert_eq!(
+            call.as_rpc_call().unwrap().request().meta.headers().unwrap().get("x-api-key"),
+            Some(&HeaderValue::from_static("secret"))
+        );
+    }
+
+    #[test]
+    fn map_meta_returns_non_rpc_call() {
+        let call = ProviderCall::<NoParams, u64>::ready(Ok(1));
+        assert!(call.map_meta(std::convert::identity).is_err());
     }
 }

--- a/crates/provider/src/provider/prov_call.rs
+++ b/crates/provider/src/provider/prov_call.rs
@@ -2,6 +2,7 @@ use alloy_json_rpc::{RequestMeta, RpcRecv, RpcSend};
 use alloy_rpc_client::{RpcCall, Waiter};
 use alloy_transport::TransportResult;
 use futures::FutureExt;
+use http::{HeaderMap, HeaderName, HeaderValue};
 use pin_project::pin_project;
 use serde_json::value::RawValue;
 use std::{
@@ -191,6 +192,28 @@ where
             _ => Err(self),
         }
     }
+
+    /// Adds HTTP headers to the underlying RPC request.
+    ///
+    /// Existing values with the same header names are replaced. This function
+    /// fails if the inner future is not an [`RpcCall`].
+    pub fn with_headers(self, headers: HeaderMap) -> Result<Self, Self> {
+        self.map_meta(|mut meta| {
+            meta.headers_mut().extend(headers);
+            meta
+        })
+    }
+
+    /// Adds an HTTP header to the underlying RPC request.
+    ///
+    /// An existing value with the same header name is replaced. This function
+    /// fails if the inner future is not an [`RpcCall`].
+    pub fn with_header(self, name: HeaderName, value: HeaderValue) -> Result<Self, Self> {
+        self.map_meta(|mut meta| {
+            meta.headers_mut().insert(name, value);
+            meta
+        })
+    }
 }
 
 impl<Params, Resp, Output, Map> ProviderCall<&Params, Resp, Output, Map>
@@ -322,5 +345,35 @@ mod tests {
     fn map_meta_returns_non_rpc_call() {
         let call = ProviderCall::<NoParams, u64>::ready(Ok(1));
         assert!(call.map_meta(std::convert::identity).is_err());
+    }
+
+    #[test]
+    fn with_headers_updates_rpc_call_headers() {
+        let client = ClientBuilder::default().transport(MockTransport::new(Asserter::new()), true);
+        let call: ProviderCall<NoParams, u64> = client.request_noparams("test_method").into();
+        let mut headers = HeaderMap::new();
+        headers.insert("x-api-key", HeaderValue::from_static("secret"));
+
+        let call = call.with_headers(headers).expect("call is an RPC call");
+
+        assert_eq!(
+            call.as_rpc_call().unwrap().request().meta.headers().unwrap().get("x-api-key"),
+            Some(&HeaderValue::from_static("secret"))
+        );
+    }
+
+    #[test]
+    fn with_header_updates_rpc_call_header() {
+        let client = ClientBuilder::default().transport(MockTransport::new(Asserter::new()), true);
+        let call: ProviderCall<NoParams, u64> = client.request_noparams("test_method").into();
+
+        let call = call
+            .with_header(HeaderName::from_static("x-api-key"), HeaderValue::from_static("secret"))
+            .expect("call is an RPC call");
+
+        assert_eq!(
+            call.as_rpc_call().unwrap().request().meta.headers().unwrap().get("x-api-key"),
+            Some(&HeaderValue::from_static("secret"))
+        );
     }
 }


### PR DESCRIPTION
## Motivation

Typed `Provider` methods return `ProviderCall`, which did not expose the request metadata mapping available on the underlying `RpcCall`. Callers that need request-scoped HTTP headers therefore had to drop down to the raw RPC client or manually unwrap the inner call.

## Solution

- Add `ProviderCall::map_meta`, forwarding metadata changes to the underlying `RpcCall`.
- Add fluent `with_headers` and `with_header` helpers for request-scoped HTTP headers.
- Return the original call when metadata cannot be changed, matching the fallible `map_resp` API.
- Document per-request HTTP header usage and cover RPC and non-RPC variants.

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes

Prompted by: @onbjerg