### PR TITLE
feat(json-rpc): add RpcError::error_code

### DIFF
--- a/crates/json-rpc/src/error.rs
+++ b/crates/json-rpc/src/error.rs
@@ -2,15 +2,20 @@ use crate::{ErrorPayload, RpcRecv};
 use alloy_primitives::B256;
 use serde_json::value::RawValue;
 
-/// A transport error kind that may carry the raw body of an error response.
+/// A transport error that may carry a JSON-RPC error in its raw response body.
 ///
 /// [`RpcError`] is generic over its transport error, which is defined by downstream transport
-/// crates and therefore opaque here. This trait is the minimal hook those crates implement so that
-/// [`RpcError::error_code`] can look inside error responses that never made it through JSON-RPC
-/// decoding, such as a JSON-RPC error served with a non-2xx HTTP status.
-pub trait ErrorResponseBody {
-    /// Returns the raw body of the error response this error carries, if any.
-    fn error_response_body(&self) -> Option<&str>;
+/// crates and therefore opaque here. This trait is the hook those crates implement so that
+/// [`RpcError::error_code`] can reach JSON-RPC errors that never made it through JSON-RPC decoding,
+/// such as an error served with a non-2xx HTTP status.
+///
+/// Implementors own the parsing, since they own the wire format their body arrives in.
+pub trait ErrorResponseCode {
+    /// Returns the JSON-RPC error code carried in this error's raw response body, if the body
+    /// contains a JSON-RPC error at all.
+    ///
+    /// Returns `None` when the error carries no body, or when the body is not a JSON-RPC error.
+    fn error_response_code(&self) -> Option<i32>;
 }
 
 /// An RPC error.
@@ -161,7 +166,7 @@ impl<E, ErrResp> RpcError<E, ErrResp> {
     }
 }
 
