### PR TITLE
fix(consensus): reject 0x00-tagged legacy transactions in typed_decode

### DIFF
--- a/crates/consensus/src/signed.rs
+++ b/crates/consensus/src/signed.rs
@@ -543,6 +543,10 @@ where
     T: RlpEcdsaDecodableTx + Typed2718 + Send + Sync,
 {
     fn typed_decode(ty: u8, buf: &mut &[u8]) -> Eip2718Result<Self> {
+        if ty == 0 {
+            return Err(Eip2718Error::UnexpectedType(0));
+        }
+
         let decoded = T::rlp_decode_signed(buf)?;
 
         if decoded.ty() != ty {

--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -14,11 +14,9 @@ use alloy_primitives::{Bytes, Signature, B256};
 ///
 /// # Note:
 ///
-/// This enum distinguishes between tagged and untagged legacy transactions, as
-/// the in-protocol merkle tree may commit to EITHER 0-prefixed or raw.
-/// Therefore we must ensure that encoding returns the precise byte-array that
-/// was decoded, preserving the presence or absence of the `TransactionType`
-/// flag.
+/// Represents an untagged legacy transaction, or a typed EIP-2718 variant. Binary decoding
+/// rejects a literal `0x00` type prefix; legacy transactions use the untagged fallback
+/// encoding.
 ///
 /// [EIP-2718]: https://eips.ethereum.org/EIPS/eip-2718
 pub type TxEnvelope = EthereumTxEnvelope<TxEip4844Variant>;
@@ -468,11 +466,9 @@ impl TryFrom<EthereumTxEnvelope<TxEip4844Variant<alloy_eips::eip4844::BlobTransa
 ///
 /// # Note:
 ///
-/// This enum distinguishes between tagged and untagged legacy transactions, as
-/// the in-protocol merkle tree may commit to EITHER 0-prefixed or raw.
-/// Therefore we must ensure that encoding returns the precise byte-array that
-/// was decoded, preserving the presence or absence of the `TransactionType`
-/// flag.
+/// Represents an untagged legacy transaction, or a typed EIP-2718 variant. Binary decoding
+/// rejects a literal `0x00` type prefix; legacy transactions use the untagged fallback
+/// encoding.
 ///
 /// [EIP-2718]: https://eips.ethereum.org/EIPS/eip-2718
 #[derive(Clone, Debug, TransactionEnvelope)]
@@ -1541,6 +1537,36 @@ mod tests {
             TxEnvelope::decode_2718_exact(&eip1559_encoded).unwrap(),
             eip1559_envelope,
             "a genuine type-tagged EIP-1559 transaction must still decode correctly"
+        );
+    }
+
+    #[test]
+    fn tagged_legacy_type_byte_is_rejected() {
+        // Per EIP-2718, `0x00` is not an assigned `TransactionType` -- legacy transactions are
+        // the untagged form. A literal `0x00` type-prefix byte must be rejected at decode, not
+        // accepted and silently re-encoded untagged (which would fail to round-trip).
+        let legacy = TxLegacy {
+            chain_id: None,
+            nonce: 0,
+            gas_limit: 21_000,
+            gas_price: 10,
+            to: Address::repeat_byte(0x11).into(),
+            value: U256::ZERO,
+            ..Default::default()
+        }
+        .into_signed(Signature::test_signature());
+        let legacy_envelope: TxEnvelope = legacy.into();
+        let untagged = legacy_envelope.encoded_2718();
+
+        // Sanity: the untagged bytes still decode fine and round-trip.
+        assert_eq!(TxEnvelope::decode_2718_exact(&untagged).unwrap(), legacy_envelope);
+
+        let mut tagged = vec![0x00];
+        tagged.extend_from_slice(&untagged);
+        assert!(
+            TxEnvelope::decode_2718_exact(&tagged).is_err(),
+            "a literal 0x00 type-prefix byte must be rejected, not accepted and re-encoded \
+             untagged"
         );
     }
 

--- a/crates/consensus/src/transaction/mod.rs
+++ b/crates/consensus/src/transaction/mod.rs
@@ -699,4 +699,30 @@ mod fallback_decode_flatten_tests {
             other => panic!("expected Ethereum(Legacy(..)), got {other:?}"),
         }
     }
+
+    #[test]
+    fn flattened_variant_rejects_tagged_legacy_type_byte() {
+        // The tagged counterpart of the test above: a literal `0x00` type-prefix byte must be
+        // rejected through the flattened variant's `typed_decode` dispatch too, not just through
+        // the top-level envelope's.
+        let legacy = TxLegacy {
+            chain_id: None,
+            nonce: 2,
+            gas_limit: 1_000_000,
+            gas_price: 10_000_000_000,
+            to: Address::left_padding_from(&[6]).into(),
+            value: U256::from(7_u64),
+            ..Default::default()
+        }
+        .into_signed(Signature::test_signature().with_parity(true));
+
+        let ethereum_envelope: TxEnvelope = legacy.into();
+        let mut tagged = vec![0x00];
+        tagged.extend_from_slice(&ethereum_envelope.encoded_2718());
+
+        assert!(
+            MyEnvelope::decode_2718_exact(&tagged).is_err(),
+            "a literal 0x00 type-prefix byte must be rejected through the flattened variant"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Per EIP-2718, `0x00` is not an assigned `TransactionType` — legacy transactions are the untagged form. `TxType::try_from(0)` returns `TxType::Legacy` (since `Legacy` is declared `#[envelope(ty = 0)]`), so the macro-generated `Decodable2718::typed_decode` accepted an EIP-2718 envelope whose type byte is a literal `0x00` and decoded the body as a legacy transaction — the same as `0x05`/`0x7f` should be, but currently aren't, rejected.

Because `EthereumTxEnvelope::Legacy` has no way to record that a tag byte was present on the wire, `encode_2718` always re-emits the untagged form, so a `0x00`-tagged input does not round-trip through `decode_2718`/`encode_2718`. geth, erigon, nethermind, and besu all reject the type byte at decode.

- Adds a guard to `Signed<T>::typed_decode` (`crates/consensus/src/signed.rs`) rejecting `ty == 0`, mirroring the guard already present in `fallback_decode` (added in #4090 for the mirror-case bug: untagged legacy incorrectly accepting a non-legacy RLP list). This fixes the issue for every envelope built via `#[derive(TransactionEnvelope)]`, matching the existing hand-written `ReceiptEnvelope::typed_decode`, which already rejects an explicit `0x00` type byte the same way.
- Updates the (previously inaccurate) doc comment on `EthereumTxEnvelope` to describe the corrected behavior.
- Adds regression tests: a top-level tagged/untagged round-trip test in `crates/consensus/src/transaction/envelope.rs`, and a flatten-composition test in `crates/consensus/src/transaction/mod.rs` mirroring the existing `flattened_variant_still_decodes_untagged_legacy` coverage from #4091.

Fixes #4165

## Test plan

- [x] `cargo test -p alloy-consensus --all-features` — 131 passed (0 failed), 22 doctests passed
- [x] `cargo test -p alloy-eips --all-features` — all passed
- [x] `cargo test -p alloy-network -p alloy-network-primitives -p alloy-consensus-any -p alloy-rpc-types -p alloy-rpc-types-eth --all-features` — all passed
- [x] `cargo clippy -p alloy-consensus --all-features -- -D warnings` — clean
- [x] `cargo fmt --check -p alloy-consensus` — clean
- [x] Verified the issue's repro script directly: `0x00`, `0x05`, and `0x7f`-tagged legacy transactions are now all consistently rejected with `UnexpectedType`, while genuinely untagged legacy transactions still decode and round-trip correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)