### PR TITLE
feat(eips): support blobless sidecar encoding

### DIFF
--- a/crates/eips/src/eip4844/sidecar.rs
+++ b/crates/eips/src/eip4844/sidecar.rs
@@ -5,11 +5,11 @@ use crate::{
         kzg_to_versioned_hash, Blob, BlobAndProofV1, Bytes48, BYTES_PER_BLOB, BYTES_PER_COMMITMENT,
         BYTES_PER_PROOF,
     },
-    eip7594::{Decodable7594, Encodable7594},
+    eip7594::{BlobSidecarEncoding, Decodable7594, Encodable7594},
 };
 use alloc::{boxed::Box, vec::Vec};
 use alloy_primitives::{bytes::BufMut, B256};
-use alloy_rlp::{Decodable, Encodable, Header};
+use alloy_rlp::{Decodable, Encodable, Header, EMPTY_LIST_CODE};
 
 #[cfg(any(test, feature = "arbitrary"))]
 use crate::eip4844::MAX_BLOBS_PER_BLOCK_DENCUN;
@@ -511,6 +511,23 @@ impl Encodable7594 for BlobTransactionSidecar {
 
     fn encode_7594(&self, out: &mut dyn BufMut) {
         self.rlp_encode_fields(out);
+    }
+
+    fn encode_7594_len_with(&self, encoding: BlobSidecarEncoding) -> usize {
+        let blobs_len = match encoding {
+            BlobSidecarEncoding::WithBlobs => self.blobs.length(),
+            BlobSidecarEncoding::WithoutBlobs => 1,
+        };
+        blobs_len + self.commitments.length() + self.proofs.length()
+    }
+
+    fn encode_7594_with(&self, encoding: BlobSidecarEncoding, out: &mut dyn BufMut) {
+        match encoding {
+            BlobSidecarEncoding::WithBlobs => self.blobs.encode(out),
+            BlobSidecarEncoding::WithoutBlobs => out.put_u8(EMPTY_LIST_CODE),
+        }
+        self.commitments.encode(out);
+        self.proofs.encode(out);
     }
 }
 

--- a/crates/eips/src/eip7594/rlp.rs
+++ b/crates/eips/src/eip7594/rlp.rs
@@ -1,6 +1,21 @@
 use alloc::vec::Vec;
 use alloy_rlp::BufMut;
 
