### PR TITLE
fix(consensus): reject invalid EIP-658 status values

### DIFF
--- a/crates/consensus/src/receipt/status.rs
+++ b/crates/consensus/src/receipt/status.rs
@@ -1,6 +1,10 @@
 use alloy_primitives::B256;
 use alloy_rlp::{Buf, BufMut, Decodable, Encodable, Error, Header};
 
+const EIP658_STATUS_FAILED_RLP_PAYLOAD: &[u8] = &[];
+const EIP658_STATUS_SUCCESS_RLP_PAYLOAD: &[u8] = &[0x01];
+const PRE_BYZANTIUM_POST_STATE_ROOT_LENGTH: usize = 32;
+
 /// Captures the result of a transaction execution.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
@@ -161,15 +165,26 @@ impl Encodable for Eip658Value {
 impl Decodable for Eip658Value {
     fn decode(buf: &mut &[u8]) -> Result<Self, Error> {
         let h = Header::decode(buf)?;
+        if h.list {
+            return Err(Error::UnexpectedList);
+        }
 
         match h.payload_length {
-            0 => Ok(Self::Eip658(false)),
-            1 => {
-                let status = buf.get_u8() != 0;
-                Ok(status.into())
+            len if len == EIP658_STATUS_FAILED_RLP_PAYLOAD.len() => Ok(Self::Eip658(false)),
+            len if len == EIP658_STATUS_SUCCESS_RLP_PAYLOAD.len() => {
+                if buf.remaining() < len {
+                    return Err(Error::InputTooShort);
+                }
+                let is_success = &buf[..len] == EIP658_STATUS_SUCCESS_RLP_PAYLOAD;
+                buf.advance(len);
+                if is_success {
+                    Ok(Self::Eip658(true))
+                } else {
+                    Err(Error::Custom("invalid EIP-658 status, must be 0 or 1"))
+                }
             }
-            32 => {
-                if buf.remaining() < 32 {
+            PRE_BYZANTIUM_POST_STATE_ROOT_LENGTH => {
+                if buf.remaining() < PRE_BYZANTIUM_POST_STATE_ROOT_LENGTH {
                     return Err(Error::InputTooShort);
                 }
                 let mut state = B256::default();
@@ -196,6 +211,19 @@ mod test {
         let state = Eip658Value::PostState(B256::default());
         state.encode(&mut buf);
         assert_eq!(Eip658Value::decode(&mut buf.as_slice()), Ok(state));
+    }
+
+    #[test]
+    fn rejects_non_canonical_status() {
+        for encoded in [[0x00], [0x02], [0x7f]] {
+            assert!(Eip658Value::decode(&mut encoded.as_slice()).is_err());
+        }
+
+        assert!(Eip658Value::decode(&mut [0xc0].as_slice()).is_err());
+
+        let mut state_list = [0_u8; 33];
+        state_list[0] = 0xe0;
+        assert!(Eip658Value::decode(&mut state_list.as_slice()).is_err());
     }
 
     #[cfg(feature = "serde")]


### PR DESCRIPTION
## Motivation

The EIP-658 receipt-status decoder treated any nonzero single-byte value as `true`. Values such as `0x2f` were consequently accepted and re-encoded as canonical `0x01`.

EIP-658 status has only two canonical RLP representations:

- false: the empty string;
- true: `0x01`.

## Solution

Accept only the two canonical status encodings, preserve 32-byte pre-Byzantium post-state roots, and reject list headers for both forms.

The regression tests cover noncanonical status bytes and list-wrapped status or state-root values, while retaining canonical status and post-state round trips.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes

## Specification

[EIP-658](https://eips.ethereum.org/EIPS/eip-658#specification) defines only status code `0` for failure and `1` for success. Under canonical RLP integer encoding, zero is the empty byte string and one is `0x01`. go-ethereum's [`Receipt.setStatus`](https://github.com/ethereum/go-ethereum/blob/02b73d4ea7181464175e0a6cbecc0a3a2655a562/core/types/receipt.go#L226-L238) similarly accepts only the canonical failed/success values or the pre-Byzantium 32-byte state root.