### PR TITLE
fix(consensus): bound sealed block RLP decoding

### DIFF
--- a/crates/consensus/src/block/mod.rs
+++ b/crates/consensus/src/block/mod.rs
@@ -399,21 +399,31 @@ mod block_rlp {
         /// This is more efficient than decoding the block and then sealing it, as the header
         /// hash is computed from the raw RLP bytes without re-encoding.
         pub fn decode_sealed(buf: &mut &[u8]) -> alloy_rlp::Result<Sealed<Self>> {
-            // Decode the outer block list header
-            let block_rlp_head = alloy_rlp::Header::decode(buf)?;
-            if !block_rlp_head.list {
-                return Err(alloy_rlp::Error::UnexpectedString);
-            }
+            // Restrict child decoding to the outer block list's declared payload.
+            let mut payload = alloy_rlp::Header::decode_bytes(buf, true)?;
 
             // Decode header and compute hash from raw RLP bytes
-            let header_start = *buf;
-            let header = H::decode(buf)?;
-            let header_hash = keccak256(&header_start[..header_start.len() - buf.len()]);
+            let header_start = payload;
+            let header = H::decode(&mut payload)?;
+            let header_length = header_start
+                .len()
+                .checked_sub(payload.len())
+                .ok_or(alloy_rlp::Error::InputTooShort)?;
+            let header_rlp =
+                header_start.get(..header_length).ok_or(alloy_rlp::Error::InputTooShort)?;
+            let header_hash = keccak256(header_rlp);
 
             // Decode remaining body fields
-            let transactions = Vec::<T>::decode(buf)?;
-            let ommers = Vec::<H>::decode(buf)?;
-            let withdrawals = if buf.is_empty() { None } else { Some(Decodable::decode(buf)?) };
+            let transactions = Vec::<T>::decode(&mut payload)?;
+            let ommers = Vec::<H>::decode(&mut payload)?;
+            let withdrawals =
+                if payload.is_empty() { None } else { Some(Decodable::decode(&mut payload)?) };
+            if !payload.is_empty() {
+                return Err(alloy_rlp::Error::ListLengthMismatch {
+                    expected: header_start.len(),
+                    got: header_start.len().saturating_sub(payload.len()),
+                });
+            }
 
             let block = Self { header, body: BlockBody { transactions, ommers, withdrawals } };
 
@@ -521,6 +531,44 @@ mod tests {
         assert_eq!(sealed.header.number, 42);
         assert_eq!(sealed.body.transactions.len(), 1);
         assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn decode_sealed_rejects_fields_past_outer_rlp_boundary() {
+        let block: Block<TxEnvelope> = Block::default();
+        let mut encoded = alloy_rlp::encode(&block);
+
+        let mut payload = encoded.as_slice();
+        let outer = alloy_rlp::Header::decode(&mut payload).unwrap();
+        let header_length = encoded.len() - payload.len();
+        assert!(outer.list);
+        assert!(outer.payload_length > 56);
+
+        let mut replacement = Vec::with_capacity(header_length);
+        alloy_rlp::Header { list: true, payload_length: outer.payload_length - 1 }
+            .encode(&mut replacement);
+        assert_eq!(replacement.len(), header_length);
+        encoded[..header_length].copy_from_slice(&replacement);
+
+        assert!(Block::<TxEnvelope>::decode_sealed(&mut encoded.as_slice()).is_err());
+    }
+
+    #[test]
+    fn decode_sealed_rejects_decoder_that_expands_input() {
+        #[derive(Debug)]
+        struct ExpandingHeader;
+
+        impl Decodable for ExpandingHeader {
+            fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+                *buf = &[0, 0];
+                Ok(Self)
+            }
+        }
+
+        let mut encoded: &[u8] = &[0xc1, 0x80];
+        let result = Block::<TxEnvelope, ExpandingHeader>::decode_sealed(&mut encoded);
+
+        assert!(matches!(result, Err(alloy_rlp::Error::InputTooShort)));
     }
 
     #[test]


### PR DESCRIPTION
## Motivation

`Block::decode_sealed` decoded the outer RLP header but allowed its child decoders to read from the complete caller buffer. A malformed block could therefore consume fields beyond the payload length declared by the outer header.

This violates the outer RLP boundary and can make decoding depend on bytes belonging to a following value.

## Solution

Restrict child decoding to the payload declared by the outer header and require the bounded payload to be consumed exactly.

The regression tests cover:

- fields extending past the outer RLP boundary;
- a hostile child decoder that expands its input cursor;
- valid sealed-block round trips.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes

## Specification

The [Ethereum RLP specification](https://ethereum.org/developers/docs/data-structures-and-encoding/rlp/) defines a list payload as the concatenated encodings of its items with an exact declared payload length. [go-ethereum's `Stream.List` and `ListEnd`](https://github.com/ethereum/go-ethereum/blob/02b73d4ea7181464175e0a6cbecc0a3a2655a562/rlp/decode.go#L793-L830) enforce the same boundary by tracking the remaining bytes of every enclosing list and requiring the decoder to finish at the list's end.