### PR TITLE
fix(signer-local): reject BIP-32 indices that overflow the harden bit

### DIFF
--- a/crates/signer-local/src/mnemonic.rs
+++ b/crates/signer-local/src/mnemonic.rs
@@ -5,7 +5,7 @@
 
 use crate::{LocalSigner, LocalSignerError, PrivateKeySigner};
 use alloy_signer::utils::secret_key_to_address;
-use coins_bip32::{path::DerivationPath, prelude::Parent, xkeys::XPriv};
+use coins_bip32::{path::DerivationPath, prelude::Parent, xkeys::XPriv, BIP32_HARDEN};
 use coins_bip39::{English, Mnemonic, Wordlist};
 use k256::ecdsa::SigningKey;
 use rand::Rng;
@@ -147,13 +147,21 @@ impl<W: Wordlist> MnemonicBuilder<W> {
 
     /// Sets the derivation path of the child key to be derived. The derivation path is calculated
     /// using the default derivation path prefix used in Ethereum, i.e. "m/44'/60'/0'/0/{index}".
+    ///
+    /// An `index` at or above the BIP-32 harden bit (`0x8000_0000`) is rejected. See
+    /// [`MnemonicBuilderError::HardenBitOverflow`] for why.
     pub fn index(self, index: u32) -> Result<Self, LocalSignerError> {
         self.derivation_path(format!("{DEFAULT_DERIVATION_PATH_PREFIX}{index}"))
     }
 
     /// Sets the derivation path of the child key to be derived.
+    ///
+    /// Path components at or above the BIP-32 harden bit (`0x8000_0000`) are rejected. See
+    /// [`MnemonicBuilderError::HardenBitOverflow`] for why.
     pub fn derivation_path<T: AsRef<str>>(mut self, path: T) -> Result<Self, LocalSignerError> {
-        self.derivation_path = path.as_ref().parse()?;
+        let path = path.as_ref();
+        check_harden_bit(path)?;
+        self.derivation_path = path.parse()?;
         Ok(self)
     }
 
@@ -381,6 +389,34 @@ pub enum MnemonicBuilderError {
     /// Error suggests that a phrase (path or words) was not expected but found.
     #[error("unexpected phrase found")]
     UnexpectedPhraseFound,
+    /// A derivation path component is at or above the BIP-32 harden bit (`0x8000_0000`).
+    ///
+    /// `coins-bip32` 0.12 applies the harden marker with an unchecked `index + 0x8000_0000`, so
+    /// such a component wraps instead of erroring: in release builds `m/44'/60'/0'/0/2147483648'`
+    /// silently derives the unhardened child `0`, and a bare `2147483648` silently becomes `0'`.
+    /// Rejecting these matches `coins-bip32` 0.13.1 and go-ethereum's `ParseDerivationPath`.
+    #[error(
+        "BIP-32 derivation path component `{0}` is at or above the harden bit (0x8000_0000); \
+         valid indices are 0..=2147483647, optionally suffixed with ' or h to harden"
+    )]
+    HardenBitOverflow(String),
+}
+
+/// Rejects path components that would overflow the BIP-32 harden bit.
+///
+/// Only the numeric range is checked here; malformed syntax is left to [`DerivationPath`]'s own
+/// parser so its error messages are preserved.
+fn check_harden_bit(path: &str) -> Result<(), MnemonicBuilderError> {
+    for component in path.split('/') {
+        let digits = component
+            .strip_suffix('\'')
+            .or_else(|| component.strip_suffix('h'))
+            .unwrap_or(component);
+        if digits.parse::<u32>().is_ok_and(|index| index >= BIP32_HARDEN) {
+            return Err(MnemonicBuilderError::HardenBitOverflow(component.to_string()));
+        }
+    }
+    Ok(())
 }
 
 fn xpriv_to_signer(xpriv: &XPriv) -> PrivateKeySigner {
@@ -393,6 +429,7 @@ fn xpriv_to_signer(xpriv: &XPriv) -> PrivateKeySigner {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy_primitives::address;
     use coins_bip39::English;
     use tempfile::tempdir;
 
@@ -553,5 +590,54 @@ mod tests {
             LocalSignerError::MnemonicBuilderError(MnemonicBuilderError::ExpectedPhraseNotFound)
         ));
         assert!(iter.next().is_none());
+    }
+
+    /// The BIP-32 harden bit overflow that silently derived the wrong key.
+    ///
+    /// `coins-bip32` 0.12 hardens with an unchecked `index + 0x8000_0000`. Verified against
+    /// 0.12.0 in a release build: `m/44'/60'/0'/0/2147483648'` wrapped to the *unhardened*
+    /// child `0` and handed back anvil account 0 below, with no error. A bare `2147483648`
+    /// wrapped the other way, silently becoming `0'` (it also re-encodes as `"m/0'"`).
+    /// Debug builds panicked on the overflow instead, so neither mode was usable.
+    #[test]
+    fn mnemonic_rejects_harden_bit_overflow() {
+        const ANVIL: &str = "test test test test test test test test test test test junk";
+
+        let build = |path: &str| {
+            MnemonicBuilder::<English>::default().phrase(ANVIL).derivation_path(path)?.build()
+        };
+
+        // The key the overflowing paths used to silently resolve to.
+        let account_0 = build("m/44'/60'/0'/0/0").unwrap();
+        assert_eq!(account_0.address(), address!("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"));
+
+        for path in [
+            "m/44'/60'/0'/0/2147483648'",
+            "m/44'/60'/0'/0/2147483648",
+            "m/2147483648h",
+            &format!("m/{}", u32::MAX),
+        ] {
+            let err = build(path).unwrap_err();
+            assert!(
+                matches!(
+                    err,
+                    LocalSignerError::MnemonicBuilderError(
+                        MnemonicBuilderError::HardenBitOverflow(_)
+                    )
+                ),
+                "{path} should be rejected as harden-bit overflow, got {err:?}"
+            );
+        }
+
+        // `index` builds the path itself, so it inherits the same guard.
+        assert!(MnemonicBuilder::<English>::english().index(BIP32_HARDEN).is_err());
+
+        // The boundary must stay usable: the largest valid hardened index still derives, and
+        // gives a key distinct from account 0 rather than collapsing onto it.
+        let max_hardened = build("m/44'/60'/0'/0/2147483647'").unwrap();
+        assert_ne!(max_hardened.address(), account_0.address());
+
+        // Malformed components are still the underlying parser's to report, not ours.
+        assert!(matches!(build("m/not-a-number").unwrap_err(), LocalSignerError::Bip32Error(_)));
     }
 }