+/// Selects the blob payload representation used when encoding a blob transaction sidecar.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub enum BlobSidecarEncoding {
+    /// Encode the complete sidecar, including its blob payloads.
+    #[default]
+    WithBlobs,
+    /// Encode an empty blob list while retaining commitments and proofs.
+    ///
+    /// This is the sidecar representation used by eth/72 `PooledTransactions` responses as
+    /// specified by [EIP-8070].
+    ///
+    /// [EIP-8070]: https://eips.ethereum.org/EIPS/eip-8070
+    WithoutBlobs,
+}
+
 /// A helper trait for encoding [EIP-7594](https://eips.ethereum.org/EIPS/eip-7594) sidecars.
 pub trait Encodable7594 {
     /// The length of the 7594 encoded envelope. This is the length of the wrapper
@@ -15,6 +30,22 @@ pub trait Encodable7594 {
     ///
     /// [EIP-7594]: https://eips.ethereum.org/EIPS/eip-7594
     fn encode_7594(&self, out: &mut dyn BufMut);
+
+    /// Returns the length of the EIP-7594 encoding for the selected blob representation.
+    ///
+    /// The default delegates to [`Self::encode_7594_len`] because encodings without blob payloads
+    /// only differ for sidecar types that contain blobs.
+    fn encode_7594_len_with(&self, _encoding: BlobSidecarEncoding) -> usize {
+        self.encode_7594_len()
+    }
+
+    /// Encodes the sidecar using the selected blob representation.
+    ///
+    /// The default delegates to [`Self::encode_7594`] because encodings without blob payloads only
+    /// differ for sidecar types that contain blobs.
+    fn encode_7594_with(&self, _encoding: BlobSidecarEncoding, out: &mut dyn BufMut) {
+        self.encode_7594(out);
+    }
 
     /// Encode the sidecar according to [EIP-7594] rules. First a 1-byte
     /// wrapper version (if any), then the body of the sidecar.

--- a/crates/eips/src/eip7594/sidecar.rs
+++ b/crates/eips/src/eip7594/sidecar.rs
@@ -7,9 +7,9 @@ use crate::{
 };
 use alloc::{boxed::Box, vec::Vec};
 use alloy_primitives::{B128, B256};
-use alloy_rlp::{BufMut, Decodable, Encodable, Header};
+use alloy_rlp::{BufMut, Decodable, Encodable, Header, EMPTY_LIST_CODE};
 
-use super::{Decodable7594, Encodable7594};
+use super::{BlobSidecarEncoding, Decodable7594, Encodable7594};
 use crate::eip4844::VersionedHashIter;
 #[cfg(feature = "kzg")]
 use crate::eip4844::{AsAlloy, AsCkzg, BlobTransactionValidationError};
@@ -417,6 +417,20 @@ impl Encodable7594 for BlobTransactionSidecarVariant {
 
     fn encode_7594(&self, out: &mut dyn BufMut) {
         self.rlp_encode_fields(out);
+    }
+
+    fn encode_7594_len_with(&self, encoding: BlobSidecarEncoding) -> usize {
+        match self {
+            Self::Eip4844(sidecar) => sidecar.encode_7594_len_with(encoding),
+            Self::Eip7594(sidecar) => sidecar.encode_7594_len_with(encoding),
+        }
+    }
+
+    fn encode_7594_with(&self, encoding: BlobSidecarEncoding, out: &mut dyn BufMut) {
+        match self {
+            Self::Eip4844(sidecar) => sidecar.encode_7594_with(encoding, out),
+            Self::Eip7594(sidecar) => sidecar.encode_7594_with(encoding, out),
+        }
     }
 }
 
@@ -1283,6 +1297,24 @@ impl Encodable7594 for BlobTransactionSidecarEip7594 {
     fn encode_7594(&self, out: &mut dyn BufMut) {
         self.rlp_encode_fields(out);
     }
+
+    fn encode_7594_len_with(&self, encoding: BlobSidecarEncoding) -> usize {
+        let blobs_len = match encoding {
+            BlobSidecarEncoding::WithBlobs => self.blobs.length(),
+            BlobSidecarEncoding::WithoutBlobs => 1,
+        };
+        1 + blobs_len + self.commitments.length() + self.cell_proofs.length()
+    }
+
+    fn encode_7594_with(&self, encoding: BlobSidecarEncoding, out: &mut dyn BufMut) {
+        out.put_u8(EIP_7594_WRAPPER_VERSION);
+        match encoding {
+            BlobSidecarEncoding::WithBlobs => self.blobs.encode(out),
+            BlobSidecarEncoding::WithoutBlobs => out.put_u8(EMPTY_LIST_CODE),
+        }
+        self.commitments.encode(out);
+        self.cell_proofs.encode(out);
+    }
 }
 
 impl Decodable7594 for BlobTransactionSidecarEip7594 {
@@ -1619,6 +1651,54 @@ mod tests {
         encoded.clear();
         sidecar_variant_7594.encode_7594(&mut encoded);
         assert_eq!(sidecar_variant_7594, Decodable7594::decode_7594(&mut &encoded[..]).unwrap());
+    }
+
+    #[test]
+    fn rlp_7594_encoding_without_blobs_preserves_metadata() {
+        fn encode_without_blobs(sidecar: &impl Encodable7594) -> Vec<u8> {
+            let encoding = BlobSidecarEncoding::WithoutBlobs;
+            let mut encoded = Vec::with_capacity(sidecar.encode_7594_len_with(encoding));
+            sidecar.encode_7594_with(encoding, &mut encoded);
+            assert_eq!(encoded.len(), sidecar.encode_7594_len_with(encoding));
+            encoded
+        }
+
+        let sidecar_4844 = BlobTransactionSidecar::new(
+            vec![Blob::repeat_byte(0x01)],
+            vec![Bytes48::repeat_byte(0x02)],
+            vec![Bytes48::repeat_byte(0x03)],
+        );
+        let encoded_4844 = encode_without_blobs(&sidecar_4844);
+        let decoded_4844 = BlobTransactionSidecar::decode_7594(&mut &encoded_4844[..]).unwrap();
+        assert!(decoded_4844.blobs.is_empty());
+        assert_eq!(decoded_4844.commitments, sidecar_4844.commitments);
+        assert_eq!(decoded_4844.proofs, sidecar_4844.proofs);
+
+        let variant_4844 = BlobTransactionSidecarVariant::Eip4844(sidecar_4844);
+        assert_eq!(encode_without_blobs(&variant_4844), encoded_4844);
+
+        let sidecar_7594 = BlobTransactionSidecarEip7594::new(
+            vec![Blob::repeat_byte(0x04)],
+            vec![Bytes48::repeat_byte(0x05)],
+            vec![Bytes48::repeat_byte(0x06); CELLS_PER_EXT_BLOB],
+        );
+        let encoded_7594 = encode_without_blobs(&sidecar_7594);
+        let decoded_7594 =
+            BlobTransactionSidecarEip7594::decode_7594(&mut &encoded_7594[..]).unwrap();
+        assert!(decoded_7594.blobs.is_empty());
+        assert_eq!(decoded_7594.commitments, sidecar_7594.commitments);
+        assert_eq!(decoded_7594.cell_proofs, sidecar_7594.cell_proofs);
+
+        let variant_7594 = BlobTransactionSidecarVariant::Eip7594(sidecar_7594.clone());
+        assert_eq!(encode_without_blobs(&variant_7594), encoded_7594);
+
+        let mut with_blobs = Vec::new();
+        sidecar_7594.encode_7594_with(BlobSidecarEncoding::WithBlobs, &mut with_blobs);
+        assert_eq!(with_blobs, sidecar_7594.encoded_7594());
+        assert_eq!(
+            sidecar_7594.encode_7594_len_with(BlobSidecarEncoding::WithBlobs),
+            sidecar_7594.encode_7594_len()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add a `BlobSidecarEncoding` enum to select sidecar encodings with or without blob payloads
- extend `Encodable7594` with additive encoding and exact-length methods that accept the enum
- support blob-elided encoding for EIP-4844, EIP-7594, and variant sidecars while retaining commitments and proofs

## Motivation

eth/72 `PooledTransactions` responses encode an empty blob list while preserving sidecar metadata. [reth#26574](https://github.com/paradigmxyz/reth/pull/26574) currently implements that wire representation with reth-local borrowed wrappers. Exposing the selection in alloy avoids duplicating sidecar encoding logic, does not require mutating the stored sidecar, and keeps response size accounting aligned with the emitted bytes.