### PR TITLE
feat(serde): lenient JSON-RPC param deserializers

### DIFF
--- a/crates/provider/src/layers/cache.rs
+++ b/crates/provider/src/layers/cache.rs
@@ -673,10 +673,12 @@ mod tests {
                 *provider.send_transaction(req).await.expect("failed to send tx").tx_hash();
 
             let tx = provider.get_transaction_by_hash(tx_hash).await.unwrap(); // Received from RPC.
-            let tx2 = provider.get_transaction_by_hash(tx_hash).await.unwrap(); // Received from cache.
+            let tx2 = provider.get_transaction_by_hash(tx_hash).await.unwrap(); // Received from
+                                                                                // cache.
             assert_eq!(tx, tx2);
 
-            let receipt = provider.get_transaction_receipt(tx_hash).await.unwrap(); // Received from RPC.
+            let receipt = provider.get_transaction_receipt(tx_hash).await.unwrap(); // Received from
+                                                                                    // RPC.
             let receipt2 = provider.get_transaction_receipt(tx_hash).await.unwrap(); // Received from cache.
 
             assert_eq!(receipt, receipt2);

--- a/crates/serde/src/json_rpc.rs
+++ b/crates/serde/src/json_rpc.rs
@@ -35,7 +35,7 @@ use serde::Deserializer;
 /// # use serde::Deserialize;
 /// #[derive(Deserialize)]
 /// struct Params {
-///     #[serde(deserialize_with = "alloy_serde::lenient::deserialize")]
+///     #[serde(deserialize_with = "alloy_serde::json_rpc::deserialize")]
 ///     value: U256,
 /// }
 ///
@@ -53,7 +53,7 @@ where
 
 /// Serde functions for leniently deserializing optional numbers.
 ///
-/// See [`lenient`](crate::lenient) for more information.
+/// See [`json_rpc`](crate::json_rpc) for more information.
 pub mod opt {
     use super::private::{Lenient, LenientNumber};
     use serde::{Deserialize, Deserializer};
@@ -65,7 +65,7 @@ pub mod opt {
     /// # use serde::Deserialize;
     /// #[derive(Deserialize)]
     /// struct Params {
-    ///     #[serde(default, deserialize_with = "alloy_serde::lenient::opt::deserialize")]
+    ///     #[serde(default, deserialize_with = "alloy_serde::json_rpc::opt::deserialize")]
     ///     value: Option<u64>,
     /// }
     ///
@@ -88,7 +88,7 @@ pub mod opt {
 /// Serde functions for leniently deserializing a single number that may be wrapped in a
 /// one-element sequence, which is the JSON-RPC positional parameter shape.
 ///
-/// See [`lenient`](crate::lenient) for more information.
+/// See [`json_rpc`](crate::json_rpc) for more information.
 pub mod seq {
     use super::private::{LenientNumber, ValueOrSeq};
     use serde::Deserializer;
@@ -101,7 +101,7 @@ pub mod seq {
     /// ```
     /// # use serde::Deserialize;
     /// #[derive(Deserialize)]
-    /// struct Params(#[serde(deserialize_with = "alloy_serde::lenient::seq::deserialize")] u64);
+    /// struct Params(#[serde(deserialize_with = "alloy_serde::json_rpc::seq::deserialize")] u64);
     ///
     /// for raw in ["100", r#""0x64""#, "[100]", r#"["0x64"]"#] {
     ///     assert_eq!(serde_json::from_str::<Params>(raw).unwrap().0, 100);
@@ -121,7 +121,7 @@ pub mod seq {
     /// Serde functions for leniently deserializing an optional single number that may be wrapped
     /// in a one-element sequence.
     ///
-    /// See [`lenient`](crate::lenient) for more information.
+    /// See [`json_rpc`](crate::json_rpc) for more information.
     pub mod opt {
         use super::super::private::{LenientNumber, OptionalValueOrSeq};
         use serde::Deserializer;
@@ -136,7 +136,7 @@ pub mod seq {
         /// # use serde::Deserialize;
         /// #[derive(Deserialize)]
         /// struct Params(
-        ///     #[serde(default, deserialize_with = "alloy_serde::lenient::seq::opt::deserialize")]
+        ///     #[serde(default, deserialize_with = "alloy_serde::json_rpc::seq::opt::deserialize")]
         ///     Option<u64>,
         /// );
         ///
@@ -158,7 +158,7 @@ pub mod seq {
     }
 }
 
-/// Private implementation details of the [`lenient`](self) module.
+/// Private implementation details of the [`json_rpc`](self) module.
 #[expect(unnameable_types)]
 mod private {
     use alloy_primitives::{Uint, U128, U16, U32, U64, U8};

--- a/crates/serde/src/lenient.rs
+++ b/crates/serde/src/lenient.rs
@@ -1,0 +1,480 @@
+//! Serde functions for leniently deserializing JSON-RPC request parameters.
+//!
+//! JSON-RPC clients are inconsistent in how they encode integers in a request's `params`. The same
+//! block number can arrive as a JSON number (`100`), as a quantity string (`"0x64"`), or as a
+//! decimal string (`"100"`). On top of that, a single positional parameter can arrive either bare
+//! (`100`) or wrapped in the one-element sequence the JSON-RPC specification prescribes (`[100]`).
+//!
+//! Servers built on alloy types have to accept all of these shapes. The helpers here do that:
+//!
+//! | Function | `100` | `"0x64"` | `"100"` | `[100]` | `null` | `[]`, `[null]` |
+//! |---|---|---|---|---|---|---|
+//! | [`deserialize`] | yes | yes | yes | no | no | no |
+//! | [`opt::deserialize`] | yes | yes | yes | no | yes | no |
+//! | [`seq::deserialize`] | yes | yes | yes | yes | no | no |
+//! | [`seq::opt::deserialize`] | yes | yes | yes | yes | yes | yes |
+//!
+//! Sequences of more than one element are rejected, as is any value that does not fit the target
+//! type: overflow and malformed input are always errors, never silent truncation.
+//!
+//! The helpers support `u8` through `u128` and [`Uint`](alloy_primitives::Uint) types such as
+//! [`U256`](alloy_primitives::U256). They are deserializers only; to serialize, use the
+//! [`quantity`](crate::quantity) module, whose deserializer already accepts the three scalar
+//! shapes for primitive integers. What this module adds is a single generic entry point that also
+//! covers `Uint` targets, and the sequence handling of [`seq`].
+//!
+//! This is only valid for self-describing, human-readable [`serde`] implementations.
+
+use private::LenientNumber;
+use serde::Deserializer;
+
+/// Deserializes a number from a JSON number, a `0x`-prefixed hex string, or a decimal string.
+///
+/// ```
+/// # use alloy_primitives::U256;
+/// # use serde::Deserialize;
+/// #[derive(Deserialize)]
+/// struct Params {
+///     #[serde(deserialize_with = "alloy_serde::lenient::deserialize")]
+///     value: U256,
+/// }
+///
+/// for raw in [r#"{"value":100}"#, r#"{"value":"0x64"}"#, r#"{"value":"100"}"#] {
+///     assert_eq!(serde_json::from_str::<Params>(raw).unwrap().value, U256::from(100));
+/// }
+/// ```
+pub fn deserialize<'de, T, D>(deserializer: D) -> Result<T, D::Error>
+where
+    T: LenientNumber,
+    D: Deserializer<'de>,
+{
+    T::deserialize_lenient(deserializer)
+}
+
+/// Serde functions for leniently deserializing optional numbers.
+///
+/// See [`lenient`](crate::lenient) for more information.
+pub mod opt {
+    use super::private::{Lenient, LenientNumber};
+    use serde::{Deserialize, Deserializer};
+
+    /// Deserializes an optional number from `null`, a JSON number, a `0x`-prefixed hex string, or
+    /// a decimal string.
+    ///
+    /// ```
+    /// # use serde::Deserialize;
+    /// #[derive(Deserialize)]
+    /// struct Params {
+    ///     #[serde(default, deserialize_with = "alloy_serde::lenient::opt::deserialize")]
+    ///     value: Option<u64>,
+    /// }
+    ///
+    /// for raw in [r#"{"value":100}"#, r#"{"value":"0x64"}"#, r#"{"value":"100"}"#] {
+    ///     assert_eq!(serde_json::from_str::<Params>(raw).unwrap().value, Some(100));
+    /// }
+    /// for raw in [r#"{"value":null}"#, "{}"] {
+    ///     assert_eq!(serde_json::from_str::<Params>(raw).unwrap().value, None);
+    /// }
+    /// ```
+    pub fn deserialize<'de, T, D>(deserializer: D) -> Result<Option<T>, D::Error>
+    where
+        T: LenientNumber,
+        D: Deserializer<'de>,
+    {
+        Ok(Option::<Lenient<T>>::deserialize(deserializer)?.map(Lenient::into_inner))
+    }
+}
+
+/// Serde functions for leniently deserializing a single number that may be wrapped in a
+/// one-element sequence, which is the JSON-RPC positional parameter shape.
+///
+/// See [`lenient`](crate::lenient) for more information.
+pub mod seq {
+    use super::private::{LenientNumber, ValueOrSeq};
+    use serde::Deserializer;
+
+    /// Deserializes a single number from either a bare value or a one-element sequence: `100`,
+    /// `"0x64"`, `"100"`, `[100]`, `["0x64"]` and `["100"]` all deserialize to `100`.
+    ///
+    /// Empty sequences, sequences with more than one element, and `null` are rejected.
+    ///
+    /// ```
+    /// # use serde::Deserialize;
+    /// #[derive(Deserialize)]
+    /// struct Params(#[serde(deserialize_with = "alloy_serde::lenient::seq::deserialize")] u64);
+    ///
+    /// for raw in ["100", r#""0x64""#, "[100]", r#"["0x64"]"#] {
+    ///     assert_eq!(serde_json::from_str::<Params>(raw).unwrap().0, 100);
+    /// }
+    /// for raw in ["[]", "[1, 2]", "null", r#""0x10000000000000000""#] {
+    ///     assert!(serde_json::from_str::<Params>(raw).is_err());
+    /// }
+    /// ```
+    pub fn deserialize<'de, T, D>(deserializer: D) -> Result<T, D::Error>
+    where
+        T: LenientNumber,
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_any(ValueOrSeq::new())
+    }
+
+    /// Serde functions for leniently deserializing an optional single number that may be wrapped
+    /// in a one-element sequence.
+    ///
+    /// See [`lenient`](crate::lenient) for more information.
+    pub mod opt {
+        use super::super::private::{LenientNumber, OptionalValueOrSeq};
+        use serde::Deserializer;
+
+        /// Deserializes an optional single number from either a bare value or a sequence of at
+        /// most one element: `[]`, `[null]` and `null` deserialize to `None`, while `100`,
+        /// `"0x64"`, `[100]` and `["0x64"]` deserialize to `Some(100)`.
+        ///
+        /// Sequences with more than one element are rejected.
+        ///
+        /// ```
+        /// # use serde::Deserialize;
+        /// #[derive(Deserialize)]
+        /// struct Params(
+        ///     #[serde(default, deserialize_with = "alloy_serde::lenient::seq::opt::deserialize")]
+        ///     Option<u64>,
+        /// );
+        ///
+        /// for raw in ["100", "[100]", r#"["0x64"]"#, r#"["100"]"#] {
+        ///     assert_eq!(serde_json::from_str::<Params>(raw).unwrap().0, Some(100));
+        /// }
+        /// for raw in ["[]", "[null]", "null"] {
+        ///     assert_eq!(serde_json::from_str::<Params>(raw).unwrap().0, None);
+        /// }
+        /// assert!(serde_json::from_str::<Params>("[1, 2]").is_err());
+        /// ```
+        pub fn deserialize<'de, T, D>(deserializer: D) -> Result<Option<T>, D::Error>
+        where
+            T: LenientNumber,
+            D: Deserializer<'de>,
+        {
+            deserializer.deserialize_any(OptionalValueOrSeq::new())
+        }
+    }
+}
+
+/// Private implementation details of the [`lenient`](self) module.
+#[expect(unnameable_types)]
+mod private {
+    use alloy_primitives::{Uint, U128, U16, U32, U64, U8};
+    use core::{fmt, marker::PhantomData};
+    use serde::{
+        de::{Error, IgnoredAny, IntoDeserializer, SeqAccess, Visitor},
+        Deserialize, Deserializer,
+    };
+
+    /// A number that can be deserialized from a JSON number, a `0x`-prefixed hex string, or a
+    /// decimal string.
+    #[doc(hidden)]
+    pub trait LenientNumber: Sized {
+        fn deserialize_lenient<'de, D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>;
+    }
+
+    impl<const BITS: usize, const LIMBS: usize> LenientNumber for Uint<BITS, LIMBS> {
+        fn deserialize_lenient<'de, D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            Self::deserialize(deserializer)
+        }
+    }
+
+    macro_rules! impl_lenient_number {
+        ($($primitive:ty = $ruint:ty),* $(,)?) => {
+            $(
+                impl LenientNumber for $primitive {
+                    fn deserialize_lenient<'de, D>(deserializer: D) -> Result<Self, D::Error>
+                    where
+                        D: Deserializer<'de>,
+                    {
+                        <$ruint>::deserialize(deserializer).map(|value| value.to::<Self>())
+                    }
+                }
+            )*
+        };
+    }
+
+    impl_lenient_number! {
+        u8   = U8,
+        u16  = U16,
+        u32  = U32,
+        u64  = U64,
+        u128 = U128,
+    }
+
+    /// [`Deserialize`] adapter for [`LenientNumber`].
+    pub(crate) struct Lenient<T>(T);
+
+    impl<T> Lenient<T> {
+        pub(crate) fn into_inner(self) -> T {
+            self.0
+        }
+    }
+
+    impl<'de, T: LenientNumber> Deserialize<'de> for Lenient<T> {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            T::deserialize_lenient(deserializer).map(Self)
+        }
+    }
+
+    /// Visitor for a number that may be wrapped in a one-element sequence.
+    pub(crate) struct ValueOrSeq<T>(PhantomData<T>);
+
+    impl<T> ValueOrSeq<T> {
+        pub(crate) const fn new() -> Self {
+            Self(PhantomData)
+        }
+    }
+
+    impl<'de, T: LenientNumber> Visitor<'de> for ValueOrSeq<T> {
+        type Value = T;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter.write_str(
+                "a number, a hex or decimal string, or a sequence containing exactly one of them",
+            )
+        }
+
+        fn visit_u64<E: Error>(self, value: u64) -> Result<Self::Value, E> {
+            T::deserialize_lenient(value.into_deserializer())
+        }
+
+        fn visit_u128<E: Error>(self, value: u128) -> Result<Self::Value, E> {
+            T::deserialize_lenient(value.into_deserializer())
+        }
+
+        fn visit_str<E: Error>(self, value: &str) -> Result<Self::Value, E> {
+            T::deserialize_lenient(value.into_deserializer())
+        }
+
+        fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
+            let Some(value) = seq.next_element::<Lenient<T>>()? else {
+                return Err(A::Error::invalid_length(0, &self));
+            };
+            match remaining(&mut seq)? {
+                0 => Ok(value.into_inner()),
+                extra => Err(A::Error::invalid_length(extra + 1, &self)),
+            }
+        }
+    }
+
+    /// Visitor for an optional number that may be wrapped in a sequence of at most one element.
+    pub(crate) struct OptionalValueOrSeq<T>(PhantomData<T>);
+
+    impl<T> OptionalValueOrSeq<T> {
+        pub(crate) const fn new() -> Self {
+            Self(PhantomData)
+        }
+    }
+
+    impl<'de, T: LenientNumber> Visitor<'de> for OptionalValueOrSeq<T> {
+        type Value = Option<T>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter.write_str(
+                "null, a number, a hex or decimal string, or a sequence containing at most one of them",
+            )
+        }
+
+        fn visit_unit<E: Error>(self) -> Result<Self::Value, E> {
+            Ok(None)
+        }
+
+        fn visit_none<E: Error>(self) -> Result<Self::Value, E> {
+            Ok(None)
+        }
+
+        fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            deserializer.deserialize_any(self)
+        }
+
+        fn visit_u64<E: Error>(self, value: u64) -> Result<Self::Value, E> {
+            T::deserialize_lenient(value.into_deserializer()).map(Some)
+        }
+
+        fn visit_u128<E: Error>(self, value: u128) -> Result<Self::Value, E> {
+            T::deserialize_lenient(value.into_deserializer()).map(Some)
+        }
+
+        fn visit_str<E: Error>(self, value: &str) -> Result<Self::Value, E> {
+            T::deserialize_lenient(value.into_deserializer()).map(Some)
+        }
+
+        fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
+            let value = seq.next_element::<Option<Lenient<T>>>()?.flatten();
+            match remaining(&mut seq)? {
+                0 => Ok(value.map(Lenient::into_inner)),
+                extra => Err(A::Error::invalid_length(extra + 1, &self)),
+            }
+        }
+    }
+
+    /// Drains the sequence and returns the number of elements that were left in it.
+    fn remaining<'de, A: SeqAccess<'de>>(seq: &mut A) -> Result<usize, A::Error> {
+        let mut extra = 0;
+        while seq.next_element::<IgnoredAny>()?.is_some() {
+            extra += 1;
+        }
+        Ok(extra)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::private::LenientNumber;
+    use alloc::string::ToString;
+    use alloy_primitives::U256;
+    use serde::{de::IntoDeserializer, Deserialize};
+    use serde_json::{json, Value};
+
+    fn value<T: LenientNumber>(value: Value) -> Result<T, serde_json::Error> {
+        super::deserialize(value.into_deserializer())
+    }
+
+    fn opt_value<T: LenientNumber>(value: Value) -> Result<Option<T>, serde_json::Error> {
+        super::opt::deserialize(value.into_deserializer())
+    }
+
+    fn seq<T: LenientNumber>(value: Value) -> Result<T, serde_json::Error> {
+        super::seq::deserialize(value.into_deserializer())
+    }
+
+    fn opt_seq<T: LenientNumber>(value: Value) -> Result<Option<T>, serde_json::Error> {
+        super::seq::opt::deserialize(value.into_deserializer())
+    }
+
+    #[test]
+    fn deserializes_number_hex_and_decimal_strings() {
+        for raw in [json!(100), json!("0x64"), json!("100")] {
+            assert_eq!(value::<u64>(raw.clone()).unwrap(), 100);
+            assert_eq!(value::<U256>(raw.clone()).unwrap(), U256::from(100));
+            assert_eq!(opt_value::<u64>(raw).unwrap(), Some(100));
+        }
+
+        assert_eq!(value::<u64>(json!(u64::MAX)).unwrap(), u64::MAX);
+        assert_eq!(opt_value::<u64>(json!(null)).unwrap(), None);
+    }
+
+    #[test]
+    fn rejects_values_that_do_not_fit_the_target_type() {
+        for raw in [
+            json!("0x10000000000000000"),
+            json!("18446744073709551616"),
+            json!(-1),
+            json!(1.5),
+            json!(null),
+            json!([100]),
+        ] {
+            assert!(value::<u64>(raw).is_err());
+        }
+
+        // narrower types are not truncated
+        assert_eq!(value::<u8>(json!(255)).unwrap(), 255);
+        assert!(value::<u8>(json!(256)).is_err());
+        assert!(value::<u8>(json!("0x100")).is_err());
+
+        assert!(value::<U256>(json!(
+            "0x10000000000000000000000000000000000000000000000000000000000000000"
+        ))
+        .is_err());
+        assert!(value::<U256>(json!(
+            "115792089237316195423570985008687907853269984665640564039457584007913129639936"
+        ))
+        .is_err());
+    }
+
+    #[test]
+    fn deserializes_single_param_sequence_and_bare_value() {
+        for raw in
+            [json!([100]), json!(100), json!(["0x64"]), json!("0x64"), json!(["100"]), json!("100")]
+        {
+            assert_eq!(seq::<u64>(raw.clone()).unwrap(), 100);
+            assert_eq!(seq::<U256>(raw.clone()).unwrap(), U256::from(100));
+            assert_eq!(opt_seq::<u64>(raw).unwrap(), Some(100));
+        }
+
+        for raw in [json!([u64::MAX]), json!(u64::MAX)] {
+            assert_eq!(seq::<u64>(raw.clone()).unwrap(), u64::MAX);
+            assert_eq!(opt_seq::<u64>(raw).unwrap(), Some(u64::MAX));
+        }
+    }
+
+    #[test]
+    fn rejects_invalid_sequence_shape_and_overflow() {
+        for raw in [
+            json!([]),
+            json!([1, 2]),
+            json!([null]),
+            json!(null),
+            json!([["0x64"]]),
+            json!(["0x10000000000000000"]),
+            json!("0x10000000000000000"),
+            json!(["18446744073709551616"]),
+            json!("18446744073709551616"),
+        ] {
+            assert!(seq::<u64>(raw).is_err());
+        }
+
+        assert!(seq::<u8>(json!([256])).is_err());
+    }
+
+    #[test]
+    fn deserializes_optional_single_param_sequence() {
+        for raw in [json!([]), json!([null]), json!(null)] {
+            assert_eq!(opt_seq::<u64>(raw.clone()).unwrap(), None);
+            assert_eq!(opt_seq::<U256>(raw).unwrap(), None);
+        }
+
+        for raw in [
+            json!([1, 2]),
+            json!([["0x64"]]),
+            json!(["0x10000000000000000"]),
+            json!(["18446744073709551616"]),
+        ] {
+            assert!(opt_seq::<u64>(raw).is_err());
+        }
+    }
+
+    #[test]
+    fn reports_the_actual_sequence_length() {
+        let err = seq::<u64>(json!([1, 2, 3])).unwrap_err();
+        assert!(err.to_string().starts_with("invalid length 3"), "{err}");
+
+        let err = opt_seq::<u64>(json!([1, 2])).unwrap_err();
+        assert!(err.to_string().starts_with("invalid length 2"), "{err}");
+    }
+
+    #[test]
+    fn deserializes_params_struct() {
+        #[derive(Debug, PartialEq, Eq, Deserialize)]
+        struct Params {
+            #[serde(deserialize_with = "super::seq::deserialize")]
+            block: u64,
+            #[serde(default, deserialize_with = "super::seq::opt::deserialize")]
+            timestamp: Option<U256>,
+        }
+
+        let params: Params =
+            serde_json::from_str(r#"{"block": ["0x64"], "timestamp": ["1700000000"]}"#).unwrap();
+        assert_eq!(params, Params { block: 100, timestamp: Some(U256::from(1700000000u64)) });
+
+        let params: Params = serde_json::from_str(r#"{"block": 100, "timestamp": []}"#).unwrap();
+        assert_eq!(params, Params { block: 100, timestamp: None });
+
+        let params: Params = serde_json::from_str(r#"{"block": "100"}"#).unwrap();
+        assert_eq!(params, Params { block: 100, timestamp: None });
+    }
+}

--- a/crates/serde/src/lib.rs
+++ b/crates/serde/src/lib.rs
@@ -19,6 +19,8 @@ pub mod checksum;
 mod optional;
 pub use self::optional::*;
 
+pub mod lenient;
+
 pub mod quantity;
 
 /// Storage related helpers.

--- a/crates/serde/src/lib.rs
+++ b/crates/serde/src/lib.rs
@@ -19,7 +19,7 @@ pub mod checksum;
 mod optional;
 pub use self::optional::*;
 
-pub mod lenient;
+pub mod json_rpc;
 
 pub mod quantity;
 


### PR DESCRIPTION
Every JSON-RPC server built on alloy types has to be lenient about how integers arrive in a request's `params`. The same block number shows up as a JSON number (`100`), as a quantity string (`"0x64"`) or as a decimal string (`"100"`), and a single positional parameter arrives either bare (`100`) or wrapped in the one-element sequence the spec actually prescribes (`[100]`, `["0x64"]`). Nothing in `alloy-serde` covers this today: `quantity` handles the three scalar shapes for primitive integers but has no notion of the positional-params sequence, and there is no single generic entry point that also works for `U256`.

The evidence that this belongs upstream is that Foundry maintains its own copy in `crates/common/src/serde_helpers.rs` (https://github.com/foundry-rs/foundry/blob/master/crates/common/src/serde_helpers.rs), where anvil's `EthRequest` uses it on roughly thirty variants, and the number-or-hex half of it is duplicated a second time inside Foundry in `crates/config/src/utils.rs`.

This adds a `json_rpc` module following the layout of `quantity`: `json_rpc::deserialize` for the scalar shapes, `json_rpc::opt::deserialize` for the optional version, `json_rpc::seq::deserialize` for a value that may be wrapped in a one-element sequence, and `json_rpc::seq::opt::deserialize`, which additionally accepts `null`, `[]` and `[null]` as `None`. The helpers are generic over `u8` through `u128` and over `Uint` targets such as `U256`, so a single implementation serves both the `u64` and `U256` call sites that Foundry currently duplicates.

Deserialization delegates to the target type's own ruint-backed implementation rather than reimplementing hex parsing, which keeps error messages consistent with the rest of the crate and means overflow and malformed input are always errors rather than silent truncation: `"0x10000000000000000"` and `"18446744073709551616"` both fail for a `u64` target, as does `256` for a `u8` one. Sequences longer than one element are rejected with the observed length. Everything is deserialize-only, since serialization already has a canonical home in `quantity`, and the module stays within the crate's `no_std` plus `alloc` constraints.

The port is a behavioral superset of Foundry's helpers with one deliberate difference: Foundry's `deserialize_u64_seq_opt` rejects a bare value, accepting only sequences, while `seq::opt` here accepts a bare value the same way `seq` does. The asymmetry did not seem worth preserving in a general-purpose helper.

This PR was written with AI assistance (Claude Code); the design, review and verification are mine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
