### PR TITLE
feat(genesis): support feature-gated account extensions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,3 +172,6 @@ ci_info = "0.14.14"
 similar-asserts = "1.5"
 tempfile = "3.20"
 tower-http = "0.6.1"
+
+[patch.crates-io]
+alloy-trie = { git = "https://github.com/alloy-rs/trie", rev = "b7185a1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -174,4 +174,4 @@ tempfile = "3.20"
 tower-http = "0.6.1"
 
 [patch.crates-io]
-alloy-trie = { git = "https://github.com/alloy-rs/trie", rev = "b7185a1" }
+alloy-trie = { git = "https://github.com/alloy-rs/trie", rev = "656566e48ec46279e41d15eb52732e86f704712f" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -174,4 +174,4 @@ tempfile = "3.20"
 tower-http = "0.6.1"
 
 [patch.crates-io]
-alloy-trie = { git = "https://github.com/alloy-rs/trie", rev = "288294aa3fbe9e699bb2d8bd966bb7ff3ec59882" }
+alloy-trie = { git = "https://github.com/alloy-rs/trie", rev = "169955f" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -174,4 +174,4 @@ tempfile = "3.20"
 tower-http = "0.6.1"
 
 [patch.crates-io]
-alloy-trie = { git = "https://github.com/alloy-rs/trie", rev = "656566e48ec46279e41d15eb52732e86f704712f" }
+alloy-trie = { git = "https://github.com/alloy-rs/trie", rev = "288294aa3fbe9e699bb2d8bd966bb7ff3ec59882" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -174,4 +174,4 @@ tempfile = "3.20"
 tower-http = "0.6.1"
 
 [patch.crates-io]
-alloy-trie = { git = "https://github.com/alloy-rs/trie", rev = "169955f" }
+alloy-trie = { git = "https://github.com/alloy-rs/trie", rev = "6c7689d" }

--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -130,4 +130,5 @@ borsh = [
 	"dep:borsh",
 	"alloy-primitives/borsh",
 	"alloy-eips/borsh",
+	"alloy-trie/borsh"
 ]

--- a/crates/genesis/Cargo.toml
+++ b/crates/genesis/Cargo.toml
@@ -23,9 +23,9 @@ rustdoc-args = [
 workspace = true
 
 [dependencies]
-alloy-eips = { workspace = true, features = ["serde"] }
+alloy-eips = { version = "2.4.1", features = ["serde"], default-features = false }
 alloy-primitives.workspace = true
-alloy-serde.workspace = true
+alloy-serde = { version = "2.4.1", default-features = false }
 alloy-trie = { workspace = true, features = ["ethereum"] }
 
 # serde

--- a/crates/genesis/Cargo.toml
+++ b/crates/genesis/Cargo.toml
@@ -23,9 +23,9 @@ rustdoc-args = [
 workspace = true
 
 [dependencies]
-alloy-eips = { version = "2.4.1", features = ["serde"], default-features = false }
+alloy-eips = { workspace = true, features = ["serde"] }
 alloy-primitives.workspace = true
-alloy-serde = { version = "2.4.1", default-features = false }
+alloy-serde.workspace = true
 alloy-trie = { workspace = true, features = ["ethereum"] }
 
 # serde

--- a/crates/genesis/Cargo.toml
+++ b/crates/genesis/Cargo.toml
@@ -40,6 +40,7 @@ bincode = { workspace = true, features = ["serde"] }
 serde_json.workspace = true
 
 [features]
+account-ext = ["alloy-trie/account-ext", "alloy-trie/serde"]
 default = ["std"]
 std = [
 	"alloy-primitives/std",
@@ -53,6 +54,7 @@ std = [
 ]
 serde-bincode-compat = ["dep:serde_with", "alloy-eips/serde-bincode-compat"]
 borsh = [
+    "alloy-trie/borsh",
 	"dep:borsh",
 	"alloy-primitives/borsh",
 	"alloy-eips/borsh",

--- a/crates/genesis/src/lib.rs
+++ b/crates/genesis/src/lib.rs
@@ -315,6 +315,7 @@ impl From<GenesisAccount> for TrieAccount {
             balance: account.balance,
             storage_root,
             code_hash,
+            extension: (),
         }
     }
 }

--- a/crates/genesis/src/lib.rs
+++ b/crates/genesis/src/lib.rs
@@ -19,6 +19,8 @@ use alloy_eips::{
 };
 use alloy_primitives::{keccak256, Address, Bytes, B256, U256};
 use alloy_serde::{storage::deserialize_storage_map, OtherFields};
+#[cfg(feature = "account-ext")]
+pub use alloy_trie::AccountExtension;
 use alloy_trie::{TrieAccount, EMPTY_ROOT_HASH, KECCAK_EMPTY};
 use core::str::FromStr;
 use serde::{de::Error as DeError, Deserialize, Deserializer, Serialize};
@@ -224,7 +226,7 @@ pub struct GenesisAccount {
     /// Complete RLP fields appended to the account trie leaf.
     #[cfg(feature = "account-ext")]
     #[serde(default, skip_serializing_if = "alloy_trie::AccountExtension::is_empty")]
-    pub extension: alloy_trie::AccountExtension,
+    pub extension: AccountExtension,
     /// The nonce of the account at genesis.
     #[serde(skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt", default)]
     pub nonce: Option<u64>,
@@ -1240,6 +1242,17 @@ where
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "account-ext")]
+    #[test]
+    fn genesis_extension_is_committed_to_the_trie() {
+        let account: super::GenesisAccount =
+            serde_json::from_str(r#"{"balance":"0x0","extension":"0x0102"}"#).unwrap();
+        let pointer = account.extension.as_ptr();
+        let trie = account.into_trie_account();
+        assert_eq!(trie.extension.as_ref(), &[1, 2]);
+        assert_eq!(trie.extension.as_ptr(), pointer);
+        assert_ne!(trie.trie_hash_slow(), alloy_trie::TrieAccount::default().trie_hash_slow());
+    }
     use super::*;
     use alloc::{collections::BTreeMap, vec};
     use alloy_primitives::{hex, Bytes};

--- a/crates/genesis/src/lib.rs
+++ b/crates/genesis/src/lib.rs
@@ -223,7 +223,7 @@ impl Genesis {
 #[serde(deny_unknown_fields)]
 #[cfg_attr(feature = "borsh", derive(borsh::BorshSerialize, borsh::BorshDeserialize))]
 pub struct GenesisAccount {
-    /// Complete RLP fields appended to the account trie leaf.
+    /// Raw chain-specific bytes, encoded as a fifth RLP string in the account trie leaf.
     #[cfg(feature = "account-ext")]
     #[serde(default, skip_serializing_if = "alloy_trie::AccountExtension::is_empty")]
     pub extension: AccountExtension,
@@ -1246,10 +1246,10 @@ mod tests {
     #[test]
     fn genesis_extension_is_committed_to_the_trie() {
         let account: super::GenesisAccount =
-            serde_json::from_str(r#"{"balance":"0x0","extension":"0x0102"}"#).unwrap();
+            serde_json::from_str(r#"{"balance":"0x0","extension":"0x82aa"}"#).unwrap();
         let pointer = account.extension.as_ptr();
         let trie = account.into_trie_account();
-        assert_eq!(trie.extension.as_ref(), &[1, 2]);
+        assert_eq!(trie.extension.as_ref(), &[0x82, 0xaa]);
         assert_eq!(trie.extension.as_ptr(), pointer);
         assert_ne!(trie.trie_hash_slow(), alloy_trie::TrieAccount::default().trie_hash_slow());
     }

--- a/crates/genesis/src/lib.rs
+++ b/crates/genesis/src/lib.rs
@@ -221,6 +221,10 @@ impl Genesis {
 #[serde(deny_unknown_fields)]
 #[cfg_attr(feature = "borsh", derive(borsh::BorshSerialize, borsh::BorshDeserialize))]
 pub struct GenesisAccount {
+    /// Complete RLP fields appended to the account trie leaf.
+    #[cfg(feature = "account-ext")]
+    #[serde(default, skip_serializing_if = "alloy_trie::AccountExtension::is_empty")]
+    pub extension: alloy_trie::AccountExtension,
     /// The nonce of the account at genesis.
     #[serde(skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt", default)]
     pub nonce: Option<u64>,
@@ -315,7 +319,8 @@ impl From<GenesisAccount> for TrieAccount {
             balance: account.balance,
             storage_root,
             code_hash,
-            extension: (),
+            #[cfg(feature = "account-ext")]
+            extension: account.extension,
         }
     }
 }
@@ -1297,6 +1302,8 @@ mod tests {
             code: Some(b"code".into()),
             storage: Some(BTreeMap::default()),
             private_key: None,
+            #[cfg(feature = "account-ext")]
+            extension: Default::default(),
         };
         let mut updated_account = BTreeMap::default();
         updated_account.insert(same_address, new_alloc_account);
@@ -2051,6 +2058,8 @@ mod tests {
                         code: None,
                         storage: None,
                         private_key: None,
+            #[cfg(feature = "account-ext")]
+            extension: Default::default(),
                     },
                 ),
                 (
@@ -2061,6 +2070,8 @@ mod tests {
                         code: Some(Bytes::from_str("0x12").unwrap()),
                         storage: None,
                         private_key: None,
+            #[cfg(feature = "account-ext")]
+            extension: Default::default(),
                     },
                 ),
                 (
@@ -2078,6 +2089,8 @@ mod tests {
     unwrap(),                         ),
                         ])),
                         private_key: None,
+            #[cfg(feature = "account-ext")]
+            extension: Default::default(),
                     },
                 ),
                 (
@@ -2088,6 +2101,8 @@ mod tests {
                         code: None,
                         storage: None,
                         private_key: None,
+            #[cfg(feature = "account-ext")]
+            extension: Default::default(),
                     },
                 ),
                 (
@@ -2098,6 +2113,8 @@ mod tests {
                         code: None,
                         storage: None,
                         private_key: None,
+            #[cfg(feature = "account-ext")]
+            extension: Default::default(),
                     },
                 ),
                 (
@@ -2108,6 +2125,8 @@ mod tests {
                         code: None,
                         storage: None,
                         private_key: None,
+            #[cfg(feature = "account-ext")]
+            extension: Default::default(),
                     },
                 ),
                 (
@@ -2118,6 +2137,8 @@ mod tests {
                         code: None,
                         storage: None,
                         private_key: None,
+            #[cfg(feature = "account-ext")]
+            extension: Default::default(),
                     },
                 ),
                 (
@@ -2128,6 +2149,8 @@ mod tests {
                         code: None,
                         storage: None,
                         private_key: None,
+            #[cfg(feature = "account-ext")]
+            extension: Default::default(),
                     },
                 ),
             ]),
@@ -2386,6 +2409,8 @@ mod tests {
             code: Some(Bytes::from(vec![0x60, 0x61])),
             storage: Some(storage),
             private_key: None,
+            #[cfg(feature = "account-ext")]
+            extension: Default::default(),
         };
 
         // Convert the GenesisAccount to a TrieAccount
@@ -2414,6 +2439,8 @@ mod tests {
             code: None,
             storage: Some(storage),
             private_key: None,
+            #[cfg(feature = "account-ext")]
+            extension: Default::default(),
         };
 
         // Convert the GenesisAccount to a TrieAccount

--- a/crates/rpc-types-eth/Cargo.toml
+++ b/crates/rpc-types-eth/Cargo.toml
@@ -46,6 +46,7 @@ arbitrary = { version = "1.3", features = ["derive"], optional = true }
 alloy-sol-types.workspace = true
 
 [dev-dependencies]
+rmp-serde = "1.3"
 alloy-primitives = { workspace = true, features = [
     "rand",
     "rlp",

--- a/crates/rpc-types-eth/Cargo.toml
+++ b/crates/rpc-types-eth/Cargo.toml
@@ -23,6 +23,7 @@ rustdoc-args = [
 workspace = true
 
 [dependencies]
+alloy-trie = { workspace = true, optional = true }
 alloy-eips.workspace = true
 alloy-consensus.workspace = true
 alloy-consensus-any.workspace = true
@@ -61,6 +62,7 @@ assert_matches.workspace = true
 bincode = { workspace = true, features = ["serde"] }
 
 [features]
+account-ext = ["dep:alloy-trie", "alloy-trie/account-ext", "alloy-trie/serde"]
 default = ["std", "serde"]
 std = [
 	"alloy-primitives/std",

--- a/crates/rpc-types-eth/Cargo.toml
+++ b/crates/rpc-types-eth/Cargo.toml
@@ -65,6 +65,7 @@ bincode = { workspace = true, features = ["serde"] }
 account-ext = ["dep:alloy-trie", "alloy-trie/account-ext", "alloy-trie/serde"]
 default = ["std", "serde"]
 std = [
+	"alloy-trie?/std",
 	"alloy-primitives/std",
 	"alloy-consensus/std",
 	"alloy-eips/std",
@@ -79,6 +80,7 @@ std = [
 	"thiserror/std"
 ]
 serde = [
+	"alloy-trie?/serde",
 	"dep:serde",
 	"dep:serde_json",
 	"dep:alloy-serde",
@@ -90,6 +92,7 @@ serde = [
 	"alloy-network-primitives/serde"
 ]
 arbitrary = [
+	"alloy-trie?/arbitrary",
 	"std",
 	"dep:arbitrary",
 	"alloy-consensus/arbitrary",

--- a/crates/rpc-types-eth/src/account.rs
+++ b/crates/rpc-types-eth/src/account.rs
@@ -6,10 +6,12 @@ use alloy_primitives::{
 
 // re-export account type for `eth_getAccount`
 pub use alloy_consensus::TrieAccount as Account;
+#[cfg(feature = "account-ext")]
+use alloy_trie::AccountExtension;
 
 /// Account information.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct AccountInfo {
     /// Account balance
@@ -19,6 +21,32 @@ pub struct AccountInfo {
     pub nonce: u64,
     /// Account code
     pub code: Bytes,
+    /// Chain-specific account payload.
+    #[cfg(feature = "account-ext")]
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub extension: AccountExtension,
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for AccountInfo {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeStruct;
+
+        #[cfg(feature = "account-ext")]
+        let include_extension = !serializer.is_human_readable() || !self.extension.is_empty();
+        #[cfg(not(feature = "account-ext"))]
+        let include_extension = false;
+        let mut state =
+            serializer.serialize_struct("AccountInfo", 3 + usize::from(include_extension))?;
+        state.serialize_field("balance", &self.balance)?;
+        state.serialize_field("nonce", &alloy_primitives::U64::from(self.nonce))?;
+        state.serialize_field("code", &self.code)?;
+        #[cfg(feature = "account-ext")]
+        if include_extension {
+            state.serialize_field("extension", &self.extension)?;
+        }
+        state.end()
+    }
 }
 
 impl AccountInfo {
@@ -43,9 +71,38 @@ impl AccountInfo {
     /// - code hash is the Keccak256 hash of the empty string `""`
     /// - balance is zero
     /// - nonce is zero
+    /// - the account extension is empty, if enabled
     #[inline]
     pub fn is_empty(&self) -> bool {
+        #[cfg(feature = "account-ext")]
+        if !self.extension.is_empty() {
+            return false;
+        }
         self.is_empty_code_hash() && self.balance.is_zero() && self.nonce == 0
+    }
+}
+
+#[cfg(all(test, feature = "serde", feature = "account-ext"))]
+mod account_info_tests {
+    use super::*;
+
+    #[test]
+    fn extension_serde_and_emptiness() {
+        let legacy = serde_json::json!({"balance": "0x0", "nonce": "0x0", "code": "0x"});
+        let mut info: AccountInfo = serde_json::from_value(legacy.clone()).unwrap();
+        assert!(info.is_empty());
+        assert_eq!(serde_json::to_value(&info).unwrap(), legacy);
+        for payload in [Vec::new(), vec![0x01]] {
+            info.extension = payload.clone().into();
+            assert_eq!(info.is_empty(), payload.is_empty());
+            let json = serde_json::to_value(&info).unwrap();
+            assert_eq!(serde_json::from_value::<AccountInfo>(json).unwrap(), info);
+            let bytes = bincode::serde::encode_to_vec(&info, bincode::config::standard()).unwrap();
+            let (decoded, consumed): (AccountInfo, usize) =
+                bincode::serde::decode_from_slice(&bytes, bincode::config::standard()).unwrap();
+            assert_eq!(decoded, info);
+            assert_eq!(consumed, bytes.len());
+        }
     }
 }
 

--- a/crates/rpc-types-eth/src/account.rs
+++ b/crates/rpc-types-eth/src/account.rs
@@ -11,7 +11,7 @@ use alloy_trie::AccountExtension;
 
 /// Account information.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct AccountInfo {
     /// Account balance
@@ -23,30 +23,11 @@ pub struct AccountInfo {
     pub code: Bytes,
     /// Chain-specific account payload.
     #[cfg(feature = "account-ext")]
-    #[cfg_attr(feature = "serde", serde(default))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(default, skip_serializing_if = "AccountExtension::is_empty")
+    )]
     pub extension: AccountExtension,
-}
-
-#[cfg(feature = "serde")]
-impl serde::Serialize for AccountInfo {
-    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        use serde::ser::SerializeStruct;
-
-        #[cfg(feature = "account-ext")]
-        let include_extension = !serializer.is_human_readable() || !self.extension.is_empty();
-        #[cfg(not(feature = "account-ext"))]
-        let include_extension = false;
-        let mut state =
-            serializer.serialize_struct("AccountInfo", 3 + usize::from(include_extension))?;
-        state.serialize_field("balance", &self.balance)?;
-        state.serialize_field("nonce", &alloy_primitives::U64::from(self.nonce))?;
-        state.serialize_field("code", &self.code)?;
-        #[cfg(feature = "account-ext")]
-        if include_extension {
-            state.serialize_field("extension", &self.extension)?;
-        }
-        state.end()
-    }
 }
 
 impl AccountInfo {
@@ -92,19 +73,27 @@ mod account_info_tests {
         let mut info: AccountInfo = serde_json::from_value(legacy.clone()).unwrap();
         assert!(info.is_empty());
         assert_eq!(serde_json::to_value(&info).unwrap(), legacy);
+        #[derive(serde::Serialize, serde::Deserialize)]
+        struct LegacyAccountInfo {
+            balance: U256,
+            #[serde(with = "alloy_serde::quantity")]
+            nonce: u64,
+            code: Bytes,
+        }
+        let legacy =
+            LegacyAccountInfo { balance: info.balance, nonce: info.nonce, code: info.code.clone() };
+        let encoded = rmp_serde::to_vec(&info).unwrap();
+        assert_eq!(encoded, rmp_serde::to_vec(&legacy).unwrap());
+        let decoded: LegacyAccountInfo = rmp_serde::from_slice(&encoded).unwrap();
+        assert_eq!(rmp_serde::to_vec(&decoded).unwrap(), encoded);
         for payload in [Vec::new(), vec![0x82, 0xaa], vec![42; 2048]] {
             info.extension = payload.clone().into();
             assert_eq!(info.is_empty(), payload.is_empty());
             let json = serde_json::to_value(&info).unwrap();
             assert_eq!(serde_json::from_value::<AccountInfo>(json).unwrap(), info);
-            let bytes = bincode::serde::encode_to_vec(&info, bincode::config::standard()).unwrap();
-            let mut suffix = (payload.len() as u16).to_be_bytes().to_vec();
-            suffix.extend_from_slice(&payload);
-            assert!(bytes.ends_with(&suffix));
-            let (decoded, consumed): (AccountInfo, usize) =
-                bincode::serde::decode_from_slice(&bytes, bincode::config::standard()).unwrap();
+            let bytes = rmp_serde::to_vec(&info).unwrap();
+            let decoded: AccountInfo = rmp_serde::from_slice(&bytes).unwrap();
             assert_eq!(decoded, info);
-            assert_eq!(consumed, bytes.len());
         }
     }
 }

--- a/crates/rpc-types-eth/src/account.rs
+++ b/crates/rpc-types-eth/src/account.rs
@@ -92,12 +92,15 @@ mod account_info_tests {
         let mut info: AccountInfo = serde_json::from_value(legacy.clone()).unwrap();
         assert!(info.is_empty());
         assert_eq!(serde_json::to_value(&info).unwrap(), legacy);
-        for payload in [Vec::new(), vec![0x01]] {
+        for payload in [Vec::new(), vec![0x82, 0xaa], vec![42; 2048]] {
             info.extension = payload.clone().into();
             assert_eq!(info.is_empty(), payload.is_empty());
             let json = serde_json::to_value(&info).unwrap();
             assert_eq!(serde_json::from_value::<AccountInfo>(json).unwrap(), info);
             let bytes = bincode::serde::encode_to_vec(&info, bincode::config::standard()).unwrap();
+            let mut suffix = (payload.len() as u16).to_be_bytes().to_vec();
+            suffix.extend_from_slice(&payload);
+            assert!(bytes.ends_with(&suffix));
             let (decoded, consumed): (AccountInfo, usize) =
                 bincode::serde::decode_from_slice(&bytes, bincode::config::standard()).unwrap();
             assert_eq!(decoded, info);

--- a/deny.toml
+++ b/deny.toml
@@ -67,3 +67,4 @@ license-files = [{ path = "LICENSE", hash = 0x001c7e6c }]
 [sources]
 unknown-registry = "deny"
 unknown-git = "deny"
+allow-git = ["https://github.com/alloy-rs/trie"]


### PR DESCRIPTION
Adds optional raw account payloads to GenesisAccount and RPC AccountInfo behind `account-ext`, preserving them through genesis root computation and RPC responses. Empty payloads are omitted from JSON. Depends on alloy-rs/trie#156.