### PR TITLE
docs(rpc-types-eth): fix incorrect doc links in Filter matching methods

### DIFF
--- a/crates/rpc-types-eth/src/filter.rs
+++ b/crates/rpc-types-eth/src/filter.rs
@@ -760,9 +760,9 @@ impl Filter {
     /// This checks [`Log<LogData>`], the raw, primitive type carrying un-parsed
     /// [`LogData`].
     ///
-    /// - For un-parsed RPC logs [`crate::Log<LogData>`], see [`Self::rpc_matches`] and
-    ///   [`Self::rpc_matches_parsed`].
-    /// - For parsed [`Log`]s (e.g. those returned by a contract), see [`Self::matches_parsed`].
+    /// - For un-parsed RPC logs [`crate::Log<LogData>`] see [`Self::rpc_matches`].
+    /// - For parsed [`Log<T>`]s (e.g. those returned by a contract), see [`Self::matches_parsed`].
+    /// - For parsed RPC [`crate::Log<T>`]s see [`Self::rpc_matches_parsed`].
     pub fn matches(&self, log: &Log) -> bool {
         if !self.matches_address(log.address) {
             return false;
@@ -777,9 +777,9 @@ impl Filter {
     /// This function checks [`crate::Log<LogData>`], the RPC type carrying
     /// un-parsed [`LogData`].
     ///
+    /// - For un-parsed [`Log<LogData>`] see [`Self::matches`].
     /// - For parsed [`Log<T>`]s (e.g. those returned by a contract), see [`Self::matches_parsed`].
-    /// - For parsed [`crate::Log<T>`]s (e.g. those returned by a contract), see
-    ///   [`Self::rpc_matches`].
+    /// - For parsed RPC [`crate::Log<T>`]s see [`Self::rpc_matches_parsed`].
     pub fn rpc_matches(&self, log: &crate::Log) -> bool {
         self.matches_log_block(log) && self.matches(&log.inner)
     }


### PR DESCRIPTION
## Motivation

The `Filter::rpc_matches` documentation links back to itself for parsed RPC logs instead of linking to `rpc_matches_parsed`.

The `Filter::matches` documentation incorrectly includes `rpc_matches_parsed` among the methods for un-parsed RPC logs.

## Solution

Update and complete both method lists to match `matches_parsed` and `rpc_matches_parsed`.

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
