### PR TITLE
feat: add MEV builder API extensions and priority update registry support

### DIFF
--- a/crates/provider/src/ext/mev/mod.rs
+++ b/crates/provider/src/ext/mev/mod.rs
@@ -1,7 +1,14 @@
+mod priority_update_registry;
 mod with_auth;
 
-pub use self::with_auth::{
-    sign_flashbots_payload, verify_flashbots_signature, FlashbotsSignatureError, MevBuilder,
+pub use self::{
+    priority_update_registry::{
+        priority_update_registry_domain, sign_priority_update, PrioUpdateRegistry, SignedUpdate,
+        UpdateState, PRIORITY_UPDATE_REGISTRY_ADDRESS,
+    },
+    with_auth::{
+        sign_flashbots_payload, verify_flashbots_signature, FlashbotsSignatureError, MevBuilder,
+    },
 };
 use crate::Provider;
 use alloy_network::Network;

--- a/crates/provider/src/ext/mev/mod.rs
+++ b/crates/provider/src/ext/mev/mod.rs
@@ -3,8 +3,8 @@ mod with_auth;
 
 pub use self::{
     priority_update_registry::{
-        priority_update_registry_domain, sign_priority_update, PrioUpdateRegistry, SignedUpdate,
-        UpdateState, PRIORITY_UPDATE_REGISTRY_ADDRESS,
+        priority_update_registry_domain, PrioUpdateRegistry, SignedUpdate, UpdateState,
+        PRIORITY_UPDATE_REGISTRY_ADDRESS,
     },
     with_auth::{
         sign_flashbots_payload, verify_flashbots_signature, FlashbotsSignatureError, MevBuilder,

--- a/crates/provider/src/ext/mev/priority_update_registry.rs
+++ b/crates/provider/src/ext/mev/priority_update_registry.rs
@@ -1,0 +1,244 @@
+//! Support for the Flashbots [priority update registry].
+//!
+//! The priority update registry is an on-chain registry that allows authorized updaters
+//! (e.g. PropAMM market makers) to publish per-block priority updates that are read by their
+//! target contracts during execution. Block builders that support priority updates guarantee
+//! that updates for a contract land in the block before any transaction that interacts with
+//! that contract, and that updates for contracts not touched in the block are excluded.
+//!
+//! The registry is deployed at [`PRIORITY_UPDATE_REGISTRY_ADDRESS`] via the deterministic
+//! CREATE2 factory, see the [priority update registry] repository for deployment details.
+//!
+//! Priority updates are either submitted directly by an authorized updater via
+//! `updateState`, or relayed as EIP-712 signed updates via `batchUpdateStateWithSignature`.
+//! Use [`sign_priority_update`] to create such a [`SignedUpdate`] from an [`UpdateState`]
+//! message.
+//!
+//! Builders currently ingest priority update transactions from makers over builder-specific
+//! authenticated WebSocket endpoints, see e.g.:
+//! - Titan: <https://docs.titanbuilder.xyz/propamms/makers>
+//! - Bombora: <https://bombora.build/docs/propamm-makers>
+//! - BuilderNet: <https://buildernet.org/docs/api>
+//!
+//! [priority update registry]: https://github.com/flashbots/priority-update-registry
+
+use alloy_primitives::{address, Address, ChainId};
+use alloy_signer::Signer;
+use alloy_sol_types::{eip712_domain, sol, Eip712Domain, SolStruct};
+
+pub use PrioUpdateRegistry::SignedUpdate;
+
+/// The address of the Flashbots priority update registry:
+/// [`0xda7afeed01fe625cf15d187a19f94b45f00b8c5f`](https://etherscan.io/address/0xda7afeed01fe625cf15d187a19f94b45f00b8c5f)
+///
+/// The registry is deployed via the deterministic CREATE2 factory, see the
+/// [deployment details](https://github.com/flashbots/priority-update-registry#deployments).
+pub const PRIORITY_UPDATE_REGISTRY_ADDRESS: Address =
+    address!("0xda7afeed01fe625cf15d187a19f94b45f00b8c5f");
+
+sol! {
+    /// The EIP-712 message signed by an updater for
+    /// `PrioUpdateRegistry::batchUpdateStateWithSignature`.
+    ///
+    /// The encoded type is
+    /// `UpdateState(address target,uint256 laneIndex,uint32 updateTimestamp,uint256[] slots)`,
+    /// matching the registry's `UPDATE_TYPEHASH`. Note that the relayed [`SignedUpdate`]
+    /// additionally carries the `signer`, which is not part of the signed payload.
+    #[derive(Debug, PartialEq, Eq)]
+    struct UpdateState {
+        /// The address whose state is being updated.
+        address target;
+        /// The lane to write, scoped to `target`.
+        uint256 laneIndex;
+        /// The timestamp associated with this update.
+        uint32 updateTimestamp;
+        /// The slot values to write. Length must be in `[1, 255]` and `slots[0]` must fit in
+        /// 27 bytes (its top 5 bytes are reserved for `updateTimestamp` and the slot count).
+        uint256[] slots;
+    }
+
+    /// The Flashbots [priority update registry](https://github.com/flashbots/priority-update-registry)
+    /// contract.
+    #[derive(Debug, PartialEq, Eq)]
+    interface PrioUpdateRegistry {
+        /// A signed state update relayed via `batchUpdateStateWithSignature`.
+        ///
+        /// `signer` is not part of the EIP-712 hash: it is supplied alongside the signature so
+        /// the contract knows which address's authorization to check. If `signer == target`,
+        /// the signature is verified against `target` via ERC-1271; otherwise it must
+        /// ECDSA-recover to `signer`, and `signer` must be an authorized updater for `target`.
+        struct SignedUpdate {
+            /// The address whose state is being updated.
+            address target;
+            /// The address whose signature authorizes this update.
+            address signer;
+            /// The lane to write, scoped to `target`.
+            uint256 laneIndex;
+            /// The timestamp associated with this update.
+            uint32 updateTimestamp;
+            /// The slot values to write.
+            uint256[] slots;
+            /// The EIP-712 signature over `(target, laneIndex, updateTimestamp, slots)`.
+            bytes signature;
+        }
+
+        /// Thrown when the caller or signer is not authorized to update state for `target`.
+        error NotAuthorized();
+        /// Thrown when `slots` has length zero.
+        error EmptySlots();
+        /// Thrown when `slots[0]` does not fit in 27 bytes.
+        error Slot0Exceeds27Bytes();
+        /// Thrown when `slots` has more than 255 entries.
+        error TooManySlots();
+        /// Thrown when `updateTimestamp` lies outside the accepted window around
+        /// `block.timestamp`.
+        error InvalidUpdateTimestamp();
+        /// Thrown on writes when `updateTimestamp` is older than the stored timestamp, or on
+        /// reads when the stored timestamp lies outside the requested window.
+        error StaleUpdate();
+
+        /// Emitted when `updater` is authorized to write state on behalf of `target`.
+        event UpdaterAdded(address indexed target, address indexed updater);
+        /// Emitted when the authorization of `updater` for `target` is revoked.
+        event UpdaterRemoved(address indexed target, address indexed updater);
+
+        /// Maximum age (in seconds) by which `updateTimestamp` may lag `block.timestamp` on
+        /// writes.
+        function MAX_UPDATE_AGE() external view returns (uint256);
+        /// Maximum lead time (in seconds) by which `updateTimestamp` may exceed
+        /// `block.timestamp` on writes.
+        function MAX_UPDATE_LEAD_TIME() external view returns (uint256);
+        /// The EIP-712 type hash for an [`UpdateState`] message.
+        function UPDATE_TYPEHASH() external view returns (bytes32);
+        /// The EIP-712 domain separator used for signed updates.
+        function DOMAIN_SEPARATOR() external view returns (bytes32);
+        /// Returns whether `updater` is authorized to write state on behalf of `target`.
+        function isUpdater(address target, address updater) external view returns (bool);
+        /// Authorizes `updater` to write state on behalf of the caller.
+        function addUpdater(address updater) external;
+        /// Revokes the authorization of `updater` to write state on behalf of the caller.
+        function removeUpdater(address updater) external;
+        /// Returns the stored state for the caller at the given `laneIndex`, enforcing that
+        /// the stored `updateTimestamp` lies within `[minTimestamp, maxTimestamp]`.
+        function getState(uint256 laneIndex, uint32 minTimestamp, uint32 maxTimestamp)
+            external
+            view
+            returns (uint32 updateTimestamp, uint256[] memory slots);
+        /// Writes a state update for `target` at `laneIndex`, with the caller acting as the
+        /// updater.
+        function updateState(
+            address target,
+            uint256 laneIndex,
+            uint32 updateTimestamp,
+            uint256[] calldata slots
+        ) external;
+        /// Applies a batch of signed state updates. Anyone may relay the batch.
+        function batchUpdateStateWithSignature(SignedUpdate[] calldata updates) external;
+    }
+}
+
+/// Returns the [`Eip712Domain`] of the priority update registry for the given chain.
+///
+/// The domain is `("PrioUpdateRegistry", "1", chain_id, `[`PRIORITY_UPDATE_REGISTRY_ADDRESS`]`)`.
+pub fn priority_update_registry_domain(chain_id: ChainId) -> Eip712Domain {
+    eip712_domain! {
+        name: "PrioUpdateRegistry",
+        version: "1",
+        chain_id: chain_id,
+        verifying_contract: PRIORITY_UPDATE_REGISTRY_ADDRESS,
+    }
+}
+
+/// Signs the given [`UpdateState`] message for the priority update registry on the given
+/// chain, returning a [`SignedUpdate`] that can be relayed by anyone via
+/// `PrioUpdateRegistry::batchUpdateStateWithSignature`.
+///
+/// Note: signatures are not single-use, a [`SignedUpdate`] remains relayable as long as the
+/// lane's stored timestamp does not exceed `updateTimestamp` and `updateTimestamp` is within
+/// the registry's accepted window. Replays always produce the same on-chain state.
+///
+/// # Example
+///
+/// ```
+/// use alloy_primitives::U256;
+/// use alloy_provider::ext::{sign_priority_update, UpdateState};
+/// use alloy_signer_local::PrivateKeySigner;
+///
+/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// let signer = PrivateKeySigner::random();
+/// let update = UpdateState {
+///     target: "0x5979458912f80b96d30d4220af8e2e4925a33320".parse()?,
+///     laneIndex: U256::ZERO,
+///     updateTimestamp: 1753977388,
+///     slots: vec![U256::from(1)],
+/// };
+/// let signed = sign_priority_update(&signer, 1, update).await?;
+/// assert_eq!(signed.signer, signer.address());
+/// # Ok(())
+/// # }
+/// ```
+pub async fn sign_priority_update<S>(
+    signer: &S,
+    chain_id: ChainId,
+    update: UpdateState,
+) -> Result<SignedUpdate, alloy_signer::Error>
+where
+    S: Signer + Send + Sync,
+{
+    let hash = update.eip712_signing_hash(&priority_update_registry_domain(chain_id));
+    let signature = signer.sign_hash(&hash).await?;
+    Ok(SignedUpdate {
+        target: update.target,
+        signer: signer.address(),
+        laneIndex: update.laneIndex,
+        updateTimestamp: update.updateTimestamp,
+        slots: update.slots,
+        signature: signature.as_bytes().into(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::{keccak256, Signature, U256};
+    use alloy_signer_local::PrivateKeySigner;
+
+    #[test]
+    fn update_state_type_hash_matches_registry() {
+        // Must match the registry's `UPDATE_TYPEHASH` constant.
+        let expected = keccak256(
+            "UpdateState(address target,uint256 laneIndex,uint32 updateTimestamp,uint256[] slots)",
+        );
+        let update = UpdateState {
+            target: Address::ZERO,
+            laneIndex: U256::ZERO,
+            updateTimestamp: 0,
+            slots: vec![],
+        };
+        assert_eq!(update.eip712_type_hash(), expected);
+    }
+
+    #[tokio::test]
+    async fn can_sign_priority_update() {
+        let signer = PrivateKeySigner::random();
+        let update = UpdateState {
+            target: address!("0x5979458912f80b96d30d4220af8e2e4925a33320"),
+            laneIndex: U256::ZERO,
+            updateTimestamp: 1753977388,
+            slots: vec![U256::from(1), U256::from(2)],
+        };
+
+        let signed = sign_priority_update(&signer, 1, update.clone()).await.unwrap();
+        assert_eq!(signed.signer, signer.address());
+        assert_eq!(signed.target, update.target);
+        assert_eq!(signed.slots, update.slots);
+
+        // the signature must recover to the signer and carry a 27/28 recovery byte as
+        // expected by the registry's on-chain ECDSA recovery
+        assert_eq!(signed.signature.len(), 65);
+        assert!(matches!(signed.signature[64], 27 | 28));
+        let digest = update.eip712_signing_hash(&priority_update_registry_domain(1));
+        let signature = Signature::from_raw(&signed.signature).unwrap();
+        assert_eq!(signature.recover_address_from_prehash(&digest).unwrap(), signer.address());
+    }
+}

--- a/crates/provider/src/ext/mev/priority_update_registry.rs
+++ b/crates/provider/src/ext/mev/priority_update_registry.rs
@@ -11,7 +11,7 @@
 //!
 //! Priority updates are either submitted directly by an authorized updater via
 //! `updateState`, or relayed as EIP-712 signed updates via `batchUpdateStateWithSignature`.
-//! Use [`sign_priority_update`] to create such a [`SignedUpdate`] from an [`UpdateState`]
+//! Use [`UpdateState::sign`] to create such a [`SignedUpdate`] from an [`UpdateState`]
 //! message.
 //!
 //! Builders currently ingest priority update transactions from makers over builder-specific
@@ -149,52 +149,54 @@ pub const fn priority_update_registry_domain(chain_id: ChainId) -> Eip712Domain 
     }
 }
 
-/// Signs the given [`UpdateState`] message for the priority update registry on the given
-/// chain, returning a [`SignedUpdate`] that can be relayed by anyone via
-/// `PrioUpdateRegistry::batchUpdateStateWithSignature`.
-///
-/// Note: signatures are not single-use, a [`SignedUpdate`] remains relayable as long as the
-/// lane's stored timestamp does not exceed `updateTimestamp` and `updateTimestamp` is within
-/// the registry's accepted window. Replays always produce the same on-chain state.
-///
-/// # Example
-///
-/// ```
-/// use alloy_primitives::U256;
-/// use alloy_provider::ext::{sign_priority_update, UpdateState};
-/// use alloy_signer_local::PrivateKeySigner;
-///
-/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-/// let signer = PrivateKeySigner::random();
-/// let update = UpdateState {
-///     target: "0x5979458912f80b96d30d4220af8e2e4925a33320".parse()?,
-///     laneIndex: U256::ZERO,
-///     updateTimestamp: 1753977388,
-///     slots: vec![U256::from(1)],
-/// };
-/// let signed = sign_priority_update(&signer, 1, update).await?;
-/// assert_eq!(signed.signer, signer.address());
-/// # Ok(())
-/// # }
-/// ```
-pub async fn sign_priority_update<S>(
-    signer: &S,
-    chain_id: ChainId,
-    update: UpdateState,
-) -> Result<SignedUpdate, alloy_signer::Error>
-where
-    S: Signer + Send + Sync,
-{
-    let hash = update.eip712_signing_hash(&priority_update_registry_domain(chain_id));
-    let signature = signer.sign_hash(&hash).await?;
-    Ok(SignedUpdate {
-        target: update.target,
-        signer: signer.address(),
-        laneIndex: update.laneIndex,
-        updateTimestamp: update.updateTimestamp,
-        slots: update.slots,
-        signature: signature.as_bytes().into(),
-    })
+impl UpdateState {
+    /// Signs this update for the priority update registry on the given chain, returning a
+    /// [`SignedUpdate`] that can be relayed by anyone via
+    /// `PrioUpdateRegistry::batchUpdateStateWithSignature`.
+    ///
+    /// Note: signatures are not single-use, a [`SignedUpdate`] remains relayable as long as
+    /// the lane's stored timestamp does not exceed `updateTimestamp` and `updateTimestamp` is
+    /// within the registry's accepted window. Replays always produce the same on-chain state.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use alloy_primitives::U256;
+    /// use alloy_provider::ext::UpdateState;
+    /// use alloy_signer_local::PrivateKeySigner;
+    ///
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let signer = PrivateKeySigner::random();
+    /// let update = UpdateState {
+    ///     target: "0x5979458912f80b96d30d4220af8e2e4925a33320".parse()?,
+    ///     laneIndex: U256::ZERO,
+    ///     updateTimestamp: 1753977388,
+    ///     slots: vec![U256::from(1)],
+    /// };
+    /// let signed = update.sign(&signer, 1).await?;
+    /// assert_eq!(signed.signer, signer.address());
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn sign<S>(
+        self,
+        signer: &S,
+        chain_id: ChainId,
+    ) -> Result<SignedUpdate, alloy_signer::Error>
+    where
+        S: Signer + Send + Sync,
+    {
+        let hash = self.eip712_signing_hash(&priority_update_registry_domain(chain_id));
+        let signature = signer.sign_hash(&hash).await?;
+        Ok(SignedUpdate {
+            target: self.target,
+            signer: signer.address(),
+            laneIndex: self.laneIndex,
+            updateTimestamp: self.updateTimestamp,
+            slots: self.slots,
+            signature: signature.as_bytes().into(),
+        })
+    }
 }
 
 #[cfg(test)]
@@ -228,7 +230,7 @@ mod tests {
             slots: vec![U256::from(1), U256::from(2)],
         };
 
-        let signed = sign_priority_update(&signer, 1, update.clone()).await.unwrap();
+        let signed = update.clone().sign(&signer, 1).await.unwrap();
         assert_eq!(signed.signer, signer.address());
         assert_eq!(signed.target, update.target);
         assert_eq!(signed.slots, update.slots);

--- a/crates/provider/src/ext/mev/priority_update_registry.rs
+++ b/crates/provider/src/ext/mev/priority_update_registry.rs
@@ -140,7 +140,7 @@ sol! {
 /// Returns the [`Eip712Domain`] of the priority update registry for the given chain.
 ///
 /// The domain is `("PrioUpdateRegistry", "1", chain_id, `[`PRIORITY_UPDATE_REGISTRY_ADDRESS`]`)`.
-pub fn priority_update_registry_domain(chain_id: ChainId) -> Eip712Domain {
+pub const fn priority_update_registry_domain(chain_id: ChainId) -> Eip712Domain {
     eip712_domain! {
         name: "PrioUpdateRegistry",
         version: "1",

--- a/crates/provider/src/ext/mod.rs
+++ b/crates/provider/src/ext/mod.rs
@@ -65,8 +65,9 @@ mod mev;
 
 #[cfg(feature = "mev-api")]
 pub use mev::{
-    sign_flashbots_payload, verify_flashbots_signature, FlashbotsSignatureError, MevApi,
-    MevBuilder, FLASHBOTS_SIGNATURE_HEADER,
+    priority_update_registry_domain, sign_flashbots_payload, sign_priority_update,
+    verify_flashbots_signature, FlashbotsSignatureError, MevApi, MevBuilder, PrioUpdateRegistry,
+    SignedUpdate, UpdateState, FLASHBOTS_SIGNATURE_HEADER, PRIORITY_UPDATE_REGISTRY_ADDRESS,
 };
 
 /// Reth related apis.

--- a/crates/provider/src/ext/mod.rs
+++ b/crates/provider/src/ext/mod.rs
@@ -65,9 +65,9 @@ mod mev;
 
 #[cfg(feature = "mev-api")]
 pub use mev::{
-    priority_update_registry_domain, sign_flashbots_payload, sign_priority_update,
-    verify_flashbots_signature, FlashbotsSignatureError, MevApi, MevBuilder, PrioUpdateRegistry,
-    SignedUpdate, UpdateState, FLASHBOTS_SIGNATURE_HEADER, PRIORITY_UPDATE_REGISTRY_ADDRESS,
+    priority_update_registry_domain, sign_flashbots_payload, verify_flashbots_signature,
+    FlashbotsSignatureError, MevApi, MevBuilder, PrioUpdateRegistry, SignedUpdate, UpdateState,
+    FLASHBOTS_SIGNATURE_HEADER, PRIORITY_UPDATE_REGISTRY_ADDRESS,
 };
 
 /// Reth related apis.

--- a/crates/rpc-types-mev/src/eth_calls.rs
+++ b/crates/rpc-types-mev/src/eth_calls.rs
@@ -227,10 +227,20 @@ pub struct EthCancelPrivateTransaction {
 ///
 /// Note: this is for `eth_sendBundle` and not `mev_sendBundle`
 ///
-/// This implement the refund capabilities from here:
+/// This is a superset of the fields accepted by the major block builders.
+///
+/// It implements the refund and replacement capabilities from BuilderNet:
 /// <https://buildernet.org/docs/api#eth_sendbundle>
+/// as well as the extensions supported by Titan, Quasar and Bombora:
+/// <https://docs.titanbuilder.xyz/api/eth_sendbundle>
+/// <https://docs.quasar.win/api/eth_sendbundle>
+/// <https://bombora.build/docs/eth-sendBundle>
 /// But keeps compatibility with original Flashbots API:
 /// <https://docs.flashbots.net/flashbots-auction/searchers/advanced/rpc-endpoint#eth_sendbundle>
+///
+/// Note: not all builders support all fields, fields that are unsupported by a builder are
+/// usually ignored. Builder-specific fields without dedicated support here can be set via
+/// [`EthSendBundle::extra_fields`].
 #[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EthSendBundle {
@@ -259,6 +269,28 @@ pub struct EthSendBundle {
     /// UUID that can be used to cancel/replace this bundle
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub replacement_uuid: Option<String>,
+    /// A monotonically increasing sequence number for bundles sharing the same
+    /// `replacementUuid`. Later bundles must have a higher sequence number, otherwise they are
+    /// dropped. If `0` or omitted, ordering falls back to builder receive time.
+    ///
+    /// Supported by Titan, Quasar and Bombora:
+    /// <https://docs.titanbuilder.xyz/api/eth_sendbundle>
+    /// <https://docs.quasar.win/api/eth_sendbundle>
+    /// <https://bombora.build/docs/eth-sendBundle>
+    #[serde(
+        default,
+        deserialize_with = "alloy_serde::quantity::opt::deserialize",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub replacement_seq_number: Option<u64>,
+    /// Used to order bundles sharing the same `replacementUuid`, BuilderNet's equivalent of
+    /// `replacementSeqNumber`: <https://buildernet.org/docs/api#eth_sendbundle>
+    #[serde(
+        default,
+        deserialize_with = "alloy_serde::quantity::opt::deserialize",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub replacement_nonce: Option<u64>,
     /// A list of tx hashes that are allowed to be discarded
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub dropping_tx_hashes: Vec<TxHash>,
@@ -273,8 +305,36 @@ pub struct EthSendBundle {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub refund_recipient: Option<Address>,
     /// A list of tx hashes used to determine the refund
+    ///
+    /// Note: builders that support this usually only allow a single entry and default to the
+    /// last transaction in the bundle.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub refund_tx_hashes: Vec<TxHash>,
+    /// The identity that BuilderNet refunds should be attributed to:
+    /// <https://buildernet.org/docs/api#eth_sendbundle>
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub refund_identity: Option<Address>,
+    /// If true, the `refundPercent` refund is processed asynchronously via BuilderNet's delayed
+    /// refund flow: <https://buildernet.org/docs/api#eth_sendbundle>
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub delayed_refund: Option<bool>,
+    /// The version of the bundle format, set to `v2` to enable BuilderNet's target pool fields
+    /// (`desiredState`, `targetAddresses`, `targetSlots`):
+    /// <https://buildernet.org/docs/api#eth_sendbundle>
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    /// Desired placement of the bundle within the block, e.g. `BottomOfBlock`. Requires
+    /// `version: "v2"`: <https://buildernet.org/docs/api#eth_sendbundle>
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub desired_state: Option<String>,
+    /// Contract addresses whose state the bundle targets. Requires `version: "v2"`:
+    /// <https://buildernet.org/docs/api#eth_sendbundle>
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub target_addresses: Vec<Address>,
+    /// Hex-encoded storage slots per target address. Requires `version: "v2"`:
+    /// <https://buildernet.org/docs/api#eth_sendbundle>
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub target_slots: Vec<Vec<U256>>,
     /// Additional fields that are specific to the builder
     #[serde(flatten, default)]
     pub extra_fields: OtherFields,
@@ -438,9 +498,14 @@ pub struct EthSendBlobs {
 
 /// Bundle of transactions for `eth_sendEndOfBlockBundle`
 ///
+/// End-of-block bundles are only included if at least one of their `targetPools` was modified
+/// earlier in the block: after a block is built, the bundle is re-simulated on the end-of-block
+/// state and appended on success.
+///
 /// For more details see:
-/// <https://docs.titanbuilder.xyz/api/eth_sendendofblockbundle> or
-/// <https://docs.quasar.win/eth_sendendofblockbundle>
+/// <https://docs.titanbuilder.xyz/api/eth_sendendofblockbundle>,
+/// <https://docs.quasar.win/api/eth_sendendofblockbundle> or
+/// <https://bombora.build/docs/eth-sendEndOfBlockBundle>
 #[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EthSendEndOfBlockBundle {
@@ -455,6 +520,21 @@ pub struct EthSendEndOfBlockBundle {
     /// Pool addresses targeted by the bundle
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub target_pools: Vec<Address>,
+    /// UUID that can be used to cancel/replace this bundle
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub replacement_uuid: Option<String>,
+    /// A monotonically increasing sequence number for bundles sharing the same
+    /// `replacementUuid`. Later bundles must have a higher sequence number, otherwise they are
+    /// dropped. If `0` or omitted, ordering falls back to builder receive time.
+    #[serde(
+        default,
+        deserialize_with = "alloy_serde::quantity::opt::deserialize",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub replacement_seq_number: Option<u64>,
+    /// Additional fields that are specific to the builder
+    #[serde(flatten, default)]
+    pub extra_fields: OtherFields,
 }
 
 #[cfg(test)]
@@ -589,6 +669,7 @@ mod tests {
                 "0x4444444444444444444444444444444444444444444444444444444444444444"
             )],
             extra_fields: OtherFields::from_iter([("customField", json!(42))]),
+            ..Default::default()
         };
         let s = r#"
             {
@@ -609,6 +690,73 @@ mod tests {
         let value = serde_json::to_value(&bundle).unwrap();
 
         assert_eq!(value, expected);
+    }
+
+    #[test]
+    fn can_serde_eth_send_bundle_builder_extensions() {
+        let s = r#"{
+                "txs": ["0x1234"],
+                "blockNumber": "0x1",
+                "replacementUuid": "11111111-1111-4111-8111-111111111111",
+                "replacementSeqNumber": 2,
+                "replacementNonce": 3,
+                "refundIdentity": "0x5555555555555555555555555555555555555555",
+                "delayedRefund": true,
+                "version": "v2",
+                "desiredState": "BottomOfBlock",
+                "targetAddresses": ["0x6666666666666666666666666666666666666666"],
+                "targetSlots": [["0x1", "0x2"]]
+            }"#;
+        let bundle = serde_json::from_str::<EthSendBundle>(s).unwrap();
+        assert_eq!(bundle.replacement_seq_number, Some(2));
+        assert_eq!(bundle.replacement_nonce, Some(3));
+        assert_eq!(
+            bundle.refund_identity,
+            Some(address!("0x5555555555555555555555555555555555555555"))
+        );
+        assert_eq!(bundle.delayed_refund, Some(true));
+        assert_eq!(bundle.version.as_deref(), Some("v2"));
+        assert_eq!(bundle.desired_state.as_deref(), Some("BottomOfBlock"));
+        assert_eq!(
+            bundle.target_addresses,
+            vec![address!("0x6666666666666666666666666666666666666666")]
+        );
+        assert_eq!(
+            bundle.target_slots,
+            vec![vec![alloy_primitives::U256::from(1), alloy_primitives::U256::from(2)]]
+        );
+        // typed fields must not leak into the flattened extra fields
+        assert!(bundle.extra_fields.is_empty());
+
+        let value = serde_json::to_value(&bundle).unwrap();
+        let rt = serde_json::from_value::<EthSendBundle>(value).unwrap();
+        assert_eq!(rt, bundle);
+    }
+
+    #[test]
+    fn can_serde_eth_send_end_of_block_bundle() {
+        let s = r#"{
+                "txs": ["0x1234"],
+                "blockNumber": "0x1234567",
+                "revertingTxHashes": ["0x1111111111111111111111111111111111111111111111111111111111111111"],
+                "targetPools": ["0x11b815efb8f581194ae79006d24e0d814b7697f6"],
+                "replacementUuid": "11111111-1111-4111-8111-111111111111",
+                "replacementSeqNumber": 1
+            }"#;
+        let bundle = serde_json::from_str::<crate::EthSendEndOfBlockBundle>(s).unwrap();
+        assert_eq!(
+            bundle.replacement_uuid.as_deref(),
+            Some("11111111-1111-4111-8111-111111111111")
+        );
+        assert_eq!(bundle.replacement_seq_number, Some(1));
+        assert_eq!(
+            bundle.target_pools,
+            vec![address!("0x11b815efb8f581194ae79006d24e0d814b7697f6")]
+        );
+
+        let value = serde_json::to_value(&bundle).unwrap();
+        let rt = serde_json::from_value::<crate::EthSendEndOfBlockBundle>(value).unwrap();
+        assert_eq!(rt, bundle);
     }
 
     #[test]

--- a/crates/rpc-types-mev/src/lib.rs
+++ b/crates/rpc-types-mev/src/lib.rs
@@ -23,6 +23,10 @@ pub use mev_calls::*;
 
 pub mod mevshare;
 
+// types for the PropAMM taker APIs exposed by block builders
+mod pamm;
+pub use pamm::*;
+
 // types for stats endpoint like flashbots_getUserStats and flashbots_getBundleStats
 mod stats;
 pub use stats::*;

--- a/crates/rpc-types-mev/src/pamm.rs
+++ b/crates/rpc-types-mev/src/pamm.rs
@@ -1,0 +1,264 @@
+//! Types for the PropAMM (proprietary AMM) taker APIs exposed by block builders.
+//!
+//! PropAMMs are on-chain pools whose prices are refreshed every block: market makers stream
+//! signed quote updates directly to block builders, and the builder guarantees that the
+//! maker's freshest quote lands immediately before the transaction that reads it.
+//!
+//! These types cover the public taker surface:
+//! - the state override stream (`/ws/pamm_quote_stream`) and `titan_getPammStateOverrides`:
+//!   [`PammQuoteStreamMessage`], [`PammStateOverrides`]
+//! - the price level stream (`/ws/pamm_price_levels`) and `titan_getPammPriceLevels`:
+//!   [`PammPriceLevelsSnapshot`]
+//! - quote requests (`titan_getPammQuote`, `titan_getPammQuoteVenue`): [`PammQuote`]
+//!
+//! The maker side (`/ws/sendquoteupdate`) is a protobuf-over-WebSocket protocol and not
+//! covered by these types. On-chain, quote updates target the Flashbots priority update
+//! registry: <https://github.com/flashbots/priority-update-registry>
+//!
+//! References:
+//! - Titan: <https://docs.titanbuilder.xyz/propamms>
+//! - Bombora: <https://bombora.build/docs/propamm>
+//! - BuilderNet: <https://buildernet.org/docs/api>
+
+use alloy_primitives::{Address, U256};
+use alloy_rpc_types_eth::state::StateOverride;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+/// A message on the PropAMM state override stream (`/ws/pamm_quote_stream`).
+///
+/// Every message is a complete snapshot of the latest maker quotes for the upcoming block,
+/// expressed as state overrides on the priority update registry. The overrides can be passed
+/// directly to simulation tooling that supports state overrides (e.g. `eth_call`,
+/// `eth_simulateV1`) to simulate routes against next-block prices.
+///
+/// See:
+/// - Titan: <https://docs.titanbuilder.xyz/propamms/takers>
+/// - Bombora: <https://bombora.build/docs/propamm-takers>
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PammQuoteStreamMessage {
+    /// The consensus slot the quotes target.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub slot: Option<u64>,
+    /// The block number the quotes target.
+    #[serde(alias = "block_number")]
+    pub block_number: u64,
+    /// Unix timestamp in nanoseconds at which the snapshot was emitted.
+    pub timestamp: u64,
+    /// The latest quote per PropAMM, keyed by the PropAMM's stream address.
+    #[serde(flatten)]
+    pub pamms: BTreeMap<Address, PammQuoteStreamEntry>,
+}
+
+/// A single PropAMM entry of a [`PammQuoteStreamMessage`].
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PammQuoteStreamEntry {
+    /// The state override representing the maker's latest quote for this PropAMM.
+    #[serde(alias = "state_override")]
+    pub state_override: StateOverride,
+}
+
+/// Response for `titan_getPammStateOverrides`: the latest maker quotes as state overrides on
+/// the priority update registry.
+///
+/// <https://docs.titanbuilder.xyz/propamms/takers>
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PammStateOverrides {
+    /// The block number the overrides target.
+    #[serde(with = "alloy_serde::quantity")]
+    pub block_number: u64,
+    /// The state overrides representing the latest maker quotes, merged over all PropAMMs.
+    pub state_overrides: StateOverride,
+}
+
+/// A snapshot of PropAMM price levels, as returned by `titan_getPammPriceLevels` and streamed
+/// on `/ws/pamm_price_levels`.
+///
+/// Every snapshot is complete; a newer snapshot supersedes all previous ones.
+///
+/// <https://docs.titanbuilder.xyz/propamms/takers>
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PammPriceLevelsSnapshot {
+    /// The consensus slot the price levels target.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub slot: Option<u64>,
+    /// The block number the price levels target.
+    #[serde(alias = "block_number")]
+    pub block_number: u64,
+    /// Unix timestamp in nanoseconds at which the snapshot was emitted.
+    pub timestamp: u64,
+    /// The price levels per PropAMM.
+    pub pamms: Vec<PammPriceLevels>,
+}
+
+/// Price levels of a single PropAMM, see [`PammPriceLevelsSnapshot`].
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PammPriceLevels {
+    /// The address of the PropAMM.
+    pub pamm: Address,
+    /// The price levels per token pair.
+    pub pairs: Vec<PammPairPriceLevels>,
+}
+
+/// Price levels of a single token pair of a PropAMM, see [`PammPriceLevels`].
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PammPairPriceLevels {
+    /// The input token of the swap.
+    pub token_in: Address,
+    /// The output token of the swap.
+    pub token_out: Address,
+    /// The price levels, ordered by increasing input amount.
+    pub order_book: Vec<PammPriceLevel>,
+}
+
+/// A single price level of a PropAMM order book, see [`PammPairPriceLevels`].
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PammPriceLevel {
+    /// The input amount of the level.
+    pub amount_in: U256,
+    /// The output amount received for the input amount.
+    pub amount_out: U256,
+    /// How the level was derived.
+    pub variant: PammPriceLevelVariant,
+}
+
+/// How a [`PammPriceLevel`] was derived.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PammPriceLevelVariant {
+    /// The level was simulated in the EVM with a synthesized taker transaction.
+    #[default]
+    Simulated,
+    /// The level was linearly interpolated between simulated levels.
+    Interpolated,
+}
+
+/// A PropAMM quote as returned by `titan_getPammQuote` and `titan_getPammQuoteVenue`.
+///
+/// <https://docs.titanbuilder.xyz/propamms/takers>
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PammQuote {
+    /// The input token of the swap.
+    pub token_in: Address,
+    /// The output token of the swap.
+    pub token_out: Address,
+    /// The input amount of the swap.
+    pub amount_in: U256,
+    /// The output amount received for the input amount.
+    pub amount_out: U256,
+    /// The PropAMM the quote is for.
+    pub pamm: Address,
+    /// The router contract to route the swap through.
+    pub router: Address,
+    /// The block number the quote is valid for.
+    pub block_number: u64,
+    /// The consensus slot the quote is valid for.
+    pub slot: u64,
+    /// Unix timestamp in nanoseconds at which the quote was emitted.
+    pub timestamp: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::address;
+
+    #[test]
+    fn can_serde_pamm_quote_stream_message() {
+        let s = r#"{
+            "slot": 12345678,
+            "blockNumber": 23040121,
+            "timestamp": 1753977388000000000,
+            "0xbc60639345dfa607d73b74e88c2d54d8b8ad7cc3": {
+                "stateOverride": {
+                    "0xda7afeed01fe625cf15d187a19f94b45f00b8c5f": {
+                        "stateDiff": {
+                            "0x0000000000000000000000000000000000000000000000000000000000000001": "0x0000000000000000000000000000000000000000000000000000000000000002"
+                        }
+                    }
+                }
+            }
+        }"#;
+        let msg = serde_json::from_str::<PammQuoteStreamMessage>(s).unwrap();
+        assert_eq!(msg.slot, Some(12345678));
+        assert_eq!(msg.block_number, 23040121);
+        assert_eq!(msg.timestamp, 1753977388000000000);
+        let entry = &msg.pamms[&address!("0xbc60639345dfa607d73b74e88c2d54d8b8ad7cc3")];
+        let account =
+            &entry.state_override[&address!("0xda7afeed01fe625cf15d187a19f94b45f00b8c5f")];
+        assert_eq!(account.state_diff.as_ref().unwrap().len(), 1);
+
+        let value = serde_json::to_value(&msg).unwrap();
+        let rt = serde_json::from_value::<PammQuoteStreamMessage>(value).unwrap();
+        assert_eq!(rt, msg);
+    }
+
+    #[test]
+    fn can_deserialize_pamm_state_overrides() {
+        let s = r#"{
+            "blockNumber": "0x16f3a10",
+            "stateOverrides": {
+                "0xda7afeed01fe625cf15d187a19f94b45f00b8c5f": {
+                    "stateDiff": {
+                        "0x0000000000000000000000000000000000000000000000000000000000000001": "0x0000000000000000000000000000000000000000000000000000000000000002"
+                    }
+                }
+            }
+        }"#;
+        let overrides = serde_json::from_str::<PammStateOverrides>(s).unwrap();
+        assert_eq!(overrides.block_number, 0x16f3a10);
+        assert_eq!(overrides.state_overrides.len(), 1);
+    }
+
+    #[test]
+    fn can_deserialize_pamm_price_levels() {
+        let s = r#"{
+            "slot": 12345678,
+            "blockNumber": 23040121,
+            "timestamp": 1753977388000000000,
+            "pamms": [{
+                "pamm": "0x5979458912f80b96d30d4220af8e2e4925a33320",
+                "pairs": [{
+                    "tokenIn": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                    "tokenOut": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                    "orderBook": [
+                        {"amountIn": "0xde0b6b3a7640000", "amountOut": "0xd3c21b", "variant": "Simulated"},
+                        {"amountIn": "0x1bc16d674ec80000", "amountOut": "0x1a78436", "variant": "Interpolated"}
+                    ]
+                }]
+            }]
+        }"#;
+        let snapshot = serde_json::from_str::<PammPriceLevelsSnapshot>(s).unwrap();
+        assert_eq!(snapshot.pamms.len(), 1);
+        let pair = &snapshot.pamms[0].pairs[0];
+        assert_eq!(pair.order_book.len(), 2);
+        assert_eq!(pair.order_book[0].variant, PammPriceLevelVariant::Simulated);
+        assert_eq!(pair.order_book[1].variant, PammPriceLevelVariant::Interpolated);
+    }
+
+    #[test]
+    fn can_deserialize_pamm_quote() {
+        let s = r#"{
+            "tokenIn": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "tokenOut": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            "amountIn": "0xde0b6b3a7640000",
+            "amountOut": "0xd3c21b",
+            "pamm": "0x5979458912f80b96d30d4220af8e2e4925a33320",
+            "router": "0x4ddf368080cd7946db5b459ad591c350158175e1",
+            "blockNumber": 23040121,
+            "slot": 12345678,
+            "timestamp": 1753977388000000000
+        }"#;
+        let quote = serde_json::from_str::<PammQuote>(s).unwrap();
+        assert_eq!(quote.router, address!("0x4ddf368080cd7946db5b459ad591c350158175e1"));
+        assert_eq!(quote.amount_in, U256::from(1000000000000000000u64));
+        assert_eq!(quote.block_number, 23040121);
+    }
+}

--- a/crates/rpc-types-mev/src/stats.rs
+++ b/crates/rpc-types-mev/src/stats.rs
@@ -1,6 +1,6 @@
 use crate::{u256_numeric_string, ConsideredByBuildersAt, SealedByBuildersAt};
 
-use alloy_primitives::U256;
+use alloy_primitives::{TxHash, B256, U256};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 /// Response for `flashbots_getBundleStatsV2` represents stats for a single bundle
@@ -127,12 +127,232 @@ pub struct UserStats {
     pub last_1d_gas_simulated: U256,
 }
 
+/// Request for builder-specific `*_getBundleStats` endpoints, e.g. Titan's
+/// `titan_getBundleStats` or Bombora's `bombora_getBundleStats`.
+///
+/// Note: Quasar's `quasar_getBundleStats` expects the parameter key in snake case
+/// (`bundle_hash`), which is accepted when deserializing but not produced when serializing.
+///
+/// See also:
+/// - Titan: <https://docs.titanbuilder.xyz/bundle-tracing>
+/// - Bombora: <https://bombora.build/docs/bombora-getBundleStats>
+/// - Quasar: <https://docs.quasar.win/bundle-tracing>
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetBundleStatsRequest {
+    /// The bundle hash of the bundle as returned by `eth_sendBundle`.
+    #[serde(alias = "bundle_hash")]
+    pub bundle_hash: B256,
+}
+
+/// Response for builder-specific `*_getBundleStats` endpoints.
+///
+/// This covers the shared response format of:
+/// - Titan: `titan_getBundleStats` <https://docs.titanbuilder.xyz/bundle-tracing>
+/// - Bombora: `bombora_getBundleStats` <https://bombora.build/docs/bombora-getBundleStats>
+/// - Quasar: `quasar_getBundleStats` <https://docs.quasar.win/bundle-tracing>
+///
+/// Fields that are only reported by some builders are optional.
+///
+/// Note: this is distinct from the (deprecated) Flashbots `flashbots_getBundleStatsV2`
+/// response, see [`BundleStats`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BuilderBundleStats {
+    /// Status of the bundle.
+    pub status: BuilderBundleStatus,
+    /// The builder payment observed on the bundle's entry simulation, in wei.
+    ///
+    /// Empty or absent when the bundle failed simulation.
+    #[serde(default, with = "opt_u256_numeric_string", skip_serializing_if = "Option::is_none")]
+    pub builder_payment: Option<U256>,
+    /// The builder payment observed when the bundle was used in a build attempt, in wei.
+    ///
+    /// Populated when the bundle reached [`BuilderBundleStatus::IncludedInBlock`] or
+    /// [`BuilderBundleStatus::Submitted`]. Not reported by Quasar.
+    #[serde(default, with = "opt_u256_numeric_string", skip_serializing_if = "Option::is_none")]
+    pub builder_payment_when_included: Option<U256>,
+    /// Human readable reason when the bundle failed simulation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    /// PropAMM interaction status of the bundle. Only reported by Bombora.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pamm_status: Option<BundlePammStatus>,
+    /// Hash of the transaction that caused the simulation failure. Only reported by Quasar.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reverting_hash: Option<TxHash>,
+    /// Unix timestamp when the builder received the bundle. Only reported by Quasar.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub received_at: Option<u64>,
+    /// Unix timestamp when the bundle was simulated. Only reported by Quasar.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub simulated_at: Option<u64>,
+    /// Unix timestamp when a block containing the bundle was submitted to a relay. Only
+    /// reported by Quasar.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub submitted_at: Option<u64>,
+    /// The block number the bundle was included in. Only reported by Quasar.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub block_number: Option<u64>,
+    /// The block number the bundle targeted. Only reported by Quasar.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target_block: Option<u64>,
+    /// The bundle's `minTimestamp`. Only reported by Quasar.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub min_timestamp: Option<u64>,
+    /// The bundle's `maxTimestamp`. Only reported by Quasar.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_timestamp: Option<u64>,
+}
+
+/// Status of a bundle as reported by builder `*_getBundleStats` endpoints, see
+/// [`BuilderBundleStats`].
+///
+/// Statuses are serialized in PascalCase (e.g. `SimulationPass`) as reported by Titan and
+/// Bombora; Quasar's camelCase variants (e.g. `simulationPass`) are accepted when
+/// deserializing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum BuilderBundleStatus {
+    /// The builder has no record of the bundle.
+    #[serde(alias = "notFound")]
+    NotFound,
+    /// The bundle is pending processing.
+    #[serde(alias = "pending")]
+    Pending,
+    /// The bundle was received but arrived too late to enter the bundle pool for its target
+    /// block.
+    #[serde(alias = "received")]
+    Received,
+    /// The bundle failed validation, e.g. invalid RLP, block number, nonce or chain id.
+    #[serde(alias = "invalid")]
+    Invalid,
+    /// The bundle failed the top-of-block simulation, e.g. a non-whitelisted transaction
+    /// reverted or the builder payment was not positive.
+    #[serde(alias = "simulationFail")]
+    SimulationFail,
+    /// The bundle simulated successfully but was not selected for a block, e.g. because it
+    /// arrived too late or the builder payment was insufficient.
+    #[serde(alias = "simulationPass")]
+    SimulationPass,
+    /// The bundle was selected for a block by at least one sorting algorithm, but that block
+    /// was not submitted to a relay.
+    #[serde(alias = "includedInBlock")]
+    IncludedInBlock,
+    /// The bundle was included in at least one block that was submitted to a relay. This does
+    /// not guarantee the block won the slot.
+    #[serde(alias = "submitted")]
+    Submitted,
+}
+
+/// PropAMM interaction status of a bundle as reported by Bombora's `bombora_getBundleStats`.
+///
+/// <https://bombora.build/docs/bombora-getBundleStats>
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum BundlePammStatus {
+    /// The bundle swapped through a PropAMM pool.
+    SwappedThroughPamm,
+    /// The bundle was matched with a maker quote.
+    MatchedWithQuote,
+}
+
+/// Serde helpers for optional wei amounts encoded as numeric strings, where an empty string
+/// denotes absence.
+mod opt_u256_numeric_string {
+    use crate::u256_numeric_string;
+    use alloy_primitives::U256;
+    use serde::{de, Deserialize, Deserializer, Serializer};
+
+    pub(crate) fn deserialize<'de, D>(deserializer: D) -> Result<Option<U256>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        match Option::<serde_json::Value>::deserialize(deserializer)? {
+            None | Some(serde_json::Value::Null) => Ok(None),
+            Some(serde_json::Value::String(s)) if s.is_empty() => Ok(None),
+            Some(val) => u256_numeric_string::deserialize(val).map(Some).map_err(de::Error::custom),
+        }
+    }
+
+    pub(crate) fn serialize<S>(val: &Option<U256>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match val {
+            Some(val) => u256_numeric_string::serialize(val, serializer),
+            None => serializer.serialize_none(),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use similar_asserts::assert_eq;
 
     use crate::SealedByBuildersAt;
+
+    #[test]
+    fn can_deserialize_builder_bundle_stats() {
+        // Bombora style: <https://bombora.build/docs/bombora-getBundleStats>
+        let s = r#"{
+            "status": "IncludedInBlock",
+            "builderPayment": "13618000000000",
+            "builderPaymentWhenIncluded": "13618000000000",
+            "error": "",
+            "pammStatus": null
+        }"#;
+        let stats = serde_json::from_str::<BuilderBundleStats>(s).unwrap();
+        assert_eq!(stats.status, BuilderBundleStatus::IncludedInBlock);
+        assert_eq!(stats.builder_payment, Some(U256::from(13618000000000u64)));
+        assert_eq!(stats.builder_payment_when_included, Some(U256::from(13618000000000u64)));
+        assert!(stats.pamm_status.is_none());
+
+        // failed simulation reports an empty builder payment
+        let s = r#"{
+            "status": "SimulationFail",
+            "builderPayment": "",
+            "error": "BundleRevert. Reverting Hash: 0x1111111111111111111111111111111111111111111111111111111111111111",
+            "pammStatus": "matchedWithQuote"
+        }"#;
+        let stats = serde_json::from_str::<BuilderBundleStats>(s).unwrap();
+        assert_eq!(stats.status, BuilderBundleStatus::SimulationFail);
+        assert_eq!(stats.builder_payment, None);
+        assert_eq!(stats.pamm_status, Some(BundlePammStatus::MatchedWithQuote));
+
+        // Quasar style: <https://docs.quasar.win/bundle-tracing>
+        let s = r#"{
+            "status": "submitted",
+            "builderPayment": "12934799399930",
+            "error": null,
+            "revertingHash": null,
+            "receivedAt": 1753977388,
+            "simulatedAt": 1753977388,
+            "submittedAt": 1753977409,
+            "blockNumber": 23040121,
+            "targetBlock": 23040121,
+            "minTimestamp": null,
+            "maxTimestamp": null
+        }"#;
+        let stats = serde_json::from_str::<BuilderBundleStats>(s).unwrap();
+        assert_eq!(stats.status, BuilderBundleStatus::Submitted);
+        assert_eq!(stats.builder_payment, Some(U256::from(12934799399930u64)));
+        assert_eq!(stats.received_at, Some(1753977388));
+        assert_eq!(stats.submitted_at, Some(1753977409));
+        assert_eq!(stats.block_number, Some(23040121));
+        assert_eq!(stats.target_block, Some(23040121));
+        assert_eq!(stats.min_timestamp, None);
+    }
+
+    #[test]
+    fn can_deserialize_get_bundle_stats_request() {
+        let camel = r#"{"bundleHash": "0x1111111111111111111111111111111111111111111111111111111111111111"}"#;
+        let snake = r#"{"bundle_hash": "0x1111111111111111111111111111111111111111111111111111111111111111"}"#;
+        let a = serde_json::from_str::<GetBundleStatsRequest>(camel).unwrap();
+        let b = serde_json::from_str::<GetBundleStatsRequest>(snake).unwrap();
+        assert_eq!(a, b);
+        assert!(serde_json::to_string(&a).unwrap().contains("bundleHash"));
+    }
 
     #[test]
     fn can_serialize_deserialize_bundle_stats() {


### PR DESCRIPTION
This surveys the current block builder APIs (Titan, Quasar, Bombora, BuilderNet, Beaverbuild, rsync, Flashbots) and closes the gaps in our MEV types.

`EthSendBundle` gains the `replacementSeqNumber` field that Titan, Quasar and Bombora use for deterministic bundle replacement, plus BuilderNet's documented extensions: `replacementNonce`, `refundIdentity`, `delayedRefund`, and the v2 target pool fields (`version`, `desiredState`, `targetAddresses`, `targetSlots`). `EthSendEndOfBlockBundle` gains `replacementUuid`/`replacementSeqNumber`, which all three builders serving `eth_sendEndOfBlockBundle` support for cancel/replace, and an `extra_fields` escape hatch matching `EthSendBundle`.

Titan, Bombora and Quasar serve a builder-prefixed `*_getBundleStats` tracing endpoint whose response shape is shared across the three and unrelated to the (deprecated) `flashbots_getBundleStatsV2` we already model. The new `BuilderBundleStats` covers all three, including Bombora's `pammStatus` and Quasar's timing fields, and accepts both the PascalCase and camelCase status spellings builders emit.

The new `pamm` module types the public PropAMM taker surface that Titan, Bombora and BuilderNet have converged on: the state override stream (`/ws/pamm_quote_stream`, `titan_getPammStateOverrides`) whose messages deserialize onto `StateOverride` so they can be passed directly to `eth_call`/`eth_simulateV1`, the price level stream (`/ws/pamm_price_levels`, `titan_getPammPriceLevels`), and `titan_getPammQuote` responses. The maker side (`/ws/sendquoteupdate`) is an authenticated protobuf WebSocket protocol, so it is intentionally out of scope for these serde types.

On the provider side, `ext::mev` gains `sol!` bindings for the Flashbots priority update registry, the fixed CREATE2-deployed contract (`0xda7afeed01fe625cf15d187a19f94b45f00b8c5f`) that PropAMM maker quote updates target, together with the EIP-712 domain and a `sign_priority_update` helper that produces a `SignedUpdate` for `batchUpdateStateWithSignature`. This mirrors the existing Multicall3 precedent of shipping bindings for canonical deployments. A test pins the `UpdateState` type hash to the registry's on-chain `UPDATE_TYPEHASH`.

References:
- Titan: <https://docs.titanbuilder.xyz/api>, <https://docs.titanbuilder.xyz/propamms>
- Bombora: <https://bombora.build/docs/getting-started>
- Quasar: <https://docs.quasar.win>
- BuilderNet: <https://buildernet.org/docs/api>
- Priority update registry: <https://github.com/flashbots/priority-update-registry>
