### PR TITLE
feat(network-primitives): add ReceiptResponseMut

### DIFF
--- a/crates/network-primitives/src/lib.rs
+++ b/crates/network-primitives/src/lib.rs
@@ -11,7 +11,8 @@ extern crate alloc;
 
 mod traits;
 pub use traits::{
-    BlockResponse, HeaderResponse, ReceiptResponse, TransactionFailedError, TransactionResponse,
+    BlockResponse, HeaderResponse, ReceiptResponse, ReceiptResponseMut, TransactionFailedError,
+    TransactionResponse,
 };
 
 mod block;

--- a/crates/network-primitives/src/traits.rs
+++ b/crates/network-primitives/src/traits.rs
@@ -107,6 +107,25 @@ pub trait ReceiptResponse {
     }
 }
 
+/// Mutable access to the fields of a [`ReceiptResponse`].
+///
+/// This is a separate trait rather than additional methods on [`ReceiptResponse`] because that
+/// trait is implemented outside of alloy for network-specific receipt types, and adding required
+/// methods to it would be a breaking change for every external implementor. Implementing this
+/// trait is opt-in and can be done independently.
+///
+/// The primary use case is patching a receipt whose reported `contractAddress` is absent because
+/// the deployment happened through a factory, for example a CREATE2 deployment: the node reports
+/// no contract address, but the caller knows the deployed address and needs to write it back.
+pub trait ReceiptResponseMut: ReceiptResponse {
+    /// Sets the address of the created contract, or `None` if the transaction was not a
+    /// deployment.
+    ///
+    /// This takes an [`Option`] to mirror [`ReceiptResponse::contract_address`], so that the
+    /// field can also be cleared.
+    fn set_contract_address(&mut self, contract_address: Option<Address>);
+}
+
 /// Transaction JSON-RPC response. Aggregates transaction data with its block and signer context.
 ///
 /// The optional fee accessors split fixed-price and dynamic-fee consensus caps by transaction type
@@ -300,6 +319,12 @@ impl<T: ReceiptResponse> ReceiptResponse for WithOtherFields<T> {
 
     fn state_root(&self) -> Option<B256> {
         self.inner.state_root()
+    }
+}
+
+impl<T: ReceiptResponseMut> ReceiptResponseMut for WithOtherFields<T> {
+    fn set_contract_address(&mut self, contract_address: Option<Address>) {
+        self.inner.set_contract_address(contract_address);
     }
 }
 

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -33,7 +33,7 @@ pub use any::{
 pub use alloy_eips::eip2718;
 use alloy_eips::Typed2718;
 pub use alloy_network_primitives::{
-    self as primitives, BlockResponse, ReceiptResponse, TransactionResponse,
+    self as primitives, BlockResponse, ReceiptResponse, ReceiptResponseMut, TransactionResponse,
 };
 
 /// Captures type info for network-specific RPC requests/responses.

--- a/crates/rpc-types-any/src/transaction/receipt.rs
+++ b/crates/rpc-types-any/src/transaction/receipt.rs
@@ -1,5 +1,5 @@
 use alloy_consensus_any::AnyReceiptEnvelope;
-use alloy_network_primitives::ReceiptResponse;
+use alloy_network_primitives::{ReceiptResponse, ReceiptResponseMut};
 use alloy_primitives::{Address, BlockHash, TxHash, B256};
 use alloy_rpc_types_eth::{Log, TransactionReceipt};
 use alloy_serde::{OtherFields, WithOtherFields};
@@ -269,6 +269,12 @@ impl ReceiptResponse for AnyTransactionReceipt {
 
     fn state_root(&self) -> Option<B256> {
         self.0.inner.state_root()
+    }
+}
+
+impl ReceiptResponseMut for AnyTransactionReceipt {
+    fn set_contract_address(&mut self, contract_address: Option<Address>) {
+        self.0.inner.contract_address = contract_address;
     }
 }
 

--- a/crates/rpc-types-eth/src/transaction/receipt.rs
+++ b/crates/rpc-types-eth/src/transaction/receipt.rs
@@ -1,6 +1,6 @@
 use crate::Log;
 use alloy_consensus::{ReceiptEnvelope, TxReceipt, TxType};
-use alloy_network_primitives::ReceiptResponse;
+use alloy_network_primitives::{ReceiptResponse, ReceiptResponseMut};
 use alloy_primitives::{Address, BlockHash, TxHash, B256};
 use alloy_sol_types::SolEvent;
 
@@ -312,6 +312,12 @@ impl<T: TxReceipt<Log = Log>> ReceiptResponse for TransactionReceipt<T> {
     }
 }
 