### PR DESCRIPTION
A BIP-32 path component at or above the harden bit silently derives the wrong key instead of erroring. `coins-bip32` 0.12 applies the harden marker as an unchecked `index + 0x8000_0000`, and `MnemonicBuilder::derivation_path` and `MnemonicBuilder::index` both forward straight to `DerivationPath::parse`, so alloy inherits it directly.

Checked against 0.12.0 in a release build using the anvil test mnemonic `test test test test test test test test test test test junk`. The path `m/44'/60'/0'/0/2147483648'` parses `2147483648` as `0x8000_0000`, adds the harden bit, wraps to `0`, and derives the *unhardened* child zero: address `0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266`, private key `0xac0974be...f4f2ff80`. That is account 0, byte for byte, returned with no error or warning for a path the caller never asked for. A bare `2147483648` wraps the other way and silently becomes `0'`, deriving `0xf44898b6Ac8782197a68a5e3D5474b67C7062427`; it also round-trips ambiguously, since `"m/2147483648".parse::<DerivationPath>()` re-encodes as `"m/0'"`. Debug builds panic on the overflow rather than wrapping, so neither profile behaves acceptably, and the one that ships is the one that fails silently. A user who mistypes an index or builds one programmatically gets a valid-looking wallet at an address they did not intend.

This rejects such components at the builder boundary with a new `MnemonicBuilderError::HardenBitOverflow`, leaving genuinely malformed syntax to `DerivationPath`'s own parser so its error messages are preserved. The boundary is unchanged for valid input: `2147483647'`, the largest legal hardened index, still derives.

Foundry hit this and carries a `validate_bip32_path` guard in `crates/common/src/wallet.rs` for exactly this reason, which is evidence a downstream already had to defend against it rather than a hypothetical.

Worth noting on sequencing: this is a stopgap, not the root fix. Upstream fixed it in [summa-tx/coins#144](https://github.com/summa-tx/coins/pull/144), released in `coins-bip32` 0.13.1 and 0.13.2, and that repo is actively maintained. Alloy cannot simply take it, because `alloy-signer-local` re-exports `coins_bip39` publicly and exposes `coins_bip32::DerivationPath` in its signatures, so a 0.13 bump is a semver-breaking change that cannot ship as a patch. The guard closes the hole on the current dependency now and should be dropped when alloy next bumps to 0.13.

The regression test fails in both profiles if the guard is removed: in release `unwrap_err` fails because the path parses, and in debug the underlying add panics. Note that `alloy-signer-local` cannot be tested in release at all right now, since the unconditional `yubihsm` dev-dependency hard-errors with "MockHsm is not intended for use in release builds", so the release behavior above was confirmed in a standalone crate against the same dependency version.

Written with assistance from Claude Code; the bug reproduction, fix, and test were reviewed and verified by me.
