### PR TITLE
fix(eips): reject unwrapped typed network encoding

### DIFF
--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -1449,6 +1449,17 @@ mod tests {
     }
 
     #[test]
+    fn network_decode_rejects_unwrapped_typed_transaction() {
+        let tx = TxEnvelope::Eip1559(TxEip1559::default().into_signed(Signature::test_signature()));
+        let encoded = tx.encoded_2718();
+        assert_eq!(encoded.first().copied(), Some(TxType::Eip1559 as u8));
+
+        let mut input = encoded.as_slice();
+        assert!(TxEnvelope::network_decode(&mut input).is_err());
+        assert_eq!(input, encoded.as_slice());
+    }
+
+    #[test]
     fn decode_encode_known_rpc_transaction() {
         // test data pulled from hive test that sends blob transactions
         let network_data_path =

--- a/crates/eips/src/eip2718.rs
+++ b/crates/eips/src/eip2718.rs
@@ -4,7 +4,7 @@
 
 use alloc::{borrow::Cow, vec::Vec};
 use alloy_primitives::{keccak256, Bytes, Sealable, Sealed, B256};
-use alloy_rlp::{Buf, BufMut, Header, EMPTY_STRING_CODE};
+use alloy_rlp::{Buf, BufMut, Header};
 use auto_impl::auto_impl;
 use core::fmt;
 
@@ -167,6 +167,12 @@ pub trait Decodable2718: Sized {
         if h.list {
             return Self::fallback_decode(buf);
         }
+
+        // `Header::decode` does not advance past a canonical single byte. Such an input is a
+        // direct EIP-2718 type prefix, not the RLP string required by the network encoding.
+        if h_decode.len() == buf.len() {
+            return Err(alloy_rlp::Error::UnexpectedLength.into());
+        }
         *buf = h_decode;
 
         let remaining_len = buf.len();
@@ -178,10 +184,7 @@ pub trait Decodable2718: Sized {
         let tx = Self::typed_decode(ty, buf)?;
 
         let bytes_consumed = remaining_len - buf.len();
-        // because Header::decode works for single bytes (including the tx type), returning a
-        // string Header with payload_length of 1, we need to make sure this check is only
-        // performed for transactions with a string header
-        if bytes_consumed != h.payload_length && h_decode[0] > EMPTY_STRING_CODE {
+        if bytes_consumed != h.payload_length {
             return Err(alloy_rlp::Error::UnexpectedLength.into());
         }
 


### PR DESCRIPTION
## Motivation

EIP-2718 typed transactions have distinct canonical encodings:

- direct encoding: `type || payload`;
- network encoding: an RLP string containing `type || payload`.

`network_decode` also accepted the unwrapped direct form. Re-encoding the resulting transaction as a network value added the missing wrapper, violating decode/encode canonicality.

## Solution

Require typed values passed to `network_decode` to have the network RLP-string wrapper. Direct typed transaction decoding remains supported through `decode_2718`.

A regression test verifies that unwrapped typed transactions are rejected while valid wrapped network transactions continue to round trip.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes

## Specification

The [Ethereum Wire Protocol transaction encoding](https://github.com/ethereum/devp2p/blob/77264dbc983a06aab74a79aec85d9e18361df03e/caps/eth.md#L174-L198) specifies EIP-2718 typed transactions as RLP byte arrays whose contents are `tx-type || tx-data`. go-ethereum likewise distinguishes [`Transaction.DecodeRLP`](https://github.com/ethereum/go-ethereum/blob/02b73d4ea7181464175e0a6cbecc0a3a2655a562/core/types/transaction.go#L142-L176), which reads the network RLP wrapper, from [`UnmarshalBinary`](https://github.com/ethereum/go-ethereum/blob/02b73d4ea7181464175e0a6cbecc0a3a2655a562/core/types/transaction.go#L178-L198), which reads the bare EIP-2718 encoding.