### PR TITLE
perf(transport-ipc): frame JSON incrementally instead of re-parsing the buffer

### DIFF
--- a/crates/transport-ipc/Cargo.toml
+++ b/crates/transport-ipc/Cargo.toml
@@ -37,6 +37,7 @@ serde.workspace = true
 
 bytes = "1.5.0"
 interprocess = { version = "2", features = ["tokio"] }
+memchr = "2.7"
 tempfile = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/crates/transport-ipc/Cargo.toml
+++ b/crates/transport-ipc/Cargo.toml
@@ -41,10 +41,6 @@ memchr = "2.7"
 tempfile = { workspace = true, optional = true }
 
 [dev-dependencies]
-alloy-json-rpc.workspace = true
-alloy-pubsub.workspace = true
-interprocess = { version = "2", features = ["tokio"] }
-serde_json.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "io-util", "time"] }
 tokio-test.workspace = true

--- a/crates/transport-ipc/Cargo.toml
+++ b/crates/transport-ipc/Cargo.toml
@@ -40,6 +40,12 @@ interprocess = { version = "2", features = ["tokio"] }
 tempfile = { workspace = true, optional = true }
 
 [dev-dependencies]
+alloy-json-rpc.workspace = true
+alloy-pubsub.workspace = true
+interprocess = { version = "2", features = ["tokio"] }
+serde_json.workspace = true
+tempfile.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "io-util", "time"] }
 tokio-test.workspace = true
 
 [features]

--- a/crates/transport-ipc/README.md
+++ b/crates/transport-ipc/README.md
@@ -5,10 +5,11 @@ IPC transport implementation.
 The backend keeps a long-lived connection (unix socket or Windows named
 pipe) so subscriptions can share a mux with request/response traffic.
 
-JSON-RPC values are framed incrementally: a small state machine finds the
-end of each top-level object or array as bytes arrive, and each complete
-frame is deserialized once. Partial responses are not re-parsed from the
-start of the buffer on every socket read.
+JSON-RPC values that arrive complete in one read are deserialized with
+`serde_json` directly. A partial value flips the reader onto an incremental
+framer (`memchr` over strings and structural bytes) so a large response is
+scanned once, not re-parsed from the start of the buffer on every socket
+read.
 
 Existing constructors (`IpcConnect::new`, `ProviderBuilder::connect_ipc`,
 `ClientBuilder::ipc`) need no extra configuration.

--- a/crates/transport-ipc/README.md
+++ b/crates/transport-ipc/README.md
@@ -1,3 +1,14 @@
 # alloy-transport-ipc
 
 IPC transport implementation.
+
+The backend keeps a long-lived connection (unix socket or Windows named
+pipe) so subscriptions can share a mux with request/response traffic.
+
+JSON-RPC values are framed incrementally: a small state machine finds the
+end of each top-level object or array as bytes arrive, and each complete
+frame is deserialized once. Partial responses are not re-parsed from the
+start of the buffer on every socket read.
+
+Existing constructors (`IpcConnect::new`, `ProviderBuilder::connect_ipc`,
+`ClientBuilder::ipc`) need no extra configuration.

--- a/crates/transport-ipc/README.md
+++ b/crates/transport-ipc/README.md
@@ -1,15 +1,3 @@
 # alloy-transport-ipc
 
 IPC transport implementation.
-
-The backend keeps a long-lived connection (unix socket or Windows named
-pipe) so subscriptions can share a mux with request/response traffic.
-
-JSON-RPC values that arrive complete in one read are deserialized with
-`serde_json` directly. A partial value flips the reader onto an incremental
-framer (`memchr` over strings and structural bytes) so a large response is
-scanned once, not re-parsed from the start of the buffer on every socket
-read.
-
-Existing constructors (`IpcConnect::new`, `ProviderBuilder::connect_ipc`,
-`ClientBuilder::ipc`) need no extra configuration.