-impl<E: ErrorResponseBody, ErrResp> RpcError<E, ErrResp> {
+impl<E: ErrorResponseCode, ErrResp> RpcError<E, ErrResp> {
     /// Returns the JSON-RPC error code this error reports, if any.
     ///
     /// This covers regular JSON-RPC error responses as well as JSON-RPC errors that a provider
@@ -175,8 +180,8 @@ impl<E: ErrorResponseBody, ErrResp> RpcError<E, ErrResp> {
     /// use alloy_json_rpc::{ErrorPayload, RpcError};
     ///
     /// # struct NoBody;
-    /// # impl alloy_json_rpc::ErrorResponseBody for NoBody {
-    /// #     fn error_response_body(&self) -> Option<&str> {
+    /// # impl alloy_json_rpc::ErrorResponseCode for NoBody {
+    /// #     fn error_response_code(&self) -> Option<i32> {
     /// #         None
     /// #     }
     /// # }
@@ -187,7 +192,7 @@ impl<E: ErrorResponseBody, ErrResp> RpcError<E, ErrResp> {
         if let Some(payload) = self.as_error_resp() {
             return Some(payload.code);
         }
-        error_code_from_body(self.as_transport_err()?.error_response_body()?)
+        self.as_transport_err()?.error_response_code().map(i64::from)
     }
 }
 
@@ -229,32 +234,21 @@ impl<E> RpcError<E, Box<RawValue>> {
     }
 }
 
-/// Extracts a JSON-RPC error code from a raw error response body.
-///
-/// Accepts both a full JSON-RPC error response and a bare error object.
-fn error_code_from_body(body: &str) -> Option<i64> {
-    // Transports may append human-readable diagnostics after the JSON-RPC body, so parse the first
-    // complete JSON value instead of requiring the entire body to be JSON.
-    let value =
-        serde_json::Deserializer::from_str(body).into_iter::<serde_json::Value>().next()?.ok()?;
-    value.get("error").unwrap_or(&value).get("code")?.as_i64()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    /// A stand-in transport error carrying an optional raw error-response body.
-    struct Body(Option<&'static str>);
+    /// A stand-in transport error that reports a JSON-RPC code from its response body.
+    struct Body(Option<i32>);
 
-    impl ErrorResponseBody for Body {
-        fn error_response_body(&self) -> Option<&str> {
+    impl ErrorResponseCode for Body {
+        fn error_response_code(&self) -> Option<i32> {
             self.0
         }
     }
 
-    fn transport(body: Option<&'static str>) -> RpcError<Body> {
-        RpcError::Transport(Body(body))
+    fn transport(code: Option<i32>) -> RpcError<Body> {
+        RpcError::Transport(Body(code))
     }
 
     #[test]
@@ -264,36 +258,22 @@ mod tests {
     }
 
     #[test]
-    fn error_code_from_error_response_body() {
-        let nested =
-            transport(Some(r#"{"jsonrpc":"2.0","error":{"code":-32601,"message":"no method"}}"#));
-        assert_eq!(nested.error_code(), Some(-32601));
-
-        let bare = transport(Some(r#"{"code":-32000,"message":"Server error"}"#));
-        assert_eq!(bare.error_code(), Some(-32000));
-    }
-
-    #[test]
-    fn error_code_ignores_trailing_diagnostics() {
-        let error = transport(Some(
-            "{\"code\":-32000,\"message\":\"Server error\"}\nupstream request failed",
-        ));
-        assert_eq!(error.error_code(), Some(-32000));
+    fn error_code_from_transport_body() {
+        assert_eq!(transport(Some(-32601)).error_code(), Some(-32601));
     }
 
     #[test]
     fn error_code_none_for_unrelated_errors() {
         assert_eq!(transport(None).error_code(), None);
-        assert_eq!(transport(Some("not JSON")).error_code(), None);
         assert_eq!(RpcError::<Body>::NullResp.error_code(), None);
     }
 
     #[test]
     fn error_code_is_callable_generically() {
-        fn code<E: ErrorResponseBody, ErrResp>(err: &RpcError<E, ErrResp>) -> Option<i64> {
+        fn code<E: ErrorResponseCode, ErrResp>(err: &RpcError<E, ErrResp>) -> Option<i64> {
             err.error_code()
         }
 
-        assert_eq!(code(&transport(Some(r#"{"code":-32602}"#))), Some(-32602));
+        assert_eq!(code(&transport(Some(-32602))), Some(-32602));
     }
 }

--- a/crates/json-rpc/src/error.rs
+++ b/crates/json-rpc/src/error.rs
@@ -2,6 +2,17 @@ use crate::{ErrorPayload, RpcRecv};
 use alloy_primitives::B256;
 use serde_json::value::RawValue;
 
+/// A transport error kind that may carry the raw body of an error response.
+///
+/// [`RpcError`] is generic over its transport error, which is defined by downstream transport
+/// crates and therefore opaque here. This trait is the minimal hook those crates implement so that
+/// [`RpcError::error_code`] can look inside error responses that never made it through JSON-RPC
+/// decoding, such as a JSON-RPC error served with a non-2xx HTTP status.
+pub trait ErrorResponseBody {
+    /// Returns the raw body of the error response this error carries, if any.
+    fn error_response_body(&self) -> Option<&str>;
+}
+
 /// An RPC error.
 #[derive(Debug, thiserror::Error)]
 pub enum RpcError<E, ErrResp = Box<RawValue>> {
@@ -150,6 +161,36 @@ impl<E, ErrResp> RpcError<E, ErrResp> {
     }
 }
 
+impl<E: ErrorResponseBody, ErrResp> RpcError<E, ErrResp> {
+    /// Returns the JSON-RPC error code this error reports, if any.
+    ///
+    /// This covers regular JSON-RPC error responses as well as JSON-RPC errors that a provider
+    /// buried inside a transport-level error response, for example a `-32601` served with an HTTP
+    /// 403. The latter never reach [`RpcError::ErrorResp`], so [`RpcError::as_error_resp`] alone
+    /// misses them.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use alloy_json_rpc::{ErrorPayload, RpcError};
+    ///
+    /// # struct NoBody;
+    /// # impl alloy_json_rpc::ErrorResponseBody for NoBody {
+    /// #     fn error_response_body(&self) -> Option<&str> {
+    /// #         None
+    /// #     }
+    /// # }
+    /// let error: RpcError<NoBody> = RpcError::ErrorResp(ErrorPayload::method_not_found());
+    /// assert_eq!(error.error_code(), Some(-32601));
+    /// ```
+    pub fn error_code(&self) -> Option<i64> {
+        if let Some(payload) = self.as_error_resp() {
+            return Some(payload.code);
+        }
+        error_code_from_body(self.as_transport_err()?.error_response_body()?)
+    }
+}
+
 impl<E> RpcError<E, Box<RawValue>> {
     /// Parses the error data field as a hex string of specified length.
     ///
@@ -185,5 +226,74 @@ impl<E> RpcError<E, Box<RawValue>> {
     /// ```
     pub fn tx_hash_data(&self) -> Option<B256> {
         self.parse_data()
+    }
+}
+
+/// Extracts a JSON-RPC error code from a raw error response body.
+///
+/// Accepts both a full JSON-RPC error response and a bare error object.
+fn error_code_from_body(body: &str) -> Option<i64> {
+    // Transports may append human-readable diagnostics after the JSON-RPC body, so parse the first
+    // complete JSON value instead of requiring the entire body to be JSON.
+    let value =
+        serde_json::Deserializer::from_str(body).into_iter::<serde_json::Value>().next()?.ok()?;
+    value.get("error").unwrap_or(&value).get("code")?.as_i64()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A stand-in transport error carrying an optional raw error-response body.
+    struct Body(Option<&'static str>);
+
+    impl ErrorResponseBody for Body {
+        fn error_response_body(&self) -> Option<&str> {
+            self.0
+        }
+    }
+
+    fn transport(body: Option<&'static str>) -> RpcError<Body> {
+        RpcError::Transport(Body(body))
+    }
+
+    #[test]
+    fn error_code_from_error_response() {
+        let error: RpcError<Body> = RpcError::ErrorResp(ErrorPayload::invalid_request());
+        assert_eq!(error.error_code(), Some(-32600));
+    }
+
+    #[test]
+    fn error_code_from_error_response_body() {
+        let nested =
+            transport(Some(r#"{"jsonrpc":"2.0","error":{"code":-32601,"message":"no method"}}"#));
+        assert_eq!(nested.error_code(), Some(-32601));
+
+        let bare = transport(Some(r#"{"code":-32000,"message":"Server error"}"#));
+        assert_eq!(bare.error_code(), Some(-32000));
+    }
+
+    #[test]
+    fn error_code_ignores_trailing_diagnostics() {
+        let error = transport(Some(
+            "{\"code\":-32000,\"message\":\"Server error\"}\nupstream request failed",
+        ));
+        assert_eq!(error.error_code(), Some(-32000));
+    }
+
+    #[test]
+    fn error_code_none_for_unrelated_errors() {
+        assert_eq!(transport(None).error_code(), None);
+        assert_eq!(transport(Some("not JSON")).error_code(), None);
+        assert_eq!(RpcError::<Body>::NullResp.error_code(), None);
+    }
+
+    #[test]
+    fn error_code_is_callable_generically() {
+        fn code<E: ErrorResponseBody, ErrResp>(err: &RpcError<E, ErrResp>) -> Option<i64> {
+            err.error_code()
+        }
+
+        assert_eq!(code(&transport(Some(r#"{"code":-32602}"#))), Some(-32602));
     }
 }

--- a/crates/json-rpc/src/error.rs
+++ b/crates/json-rpc/src/error.rs
@@ -15,7 +15,7 @@ pub trait ErrorResponseCode {
     /// contains a JSON-RPC error at all.
     ///
     /// Returns `None` when the error carries no body, or when the body is not a JSON-RPC error.
-    fn error_response_code(&self) -> Option<i32>;
+    fn error_response_code(&self) -> Option<i64>;
 }
 
 /// An RPC error.
@@ -181,7 +181,7 @@ impl<E: ErrorResponseCode, ErrResp> RpcError<E, ErrResp> {
     ///
     /// # struct NoBody;
     /// # impl alloy_json_rpc::ErrorResponseCode for NoBody {
-    /// #     fn error_response_code(&self) -> Option<i32> {
+    /// #     fn error_response_code(&self) -> Option<i64> {
     /// #         None
     /// #     }
     /// # }
@@ -192,7 +192,7 @@ impl<E: ErrorResponseCode, ErrResp> RpcError<E, ErrResp> {
         if let Some(payload) = self.as_error_resp() {
             return Some(payload.code);
         }
-        self.as_transport_err()?.error_response_code().map(i64::from)
+        self.as_transport_err()?.error_response_code()
     }
 }
 
@@ -239,15 +239,15 @@ mod tests {
     use super::*;
 
     /// A stand-in transport error that reports a JSON-RPC code from its response body.
-    struct Body(Option<i32>);
+    struct Body(Option<i64>);
 
     impl ErrorResponseCode for Body {
-        fn error_response_code(&self) -> Option<i32> {
+        fn error_response_code(&self) -> Option<i64> {
             self.0
         }
     }
 
-    fn transport(code: Option<i32>) -> RpcError<Body> {
+    fn transport(code: Option<i64>) -> RpcError<Body> {
         RpcError::Transport(Body(code))
     }
 

--- a/crates/json-rpc/src/lib.rs
+++ b/crates/json-rpc/src/lib.rs
@@ -84,7 +84,7 @@ mod common;
 pub use common::Id;
 
 mod error;
-pub use error::{ErrorResponseBody, RpcError};
+pub use error::{ErrorResponseCode, RpcError};
 
 mod notification;
 pub use notification::{EthNotification, PubSubItem, SubId};

--- a/crates/json-rpc/src/lib.rs
+++ b/crates/json-rpc/src/lib.rs
@@ -84,7 +84,7 @@ mod common;
 pub use common::Id;
 
 mod error;
-pub use error::RpcError;
+pub use error::{ErrorResponseBody, RpcError};
 
 mod notification;
 pub use notification::{EthNotification, PubSubItem, SubId};

--- a/crates/transport/src/error.rs
+++ b/crates/transport/src/error.rs
@@ -1,4 +1,4 @@
-use alloy_json_rpc::{ErrorPayload, Id, RpcError, RpcResult};
+use alloy_json_rpc::{ErrorPayload, ErrorResponseBody, Id, RpcError, RpcResult};
 use serde::Deserialize;
 use serde_json::value::RawValue;
 use std::{error::Error as StdError, fmt::Debug, time::Duration};
@@ -218,6 +218,12 @@ impl HttpError {
     }
 }
 
+impl ErrorResponseBody for TransportErrorKind {
+    fn error_response_body(&self) -> Option<&str> {
+        self.as_http_error().map(|err| err.body.as_str())
+    }
+}
+
 /// Extension trait to implement methods for [`RpcError<TransportErrorKind, E>`].
 pub(crate) trait RpcErrorExt {
     /// Analyzes whether to retry the request depending on the error.
@@ -419,5 +425,34 @@ mod tests {
         assert!(kind.is_http_error());
         assert_eq!(kind.retry_after(), Some(Duration::from_secs(52)));
         assert_eq!(kind.as_http_error().unwrap().status, 429);
+    }
+
+    #[test]
+    fn extracts_rpc_error_code() {
+        let error: TransportError = TransportError::ErrorResp(ErrorPayload::invalid_request());
+        assert_eq!(error.error_code(), Some(-32600));
+
+        let error = TransportErrorKind::http_error(
+            400,
+            r#"{"jsonrpc":"2.0","error":{"code":-32601,"message":"Method not found"}}"#.to_owned(),
+        );
+        assert_eq!(error.error_code(), Some(-32601));
+    }
+
+    #[test]
+    fn extracts_rpc_error_code_from_http_body_with_diagnostics() {
+        let error = TransportErrorKind::http_error(
+            400,
+            "{\"code\":-32000,\"message\":\"Server error\"}\nupstream request failed".to_owned(),
+        );
+        assert_eq!(error.error_code(), Some(-32000));
+    }
+
+    #[test]
+    fn rpc_error_code_returns_none_for_unrelated_errors() {
+        assert_eq!(TransportErrorKind::backend_gone().error_code(), None);
+
+        let error = TransportErrorKind::http_error(500, "not JSON".to_owned());
+        assert_eq!(error.error_code(), None);
     }
 }

--- a/crates/transport/src/error.rs
+++ b/crates/transport/src/error.rs
@@ -1,4 +1,4 @@
-use alloy_json_rpc::{ErrorPayload, ErrorResponseBody, Id, RpcError, RpcResult};
+use alloy_json_rpc::{ErrorPayload, ErrorResponseCode, Id, RpcError, RpcResult};
 use serde::Deserialize;
 use serde_json::value::RawValue;
 use std::{error::Error as StdError, fmt::Debug, time::Duration};
@@ -218,10 +218,21 @@ impl HttpError {
     }
 }
 
-impl ErrorResponseBody for TransportErrorKind {
-    fn error_response_body(&self) -> Option<&str> {
-        self.as_http_error().map(|err| err.body.as_str())
+impl ErrorResponseCode for TransportErrorKind {
+    fn error_response_code(&self) -> Option<i32> {
+        error_code_from_body(&self.as_http_error()?.body)
     }
+}
+
+/// Extracts a JSON-RPC error code from a raw HTTP error response body.
+///
+/// Accepts both a full JSON-RPC error response and a bare error object.
+fn error_code_from_body(body: &str) -> Option<i32> {
+    // HTTP transports may append human-readable diagnostics after the JSON-RPC body, so parse the
+    // first complete JSON value instead of requiring the entire body to be JSON.
+    let value =
+        serde_json::Deserializer::from_str(body).into_iter::<serde_json::Value>().next()?.ok()?;
+    value.get("error").unwrap_or(&value).get("code")?.as_i64()?.try_into().ok()
 }
 
 /// Extension trait to implement methods for [`RpcError<TransportErrorKind, E>`].
@@ -437,6 +448,11 @@ mod tests {
             r#"{"jsonrpc":"2.0","error":{"code":-32601,"message":"Method not found"}}"#.to_owned(),
         );
         assert_eq!(error.error_code(), Some(-32601));
+
+        // a bare error object, without the enclosing response
+        let error =
+            TransportErrorKind::http_error(400, r#"{"code":-32000,"message":"err"}"#.to_owned());
+        assert_eq!(error.error_code(), Some(-32000));
     }
 
     #[test]
@@ -453,6 +469,10 @@ mod tests {
         assert_eq!(TransportErrorKind::backend_gone().error_code(), None);
 
         let error = TransportErrorKind::http_error(500, "not JSON".to_owned());
+        assert_eq!(error.error_code(), None);
+
+        // a code outside the JSON-RPC range is not a JSON-RPC error code
+        let error = TransportErrorKind::http_error(500, r#"{"code":4294967296}"#.to_owned());
         assert_eq!(error.error_code(), None);
     }
 }

--- a/crates/transport/src/error.rs
+++ b/crates/transport/src/error.rs
@@ -219,7 +219,7 @@ impl HttpError {
 }
 
 impl ErrorResponseCode for TransportErrorKind {
-    fn error_response_code(&self) -> Option<i32> {
+    fn error_response_code(&self) -> Option<i64> {
         error_code_from_body(&self.as_http_error()?.body)
     }
 }
@@ -227,12 +227,12 @@ impl ErrorResponseCode for TransportErrorKind {
 /// Extracts a JSON-RPC error code from a raw HTTP error response body.
 ///
 /// Accepts both a full JSON-RPC error response and a bare error object.
-fn error_code_from_body(body: &str) -> Option<i32> {
+fn error_code_from_body(body: &str) -> Option<i64> {
     // HTTP transports may append human-readable diagnostics after the JSON-RPC body, so parse the
     // first complete JSON value instead of requiring the entire body to be JSON.
     let value =
         serde_json::Deserializer::from_str(body).into_iter::<serde_json::Value>().next()?.ok()?;
-    value.get("error").unwrap_or(&value).get("code")?.as_i64()?.try_into().ok()
+    value.get("error").unwrap_or(&value).get("code")?.as_i64()
 }
 
 /// Extension trait to implement methods for [`RpcError<TransportErrorKind, E>`].
@@ -456,6 +456,24 @@ mod tests {
     }
 
     #[test]
+    fn extracts_rpc_error_codes_outside_i32_range() {
+        for code in [i64::MIN, i64::from(i32::MIN) - 1, i64::from(i32::MAX) + 1, i64::MAX] {
+            let mut payload = ErrorPayload::invalid_request();
+            payload.code = code;
+            let error: TransportError = TransportError::ErrorResp(payload);
+            assert_eq!(error.error_code(), Some(code));
+
+            for body in [
+                format!(r#"{{"code":{code},"message":"err"}}"#),
+                format!(r#"{{"jsonrpc":"2.0","error":{{"code":{code},"message":"err"}}}}"#),
+            ] {
+                let error = TransportErrorKind::http_error(400, body);
+                assert_eq!(error.error_code(), Some(code));
+            }
+        }
+    }
+
+    #[test]
     fn extracts_rpc_error_code_from_http_body_with_diagnostics() {
         let error = TransportErrorKind::http_error(
             400,
@@ -471,8 +489,9 @@ mod tests {
         let error = TransportErrorKind::http_error(500, "not JSON".to_owned());
         assert_eq!(error.error_code(), None);
 
-        // a code outside the JSON-RPC range is not a JSON-RPC error code
-        let error = TransportErrorKind::http_error(500, r#"{"code":4294967296}"#.to_owned());
+        // a code outside the supported i64 range cannot be represented
+        let error =
+            TransportErrorKind::http_error(500, r#"{"code":9223372036854775808}"#.to_owned());
         assert_eq!(error.error_code(), None);
     }
 }

--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -28,7 +28,7 @@ pub use error::{HttpError, TransportError, TransportResult};
 mod r#trait;
 pub use r#trait::Transport;
 
-pub use alloy_json_rpc::{RpcError, RpcResult};
+pub use alloy_json_rpc::{ErrorResponseBody, RpcError, RpcResult};
 pub use futures_utils_wasm::{impl_future, BoxFuture};
 
 pub mod layers;

--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -28,7 +28,7 @@ pub use error::{HttpError, TransportError, TransportResult};
 mod r#trait;
 pub use r#trait::Transport;
 
-pub use alloy_json_rpc::{ErrorResponseBody, RpcError, RpcResult};
+pub use alloy_json_rpc::{ErrorResponseCode, RpcError, RpcResult};
 pub use futures_utils_wasm::{impl_future, BoxFuture};
 
 pub mod layers;


### PR DESCRIPTION
Some providers return JSON-RPC errors inside non-2xx HTTP responses. A missing-method error served as HTTP 403 becomes a transport error, so callers using `as_error_resp()` cannot inspect its JSON-RPC code.

Add `RpcError::error_code()` to return the code from either a regular error response or a transport error implementing the new `ErrorResponseCode` trait. The trait lives in `alloy-json-rpc`; `alloy-transport` implements it by parsing HTTP error bodies. Both nested error responses and bare error objects are supported, including bodies with trailing diagnostics. Codes use `i64` throughout, matching `ErrorPayload::code` and preserving application codes outside the `i32` range.

This supersedes #4169, which exposed extraction as a free function. Consumers such as Foundry can use `error.error_code()` instead of maintaining their own extraction helpers.

This PR was prepared with AI assistance.