+impl<T: TxReceipt<Log = Log>> ReceiptResponseMut for TransactionReceipt<T> {
+    fn set_contract_address(&mut self, contract_address: Option<Address>) {
+        self.contract_address = contract_address;
+    }
+}
+
 impl From<TransactionReceipt> for TransactionReceipt<ReceiptEnvelope<alloy_primitives::Log>> {
     fn from(value: TransactionReceipt) -> Self {
         value.into_primitives_receipt()
@@ -327,6 +333,60 @@ mod test {
     use arbitrary::Arbitrary;
     use rand::Rng;
     use similar_asserts::assert_eq;
+
+    /// Patches a receipt through the [`ReceiptResponseMut`] bound, so the test fails to compile
+    /// if the trait is unusable in generic code.
+    fn patch_contract_address<R: ReceiptResponseMut>(
+        receipt: &mut R,
+        contract_address: Option<Address>,
+    ) -> Option<Address> {
+        receipt.set_contract_address(contract_address);
+        // reachable through the `ReceiptResponse` supertrait
+        receipt.contract_address()
+    }
+
+    #[test]
+    fn set_contract_address_through_trait() {
+        // A CREATE2 deployment through a factory: the node reports no contract address, but the
+        // caller knows the deployed address.
+        let mut receipt = TransactionReceipt {
+            inner: ReceiptEnvelope::Eip1559(ReceiptWithBloom {
+                receipt: Receipt {
+                    status: Eip658Value::Eip658(true),
+                    cumulative_gas_used: 0,
+                    logs: Vec::new(),
+                },
+                logs_bloom: Bloom::ZERO,
+            }),
+            transaction_hash: B256::ZERO,
+            transaction_index: Some(0),
+            block_hash: None,
+            block_number: None,
+            gas_used: 0,
+            effective_gas_price: 0,
+            blob_gas_used: None,
+            blob_gas_price: None,
+            from: Address::ZERO,
+            to: None,
+            contract_address: None,
+        };
+        assert_eq!(receipt.contract_address(), None);
+
+        let deployed = address!("d937e6195ddf60b91de26a27c59492bbb48690fa");
+        assert_eq!(patch_contract_address(&mut receipt, Some(deployed)), Some(deployed));
+        assert_eq!(receipt.contract_address, Some(deployed));
+
+        assert_eq!(patch_contract_address(&mut receipt, None), None);
+        assert_eq!(receipt.contract_address, None);
+
+        // the `WithOtherFields` forwarding impl
+        #[cfg(feature = "serde")]
+        {
+            let mut receipt = alloy_serde::WithOtherFields::new(receipt);
+            assert_eq!(patch_contract_address(&mut receipt, Some(deployed)), Some(deployed));
+            assert_eq!(receipt.inner.contract_address, Some(deployed));
+        }
+    }
 
     #[test]
     fn transaction_receipt_arbitrary() {


### PR DESCRIPTION
Deploying a contract through a CREATE2 factory leaves the receipt with a null `contractAddress`: the factory created the contract, not the transaction, so the node has nothing to report there. The caller knows the real address, but `ReceiptResponse` is getter-only, so there is no way to write it back through the trait and generic code over `N: Network` cannot patch the receipt at all before handing it on to something like contract verification.

`ReceiptResponseMut` fills that gap with a single method, `set_contract_address`. It is deliberately a separate trait rather than extra methods on `ReceiptResponse`, because `ReceiptResponse` is implemented outside of alloy for network-specific receipt types and adding a required method to it would break every external implementor. As a separate opt-in trait it costs downstreams nothing and can grow later if other fields turn out to have real callers. It does take `ReceiptResponse` as a supertrait, since anything worth mutating already has a read side and callers almost always want both — the test here reads the patched value straight back through the supertrait bound.

The setter takes `Option<Address>` rather than a bare `Address` to mirror the `contract_address` getter, which also lets callers clear the field; the CREATE2 case only ever passes `Some`.

Foundry is the concrete motivation. It currently carries its own [`FoundryReceiptResponse`](https://github.com/foundry-rs/foundry/blob/master/crates/common/src/transactions/receipt.rs) with three near-identical impls, one per receipt type it supports, whose bodies are each a single field assignment, purely because this setter does not exist upstream. That trait and its impls can be dropped once this is released.

Implemented for `TransactionReceipt<T>`, `AnyTransactionReceipt` — whose inner receipt is reachable mutably through its public `WithOtherFields` field, so the impl is a plain assignment — and forwarded through the existing `WithOtherFields<T>` blanket impl. The trait is re-exported from `alloy-network` alongside `ReceiptResponse`, and stays within the crate's `no_std` constraints.

This was written with AI assistance.