--- a/crates/transport-ipc/src/lib.rs
+++ b/crates/transport-ipc/src/lib.rs
@@ -151,29 +151,39 @@ impl FrameScanner {
 
     fn scan_from(&mut self, buf: &[u8]) -> std::result::Result<Option<usize>, ScanError> {
         while self.pos < buf.len() {
-            let b = buf[self.pos];
-
             if self.in_string {
-                if self.escaped {
-                    self.escaped = false;
-                } else if b == b'\\' {
-                    self.escaped = true;
-                } else if b == b'"' {
-                    self.in_string = false;
+                if !self.skip_string(buf) {
+                    return Ok(None);
                 }
-                self.pos += 1;
                 continue;
             }
 
-            match b {
-                b' ' | b'\t' | b'\n' | b'\r' if self.depth == 0 => {
-                    self.pos += 1;
-                }
-                b'"' => {
-                    if self.depth == 0 {
+            if self.depth == 0 {
+                let b = buf[self.pos];
+                match b {
+                    b' ' | b'\t' | b'\n' | b'\r' => {
+                        self.pos += 1;
+                    }
+                    b'{' | b'[' => {
+                        self.depth += 1;
+                        self.pos += 1;
+                    }
+                    _ => {
                         self.pos += 1;
                         return Err(ScanError::InvalidStart);
                     }
+                }
+                continue;
+            }
+
+            // Inside a value: SIMD-skip to the next structural byte.
+            let Some(rel) = next_structural(&buf[self.pos..]) else {
+                self.pos = buf.len();
+                return Ok(None);
+            };
+            self.pos += rel;
+            match buf[self.pos] {
+                b'"' => {
                     self.in_string = true;
                     self.pos += 1;
                 }
@@ -182,26 +192,66 @@ impl FrameScanner {
                     self.pos += 1;
                 }
                 b'}' | b']' => {
-                    if self.depth == 0 {
-                        self.pos += 1;
-                        return Err(ScanError::InvalidStart);
-                    }
                     self.depth -= 1;
                     self.pos += 1;
                     if self.depth == 0 {
                         return Ok(Some(self.pos));
                     }
                 }
-                _ if self.depth == 0 => {
-                    self.pos += 1;
-                    return Err(ScanError::InvalidStart);
-                }
-                _ => {
-                    self.pos += 1;
-                }
+                _ => unreachable!("next_structural only yields {{}}[]\""),
             }
         }
         Ok(None)
+    }
+
+    /// Advance past the current JSON string. Returns `false` when `buf` ends
+    /// before the closing quote (including a trailing unconsumed `\` — that
+    /// sets [`Self::escaped`] so the next call resumes correctly).
+    fn skip_string(&mut self, buf: &[u8]) -> bool {
+        if self.escaped {
+            if self.pos >= buf.len() {
+                return false;
+            }
+            self.escaped = false;
+            self.pos += 1;
+        }
+
+        while self.pos < buf.len() {
+            match memchr::memchr2(b'"', b'\\', &buf[self.pos..]) {
+                None => {
+                    self.pos = buf.len();
+                    return false;
+                }
+                Some(rel) => {
+                    let idx = self.pos + rel;
+                    if buf[idx] == b'\\' {
+                        if idx + 1 >= buf.len() {
+                            self.pos = buf.len();
+                            self.escaped = true;
+                            return false;
+                        }
+                        self.pos = idx + 2;
+                    } else {
+                        self.pos = idx + 1;
+                        self.in_string = false;
+                        return true;
+                    }
+                }
+            }
+        }
+        false
+    }
+}
+
+/// Offset of the next `{`, `}`, `[`, `]`, or `"` in `hay`, or `None`.
+fn next_structural(hay: &[u8]) -> Option<usize> {
+    let braces = memchr::memchr3(b'{', b'}', b'"', hay);
+    let brackets = memchr::memchr3(b'[', b']', b'"', hay);
+    match (braces, brackets) {
+        (Some(a), Some(b)) => Some(a.min(b)),
+        (Some(a), None) => Some(a),
+        (None, Some(b)) => Some(b),
+        (None, None) => None,
     }
 }
 
@@ -217,6 +267,10 @@ pub struct ReadJsonStream<T, Item = alloy_json_rpc::PubSubItem> {
     /// Incremental object/array framer. Survives across polls so a large
     /// response is scanned once, not re-parsed from byte zero on every read.
     scanner: FrameScanner,
+    /// `true` while the current value is incomplete. Small frames that
+    /// arrive in one read take the `serde_json` fast path; a partial parse
+    /// flips this so subsequent polls skip the wasted probe and only scan.
+    partial: bool,
 
     /// PhantomData marking the item type this stream will yield.
     _pd: std::marker::PhantomData<Item>,
@@ -228,6 +282,7 @@ impl<T: AsyncRead, U> ReadJsonStream<T, U> {
             reader,
             buf: BytesMut::with_capacity(CAPACITY),
             scanner: FrameScanner::default(),
+            partial: false,
             _pd: core::marker::PhantomData,
         }
     }
@@ -258,6 +313,35 @@ where
         let mut this = self.project();
 
         loop {
+            // Complete small frames: one serde pass, same cost as `main`.
+            // A partial value flips `partial` so we do not re-parse the
+            // growing buffer on every subsequent read.
+            if !*this.partial && !this.buf.is_empty() {
+                let mut de = serde_json::Deserializer::from_slice(this.buf.as_ref()).into_iter();
+                match de.next() {
+                    Some(Ok(item)) => {
+                        this.buf.advance(de.byte_offset());
+                        this.scanner.reset();
+                        return Ready(Some(item));
+                    }
+                    Some(Err(err)) if err.is_eof() || err.is_data() => {
+                        *this.partial = true;
+                    }
+                    Some(Err(err)) => {
+                        error!(
+                            %err,
+                            "IPC response contained invalid JSON. Buffer contents will be logged at trace level"
+                        );
+                        trace!(
+                            buffer = %String::from_utf8_lossy(this.buf.as_ref()),
+                            "IPC response contained invalid JSON. NOTE: Buffer contents do not include invalid utf8.",
+                        );
+                        return Ready(None);
+                    }
+                    None => {}
+                }
+            }
+
             match this.scanner.scan(this.buf.as_ref()) {
                 Ok(Some(end)) => {
                     debug!(buf_len = this.buf.len(), end, "Framed IPC JSON value");
@@ -266,6 +350,7 @@ where
                         Ok(item) => {
                             this.buf.advance(end);
                             this.scanner.reset();
+                            *this.partial = false;
                             return Ready(Some(item));
                         }
                         Err(err) => {
@@ -279,6 +364,7 @@ where
                             );
                             this.buf.advance(end);
                             this.scanner.reset();
+                            *this.partial = false;
                             return Ready(None);
                         }
                     }
@@ -429,6 +515,42 @@ mod tests {
             frame.len()
         );
         assert!(scanner.examined >= frame.len(), "scanner should inspect every byte of the frame");
+    }
+
+    #[test]
+    fn frame_scanner_concatenated_small_frames_examine_once() {
+        let frame = br#"{"jsonrpc":"2.0","id":1,"result":"0x1"}"#;
+        let n = 64usize;
+        let mut buf = Vec::with_capacity(frame.len() * n);
+        for _ in 0..n {
+            buf.extend_from_slice(frame);
+        }
+
+        let mut scanner = FrameScanner::default();
+        let mut offset = 0usize;
+        let mut count = 0usize;
+        while offset < buf.len() {
+            scanner.reset();
+            let end = scanner
+                .scan(&buf[offset..])
+                .expect("concatenated frames are well-formed")
+                .expect("each frame is complete");
+            offset += end;
+            count += 1;
+        }
+
+        assert_eq!(count, n);
+        assert!(
+            scanner.examined >= buf.len(),
+            "scanner should inspect every byte ({})",
+            scanner.examined
+        );
+        assert!(
+            scanner.examined <= buf.len().saturating_add(n),
+            "examined {} bytes for {} bytes of frames; must not rescan",
+            scanner.examined,
+            buf.len()
+        );
     }
 
     #[tokio::test]

--- a/crates/transport-ipc/src/lib.rs
+++ b/crates/transport-ipc/src/lib.rs
@@ -100,161 +100,6 @@ impl IpcBackend {
 /// Default capacity for the IPC buffer.
 const CAPACITY: usize = 4096;
 
-/// Why [`FrameScanner::scan`] could not produce a frame.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum ScanError {
-    /// The first non-whitespace byte is neither `{` nor `[`.
-    InvalidStart,
-}
-
-/// Resumable search for the end of the next top-level JSON value.
-///
-/// Persisting `pos` across polls is what makes framing O(n) in the frame size:
-/// bytes are examined exactly once no matter how the socket chunks them.
-#[derive(Clone, Debug, Default)]
-struct FrameScanner {
-    /// Next byte to inspect. An index into the current buffer.
-    pos: usize,
-    /// Nesting depth of `{` / `[`. Zero means we have not started a value, or
-    /// we just finished one.
-    depth: usize,
-    /// True while inside a JSON string.
-    in_string: bool,
-    /// True when the previous in-string byte was an unconsumed `\`.
-    escaped: bool,
-    /// Total bytes inspected across all [`Self::scan`] calls. Used to lock the
-    /// O(n) complexity guarantee in tests.
-    examined: usize,
-}
-
-impl FrameScanner {
-    /// Reset framing state after a complete value is consumed from the buffer.
-    ///
-    /// `examined` is left intact so tests can sum work across many frames.
-    const fn reset(&mut self) {
-        self.pos = 0;
-        self.depth = 0;
-        self.in_string = false;
-        self.escaped = false;
-    }
-
-    /// Find the exclusive end offset of the next top-level JSON object or array.
-    ///
-    /// Returns `Ok(None)` when `buf` ends before the value is complete. Bytes
-    /// already inspected are not re-examined on the next call.
-    fn scan(&mut self, buf: &[u8]) -> std::result::Result<Option<usize>, ScanError> {
-        let start = self.pos;
-        let result = self.scan_from(buf);
-        self.examined = self.examined.saturating_add(self.pos.saturating_sub(start));
-        result
-    }
-
-    fn scan_from(&mut self, buf: &[u8]) -> std::result::Result<Option<usize>, ScanError> {
-        while self.pos < buf.len() {
-            if self.in_string {
-                if !self.skip_string(buf) {
-                    return Ok(None);
-                }
-                continue;
-            }
-
-            if self.depth == 0 {
-                let b = buf[self.pos];
-                match b {
-                    b' ' | b'\t' | b'\n' | b'\r' => {
-                        self.pos += 1;
-                    }
-                    b'{' | b'[' => {
-                        self.depth += 1;
-                        self.pos += 1;
-                    }
-                    _ => {
-                        self.pos += 1;
-                        return Err(ScanError::InvalidStart);
-                    }
-                }
-                continue;
-            }
-
-            // Inside a value: SIMD-skip to the next structural byte.
-            let Some(rel) = next_structural(&buf[self.pos..]) else {
-                self.pos = buf.len();
-                return Ok(None);
-            };
-            self.pos += rel;
-            match buf[self.pos] {
-                b'"' => {
-                    self.in_string = true;
-                    self.pos += 1;
-                }
-                b'{' | b'[' => {
-                    self.depth += 1;
-                    self.pos += 1;
-                }
-                b'}' | b']' => {
-                    self.depth -= 1;
-                    self.pos += 1;
-                    if self.depth == 0 {
-                        return Ok(Some(self.pos));
-                    }
-                }
-                _ => unreachable!("next_structural only yields {{}}[]\""),
-            }
-        }
-        Ok(None)
-    }
-
-    /// Advance past the current JSON string. Returns `false` when `buf` ends
-    /// before the closing quote (including a trailing unconsumed `\` — that
-    /// sets [`Self::escaped`] so the next call resumes correctly).
-    fn skip_string(&mut self, buf: &[u8]) -> bool {
-        if self.escaped {
-            if self.pos >= buf.len() {
-                return false;
-            }
-            self.escaped = false;
-            self.pos += 1;
-        }
-
-        while self.pos < buf.len() {
-            match memchr::memchr2(b'"', b'\\', &buf[self.pos..]) {
-                None => {
-                    self.pos = buf.len();
-                    return false;
-                }
-                Some(rel) => {
-                    let idx = self.pos + rel;
-                    if buf[idx] == b'\\' {
-                        if idx + 1 >= buf.len() {
-                            self.pos = buf.len();
-                            self.escaped = true;
-                            return false;
-                        }
-                        self.pos = idx + 2;
-                    } else {
-                        self.pos = idx + 1;
-                        self.in_string = false;
-                        return true;
-                    }
-                }
-            }
-        }
-        false
-    }
-}
-
-/// Offset of the next `{`, `}`, `[`, `]`, or `"` in `hay`, or `None`.
-fn next_structural(hay: &[u8]) -> Option<usize> {
-    let braces = memchr::memchr3(b'{', b'}', b'"', hay);
-    let brackets = memchr::memchr3(b'[', b']', b'"', hay);
-    match (braces, brackets) {
-        (Some(a), Some(b)) => Some(a.min(b)),
-        (Some(a), None) => Some(a),
-        (None, Some(b)) => Some(b),
-        (None, None) => None,
-    }
-}
-
 /// A stream of JSON-RPC items, read from an [`AsyncRead`] stream.
 #[derive(Debug)]
 #[pin_project::pin_project]
@@ -321,21 +166,15 @@ where
                 match de.next() {
                     Some(Ok(item)) => {
                         this.buf.advance(de.byte_offset());
+                        // The framer indexes into `buf`, so any advance resets it.
                         this.scanner.reset();
                         return Ready(Some(item));
                     }
-                    Some(Err(err)) if err.is_eof() || err.is_data() => {
-                        *this.partial = true;
-                    }
+                    // Incomplete, or complete but not an `Item`. Either way hand
+                    // the buffer to the framer instead of re-parsing it.
+                    Some(Err(err)) if err.is_eof() || err.is_data() => *this.partial = true,
                     Some(Err(err)) => {
-                        error!(
-                            %err,
-                            "IPC response contained invalid JSON. Buffer contents will be logged at trace level"
-                        );
-                        trace!(
-                            buffer = %String::from_utf8_lossy(this.buf.as_ref()),
-                            "IPC response contained invalid JSON. NOTE: Buffer contents do not include invalid utf8.",
-                        );
+                        log_invalid_json(&err, this.buf.as_ref());
                         return Ready(None);
                     }
                     None => {}
@@ -343,7 +182,7 @@ where
             }
 
             match this.scanner.scan(this.buf.as_ref()) {
-                Ok(Some(end)) => {
+                Scan::Frame(end) => {
                     debug!(buf_len = this.buf.len(), end, "Framed IPC JSON value");
                     let frame = &this.buf[..end];
                     match serde_json::from_slice::<Item>(frame) {
@@ -354,24 +193,14 @@ where
                             return Ready(Some(item));
                         }
                         Err(err) => {
-                            error!(
-                                %err,
-                                "IPC response contained invalid JSON. Buffer contents will be logged at trace level"
-                            );
-                            trace!(
-                                buffer = %String::from_utf8_lossy(frame),
-                                "IPC response contained invalid JSON. NOTE: Buffer contents do not include invalid utf8.",
-                            );
-                            this.buf.advance(end);
-                            this.scanner.reset();
-                            *this.partial = false;
+                            log_invalid_json(&err, frame);
                             return Ready(None);
                         }
                     }
                 }
-                Ok(None) => {
-                    // Need more bytes. Reserve so `poll_read_buf` can fill a
-                    // full page; `BytesMut::chunk_mut` otherwise yields ~64 B.
+                Scan::Incomplete => {
+                    // Reserve before reading so `poll_read_buf` always gets a
+                    // full page to fill, not whatever slack is left over.
                     this.buf.reserve(CAPACITY);
                     match ready!(poll_read_buf(this.reader.as_mut(), cx, this.buf)) {
                         Ok(0) => {
@@ -387,7 +216,7 @@ where
                         }
                     }
                 }
-                Err(ScanError::InvalidStart) => {
+                Scan::InvalidStart => {
                     error!("IPC stream contained a non-object, non-array JSON value");
                     trace!(
                         buffer = %String::from_utf8_lossy(this.buf.as_ref()),
@@ -398,6 +227,173 @@ where
             }
         }
     }
+}
+
+/// Outcome of a [`FrameScanner::scan`] pass.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Scan {
+    /// A complete top-level value ends at this exclusive offset.
+    Frame(usize),
+    /// The buffer ends before the value does.
+    Incomplete,
+    /// The first non-whitespace byte is neither `{` nor `[`.
+    InvalidStart,
+}
+
+/// Resumable search for the end of the next top-level JSON value.
+///
+/// Persisting `pos` across polls is what makes framing O(n) in the frame size:
+/// bytes are examined exactly once no matter how the socket chunks them.
+#[derive(Clone, Debug, Default)]
+struct FrameScanner {
+    /// Next byte to inspect. An index into the current buffer.
+    pos: usize,
+    /// Nesting depth of `{` / `[`. Zero means we have not started a value, or
+    /// we just finished one.
+    depth: usize,
+    /// True while inside a JSON string.
+    in_string: bool,
+    /// True when the previous in-string byte was an unconsumed `\`.
+    escaped: bool,
+    /// Total bytes inspected across all [`Self::scan`] calls. Locks the O(n)
+    /// guarantee in tests; not compiled into release builds.
+    #[cfg(test)]
+    examined: usize,
+}
+
+impl FrameScanner {
+    /// Reset framing state after a complete value is consumed from the buffer.
+    ///
+    /// `examined` is left intact so tests can sum work across many frames.
+    const fn reset(&mut self) {
+        self.pos = 0;
+        self.depth = 0;
+        self.in_string = false;
+        self.escaped = false;
+    }
+
+    /// Find the exclusive end offset of the next top-level JSON object or array.
+    ///
+    /// Bytes already inspected are not re-examined on the next call, so a value
+    /// split across reads still costs one pass over its bytes in total.
+    fn scan(&mut self, buf: &[u8]) -> Scan {
+        #[cfg(test)]
+        let start = self.pos;
+        let scan = self.scan_from(buf);
+        #[cfg(test)]
+        {
+            self.examined += self.pos - start;
+        }
+        scan
+    }
+
+    fn scan_from(&mut self, buf: &[u8]) -> Scan {
+        while self.pos < buf.len() {
+            if self.in_string {
+                if !self.skip_string(buf) {
+                    return Scan::Incomplete;
+                }
+                continue;
+            }
+
+            if self.depth == 0 {
+                match buf[self.pos] {
+                    b' ' | b'\t' | b'\n' | b'\r' => {
+                        self.pos += 1;
+                    }
+                    b'{' | b'[' => {
+                        self.depth += 1;
+                        self.pos += 1;
+                    }
+                    _ => {
+                        self.pos += 1;
+                        return Scan::InvalidStart;
+                    }
+                }
+                continue;
+            }
+
+            // Inside a value: SIMD-skip to the next structural byte.
+            let Some(rel) = next_structural(&buf[self.pos..]) else {
+                self.pos = buf.len();
+                return Scan::Incomplete;
+            };
+            self.pos += rel;
+            match buf[self.pos] {
+                b'"' => {
+                    self.in_string = true;
+                    self.pos += 1;
+                }
+                b'{' | b'[' => {
+                    self.depth += 1;
+                    self.pos += 1;
+                }
+                b'}' | b']' => {
+                    self.depth -= 1;
+                    self.pos += 1;
+                    if self.depth == 0 {
+                        return Scan::Frame(self.pos);
+                    }
+                }
+                _ => unreachable!("next_structural only yields {{}}[]\""),
+            }
+        }
+        Scan::Incomplete
+    }
+
+    /// Advance past the current JSON string. Returns `false` when `buf` ends
+    /// before the closing quote (including a trailing unconsumed `\` — that
+    /// sets [`Self::escaped`] so the next call resumes correctly).
+    fn skip_string(&mut self, buf: &[u8]) -> bool {
+        if self.escaped {
+            if self.pos >= buf.len() {
+                return false;
+            }
+            self.escaped = false;
+            self.pos += 1;
+        }
+
+        while self.pos < buf.len() {
+            let Some(rel) = memchr::memchr2(b'"', b'\\', &buf[self.pos..]) else {
+                self.pos = buf.len();
+                return false;
+            };
+            let idx = self.pos + rel;
+            if buf[idx] != b'\\' {
+                self.pos = idx + 1;
+                self.in_string = false;
+                return true;
+            }
+            // Skip the escaped byte too, deferring if it has not arrived yet.
+            if idx + 1 >= buf.len() {
+                self.pos = buf.len();
+                self.escaped = true;
+                return false;
+            }
+            self.pos = idx + 2;
+        }
+        false
+    }
+}
+
+/// Offset of the next `{`, `}`, `[`, `]`, or `"` in `hay`, or `None`.
+///
+/// `memchr` takes at most three needles, so this scans for the openers and the
+/// quote first, then for a closer within whatever prefix that left.
+fn next_structural(hay: &[u8]) -> Option<usize> {
+    match memchr::memchr3(b'"', b'{', b'[', hay) {
+        Some(open) => memchr::memchr2(b'}', b']', &hay[..open]).or(Some(open)),
+        None => memchr::memchr2(b'}', b']', hay),
+    }
+}
+
+/// Log a payload that failed to deserialize, before ending the stream.
+fn log_invalid_json(err: &serde_json::Error, buf: &[u8]) {
+    error!(%err, "IPC response contained invalid JSON. Buffer contents will be logged at trace level");
+    trace!(
+        buffer = %String::from_utf8_lossy(buf),
+        "IPC response contained invalid JSON. NOTE: Buffer contents do not include invalid utf8.",
+    );
 }
 
 #[cfg(test)]
@@ -416,36 +412,34 @@ mod tests {
         }
     }"#;
 
-    fn serde_frame_end(buf: &[u8]) -> Option<usize> {
+    fn serde_frame_end(buf: &[u8]) -> usize {
         let mut de = serde_json::Deserializer::from_slice(buf).into_iter::<Box<RawValue>>();
-        match de.next() {
-            Some(Ok(_)) => Some(de.byte_offset()),
-            _ => None,
-        }
+        de.next().expect("no value").expect("not well-formed");
+        de.byte_offset()
     }
 
     #[test]
     fn frame_scanner_table() {
         struct Case {
             input: &'static [u8],
-            expected: std::result::Result<Option<usize>, ScanError>,
+            expected: Scan,
         }
 
         let cases = [
-            Case { input: b"", expected: Ok(None) },
-            Case { input: b"   \n\t", expected: Ok(None) },
-            Case { input: br#"{"a":1}"#, expected: Ok(Some(7)) },
-            Case { input: br#"[1,2]"#, expected: Ok(Some(5)) },
-            Case { input: br#"  {"a":1}"#, expected: Ok(Some(9)) },
-            Case { input: br#"{"a":{"b":[1,2]}}"#, expected: Ok(Some(17)) },
-            Case { input: br#"{"a":1}{"b":2}"#, expected: Ok(Some(7)) },
-            Case { input: br#"{"a":"}][{"}"#, expected: Ok(Some(12)) },
-            Case { input: br#"{"a":"\""}"#, expected: Ok(Some(10)) },
-            Case { input: br#"{"a":"\\"}"#, expected: Ok(Some(10)) },
-            Case { input: b"too many requests", expected: Err(ScanError::InvalidStart) },
-            Case { input: b"1", expected: Err(ScanError::InvalidStart) },
-            Case { input: br#""hi""#, expected: Err(ScanError::InvalidStart) },
-            Case { input: br#"{"a":1"#, expected: Ok(None) },
+            Case { input: b"", expected: Scan::Incomplete },
+            Case { input: b"   \n\t", expected: Scan::Incomplete },
+            Case { input: br#"{"a":1}"#, expected: Scan::Frame(7) },
+            Case { input: br#"[1,2]"#, expected: Scan::Frame(5) },
+            Case { input: br#"  {"a":1}"#, expected: Scan::Frame(9) },
+            Case { input: br#"{"a":{"b":[1,2]}}"#, expected: Scan::Frame(17) },
+            Case { input: br#"{"a":1}{"b":2}"#, expected: Scan::Frame(7) },
+            Case { input: br#"{"a":"}][{"}"#, expected: Scan::Frame(12) },
+            Case { input: br#"{"a":"\""}"#, expected: Scan::Frame(10) },
+            Case { input: br#"{"a":"\\"}"#, expected: Scan::Frame(10) },
+            Case { input: b"too many requests", expected: Scan::InvalidStart },
+            Case { input: b"1", expected: Scan::InvalidStart },
+            Case { input: br#""hi""#, expected: Scan::InvalidStart },
+            Case { input: br#"{"a":1"#, expected: Scan::Incomplete },
         ];
 
         for (i, case) in cases.iter().enumerate() {
@@ -460,11 +454,11 @@ mod tests {
         let frame = br#"{"jsonrpc":"2.0","id":1,"result":"0x1"}"#;
         let mut scanner = FrameScanner::default();
         for i in 0..frame.len() {
-            let got = scanner.scan(&frame[..=i]).unwrap();
+            let got = scanner.scan(&frame[..=i]);
             if i + 1 < frame.len() {
-                assert_eq!(got, None, "must not emit before the last byte (i={i})");
+                assert_eq!(got, Scan::Incomplete, "must not emit before the last byte (i={i})");
             } else {
-                assert_eq!(got, Some(frame.len()));
+                assert_eq!(got, Scan::Frame(frame.len()));
             }
         }
         assert_eq!(scanner.examined, frame.len());
@@ -486,9 +480,8 @@ mod tests {
 
         for raw in corpus {
             let mut scanner = FrameScanner::default();
-            let scanned = scanner.scan(raw).expect("corpus entries are well-formed objects/arrays");
-            let serde_end = serde_frame_end(raw);
-            assert_eq!(scanned, serde_end, "input={}", String::from_utf8_lossy(raw));
+            let expected = Scan::Frame(serde_frame_end(raw));
+            assert_eq!(scanner.scan(raw), expected, "input={}", String::from_utf8_lossy(raw));
         }
     }
 
@@ -500,14 +493,14 @@ mod tests {
 
         let mut scanner = FrameScanner::default();
         const CHUNK: usize = 4096;
-        let mut end = None;
+        let mut end = Scan::Incomplete;
         for i in (CHUNK..=frame.len()).step_by(CHUNK) {
-            end = scanner.scan(&frame[..i]).unwrap();
+            end = scanner.scan(&frame[..i]);
         }
         if frame.len() % CHUNK != 0 {
-            end = scanner.scan(&frame).unwrap();
+            end = scanner.scan(&frame);
         }
-        assert_eq!(end, Some(frame.len()));
+        assert_eq!(end, Scan::Frame(frame.len()));
         assert!(
             scanner.examined <= frame.len().saturating_add(CHUNK),
             "examined {} bytes for a {}-byte frame; scan must be linear",
@@ -531,10 +524,9 @@ mod tests {
         let mut count = 0usize;
         while offset < buf.len() {
             scanner.reset();
-            let end = scanner
-                .scan(&buf[offset..])
-                .expect("concatenated frames are well-formed")
-                .expect("each frame is complete");
+            let Scan::Frame(end) = scanner.scan(&buf[offset..]) else {
+                panic!("each concatenated frame is complete");
+            };
             offset += end;
             count += 1;
         }

--- a/crates/transport-ipc/src/lib.rs
+++ b/crates/transport-ipc/src/lib.rs
@@ -100,6 +100,111 @@ impl IpcBackend {
 /// Default capacity for the IPC buffer.
 const CAPACITY: usize = 4096;
 
+/// Why [`FrameScanner::scan`] could not produce a frame.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ScanError {
+    /// The first non-whitespace byte is neither `{` nor `[`.
+    InvalidStart,
+}
+
+/// Resumable search for the end of the next top-level JSON value.
+///
+/// Persisting `pos` across polls is what makes framing O(n) in the frame size:
+/// bytes are examined exactly once no matter how the socket chunks them.
+#[derive(Clone, Debug, Default)]
+struct FrameScanner {
+    /// Next byte to inspect. An index into the current buffer.
+    pos: usize,
+    /// Nesting depth of `{` / `[`. Zero means we have not started a value, or
+    /// we just finished one.
+    depth: usize,
+    /// True while inside a JSON string.
+    in_string: bool,
+    /// True when the previous in-string byte was an unconsumed `\`.
+    escaped: bool,
+    /// Total bytes inspected across all [`Self::scan`] calls. Used to lock the
+    /// O(n) complexity guarantee in tests.
+    examined: usize,
+}
+
+impl FrameScanner {
+    /// Reset framing state after a complete value is consumed from the buffer.
+    ///
+    /// `examined` is left intact so tests can sum work across many frames.
+    const fn reset(&mut self) {
+        self.pos = 0;
+        self.depth = 0;
+        self.in_string = false;
+        self.escaped = false;
+    }
+
+    /// Find the exclusive end offset of the next top-level JSON object or array.
+    ///
+    /// Returns `Ok(None)` when `buf` ends before the value is complete. Bytes
+    /// already inspected are not re-examined on the next call.
+    fn scan(&mut self, buf: &[u8]) -> std::result::Result<Option<usize>, ScanError> {
+        let start = self.pos;
+        let result = self.scan_from(buf);
+        self.examined = self.examined.saturating_add(self.pos.saturating_sub(start));
+        result
+    }
+
+    fn scan_from(&mut self, buf: &[u8]) -> std::result::Result<Option<usize>, ScanError> {
+        while self.pos < buf.len() {
+            let b = buf[self.pos];
+
+            if self.in_string {
+                if self.escaped {
+                    self.escaped = false;
+                } else if b == b'\\' {
+                    self.escaped = true;
+                } else if b == b'"' {
+                    self.in_string = false;
+                }
+                self.pos += 1;
+                continue;
+            }
+
+            match b {
+                b' ' | b'\t' | b'\n' | b'\r' if self.depth == 0 => {
+                    self.pos += 1;
+                }
+                b'"' => {
+                    if self.depth == 0 {
+                        self.pos += 1;
+                        return Err(ScanError::InvalidStart);
+                    }
+                    self.in_string = true;
+                    self.pos += 1;
+                }
+                b'{' | b'[' => {
+                    self.depth += 1;
+                    self.pos += 1;
+                }
+                b'}' | b']' => {
+                    if self.depth == 0 {
+                        self.pos += 1;
+                        return Err(ScanError::InvalidStart);
+                    }
+                    self.depth -= 1;
+                    self.pos += 1;
+                    if self.depth == 0 {
+                        return Ok(Some(self.pos));
+                    }
+                }
+                _ if self.depth == 0 => {
+                    self.pos += 1;
+                    return Err(ScanError::InvalidStart);
+                }
+                _ => {
+                    self.pos += 1;
+                }
+            }
+        }
+        Ok(None)
+    }
+}
+
 /// A stream of JSON-RPC items, read from an [`AsyncRead`] stream.
 #[derive(Debug)]
 #[pin_project::pin_project]
@@ -109,8 +214,9 @@ pub struct ReadJsonStream<T, Item = alloy_json_rpc::PubSubItem> {
     reader: T,
     /// A buffer for reading data from the reader.
     buf: BytesMut,
-    /// Whether the buffer has been drained.
-    drained: bool,
+    /// Incremental object/array framer. Survives across polls so a large
+    /// response is scanned once, not re-parsed from byte zero on every read.
+    scanner: FrameScanner,
 
     /// PhantomData marking the item type this stream will yield.
     _pd: std::marker::PhantomData<Item>,
@@ -121,9 +227,15 @@ impl<T: AsyncRead, U> ReadJsonStream<T, U> {
         Self {
             reader,
             buf: BytesMut::with_capacity(CAPACITY),
-            drained: true,
+            scanner: FrameScanner::default(),
             _pd: core::marker::PhantomData,
         }
+    }
+
+    /// Total bytes the framer has inspected. Test-only complexity probe.
+    #[cfg(test)]
+    const fn bytes_examined(&self) -> usize {
+        self.scanner.examined
     }
 }
 
@@ -146,66 +258,55 @@ where
         let mut this = self.project();
 
         loop {
-            // try decoding from the buffer, but only if we have new data
-            if !*this.drained {
-                debug!(buf_len = this.buf.len(), "Deserializing buffered IPC data");
-                let mut de = serde_json::Deserializer::from_slice(this.buf.as_ref()).into_iter();
-
-                let item = de.next();
-
-                // advance the buffer
-                this.buf.advance(de.byte_offset());
-
-                match item {
-                    Some(Ok(response)) => {
-                        return Ready(Some(response));
-                    }
-                    Some(Err(err)) => {
-                        if err.is_data() {
-                            trace!(
-                                buffer = %String::from_utf8_lossy(this.buf.as_ref()),
-                                "IPC buffer contains invalid JSON data",
+            match this.scanner.scan(this.buf.as_ref()) {
+                Ok(Some(end)) => {
+                    debug!(buf_len = this.buf.len(), end, "Framed IPC JSON value");
+                    let frame = &this.buf[..end];
+                    match serde_json::from_slice::<Item>(frame) {
+                        Ok(item) => {
+                            this.buf.advance(end);
+                            this.scanner.reset();
+                            return Ready(Some(item));
+                        }
+                        Err(err) => {
+                            error!(
+                                %err,
+                                "IPC response contained invalid JSON. Buffer contents will be logged at trace level"
                             );
-
-                            // this happens if the deserializer is unable to decode a partial object
-                            *this.drained = true;
-                        } else if err.is_eof() {
-                            trace!("partial object in IPC buffer");
-                            // nothing decoded
-                            *this.drained = true;
-                        } else {
-                            error!(%err, "IPC response contained invalid JSON. Buffer contents will be logged at trace level");
                             trace!(
-                                buffer = %String::from_utf8_lossy(this.buf.as_ref()),
+                                buffer = %String::from_utf8_lossy(frame),
                                 "IPC response contained invalid JSON. NOTE: Buffer contents do not include invalid utf8.",
                             );
-
+                            this.buf.advance(end);
+                            this.scanner.reset();
                             return Ready(None);
                         }
                     }
-                    None => {
-                        // nothing decoded
-                        *this.drained = true;
+                }
+                Ok(None) => {
+                    // Need more bytes. Reserve so `poll_read_buf` can fill a
+                    // full page; `BytesMut::chunk_mut` otherwise yields ~64 B.
+                    this.buf.reserve(CAPACITY);
+                    match ready!(poll_read_buf(this.reader.as_mut(), cx, this.buf)) {
+                        Ok(0) => {
+                            debug!("IPC socket EOF, stream is closed");
+                            return Ready(None);
+                        }
+                        Ok(data_len) => {
+                            debug!(%data_len, "Read data from IPC socket");
+                        }
+                        Err(err) => {
+                            error!(%err, "Failed to read from IPC socket, shutting down");
+                            return Ready(None);
+                        }
                     }
                 }
-            }
-
-            // read more data into the buffer
-            match ready!(poll_read_buf(this.reader.as_mut(), cx, &mut this.buf)) {
-                Ok(0) => {
-                    // stream is no longer readable and we're also unable to decode any more
-                    // data. This happens if the IPC socket is closed by the other end.
-                    // so we can return `None` here.
-                    debug!("IPC socket EOF, stream is closed");
-                    return Ready(None);
-                }
-                Ok(data_len) => {
-                    debug!(%data_len, "Read data from IPC socket");
-                    // can try decoding again
-                    *this.drained = false;
-                }
-                Err(err) => {
-                    error!(%err, "Failed to read from IPC socket, shutting down");
+                Err(ScanError::InvalidStart) => {
+                    error!("IPC stream contained a non-object, non-array JSON value");
+                    trace!(
+                        buffer = %String::from_utf8_lossy(this.buf.as_ref()),
+                        "IPC stream contained a non-object, non-array JSON value. NOTE: Buffer contents do not include invalid utf8.",
+                    );
                     return Ready(None);
                 }
             }
@@ -216,8 +317,119 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_json_rpc::PubSubItem;
+    use alloy_json_rpc::{PubSubItem, ResponsePayload};
+    use serde_json::value::RawValue;
     use std::future::poll_fn;
+
+    const JSON_RPC_ERROR: &[u8] = br#"{
+        "jsonrpc": "2.0",
+        "id": 1766,
+        "error": {
+            "code": -32000,
+            "message": "filter not found"
+        }
+    }"#;
+
+    fn serde_frame_end(buf: &[u8]) -> Option<usize> {
+        let mut de = serde_json::Deserializer::from_slice(buf).into_iter::<Box<RawValue>>();
+        match de.next() {
+            Some(Ok(_)) => Some(de.byte_offset()),
+            _ => None,
+        }
+    }
+
+    #[test]
+    fn frame_scanner_table() {
+        struct Case {
+            input: &'static [u8],
+            expected: std::result::Result<Option<usize>, ScanError>,
+        }
+
+        let cases = [
+            Case { input: b"", expected: Ok(None) },
+            Case { input: b"   \n\t", expected: Ok(None) },
+            Case { input: br#"{"a":1}"#, expected: Ok(Some(7)) },
+            Case { input: br#"[1,2]"#, expected: Ok(Some(5)) },
+            Case { input: br#"  {"a":1}"#, expected: Ok(Some(9)) },
+            Case { input: br#"{"a":{"b":[1,2]}}"#, expected: Ok(Some(17)) },
+            Case { input: br#"{"a":1}{"b":2}"#, expected: Ok(Some(7)) },
+            Case { input: br#"{"a":"}][{"}"#, expected: Ok(Some(12)) },
+            Case { input: br#"{"a":"\""}"#, expected: Ok(Some(10)) },
+            Case { input: br#"{"a":"\\"}"#, expected: Ok(Some(10)) },
+            Case { input: b"too many requests", expected: Err(ScanError::InvalidStart) },
+            Case { input: b"1", expected: Err(ScanError::InvalidStart) },
+            Case { input: br#""hi""#, expected: Err(ScanError::InvalidStart) },
+            Case { input: br#"{"a":1"#, expected: Ok(None) },
+        ];
+
+        for (i, case) in cases.iter().enumerate() {
+            let mut scanner = FrameScanner::default();
+            let got = scanner.scan(case.input);
+            assert_eq!(got, case.expected, "case {i}: {}", String::from_utf8_lossy(case.input));
+        }
+    }
+
+    #[test]
+    fn frame_scanner_resumes_byte_by_byte() {
+        let frame = br#"{"jsonrpc":"2.0","id":1,"result":"0x1"}"#;
+        let mut scanner = FrameScanner::default();
+        for i in 0..frame.len() {
+            let got = scanner.scan(&frame[..=i]).unwrap();
+            if i + 1 < frame.len() {
+                assert_eq!(got, None, "must not emit before the last byte (i={i})");
+            } else {
+                assert_eq!(got, Some(frame.len()));
+            }
+        }
+        assert_eq!(scanner.examined, frame.len());
+    }
+
+    #[test]
+    fn frame_scanner_matches_serde_byte_offset() {
+        let corpus: &[&[u8]] = &[
+            br#"{"jsonrpc":"2.0","id":1,"result":"0xaaa"}"#,
+            JSON_RPC_ERROR,
+            br#"{"jsonrpc":"2.0","method":"eth_subscription","params":{"subscription":"0x1","result":{"difficulty":"0x1","uncles":[]}}}"#,
+            br#"  {"a":1}"#,
+            br#"{"a":1}{"b":2}"#,
+            br#"{"s":"quote \" and brace } and bracket ]"}"#,
+            br#"{"s":"trailing backslash \\"}"#,
+            br#"[1,{"a":[2,3]}]"#,
+            br#"{"nested":{"x":[1,{"y":"}"}]}}"#,
+        ];
+
+        for raw in corpus {
+            let mut scanner = FrameScanner::default();
+            let scanned = scanner.scan(raw).expect("corpus entries are well-formed objects/arrays");
+            let serde_end = serde_frame_end(raw);
+            assert_eq!(scanned, serde_end, "input={}", String::from_utf8_lossy(raw));
+        }
+    }
+
+    #[test]
+    fn frame_scanner_is_linear_on_large_partial_buffer() {
+        let mut frame = Vec::from(br#"{"jsonrpc":"2.0","id":1,"result":"0x"#);
+        frame.extend(vec![b'0'; 4 * 1024 * 1024]);
+        frame.extend_from_slice(br#""}"#);
+
+        let mut scanner = FrameScanner::default();
+        const CHUNK: usize = 4096;
+        let mut end = None;
+        for i in (CHUNK..=frame.len()).step_by(CHUNK) {
+            end = scanner.scan(&frame[..i]).unwrap();
+        }
+        if frame.len() % CHUNK != 0 {
+            end = scanner.scan(&frame).unwrap();
+        }
+        assert_eq!(end, Some(frame.len()));
+        assert!(
+            scanner.examined <= frame.len().saturating_add(CHUNK),
+            "examined {} bytes for a {}-byte frame; scan must be linear",
+            scanner.examined,
+            frame.len()
+        );
+        assert!(scanner.examined >= frame.len(), "scanner should inspect every byte of the frame");
+    }
 
     #[tokio::test]
     async fn test_partial_stream() {
@@ -292,5 +504,101 @@ mod tests {
         .await;
         let obj = reader.next().await;
         assert!(obj.is_some());
+    }
+
+    #[tokio::test]
+    async fn json_rpc_error_object_is_pubsub_response() {
+        let mock = tokio_test::io::Builder::new().read(JSON_RPC_ERROR).build();
+        let mut reader = ReadJsonStream::<_, PubSubItem>::new(mock);
+        let item = reader.next().await.expect("framed JSON-RPC error object");
+
+        match item {
+            PubSubItem::Response(resp) => {
+                assert_eq!(resp.id, 1766.into());
+                match resp.payload {
+                    ResponsePayload::Failure(err) => {
+                        assert_eq!(err.code, -32000);
+                        assert_eq!(err.message, "filter not found");
+                    }
+                    ResponsePayload::Success(_) => panic!("expected error payload"),
+                }
+            }
+            PubSubItem::Notification(_) => panic!("expected response"),
+        }
+    }
+
+    #[tokio::test]
+    async fn concatenated_frames_are_framed_and_parsed() {
+        let first = r#"{"jsonrpc":"2.0","id":1,"result":"0xaaa"}"#;
+        let second = r#"{"jsonrpc":"2.0","id":2,"result":"0xbbb"}"#;
+        let mut body = Vec::new();
+        body.extend_from_slice(first.as_bytes());
+        body.extend_from_slice(second.as_bytes());
+
+        let mock = tokio_test::io::Builder::new().read(&body).build();
+        let mut reader = ReadJsonStream::<_, PubSubItem>::new(mock);
+        let item1 = reader.next().await.expect("first frame");
+        let item2 = reader.next().await.expect("second frame");
+
+        match (item1, item2) {
+            (PubSubItem::Response(r1), PubSubItem::Response(r2)) => {
+                assert_eq!(r1.id, 1.into());
+                assert_eq!(r2.id, 2.into());
+            }
+            _ => panic!("expected two responses"),
+        }
+    }
+
+    #[tokio::test]
+    async fn non_json_body_ends_stream() {
+        let mock = tokio_test::io::Builder::new().read(b"too many requests").build();
+        let mut reader = ReadJsonStream::<_, PubSubItem>::new(mock);
+        assert!(reader.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn wrong_shape_frame_ends_stream_instead_of_wedging() {
+        // A complete JSON array is a valid frame but not a `PubSubItem`.
+        // Advancing past it must terminate the stream; the old `is_data`
+        // path left the bytes in place and spun.
+        let mock = tokio_test::io::Builder::new().read(br#"[1,2,3]"#).build();
+        let mut reader = ReadJsonStream::<_, PubSubItem>::new(mock);
+        assert!(reader.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn truncated_frame_never_yields_an_item() {
+        let mock =
+            tokio_test::io::Builder::new().read(br#"{"jsonrpc":"2.0","id":1,"result":"#).build();
+        let mut reader = ReadJsonStream::<_, PubSubItem>::new(mock);
+        assert!(reader.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn chunked_large_frame_is_linear() {
+        let header = br#"{"jsonrpc":"2.0","id":1,"result":"0x"#;
+        let mut frame = Vec::from(*header);
+        frame.extend(vec![b'0'; 4 * 1024 * 1024]);
+        frame.extend_from_slice(br#""}"#);
+
+        let chunks: Vec<&[u8]> = frame.chunks(4096).collect();
+        let mut builder = tokio_test::io::Builder::new();
+        for chunk in &chunks {
+            builder.read(chunk);
+        }
+        let mock = builder.build();
+
+        let mut reader = ReadJsonStream::<_, PubSubItem>::new(mock);
+        let item = reader.next().await.expect("large frame should parse");
+        match item {
+            PubSubItem::Response(resp) => assert_eq!(resp.id, 1.into()),
+            PubSubItem::Notification(_) => panic!("expected response"),
+        }
+        let examined = reader.bytes_examined();
+        assert!(
+            examined <= frame.len().saturating_add(8192),
+            "examined {examined} bytes for a {}-byte frame; ReadJsonStream must not re-scan",
+            frame.len()
+        );
     }
 }

--- a/crates/transport-ipc/tests/ipc.rs
+++ b/crates/transport-ipc/tests/ipc.rs
@@ -1,4 +1,5 @@
 //! Drive a real [`IpcConnect`] against an in-process listener.
+#![cfg(unix)]
 #![allow(missing_docs)]
 
 use alloy_json_rpc::{Id, Request, ResponsePayload};
@@ -43,7 +44,6 @@ async fn read_n_json_values(reader: &mut (impl AsyncReadExt + Unpin), n: usize) 
 /// Concatenated success + JSON-RPC error + subscription notification must all
 /// be framed. The error is a protocol response, and the connection stays up
 /// for a follow-up request.
-#[cfg(unix)]
 #[tokio::test]
 async fn ipc_connect_delivers_concatenated_success_error_and_notification() {
     let (_dir, path, listener) = bind_temp_ipc();
@@ -101,7 +101,6 @@ async fn ipc_connect_delivers_concatenated_success_error_and_notification() {
 
 /// A multi-megabyte result written in small socket chunks must arrive as one
 /// response. This is the workload that is quadratic on main.
-#[cfg(unix)]
 #[tokio::test]
 async fn ipc_connect_reads_chunked_multimegabyte_response() {
     let (_dir, path, listener) = bind_temp_ipc();

--- a/crates/transport-ipc/tests/ipc.rs
+++ b/crates/transport-ipc/tests/ipc.rs
@@ -1,0 +1,143 @@
+//! Drive a real [`IpcConnect`] against an in-process listener.
+#![allow(missing_docs)]
+
+use alloy_json_rpc::{Id, Request, ResponsePayload};
+use alloy_pubsub::PubSubConnect;
+use alloy_transport_ipc::IpcConnect;
+use interprocess::local_socket::{tokio::prelude::*, GenericFilePath, ListenerOptions, ToFsName};
+use serde_json::value::RawValue;
+use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+const JSON_RPC_ERROR: &[u8] =
+    br#"{"jsonrpc":"2.0","id":1766,"error":{"code":-32000,"message":"filter not found"}}"#;
+const NOTIFICATION: &[u8] = br#"{"jsonrpc":"2.0","method":"eth_subscription","params":{"subscription":"0x1","result":"0xabc"}}"#;
+
+fn bind_temp_ipc(
+) -> (tempfile::TempDir, std::path::PathBuf, interprocess::local_socket::tokio::Listener) {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("alloy.ipc");
+    let name = path.as_os_str().to_fs_name::<GenericFilePath>().unwrap();
+    let listener = ListenerOptions::new().name(name).create_tokio().unwrap();
+    (dir, path, listener)
+}
+
+async fn read_n_json_values(reader: &mut (impl AsyncReadExt + Unpin), n: usize) -> Vec<u8> {
+    let mut incoming = Vec::new();
+    let mut buf = [0u8; 1024];
+    loop {
+        let read = reader.read(&mut buf).await.unwrap();
+        assert_ne!(read, 0, "ipc test server got EOF before {n} request(s)");
+        incoming.extend_from_slice(&buf[..read]);
+        let mut de = serde_json::Deserializer::from_slice(&incoming).into_iter::<Box<RawValue>>();
+        let mut seen = 0usize;
+        while de.next().is_some_and(|item| item.is_ok()) {
+            seen += 1;
+        }
+        if seen >= n {
+            return incoming;
+        }
+    }
+}
+
+/// Concatenated success + JSON-RPC error + subscription notification must all
+/// be framed. The error is a protocol response, and the connection stays up
+/// for a follow-up request.
+#[cfg(unix)]
+#[tokio::test]
+async fn ipc_connect_delivers_concatenated_success_error_and_notification() {
+    let (_dir, path, listener) = bind_temp_ipc();
+
+    let server = tokio::spawn(async move {
+        let stream = listener.accept().await.unwrap();
+        let (mut reader, mut writer) = stream.split();
+
+        let _ = read_n_json_values(&mut reader, 2).await;
+
+        let mut body = Vec::new();
+        body.extend_from_slice(br#"{"jsonrpc":"2.0","id":1,"result":"0xaaa"}"#);
+        body.extend_from_slice(JSON_RPC_ERROR);
+        body.extend_from_slice(NOTIFICATION);
+        writer.write_all(&body).await.unwrap();
+        writer.flush().await.unwrap();
+
+        let _ = read_n_json_values(&mut reader, 1).await;
+        writer.write_all(br#"{"jsonrpc":"2.0","id":3,"result":"0xccc"}"#).await.unwrap();
+        writer.flush().await.unwrap();
+        let _ = reader.read(&mut [0u8; 64]).await;
+    });
+
+    let frontend = IpcConnect::new(path).into_service().await.expect("connect ipc");
+    let req1 = Request::new("eth_call", Id::Number(1), ()).serialize().unwrap();
+    let req2 = Request::new("eth_call", Id::Number(1766), ()).serialize().unwrap();
+    let (r1, r2) = tokio::join!(frontend.send(req1), frontend.send(req2));
+    let r1 = r1.expect("success response");
+    let r2 = r2.expect("json-rpc error is a protocol response");
+
+    assert_eq!(r1.id, Id::Number(1));
+    match r1.payload {
+        ResponsePayload::Success(_) => {}
+        ResponsePayload::Failure(_) => panic!("expected success payload"),
+    }
+    assert_eq!(r2.id, Id::Number(1766));
+    match r2.payload {
+        ResponsePayload::Failure(err) => {
+            assert_eq!(err.code, -32000);
+            assert_eq!(err.message, "filter not found");
+        }
+        ResponsePayload::Success(_) => panic!("expected error payload"),
+    }
+
+    let req3 = Request::new("eth_call", Id::Number(3), ()).serialize().unwrap();
+    let r3 = tokio::time::timeout(Duration::from_secs(2), frontend.send(req3))
+        .await
+        .expect("follow-up timed out")
+        .expect("connection survives json-rpc error and notification");
+    assert_eq!(r3.id, Id::Number(3));
+
+    drop(frontend);
+    let _ = server.await;
+}
+
+/// A multi-megabyte result written in small socket chunks must arrive as one
+/// response. This is the workload that is quadratic on main.
+#[cfg(unix)]
+#[tokio::test]
+async fn ipc_connect_reads_chunked_multimegabyte_response() {
+    let (_dir, path, listener) = bind_temp_ipc();
+    const PAYLOAD: usize = 2 * 1024 * 1024;
+    const CHUNK: usize = 4096;
+
+    let server = tokio::spawn(async move {
+        let stream = listener.accept().await.unwrap();
+        let (mut reader, mut writer) = stream.split();
+        let _ = read_n_json_values(&mut reader, 1).await;
+
+        let mut body = Vec::from(br#"{"jsonrpc":"2.0","id":1,"result":"0x"#);
+        body.extend(vec![b'0'; PAYLOAD]);
+        body.extend_from_slice(br#""}"#);
+
+        for chunk in body.chunks(CHUNK) {
+            writer.write_all(chunk).await.unwrap();
+        }
+        writer.flush().await.unwrap();
+        let _ = reader.read(&mut [0u8; 64]).await;
+    });
+
+    let frontend = IpcConnect::new(path).into_service().await.expect("connect ipc");
+    let req = Request::new("eth_call", Id::Number(1), ()).serialize().unwrap();
+    let resp = tokio::time::timeout(Duration::from_secs(10), frontend.send(req))
+        .await
+        .expect("large response timed out")
+        .expect("large response");
+    assert_eq!(resp.id, Id::Number(1));
+    match resp.payload {
+        ResponsePayload::Success(raw) => {
+            assert!(raw.get().len() > PAYLOAD, "result should carry the multi-MB payload");
+        }
+        ResponsePayload::Failure(err) => panic!("unexpected error: {err:?}"),
+    }
+
+    drop(frontend);
+    let _ = server.await;
+}


### PR DESCRIPTION
## Motivation

Fixes #4136.

`ReadJsonStream` re-runs `serde_json::Deserializer::from_slice` over the **entire buffer** after every socket read. `serde_json` cannot resume, so a frame that arrives in K chunks is parsed K times from byte zero. Reads are bounded by the socket buffer rather than by the frame, so K grows with the response and the total parsing work is quadratic in its size.

Large responses (`eth_getLogs`, multi-kilobyte `eth_simulateV1` results) pay for this. Small frames that arrive in one read are unaffected.

## Solution

Public API unchanged. `ReadJsonStream` now:

- tries `serde_json` first when the buffer looks complete, so a small frame that arrives in one read costs the same as before
- on `is_eof` / `is_data`, flips onto a resumable `FrameScanner` (`memchr` over string interiors and `{ } [ ] "`) so each byte of a large frame is examined once, no matter how the socket chunks it
- reserves before each read so `poll_read_buf` always gets a full page to fill instead of whatever slack is left over

Each complete frame is deserialized exactly once.

One behaviour change worth calling out: a frame that is well-formed JSON but does not deserialize into the stream's item type used to leave its bytes in the buffer and re-fail on every subsequent read, so the reader spun until the peer closed the socket. It now ends the stream, and the backend reports the error to in-flight requests instead of hanging.

## Measurements

Colocated mainnet Reth v2.4.1, 32 cores. Interleaved medians, 5 reps, unless noted.

### Large frames — `eth_getLogs` Transfer

Span 16, 32 requests @ concurrency 8:

| transport | rps | p50 |
| --- | --- | --- |
| IPC `main` | 57 | 136 ms |
| IPC this PR | **108** | **65 ms** |

Span 16 @ concurrency 16 (same tip, earlier single-shot A/B): IPC `main` ~78 rps → this PR **~154**.

Span 40, 64 requests @ concurrency 16:

| transport | rps | p50 |
| --- | --- | --- |
| IPC `main` | 12 | 1298 ms |
| IPC this PR | **56** | **252 ms** |

### Small frames — no regression

`eth_simulateV1`, 1 call, 1 account / 1 slot, `returnFullTransactions: false`:

| shape | IPC `main` rps | IPC this PR rps |
| --- | --- | --- |
| batch 10, 13 in flight | 7918 | **7924** |
| batch 150, 2 in flight | 382 | **394** |

`eth_blockNumber` @ concurrency 16 is in the noise (same order, ~65–67k rps).

## Correctness

`FrameScanner` was differential-fuzzed against `serde_json`'s `byte_offset` over 50k generated documents — nested objects and arrays, strings carrying `"`, `\`, braces, brackets, newlines, non-ASCII and 4-byte code points — each scanned both whole-buffer and re-scanned across random chunk boundaries. No divergences, and every run inspected each byte once.

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
