### PR TITLE
fix(consensus): reject 0x00 type byte in EIP-2718 typed decoding

### DIFF
--- a/crates/consensus/src/signed.rs
+++ b/crates/consensus/src/signed.rs
@@ -543,6 +543,10 @@ where
     T: RlpEcdsaDecodableTx + Typed2718 + Send + Sync,
 {
     fn typed_decode(ty: u8, buf: &mut &[u8]) -> Eip2718Result<Self> {
+        if ty == 0 {
+            return Err(Eip2718Error::UnexpectedType(0));
+        }
+
         let decoded = T::rlp_decode_signed(buf)?;
 
         if decoded.ty() != ty {

--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -1085,6 +1085,33 @@ mod tests {
     }
 
     #[test]
+    fn test_decode_2718_rejects_tagged_0x00_legacy() {
+        use alloy_eips::eip2718::Decodable2718;
+
+        let tx = TxLegacy {
+            chain_id: None,
+            nonce: 0,
+            gas_price: 10,
+            gas_limit: 21_000,
+            to: TxKind::Call([0x11; 20].into()),
+            value: U256::ZERO,
+            input: Default::default(),
+        };
+        let sig = Signature::new(U256::from(1), U256::from(2), false);
+        let untagged = tx.into_signed(sig).encoded_2718();
+
+        let mut tagged = vec![0x00u8];
+        tagged.extend_from_slice(&untagged);
+
+        // Untagged legacy must decode successfully
+        assert!(TxEnvelope::decode_2718_exact(&untagged).is_ok());
+
+        // Tagged 0x00 legacy must be rejected per EIP-2718
+        let res = TxEnvelope::decode_2718_exact(&tagged);
+        assert!(res.is_err(), "0x00-tagged legacy should be rejected, got: {res:?}");
+    }
+
+    #[test]
     #[cfg(feature = "k256")]
     // Test vector from https://etherscan.io/tx/0xce4dc6d7a7549a98ee3b071b67e970879ff51b5b95d1c340bacd80fa1e1aab31
     fn test_decode_live_1559_tx() {

--- a/crates/consensus/src/transaction/typed.rs
+++ b/crates/consensus/src/transaction/typed.rs
@@ -141,7 +141,6 @@ impl<Eip4844: RlpEcdsaDecodableTx> EthereumTypedTransaction<Eip4844> {
 
         let tx_type = buf.get_u8();
         match tx_type {
-            0x00 => Ok(Self::Legacy(TxLegacy::decode(buf)?)),
             0x01 => Ok(Self::Eip2930(TxEip2930::decode(buf)?)),
             0x02 => Ok(Self::Eip1559(TxEip1559::decode(buf)?)),
             0x03 => Ok(Self::Eip4844(Eip4844::rlp_decode(buf)?)),

--- a/crates/tx-macros/src/expand.rs
+++ b/crates/tx-macros/src/expand.rs
@@ -580,6 +580,9 @@ impl Expander {
                 #(#variant_types: #alloy_eips::Decodable2718),*
             {
                 fn typed_decode(ty: u8, buf: &mut &[u8]) -> #alloy_eips::eip2718::Eip2718Result<Self> {
+                    if ty == 0 {
+                        return Err(#alloy_eips::eip2718::Eip2718Error::UnexpectedType(0));
+                    }
                     match ty.try_into().map_err(|_| #alloy_rlp::Error::Custom("unexpected tx type"))? {
                         #(#typed_decode_arms,)*
                     }


### PR DESCRIPTION
### Problem
Per EIP-2718, legacy transactions are strictly untagged RLP lists and `0x00` is not an assigned `TransactionType`. Previously, `EthereumTypedTransaction::decode_unsigned` and macro-derived `Decodable2718::typed_decode` accepted `0x00`-prefixed envelopes, decoding them as legacy transactions. When re-encoded via `encode_2718`, the untagged format was emitted, breaking round-trip serialization integrity and causing divergence during differential fuzzing (#4165).

### Solution
- Explicitly reject `ty == 0` in macro-generated `Decodable2718::typed_decode` and `Signed<T>::typed_decode` so that `0x00` cannot be decoded as a typed envelope.
- Removed the `0x00` match arm from `EthereumTypedTransaction::decode_unsigned` so `0x00` falls through to `Err(Eip2718Error::UnexpectedType(0x00))`.
- Added unit test `test_decode_2718_rejects_tagged_0x00_legacy` in `crates/consensus/src/transaction/envelope.rs`.

Fixes #4165