### PR TITLE
feat(signer-trezor): add TrezorTestnet derivation path preset

### DIFF
--- a/crates/signer-trezor/src/signer.rs
+++ b/crates/signer-trezor/src/signer.rs
@@ -698,4 +698,40 @@ mod tests {
             "EIP-2930 must be rejected instead of routed to the legacy path, got {err:?}",
         );
     }
+
+    #[test]
+    fn test_convert_path() {
+        assert_eq!(
+            TrezorSigner::convert_path(&DerivationType::TrezorLive(0)),
+            vec![0x8000002c, 0x8000003c, 0x80000000, 0, 0]
+        );
+        assert_eq!(
+            TrezorSigner::convert_path(&DerivationType::TrezorLive(5)),
+            vec![0x8000002c, 0x8000003c, 0x80000000, 0, 5]
+        );
+        assert_eq!(
+            TrezorSigner::convert_path(&DerivationType::TrezorTestnet(0)),
+            vec![0x8000002c, 0x80000001, 0x80000000, 0, 0]
+        );
+        assert_eq!(
+            TrezorSigner::convert_path(&DerivationType::TrezorTestnet(2)),
+            vec![0x8000002c, 0x80000001, 0x80000000, 0, 2]
+        );
+        assert_eq!(
+            TrezorSigner::convert_path(&DerivationType::Other("m/44'/60'/0'/0/1".to_string())),
+            vec![0x8000002c, 0x8000003c, 0x80000000, 0, 1]
+        );
+    }
+
+    #[test]
+    fn test_derivation_type_display() {
+        assert_eq!(DerivationType::TrezorLive(0).to_string(), "m/44'/60'/0'/0/0");
+        assert_eq!(DerivationType::TrezorLive(10).to_string(), "m/44'/60'/0'/0/10");
+        assert_eq!(DerivationType::TrezorTestnet(0).to_string(), "m/44'/1'/0'/0/0");
+        assert_eq!(DerivationType::TrezorTestnet(3).to_string(), "m/44'/1'/0'/0/3");
+        assert_eq!(
+            DerivationType::Other("m/44'/60'/0'/0".to_string()).to_string(),
+            "m/44'/60'/0'/0"
+        );
+    }
 }

--- a/crates/signer-trezor/src/signer.rs
+++ b/crates/signer-trezor/src/signer.rs
@@ -710,11 +710,11 @@ mod tests {
             vec![0x8000002c, 0x8000003c, 0x80000000, 0, 5]
         );
         assert_eq!(
-            TrezorSigner::convert_path(&DerivationType::TrezorTestnet(0)),
+            TrezorSigner::convert_path(&DerivationType::TrezorLegacyTestnet(0)),
             vec![0x8000002c, 0x80000001, 0x80000000, 0, 0]
         );
         assert_eq!(
-            TrezorSigner::convert_path(&DerivationType::TrezorTestnet(2)),
+            TrezorSigner::convert_path(&DerivationType::TrezorLegacyTestnet(2)),
             vec![0x8000002c, 0x80000001, 0x80000000, 0, 2]
         );
         assert_eq!(
@@ -727,8 +727,8 @@ mod tests {
     fn test_derivation_type_display() {
         assert_eq!(DerivationType::TrezorLive(0).to_string(), "m/44'/60'/0'/0/0");
         assert_eq!(DerivationType::TrezorLive(10).to_string(), "m/44'/60'/0'/0/10");
-        assert_eq!(DerivationType::TrezorTestnet(0).to_string(), "m/44'/1'/0'/0/0");
-        assert_eq!(DerivationType::TrezorTestnet(3).to_string(), "m/44'/1'/0'/0/3");
+        assert_eq!(DerivationType::TrezorLegacyTestnet(0).to_string(), "m/44'/1'/0'/0/0");
+        assert_eq!(DerivationType::TrezorLegacyTestnet(3).to_string(), "m/44'/1'/0'/0/3");
         assert_eq!(
             DerivationType::Other("m/44'/60'/0'/0".to_string()).to_string(),
             "m/44'/60'/0'/0"

--- a/crates/signer-trezor/src/types.rs
+++ b/crates/signer-trezor/src/types.rs
@@ -7,10 +7,16 @@ use std::fmt;
 use thiserror::Error;
 
 /// A Trezor derivation-path preset.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum DerivationType {
     /// Standard path `m/44'/60'/0'/0/<index>`.
     TrezorLive(usize),
+    /// Testnet path `m/44'/1'/0'/0/<index>`.
+    ///
+    /// Formerly used by Trezor Suite for testnets (e.g. Sepolia, Goerli, Holesky).
+    /// Note: Trezor Suite now defaults Sepolia to the standard Ethereum path `m/44'/60'/0'/0/<index>`,
+    /// but accounts previously created with the testnet path use this derivation.
+    TrezorTestnet(usize),
     /// Any other path.
     ///
     /// **Warning**: Trezor by default forbids custom derivation paths;
@@ -22,6 +28,7 @@ impl fmt::Display for DerivationType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match self {
             Self::TrezorLive(index) => write!(f, "m/44'/60'/0'/0/{index}"),
+            Self::TrezorTestnet(index) => write!(f, "m/44'/1'/0'/0/{index}"),
             Self::Other(inner) => f.write_str(inner),
         }
     }

--- a/crates/signer-trezor/src/types.rs
+++ b/crates/signer-trezor/src/types.rs
@@ -14,9 +14,7 @@ pub enum DerivationType {
     /// Testnet path `m/44'/1'/0'/0/<index>`.
     ///
     /// Formerly used by Trezor Suite for testnets (e.g. Sepolia, Goerli, Holesky).
-    /// Note: Trezor Suite now defaults Sepolia to the standard Ethereum path `m/44'/60'/0'/0/<index>`,
-    /// but accounts previously created with the testnet path use this derivation.
-    TrezorTestnet(usize),
+    TrezorLegacyTestnet(usize),
     /// Any other path.
     ///
     /// **Warning**: Trezor by default forbids custom derivation paths;
@@ -28,7 +26,7 @@ impl fmt::Display for DerivationType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match self {
             Self::TrezorLive(index) => write!(f, "m/44'/60'/0'/0/{index}"),
-            Self::TrezorTestnet(index) => write!(f, "m/44'/1'/0'/0/{index}"),
+            Self::TrezorLegacyTestnet(index) => write!(f, "m/44'/1'/0'/0/{index}"),
             Self::Other(inner) => f.write_str(inner),
         }
     }


### PR DESCRIPTION
## Motivation

Closes #4140.

Trezor Suite previously used the testnet derivation path `m/44'/1'/0'/0/<index>` (coin type `1`) for testnets like Sepolia, Goerli, and Holesky. While Trezor Suite recently updated Sepolia to use the standard Ethereum coin type (`m/44'/60'/0'/0/<index>`), previously created and funded accounts on the testnet path should still be easily accessible via a first-class derivation preset.

## Solution

1. Add `DerivationType::TrezorTestnet(usize)` corresponding to `m/44'/1'/0'/0/<index>` to `alloy-signer-trezor`.
2. Derive `PartialEq, Eq` on `DerivationType` to align with `alloy-signer-ledger`.
3. Add unit tests for `DerivationType` display formatting and `TrezorSigner::convert_path` BIP32 path derivation.

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes