### PR TITLE
feat(ens): migrate resolution to the Universal Resolver

### DIFF
--- a/crates/ens/src/lib.rs
+++ b/crates/ens/src/lib.rs
@@ -9,7 +9,7 @@
 //! ENS Name resolving utilities.
 
 mod utils;
-pub use utils::{dns_encode, namehash, reverse_address, try_dns_encode, DnsEncodeError};
+pub use utils::{dns_encode, namehash, reverse_address, DnsEncodeError};
 
 use alloy_primitives::{address, Address};
 use std::str::FromStr;
@@ -223,7 +223,7 @@ mod contract {
 #[cfg(feature = "provider")]
 mod provider {
     use crate::{
-        coin_type, namehash, try_dns_encode, EnsError, EnsMulticoinResolver, EnsResolver,
+        coin_type, dns_encode, namehash, EnsError, EnsMulticoinResolver, EnsResolver,
         EnsResolver::EnsResolverInstance, UniversalResolver, UNIVERSAL_RESOLVER_ADDRESS,
     };
     use alloy_primitives::{Address, Bytes, U256};
@@ -274,7 +274,7 @@ mod provider {
         N: Network,
     {
         async fn get_resolver(&self, name: &str) -> Result<EnsResolverInstance<&P, N>, EnsError> {
-            let dns = try_dns_encode(name)?;
+            let dns = dns_encode(name)?;
 
             let ur = UniversalResolver::new(UNIVERSAL_RESOLVER_ADDRESS, self);
             let info = ur
@@ -288,7 +288,7 @@ mod provider {
 
         async fn resolve_name(&self, name: &str) -> Result<Address, EnsError> {
             let node = namehash(name);
-            let dns = try_dns_encode(name)?;
+            let dns = dns_encode(name)?;
             let calldata = EnsResolver::addrCall { node }.abi_encode();
 
             let ur = UniversalResolver::new(UNIVERSAL_RESOLVER_ADDRESS, self);
@@ -307,7 +307,7 @@ mod provider {
             coin_type: u64,
         ) -> Result<Bytes, EnsError> {
             let node = namehash(name);
-            let dns = try_dns_encode(name)?;
+            let dns = dns_encode(name)?;
             let calldata = EnsMulticoinResolver::addrCall {
                 node,
                 coin_type: U256::from(coin_type),
@@ -337,7 +337,7 @@ mod provider {
 
         async fn lookup_txt(&self, name: &str, key: &str) -> Result<String, EnsError> {
             let node = namehash(name);
-            let dns = try_dns_encode(name)?;
+            let dns = dns_encode(name)?;
             let calldata = EnsResolver::textCall { node, key: key.to_string() }.abi_encode();
 
             let ur = UniversalResolver::new(UNIVERSAL_RESOLVER_ADDRESS, self);

--- a/crates/ens/src/lib.rs
+++ b/crates/ens/src/lib.rs
@@ -202,6 +202,16 @@ mod contract {
         /// No resolver found for the given name.
         #[error("ENS resolver not found for name {0:?}")]
         ResolverNotFound(String),
+        /// Direct resolver calls are unsafe for this name; use Universal Resolver helpers.
+        ///
+        /// Returned when the name resolves through an ENSIP-10 extended resolver or a
+        /// parent/wildcard resolver. Calling `addr`/`text`/`name` on the raw resolver
+        /// instance can return incorrect data — use `resolve_name`, `lookup_txt`, or
+        /// related helpers instead.
+        #[error(
+            "ENS name {0:?} requires Universal Resolver resolution (extended or wildcard resolver)"
+        )]
+        RequiresUniversalResolver(String),
         /// Failed to perform a reverse lookup.
         #[error("Failed to lookup ENS name from an address: {0}")]
         Lookup(alloy_contract::Error),
@@ -237,6 +247,12 @@ mod provider {
         /// Returns the resolver contract instance for the given ENS name.
         ///
         /// Determines the resolver address via the Universal Resolver.
+        ///
+        /// Returns [`EnsError::RequiresUniversalResolver`] when the name uses an
+        /// ENSIP-10 extended resolver or a parent/wildcard resolver. In those cases
+        /// direct `addr`/`text`/`name` calls on the resolver are not equivalent to
+        /// Universal Resolver resolution — use [`Self::resolve_name`],
+        /// [`Self::lookup_txt`], or the other helpers instead.
         async fn get_resolver(&self, name: &str) -> Result<EnsResolverInstance<&P, N>, EnsError>;
 
         /// Performs a forward lookup of an ENS name to an Ethereum address.
@@ -282,6 +298,13 @@ mod provider {
                 .call()
                 .await
                 .map_err(EnsError::Resolver)?;
+
+            // Extended and parent/wildcard resolvers must be queried through the
+            // Universal Resolver. Returning a raw instance invites incorrect direct
+            // `addr`/`text` calls (e.g. ur.integration-tests.eth).
+            if info.extended || !info.offset.is_zero() {
+                return Err(EnsError::RequiresUniversalResolver(name.to_string()));
+            }
 
             Ok(EnsResolverInstance::new(info.resolver, self))
         }
@@ -433,6 +456,15 @@ mod provider_tests {
 
         let res = provider.resolve_name("ur.integration-tests.eth").await.unwrap();
         assert_eq!(res, address!("0x2222222222222222222222222222222222222222"));
+    }
+
+    #[tokio::test]
+    async fn test_get_resolver_rejects_extended_resolver() {
+        let provider = ProviderBuilder::new()
+            .connect_http("https://ethereum.reth.rs/rpc".parse().unwrap());
+
+        let err = provider.get_resolver("ur.integration-tests.eth").await.unwrap_err();
+        assert!(matches!(err, EnsError::RequiresUniversalResolver(_)));
     }
 
     #[tokio::test]

--- a/crates/ens/src/lib.rs
+++ b/crates/ens/src/lib.rs
@@ -9,7 +9,7 @@
 //! ENS Name resolving utilities.
 
 mod utils;
-pub use utils::{dns_encode, namehash, reverse_address, DnsEncodeError};
+pub use utils::{dns_encode, namehash, reverse_address, try_dns_encode, DnsEncodeError};
 
 use alloy_primitives::{address, Address};
 use std::str::FromStr;
@@ -18,7 +18,7 @@ use std::str::FromStr;
 ///
 /// The primary entry-point for ENS name resolution. Supports wildcard resolvers
 /// and CCIP Read (ERC-3668).
-pub const ENS_UNIVERSAL_RESOLVER_ADDRESS: Address =
+pub const UNIVERSAL_RESOLVER_ADDRESS: Address =
     address!("0xeEeEEEeE14D718C2B47D9923Deab1335E144EeEe");
 
 /// Helpers for ENS multichain coin types.
@@ -223,8 +223,8 @@ mod contract {
 #[cfg(feature = "provider")]
 mod provider {
     use crate::{
-        coin_type, dns_encode, namehash, EnsError, EnsMulticoinResolver, EnsResolver,
-        EnsResolver::EnsResolverInstance, UniversalResolver, ENS_UNIVERSAL_RESOLVER_ADDRESS,
+        coin_type, namehash, try_dns_encode, EnsError, EnsMulticoinResolver, EnsResolver,
+        EnsResolver::EnsResolverInstance, UniversalResolver, UNIVERSAL_RESOLVER_ADDRESS,
     };
     use alloy_primitives::{Address, Bytes, U256};
     use alloy_provider::{Network, Provider};
@@ -274,9 +274,9 @@ mod provider {
         N: Network,
     {
         async fn get_resolver(&self, name: &str) -> Result<EnsResolverInstance<&P, N>, EnsError> {
-            let dns = dns_encode(name)?;
+            let dns = try_dns_encode(name)?;
 
-            let ur = UniversalResolver::new(ENS_UNIVERSAL_RESOLVER_ADDRESS, self);
+            let ur = UniversalResolver::new(UNIVERSAL_RESOLVER_ADDRESS, self);
             let info = ur
                 .requireResolver(dns.into())
                 .call()
@@ -288,10 +288,10 @@ mod provider {
 
         async fn resolve_name(&self, name: &str) -> Result<Address, EnsError> {
             let node = namehash(name);
-            let dns = dns_encode(name)?;
+            let dns = try_dns_encode(name)?;
             let calldata = EnsResolver::addrCall { node }.abi_encode();
 
-            let ur = UniversalResolver::new(ENS_UNIVERSAL_RESOLVER_ADDRESS, self);
+            let ur = UniversalResolver::new(UNIVERSAL_RESOLVER_ADDRESS, self);
             let ret = ur
                 .resolve(dns.into(), calldata.into())
                 .call()
@@ -307,14 +307,14 @@ mod provider {
             coin_type: u64,
         ) -> Result<Bytes, EnsError> {
             let node = namehash(name);
-            let dns = dns_encode(name)?;
+            let dns = try_dns_encode(name)?;
             let calldata = EnsMulticoinResolver::addrCall {
                 node,
                 coin_type: U256::from(coin_type),
             }
             .abi_encode();
 
-            let ur = UniversalResolver::new(ENS_UNIVERSAL_RESOLVER_ADDRESS, self);
+            let ur = UniversalResolver::new(UNIVERSAL_RESOLVER_ADDRESS, self);
             let ret = ur
                 .resolve(dns.into(), calldata.into())
                 .call()
@@ -325,7 +325,7 @@ mod provider {
         }
 
         async fn lookup_address(&self, address: &Address) -> Result<String, EnsError> {
-            let ur = UniversalResolver::new(ENS_UNIVERSAL_RESOLVER_ADDRESS, self);
+            let ur = UniversalResolver::new(UNIVERSAL_RESOLVER_ADDRESS, self);
             let ret = ur
                 .reverse(Bytes::copy_from_slice(address.as_slice()), U256::from(coin_type::ETH))
                 .call()
@@ -337,10 +337,10 @@ mod provider {
 
         async fn lookup_txt(&self, name: &str, key: &str) -> Result<String, EnsError> {
             let node = namehash(name);
-            let dns = dns_encode(name)?;
+            let dns = try_dns_encode(name)?;
             let calldata = EnsResolver::textCall { node, key: key.to_string() }.abi_encode();
 
-            let ur = UniversalResolver::new(ENS_UNIVERSAL_RESOLVER_ADDRESS, self);
+            let ur = UniversalResolver::new(UNIVERSAL_RESOLVER_ADDRESS, self);
             let ret = ur
                 .resolve(dns.into(), calldata.into())
                 .call()

--- a/crates/ens/src/lib.rs
+++ b/crates/ens/src/lib.rs
@@ -233,8 +233,9 @@ mod contract {
 #[cfg(feature = "provider")]
 mod provider {
     use crate::{
-        coin_type, dns_encode, namehash, EnsError, EnsMulticoinResolver, EnsResolver,
-        EnsResolver::EnsResolverInstance, UniversalResolver, UNIVERSAL_RESOLVER_ADDRESS,
+        coin_type, dns_encode, namehash, reverse_address, EnsError, EnsMulticoinResolver,
+        EnsResolver, EnsResolver::EnsResolverInstance, UniversalResolver,
+        UNIVERSAL_RESOLVER_ADDRESS,
     };
     use alloy_primitives::{Address, Bytes, U256};
     use alloy_provider::{Network, Provider};
@@ -297,7 +298,7 @@ mod provider {
                 .requireResolver(dns.into())
                 .call()
                 .await
-                .map_err(EnsError::Resolver)?;
+                .map_err(|error| map_ur_error(error, name, EnsError::Resolver))?;
 
             // Extended and parent/wildcard resolvers must be queried through the
             // Universal Resolver. Returning a raw instance invites incorrect direct
@@ -319,7 +320,7 @@ mod provider {
                 .resolve(dns.into(), calldata.into())
                 .call()
                 .await
-                .map_err(EnsError::Resolve)?;
+                .map_err(|error| map_ur_error(error, name, EnsError::Resolve))?;
 
             Address::abi_decode(ret.result.as_ref()).map_err(|_| EnsError::InvalidResponse)
         }
@@ -342,18 +343,19 @@ mod provider {
                 .resolve(dns.into(), calldata.into())
                 .call()
                 .await
-                .map_err(EnsError::Resolve)?;
+                .map_err(|error| map_ur_error(error, name, EnsError::Resolve))?;
 
             Bytes::abi_decode(ret.result.as_ref()).map_err(|_| EnsError::InvalidResponse)
         }
 
         async fn lookup_address(&self, address: &Address) -> Result<String, EnsError> {
+            let reverse_name = reverse_address(address);
             let ur = UniversalResolver::new(UNIVERSAL_RESOLVER_ADDRESS, self);
             let ret = ur
                 .reverse(Bytes::copy_from_slice(address.as_slice()), U256::from(coin_type::ETH))
                 .call()
                 .await
-                .map_err(EnsError::Lookup)?;
+                .map_err(|error| map_ur_error(error, &reverse_name, EnsError::Lookup))?;
 
             Ok(ret.name)
         }
@@ -368,9 +370,22 @@ mod provider {
                 .resolve(dns.into(), calldata.into())
                 .call()
                 .await
-                .map_err(EnsError::ResolveTxtRecord)?;
+                .map_err(|error| map_ur_error(error, name, EnsError::ResolveTxtRecord))?;
 
             String::abi_decode(ret.result.as_ref()).map_err(|_| EnsError::InvalidResponse)
+        }
+    }
+
+    /// Maps Universal Resolver contract errors, preserving [`EnsError::ResolverNotFound`].
+    fn map_ur_error(
+        error: alloy_contract::Error,
+        name: &str,
+        fallback: impl FnOnce(alloy_contract::Error) -> EnsError,
+    ) -> EnsError {
+        if error.as_decoded_error::<UniversalResolver::ResolverNotFound>().is_some() {
+            EnsError::ResolverNotFound(name.to_string())
+        } else {
+            fallback(error)
         }
     }
 }

--- a/crates/ens/src/lib.rs
+++ b/crates/ens/src/lib.rs
@@ -8,22 +8,39 @@
 
 //! ENS Name resolving utilities.
 
-use alloy_primitives::{address, Address, Keccak256, B256};
-use std::{borrow::Cow, str::FromStr};
+mod utils;
+pub use utils::{dns_encode, namehash, reverse_address, DnsEncodeError};
 
-/// ENS registry address (`0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e`)
-pub const ENS_ADDRESS: Address = address!("0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e");
+use alloy_primitives::{address, Address};
+use std::str::FromStr;
 
-/// ENS Universal Resolver address on Ethereum Mainnet
-/// (`0xeeeeeeee14d718c2b47d9923deab1335e144eeee`)
+/// ENS Universal Resolver address (`0xeEeEEEeE14D718C2B47D9923Deab1335E144EeEe`).
 ///
-/// The Universal Resolver is the canonical entry point for all ENS resolution.
-/// Resolution may require EIP-3668 CCIP Read, which must be handled outside this crate's helpers.
-pub const UNIVERSAL_RESOLVER_ADDRESS: Address =
-    address!("0xeeeeeeee14d718c2b47d9923deab1335e144eeee");
+/// The primary entry-point for ENS name resolution. Supports wildcard resolvers
+/// and CCIP Read (ERC-3668).
+pub const ENS_UNIVERSAL_RESOLVER_ADDRESS: Address =
+    address!("0xeEeEEEeE14D718C2B47D9923Deab1335E144EeEe");
 
-/// ENS const for registrar domain
-pub const ENS_REVERSE_REGISTRAR_DOMAIN: &str = "addr.reverse";
+/// Helpers for ENS multichain coin types.
+///
+/// Non-EVM chains use their static SLIP-0044 coin type according to ENSIP-9.
+/// EVM-compatible chains follow ENSIP-11: `coinType = 0x80000000 | chainId`.
+/// Use [`evm_chain`][coin_type::evm_chain] to derive an EVM coin type.
+pub mod coin_type {
+    /// Ethereum mainnet (SLIP-0044, coin type 60).
+    pub const ETH: u64 = 60;
+
+    /// Converts an EVM chain ID to its ENSIP-11 coin type.
+    ///
+    /// Chain ID `1` (Ethereum mainnet) returns [`ETH`] (`60`) per SLIP-0044.
+    /// All other chains use `0x80000000 | chain_id`.
+    pub fn evm_chain(chain_id: u32) -> u64 {
+        if chain_id == 1 {
+            return ETH;
+        }
+        0x8000_0000u64 | u64::from(chain_id)
+    }
+}
 
 #[cfg(feature = "contract")]
 pub use contract::*;
@@ -31,21 +48,17 @@ pub use contract::*;
 #[cfg(feature = "provider")]
 pub use provider::*;
 
-/// An ENS name or Ethereum address.
-///
-/// [`FromStr`] first attempts to parse an address, then treats a string containing `.` as a name.
-/// This is only a routing heuristic: it rejects dotless names and does not normalize or validate
-/// ENS names. In contrast, converting from [`String`] always creates [`Name`](Self::Name).
+/// ENS name or Ethereum Address.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum NameOrAddress {
-    /// An ENS name. The value must already be ENSIP-15 normalized; its format is not checked.
+    /// An ENS Name (format does not get checked)
     Name(String),
     /// An Ethereum Address
     Address(Address),
 }
 
 impl NameOrAddress {
-    /// Resolves a name to an Ethereum address, or returns an address unchanged without an RPC call.
+    /// Resolves the name to an Ethereum Address.
     #[cfg(feature = "provider")]
     pub async fn resolve<N: alloy_provider::Network, P: alloy_provider::Provider<N>>(
         &self,
@@ -97,131 +110,159 @@ impl FromStr for NameOrAddress {
 mod contract {
     use alloy_sol_types::sol;
 
-    // ENS Registry and Resolver contracts.
     sol! {
-        /// ENS Registry contract.
-        #[sol(rpc)]
-        contract EnsRegistry {
-            /// Returns the resolver for the specified node.
-            function resolver(bytes32 node) view returns (address);
-
-            /// returns the owner of this node
-            function owner(bytes32 node) view returns (address);
-        }
-
-        /// ENS Resolver interface.
+        /// ENS Resolver interface (ENSIP-1).
         #[sol(rpc)]
         contract EnsResolver {
-            /// Returns the address associated with the specified node.
+            /// Returns the Ethereum address associated with the specified node.
             function addr(bytes32 node) view returns (address);
 
             /// Returns the name associated with an ENS node, for reverse records.
             function name(bytes32 node) view returns (string);
 
-            /// Returns the txt associated with an ENS node
-            function text(bytes32 node,string calldata key) view virtual returns (string memory);
+            /// Returns the text record value for the specified key.
+            function text(bytes32 node, string calldata key) view virtual returns (string memory);
         }
 
-        /// ENS Universal Resolver contract.
+        /// ENS Multicoin Resolver interface (ENSIP-11).
         ///
-        /// The `resolve` item models the canonical Universal Resolver entry point.
+        /// Provides multichain address resolution. Use with the Universal Resolver and
+        /// coin types from ENSIP-9 or [`coin_type::evm_chain`][crate::coin_type::evm_chain].
+        #[sol(rpc)]
+        contract EnsMulticoinResolver {
+            /// Returns the address for `node` on the chain identified by `coin_type`.
+            ///
+            /// The returned bytes are the raw address encoding for that coin type
+            /// (e.g., 20 raw bytes for EVM chains, script bytes for Bitcoin).
+            function addr(bytes32 node, uint256 coin_type) view returns (bytes memory);
+        }
+
+        /// ENS Universal Resolver (ENSIP-23).
         ///
-        /// It may signal EIP-3668 CCIP Read with an `OffchainLookup` revert. This binding does not
-        /// follow that redirect; the caller must provide CCIP-Read handling separately.
+        /// The single entry-point for all ENS resolution. Handles routing to wildcard
+        /// resolvers and CCIP Read (ERC-3668).
         ///
-        /// The legacy `reverse(bytes)` item below does **not** match the deployed canonical
-        /// resolver's `reverse(bytes,uint256)` ABI and must not be used with
-        /// [`UNIVERSAL_RESOLVER_ADDRESS`](crate::UNIVERSAL_RESOLVER_ADDRESS).
+        /// Spec: <https://docs.ens.domains/ensip/23>
+        ///
+        /// Note: CCIP Read requires client-side handling of the `OffchainLookup` revert
+        /// (ERC-3668). Alloy does not currently implement this; calls to names that require
+        /// CCIP Read will surface as [`EnsError::Resolve`].
         #[sol(rpc)]
         contract UniversalResolver {
-            /// Resolves an ENS name with the given encoded resolver call data.
-            function resolve(bytes calldata name, bytes calldata data) external view returns (bytes memory, address);
+            error ResolverNotFound(bytes name);
+            error ResolverNotContract(bytes name, address resolver);
+            error ReverseAddressMismatch(string primary, bytes primaryAddress);
+            error UnsupportedResolverProfile(bytes4 selector);
+            error ResolverError(bytes errorData);
 
-            /// A legacy reverse-resolution ABI retained for compatibility.
+            struct ResolverInfo {
+                bytes name;
+                uint256 offset;
+                bytes32 node;
+                address resolver;
+                bool extended;
+            }
+
+            /// Like `findResolver`, but reverts with `ResolverNotFound` if no resolver exists.
+            function requireResolver(bytes memory name) public view returns (ResolverInfo memory info);
+
+            /// Returns the resolver for `name` (DNS wire-format) without performing resolution.
             ///
-            /// This selector and return shape do not match the deployed canonical Universal
-            /// Resolver. Do not call it at [`UNIVERSAL_RESOLVER_ADDRESS`](crate::UNIVERSAL_RESOLVER_ADDRESS).
-            function reverse(bytes calldata reverseName) external view returns (string memory, address, address, address);
-        }
+            /// Returns `(resolver, node, offset)` where `resolver` is the contract address,
+            /// `node` is the namehash, and `offset` is the byte offset into `name` at which
+            /// the resolver was found (for wildcard/parent resolution).
+            function findResolver(bytes memory name) public view returns (address, bytes32, uint256);
 
-        /// ENS Reverse Registrar contract
-        #[sol(rpc)]
-        contract ReverseRegistrar {}
+            /// Resolves `name` (DNS wire-format) using the encoded `data` call.
+            ///
+            /// Returns the ABI-encoded result of the resolver call and the resolver address.
+            /// Reverts with `OffchainLookup` when CCIP Read (ERC-3668) is required.
+            function resolve(bytes calldata name, bytes calldata data) external view returns (bytes memory result, address resolver);
+
+            /// Like `resolve`, but uses `gateways` for CCIP Read instead of the default.
+            function resolveWithGateways(bytes calldata name, bytes calldata data, string[] memory gateways) public view returns (bytes memory result, address resolver);
+
+            /// Reverse-resolves an address to its primary ENS name.
+            ///
+            /// `lookupAddress` is the raw byte encoding of the address.
+            /// `coinType` specifies the chain (use [`coin_type::ETH`] for Ethereum).
+            function reverse(bytes calldata lookupAddress, uint256 coinType) external view returns (string memory name, address resolver, address reverseResolver);
+
+            /// Like `reverse`, but uses `gateways` for CCIP Read instead of the default.
+            function reverseWithGateways(bytes calldata lookupAddress, uint256 coinType, string[] memory gateways) public view returns (string memory name, address resolver, address reverseResolver);
+        }
     }
 
     /// Error type for ENS resolution.
     #[derive(Debug, thiserror::Error)]
     pub enum EnsError {
-        /// Failed to get resolver from the ENS registry.
-        #[error("Failed to get resolver from the ENS registry: {0}")]
+        /// Failed to get the resolver for this name.
+        #[error("Failed to get ENS resolver: {0}")]
         Resolver(alloy_contract::Error),
-        /// Failed to get resolver from the ENS registry.
+        /// No resolver found for the given name.
         #[error("ENS resolver not found for name {0:?}")]
         ResolverNotFound(String),
-        /// Failed to get reverse registrar from the ENS registry.
-        #[error("Failed to get reverse registrar from the ENS registry: {0}")]
-        RevRegistrar(alloy_contract::Error),
-        /// Failed to get reverse registrar from the ENS registry.
-        #[error("ENS reverse registrar not found for addr.reverse")]
-        ReverseRegistrarNotFound,
-        /// Failed to lookup ENS name from an address.
+        /// Failed to perform a reverse lookup.
         #[error("Failed to lookup ENS name from an address: {0}")]
         Lookup(alloy_contract::Error),
         /// Failed to resolve ENS name to an address.
         #[error("Failed to resolve ENS name to an address: {0}")]
         Resolve(alloy_contract::Error),
-        /// Failed to get txt records of ENS name.
-        #[error("Failed to resolve txt record: {0}")]
+        /// Failed to get a text record for an ENS name.
+        #[error("Failed to resolve text record: {0}")]
         ResolveTxtRecord(alloy_contract::Error),
+        /// Failed to DNS-encode the ENS name for the Universal Resolver.
+        #[error("Failed to DNS-encode ENS name: {0}")]
+        DnsEncode(#[from] crate::DnsEncodeError),
+        /// Failed to decode the Universal Resolver response.
+        #[error("Failed to decode Universal Resolver response")]
+        InvalidResponse,
     }
 }
 
 #[cfg(feature = "provider")]
 mod provider {
     use crate::{
-        dns_encode, namehash, reverse_address, EnsError, EnsRegistry, EnsResolver,
-        EnsResolver::EnsResolverInstance, ReverseRegistrar::ReverseRegistrarInstance,
-        UniversalResolver, ENS_ADDRESS, ENS_REVERSE_REGISTRAR_DOMAIN, UNIVERSAL_RESOLVER_ADDRESS,
+        coin_type, dns_encode, namehash, EnsError, EnsMulticoinResolver, EnsResolver,
+        EnsResolver::EnsResolverInstance, UniversalResolver, ENS_UNIVERSAL_RESOLVER_ADDRESS,
     };
-    use alloy_primitives::{Address, Bytes, B256};
+    use alloy_primitives::{Address, Bytes, U256};
     use alloy_provider::{Network, Provider};
-    use alloy_sol_types::SolCall;
+    use alloy_sol_types::{SolCall, SolValue};
 
     /// Extension trait for ENS contract calls.
-    ///
-    /// All ENS name strings must already be normalized according to ENSIP-15. These helpers do not
-    /// perform complete normalization or validation before hashing or DNS-encoding them;
-    /// [`namehash`] only removes `U+FE0F`.
     #[cfg_attr(target_family = "wasm", async_trait::async_trait(?Send))]
     #[cfg_attr(not(target_family = "wasm"), async_trait::async_trait)]
     pub trait ProviderEnsExt<N: alloy_provider::Network, P: Provider<N>> {
-        /// Returns the resolver for the specified node. The `&str` is only used for error messages.
-        async fn get_resolver(
-            &self,
-            node: B256,
-            error_name: &str,
-        ) -> Result<EnsResolverInstance<&P, N>, EnsError>;
-
-        /// Returns the reverse registrar for the specified node.
-        async fn get_reverse_registrar(&self) -> Result<ReverseRegistrarInstance<&P, N>, EnsError>;
-
-        /// Performs a forward lookup of an already-normalized ENS name using the Universal
-        /// Resolver.
+        /// Returns the resolver contract instance for the given ENS name.
         ///
-        /// The name must also satisfy [`dns_encode`]'s non-empty-label and length preconditions.
+        /// Determines the resolver address via the Universal Resolver.
+        async fn get_resolver(&self, name: &str) -> Result<EnsResolverInstance<&P, N>, EnsError>;
+
+        /// Performs a forward lookup of an ENS name to an Ethereum address.
         ///
-        /// EIP-3668 CCIP-Read redirects are not followed by this helper and surface as a resolution
-        /// error unless handling is supplied outside it.
+        /// Routes through the [Universal Resolver], which handles wildcard resolvers
+        /// and CCIP Read (ERC-3668).
+        ///
+        /// [Universal Resolver]: https://docs.ens.domains/web/ensv2-readiness
         async fn resolve_name(&self, name: &str) -> Result<Address, EnsError>;
 
-        /// Reads the legacy `{address}.addr.reverse` record through the ENS registry and resolver.
+        /// Resolves an ENS name to a multichain address for the given coin type (ENSIP-11).
         ///
-        /// This is not Universal Resolver multichain reverse resolution. The returned name is not
-        /// normalized or forward-verified; normalize it, resolve it, and compare the resulting
-        /// address before treating the name as an authenticated identity.
+        /// Returns the raw address bytes as stored in the resolver. The encoding varies
+        /// by coin type: 20 raw address bytes for EVM chains, script bytes for
+        /// Bitcoin, etc. Use [`coin_type::evm_chain`][crate::coin_type::evm_chain] for
+        /// EVM chains; for non-EVM chains, pass the static SLIP-0044 coin type.
+        async fn resolve_name_for_coin_type(
+            &self,
+            name: &str,
+            coin_type: u64,
+        ) -> Result<Bytes, EnsError>;
+
+        /// Performs a reverse lookup of an address to its primary ENS name.
         async fn lookup_address(&self, address: &Address) -> Result<String, EnsError>;
 
-        /// Looks up a text record for an already-normalized ENS name.
+        /// Looks up a text record for an ENS name.
         async fn lookup_txt(&self, name: &str, key: &str) -> Result<String, EnsError>;
     }
 
@@ -232,193 +273,89 @@ mod provider {
         P: Provider<N>,
         N: Network,
     {
-        async fn get_resolver(
-            &self,
-            node: B256,
-            error_name: &str,
-        ) -> Result<EnsResolverInstance<&P, N>, EnsError> {
-            let registry = EnsRegistry::new(ENS_ADDRESS, self);
-            let address = registry.resolver(node).call().await.map_err(EnsError::Resolver)?;
-            if address == Address::ZERO {
-                return Err(EnsError::ResolverNotFound(error_name.to_string()));
-            }
-            Ok(EnsResolverInstance::new(address, self))
-        }
+        async fn get_resolver(&self, name: &str) -> Result<EnsResolverInstance<&P, N>, EnsError> {
+            let dns = dns_encode(name)?;
 
-        async fn get_reverse_registrar(&self) -> Result<ReverseRegistrarInstance<&P, N>, EnsError> {
-            let registry = EnsRegistry::new(ENS_ADDRESS, self);
-            let address = registry
-                .owner(namehash(ENS_REVERSE_REGISTRAR_DOMAIN))
+            let ur = UniversalResolver::new(ENS_UNIVERSAL_RESOLVER_ADDRESS, self);
+            let info = ur
+                .requireResolver(dns.into())
                 .call()
                 .await
-                .map_err(EnsError::RevRegistrar)?;
-            if address == Address::ZERO {
-                return Err(EnsError::ReverseRegistrarNotFound);
-            }
-            Ok(ReverseRegistrarInstance::new(address, self))
+                .map_err(EnsError::Resolver)?;
+
+            Ok(EnsResolverInstance::new(info.resolver, self))
         }
 
         async fn resolve_name(&self, name: &str) -> Result<Address, EnsError> {
-            let dns_name = dns_encode(name);
             let node = namehash(name);
-            let addr_call = EnsResolver::addrCall { node };
-            let call_data = Bytes::from(EnsResolver::addrCall::abi_encode(&addr_call));
+            let dns = dns_encode(name)?;
+            let calldata = EnsResolver::addrCall { node }.abi_encode();
 
-            let ur = UniversalResolver::new(UNIVERSAL_RESOLVER_ADDRESS, self);
-            let result = ur
-                .resolve(Bytes::from(dns_name), call_data)
+            let ur = UniversalResolver::new(ENS_UNIVERSAL_RESOLVER_ADDRESS, self);
+            let ret = ur
+                .resolve(dns.into(), calldata.into())
                 .call()
                 .await
                 .map_err(EnsError::Resolve)?;
 
-            let result_bytes = result._0;
-            if result_bytes.len() < 32 {
-                return Err(EnsError::ResolverNotFound(name.to_string()));
+            Address::abi_decode(ret.result.as_ref()).map_err(|_| EnsError::InvalidResponse)
+        }
+
+        async fn resolve_name_for_coin_type(
+            &self,
+            name: &str,
+            coin_type: u64,
+        ) -> Result<Bytes, EnsError> {
+            let node = namehash(name);
+            let dns = dns_encode(name)?;
+            let calldata = EnsMulticoinResolver::addrCall {
+                node,
+                coin_type: U256::from(coin_type),
             }
-            let addr = Address::from_slice(&result_bytes[result_bytes.len() - 20..]);
-            Ok(addr)
+            .abi_encode();
+
+            let ur = UniversalResolver::new(ENS_UNIVERSAL_RESOLVER_ADDRESS, self);
+            let ret = ur
+                .resolve(dns.into(), calldata.into())
+                .call()
+                .await
+                .map_err(EnsError::Resolve)?;
+
+            Bytes::abi_decode(ret.result.as_ref()).map_err(|_| EnsError::InvalidResponse)
         }
 
         async fn lookup_address(&self, address: &Address) -> Result<String, EnsError> {
-            let name = reverse_address(address);
-            let node = namehash(&name);
-            let resolver = self.get_resolver(node, &name).await?;
-            let name = resolver.name(node).call().await.map_err(EnsError::Lookup)?;
-            Ok(name)
+            let ur = UniversalResolver::new(ENS_UNIVERSAL_RESOLVER_ADDRESS, self);
+            let ret = ur
+                .reverse(Bytes::copy_from_slice(address.as_slice()), U256::from(coin_type::ETH))
+                .call()
+                .await
+                .map_err(EnsError::Lookup)?;
+
+            Ok(ret.name)
         }
 
         async fn lookup_txt(&self, name: &str, key: &str) -> Result<String, EnsError> {
             let node = namehash(name);
-            let resolver = self.get_resolver(node, name).await?;
-            let txt_value = resolver
-                .text(node, key.to_string())
+            let dns = dns_encode(name)?;
+            let calldata = EnsResolver::textCall { node, key: key.to_string() }.abi_encode();
+
+            let ur = UniversalResolver::new(ENS_UNIVERSAL_RESOLVER_ADDRESS, self);
+            let ret = ur
+                .resolve(dns.into(), calldata.into())
                 .call()
                 .await
                 .map_err(EnsError::ResolveTxtRecord)?;
-            Ok(txt_value)
+
+            String::abi_decode(ret.result.as_ref()).map_err(|_| EnsError::InvalidResponse)
         }
     }
-}
-
-/// Returns the ENS namehash as specified in [EIP-137](https://eips.ethereum.org/EIPS/eip-137).
-///
-/// `name` must already be ENSIP-15 normalized. Apart from removing the `U+FE0F` variation selector,
-/// this function hashes labels verbatim and does not normalize or validate them.
-pub fn namehash(name: &str) -> B256 {
-    if name.is_empty() {
-        return B256::ZERO;
-    }
-
-    // Remove the variation selector `U+FE0F` if present.
-    const VARIATION_SELECTOR: char = '\u{fe0f}';
-    let name = if name.contains(VARIATION_SELECTOR) {
-        Cow::Owned(name.replace(VARIATION_SELECTOR, ""))
-    } else {
-        Cow::Borrowed(name)
-    };
-
-    // Generate the node starting from the right.
-    // This buffer is `[node @ [u8; 32], label_hash @ [u8; 32]]`.
-    let mut buffer = [0u8; 64];
-    for label in name.rsplit('.') {
-        // node = keccak256([node, keccak256(label)])
-
-        // Hash the label.
-        let mut label_hasher = Keccak256::new();
-        label_hasher.update(label.as_bytes());
-        label_hasher.finalize_into(&mut buffer[32..]);
-
-        // Hash both the node and the label hash, writing into the node.
-        let mut buffer_hasher = Keccak256::new();
-        buffer_hasher.update(buffer.as_slice());
-        buffer_hasher.finalize_into(&mut buffer[..32]);
-    }
-    buffer[..32].try_into().unwrap()
-}
-
-/// Encodes a domain name into DNS wire format as specified in
-/// [RFC 1035](https://datatracker.ietf.org/doc/html/rfc1035).
-///
-/// Each label is prefixed with its length byte, and the name is terminated with a
-/// zero-length label (null byte).
-///
-/// This is an unchecked encoder: `name` must already be ENSIP-15 normalized and non-empty, must
-/// not contain empty labels (including leading, trailing, or repeated dots), and each UTF-8 label
-/// length must fit in a `u8`. The caller is also responsible for the applicable ENSIP-10 and DNS
-/// length limits. Invalid input is encoded without an error; an oversized label's length prefix is
-/// truncated.
-///
-/// # Examples
-///
-/// ```
-/// use alloy_ens::dns_encode;
-/// assert_eq!(dns_encode("eth"), vec![3, b'e', b't', b'h', 0]);
-/// assert_eq!(
-///     dns_encode("vitalik.eth"),
-///     vec![7, b'v', b'i', b't', b'a', b'l', b'i', b'k', 3, b'e', b't', b'h', 0]
-/// );
-/// ```
-pub fn dns_encode(name: &str) -> Vec<u8> {
-    let mut result = Vec::with_capacity(name.len() + 2);
-    for label in name.split('.') {
-        result.push(label.len() as u8);
-        result.extend_from_slice(label.as_bytes());
-    }
-    result.push(0);
-    result
-}
-
-/// Returns the reverse-registrar name of an address.
-pub fn reverse_address(addr: &Address) -> String {
-    format!("{addr:x}.{ENS_REVERSE_REGISTRAR_DOMAIN}")
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
-    use alloy_primitives::hex;
-
-    fn assert_hex(hash: B256, val: &str) {
-        assert_eq!(hash.0[..], hex::decode(val).unwrap()[..]);
-    }
-
-    #[test]
-    fn test_namehash() {
-        for (name, expected) in &[
-            ("", "0x0000000000000000000000000000000000000000000000000000000000000000"),
-            ("eth", "0x93cdeb708b7545dc668eb9280176169d1c33cfd8ed6f04690a0bcc88a93fc4ae"),
-            ("foo.eth", "0xde9b09fd7c5f901e23a3f19fecc54828e9c848539801e86591bd9801b019f84f"),
-            ("alice.eth", "0x787192fc5378cc32aa956ddfdedbf26b24e8d78e40109add0eea2c1a012c3dec"),
-            ("ret↩️rn.eth", "0x3de5f4c02db61b221e7de7f1c40e29b6e2f07eb48d65bf7e304715cd9ed33b24"),
-        ] {
-            assert_hex(namehash(name), expected);
-        }
-    }
-
-    #[test]
-    fn test_dns_encode() {
-        assert_eq!(dns_encode("eth"), vec![3, b'e', b't', b'h', 0]);
-        assert_eq!(
-            dns_encode("vitalik.eth"),
-            vec![7, b'v', b'i', b't', b'a', b'l', b'i', b'k', 3, b'e', b't', b'h', 0]
-        );
-    }
-
-    #[test]
-    fn test_reverse_address() {
-        for (addr, expected) in [
-            (
-                "0x314159265dd8dbb310642f98f50c066173c1259b",
-                "314159265dd8dbb310642f98f50c066173c1259b.addr.reverse",
-            ),
-            (
-                "0x28679A1a632125fbBf7A68d850E50623194A709E",
-                "28679a1a632125fbbf7a68d850e50623194a709e.addr.reverse",
-            ),
-        ] {
-            assert_eq!(reverse_address(&addr.parse().unwrap()), expected, "{addr}");
-        }
-    }
+    use std::str::FromStr;
 
     #[test]
     fn test_invalid_address() {
@@ -431,86 +368,100 @@ mod test {
             assert!(NameOrAddress::from_str(addr).is_err());
         }
     }
+
+    #[test]
+    fn test_name_or_address_dns_detection() {
+        assert!(matches!(NameOrAddress::from_str("foo.eth"), Ok(NameOrAddress::Name(_))));
+        assert!(matches!(NameOrAddress::from_str("ensfairy.xyz"), Ok(NameOrAddress::Name(_))));
+        assert!(matches!(NameOrAddress::from_str("sub.foo.eth"), Ok(NameOrAddress::Name(_))));
+    }
+
+    #[test]
+    fn test_coin_type_evm_chain() {
+        assert_eq!(coin_type::evm_chain(1), coin_type::ETH); // mainnet special case
+        assert_eq!(coin_type::evm_chain(8453), 0x8000_2105); // Base
+        assert_eq!(coin_type::evm_chain(10), 0x8000_000A); // Optimism
+        assert_eq!(coin_type::evm_chain(42161), 0x8000_A4B1); // Arbitrum One
+    }
+
+    #[test]
+    fn test_coin_type_evm_chain_does_not_reject_high_bit() {
+        assert_eq!(coin_type::evm_chain(0x8000_0000), 0x8000_0000);
+    }
 }
 
 #[cfg(all(test, feature = "provider"))]
-mod tests {
+mod provider_tests {
     use super::*;
     use alloy_primitives::address;
     use alloy_provider::ProviderBuilder;
 
     #[tokio::test]
-    async fn test_reverse_registrar_fetching_mainnet() {
-        let provider =
-            ProviderBuilder::new().connect_http("https://ethereum.reth.rs/rpc".parse().unwrap());
-
-        let res = provider.get_reverse_registrar().await;
-        assert_eq!(*res.unwrap().address(), address!("0xa58E81fe9b61B5c3fE2AFD33CF304c454AbFc7Cb"));
-    }
-
-    #[tokio::test]
     async fn test_pub_resolver_fetching_mainnet() {
-        let provider =
-            ProviderBuilder::new().connect_http("https://ethereum.reth.rs/rpc".parse().unwrap());
+        let provider = ProviderBuilder::new()
+            .connect_http("https://ethereum.reth.rs/rpc".parse().unwrap());
 
-        let name = "vitalik.eth";
-        let node = namehash(name);
-        let res = provider.get_resolver(node, name).await;
+        let res = provider.get_resolver("vitalik.eth").await;
         assert_eq!(*res.unwrap().address(), address!("0x231b0Ee14048e9dCcD1d247744d114a4EB5E8E63"));
     }
 
     #[tokio::test]
-    async fn test_resolve_name_via_universal_resolver() {
-        let provider =
-            ProviderBuilder::new().connect_http("https://ethereum.reth.rs/rpc".parse().unwrap());
+    async fn test_pub_resolver_text() {
+        let provider = ProviderBuilder::new()
+            .connect_http("https://ethereum.reth.rs/rpc".parse().unwrap());
 
-        let addr = provider.resolve_name("ur.integration-tests.eth").await.unwrap();
-        assert_eq!(addr, address!("0x2222222222222222222222222222222222222222"));
+        let name = "vitalik.eth";
+        let node = namehash(name);
+        let res = provider.get_resolver(name).await.unwrap();
+        let text = res.text(node, "avatar".to_string()).call().await.unwrap();
+        assert_eq!(text, "https://euc.li/vitalik.eth")
     }
 
     #[tokio::test]
-    async fn test_lookup_address_via_universal_resolver() {
-        let provider =
-            ProviderBuilder::new().connect_http("https://ethereum.reth.rs/rpc".parse().unwrap());
+    async fn test_pub_resolver_fetching_text() {
+        let provider = ProviderBuilder::new()
+            .connect_http("https://ethereum.reth.rs/rpc".parse().unwrap());
 
-        let name = provider
-            .lookup_address(&address!("0xeE9eeaAB0Bb7D9B969D701f6f8212609EDeA252E"))
+        let res = provider.lookup_txt("vitalik.eth", "avatar").await.unwrap();
+        assert_eq!(res, "https://euc.li/vitalik.eth")
+    }
+
+    #[tokio::test]
+    async fn test_universal_resolver_integration() {
+        let provider = ProviderBuilder::new()
+            .connect_http("https://ethereum.reth.rs/rpc".parse().unwrap());
+
+        let res = provider.resolve_name("ur.integration-tests.eth").await.unwrap();
+        assert_eq!(res, address!("0x2222222222222222222222222222222222222222"));
+    }
+
+    #[tokio::test]
+    async fn test_multicoin_resolver_integration() {
+        let provider = ProviderBuilder::new()
+            .connect_http("https://ethereum.reth.rs/rpc".parse().unwrap());
+
+        let res = provider
+            .resolve_name_for_coin_type(
+                "coins.integration-tests.eth",
+                coin_type::evm_chain(8453),
+            )
             .await
             .unwrap();
-        assert_eq!(name, "devrel.enslabs.eth");
-    }
-
-    #[tokio::test]
-    async fn test_lookup_txt_via_universal_resolver() {
-        let provider =
-            ProviderBuilder::new().connect_http("https://ethereum.reth.rs/rpc".parse().unwrap());
-
-        let avatar = provider.lookup_txt("integration-tests.eth", "avatar").await.unwrap();
         assert_eq!(
-            avatar,
-            "https://raw.githubusercontent.com/ensdomains/resolution-tests/refs/heads/main/assets/avatar.svg"
+            res.as_ref(),
+            address!("0xa66E90D515F576f49Af2dF40952476D56F72A420").as_slice()
         );
     }
 
     #[tokio::test]
-    async fn test_pub_resolver_text() {
-        let provider =
-            ProviderBuilder::new().connect_http("https://ethereum.reth.rs/rpc".parse().unwrap());
+    async fn test_reverse_resolver_integration() {
+        let provider = ProviderBuilder::new()
+            .connect_http("https://ethereum.reth.rs/rpc".parse().unwrap());
 
-        let name = "vitalik.eth";
-        let node = namehash(name);
-        let res = provider.get_resolver(node, name).await.unwrap();
-        let txt = res.text(node, "avatar".to_string()).call().await.unwrap();
-        assert_eq!(txt, "https://euc.li/vitalik.eth")
-    }
-
-    #[tokio::test]
-    async fn test_pub_resolver_fetching_txt() {
-        let provider =
-            ProviderBuilder::new().connect_http("https://ethereum.reth.rs/rpc".parse().unwrap());
-
-        let name = "vitalik.eth";
-        let res = provider.lookup_txt(name, "avatar").await.unwrap();
-        assert_eq!(res, "https://euc.li/vitalik.eth")
+        let res = provider
+            .lookup_address(&address!("0xeE9eeaAB0Bb7D9B969D701f6f8212609EDeA252E"))
+            .await
+            .unwrap();
+        assert_eq!(res, "devrel.enslabs.eth");
     }
 }

--- a/crates/ens/src/lib.rs
+++ b/crates/ens/src/lib.rs
@@ -188,6 +188,11 @@ mod contract {
         ///
         /// Spec: <https://docs.ens.domains/ensip/23>
         ///
+        /// `resolve` keeps unnamed returns so downstream `resolveReturn._0` / `_1`
+        /// still compile. Reverse uses the deployed ENSIP-23 ABI
+        /// `reverse(bytes,uint256)`; the historical 1-arg `reverse(bytes reverseName)`
+        /// binding did not match the chain and is not preserved.
+        ///
         /// Note: CCIP Read requires client-side handling of the `OffchainLookup` revert
         /// (ERC-3668). Alloy does not currently implement this; calls to names that require
         /// CCIP Read will surface as [`EnsError::Resolve`].
@@ -221,10 +226,10 @@ mod contract {
             ///
             /// Returns the ABI-encoded result of the resolver call and the resolver address.
             /// Reverts with `OffchainLookup` when CCIP Read (ERC-3668) is required.
-            function resolve(bytes calldata name, bytes calldata data) external view returns (bytes memory result, address resolver);
+            function resolve(bytes calldata name, bytes calldata data) external view returns (bytes memory, address);
 
             /// Like `resolve`, but uses `gateways` for CCIP Read instead of the default.
-            function resolveWithGateways(bytes calldata name, bytes calldata data, string[] memory gateways) public view returns (bytes memory result, address resolver);
+            function resolveWithGateways(bytes calldata name, bytes calldata data, string[] memory gateways) public view returns (bytes memory, address);
 
             /// Reverse-resolves an address to its primary ENS name.
             ///
@@ -237,8 +242,27 @@ mod contract {
         }
     }
 
+    /// Returns the resolver address when it is safe to call `addr`/`text`/`name` directly.
+    ///
+    /// Extended (ENSIP-10) and parent/wildcard resolvers must be queried through the
+    /// Universal Resolver instead.
+    pub(crate) fn direct_resolver_address(
+        info: &UniversalResolver::ResolverInfo,
+        name: &str,
+    ) -> Result<alloy_primitives::Address, EnsError> {
+        if info.extended || !info.offset.is_zero() {
+            Err(EnsError::RequiresUniversalResolver(name.to_string()))
+        } else {
+            Ok(info.resolver)
+        }
+    }
+
     /// Error type for ENS resolution.
+    ///
+    /// New variants (`RequiresUniversalResolver`, `DnsEncode`, `InvalidResponse`) are
+    /// an intentional semver break relative to Alloy 1.x `EnsError`.
     #[derive(Debug, thiserror::Error)]
+    #[non_exhaustive]
     pub enum EnsError {
         /// Failed to get the resolver for this name.
         #[error("Failed to get ENS resolver: {0}")]
@@ -388,14 +412,8 @@ mod provider {
                 .await
                 .map_err(|error| map_ur_error(error, name, EnsError::Resolver))?;
 
-            // Extended and parent/wildcard resolvers must be queried through the
-            // Universal Resolver. Returning a raw instance invites incorrect direct
-            // `addr`/`text` calls (e.g. ur.integration-tests.eth).
-            if info.extended || !info.offset.is_zero() {
-                return Err(EnsError::RequiresUniversalResolver(name.to_string()));
-            }
-
-            Ok(EnsResolverInstance::new(info.resolver, self))
+            let resolver = crate::direct_resolver_address(&info, name)?;
+            Ok(EnsResolverInstance::new(resolver, self))
         }
 
         async fn get_resolver(
@@ -436,7 +454,7 @@ mod provider {
                 .await
                 .map_err(|error| map_ur_error(error, name, EnsError::Resolve))?;
 
-            Address::abi_decode(ret.result.as_ref()).map_err(|_| EnsError::InvalidResponse)
+            Address::abi_decode(ret._0.as_ref()).map_err(|_| EnsError::InvalidResponse)
         }
 
         async fn resolve_name_for_coin_type(
@@ -459,7 +477,7 @@ mod provider {
                 .await
                 .map_err(|error| map_ur_error(error, name, EnsError::Resolve))?;
 
-            Bytes::abi_decode(ret.result.as_ref()).map_err(|_| EnsError::InvalidResponse)
+            Bytes::abi_decode(ret._0.as_ref()).map_err(|_| EnsError::InvalidResponse)
         }
 
         async fn lookup_address(&self, address: &Address) -> Result<String, EnsError> {
@@ -486,7 +504,7 @@ mod provider {
                 .await
                 .map_err(|error| map_ur_error(error, name, EnsError::ResolveTxtRecord))?;
 
-            String::abi_decode(ret.result.as_ref()).map_err(|_| EnsError::InvalidResponse)
+            String::abi_decode(ret._0.as_ref()).map_err(|_| EnsError::InvalidResponse)
         }
     }
 
@@ -542,6 +560,60 @@ mod tests {
         // space; IDs with the high bit set would collide with smaller IDs.
         assert_eq!(coin_type::evm_chain(0x8000_0000), None);
         assert_eq!(coin_type::evm_chain(u64::MAX), None);
+    }
+}
+
+#[cfg(all(test, feature = "contract"))]
+mod resolver_info_tests {
+    use super::*;
+    use alloy_primitives::{address, Address, Bytes, B256, U256};
+
+    fn info(extended: bool, offset: u64, resolver: Address) -> UniversalResolver::ResolverInfo {
+        UniversalResolver::ResolverInfo {
+            name: Bytes::new(),
+            offset: U256::from(offset),
+            node: B256::ZERO,
+            resolver,
+            extended,
+        }
+    }
+
+    #[test]
+    fn preserves_legacy_universal_resolver_binding_shape() {
+        let _ = UniversalResolver::resolveReturn { _0: Default::default(), _1: Address::ZERO };
+        let _ = UniversalResolver::reverseCall {
+            lookupAddress: Default::default(),
+            coinType: Default::default(),
+        };
+    }
+
+    #[test]
+    fn direct_resolver_accepts_unextended_zero_offset() {
+        let resolver = address!("0x231b0Ee14048e9dCcD1d247744d114a4EB5E8E63");
+        assert_eq!(
+            direct_resolver_address(&info(false, 0, resolver), "vitalik.eth").unwrap(),
+            resolver
+        );
+    }
+
+    #[test]
+    fn direct_resolver_rejects_extended() {
+        let err = direct_resolver_address(
+            &info(true, 0, address!("0x1111111111111111111111111111111111111111")),
+            "ur.integration-tests.eth",
+        )
+        .unwrap_err();
+        assert!(matches!(err, EnsError::RequiresUniversalResolver(_)));
+    }
+
+    #[test]
+    fn direct_resolver_rejects_wildcard_offset() {
+        let err = direct_resolver_address(
+            &info(false, 4, address!("0x1111111111111111111111111111111111111111")),
+            "sub.wildcard.eth",
+        )
+        .unwrap_err();
+        assert!(matches!(err, EnsError::RequiresUniversalResolver(_)));
     }
 }
 

--- a/crates/ens/src/lib.rs
+++ b/crates/ens/src/lib.rs
@@ -67,17 +67,21 @@ pub use contract::*;
 #[cfg(feature = "provider")]
 pub use provider::*;
 
-/// ENS name or Ethereum Address.
+/// An ENS name or Ethereum address.
+///
+/// [`FromStr`] first attempts to parse an address, then treats a string containing `.` as a name.
+/// This is only a routing heuristic: it rejects dotless names and does not normalize or validate
+/// ENS names. In contrast, converting from [`String`] always creates [`Name`](Self::Name).
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum NameOrAddress {
-    /// An ENS Name (format does not get checked)
+    /// An ENS name. The value must already be ENSIP-15 normalized; its format is not checked.
     Name(String),
     /// An Ethereum Address
     Address(Address),
 }
 
 impl NameOrAddress {
-    /// Resolves the name to an Ethereum Address.
+    /// Resolves a name to an Ethereum address, or returns an address unchanged without an RPC call.
     #[cfg(feature = "provider")]
     pub async fn resolve<N: alloy_provider::Network, P: alloy_provider::Provider<N>>(
         &self,

--- a/crates/ens/src/lib.rs
+++ b/crates/ens/src/lib.rs
@@ -21,6 +21,18 @@ use std::str::FromStr;
 pub const UNIVERSAL_RESOLVER_ADDRESS: Address =
     address!("0xeEeEEEeE14D718C2B47D9923Deab1335E144EeEe");
 
+/// ENS registry address (`0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e`).
+#[deprecated(
+    note = "resolution now routes through the Universal Resolver; use `UNIVERSAL_RESOLVER_ADDRESS` and the Universal Resolver helpers"
+)]
+pub const ENS_ADDRESS: Address = address!("0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e");
+
+/// ENS registry domain for reverse records: `addr.reverse`.
+#[deprecated(
+    note = "reverse resolution now routes through the Universal Resolver; use `reverse_address` or `lookup_address`"
+)]
+pub const ENS_REVERSE_REGISTRAR_DOMAIN: &str = "addr.reverse";
+
 /// Helpers for ENS multichain coin types.
 ///
 /// Non-EVM chains use their static SLIP-0044 coin type according to ENSIP-9.
@@ -111,6 +123,27 @@ mod contract {
     use alloy_sol_types::sol;
 
     sol! {
+        /// ENS Registry contract.
+        ///
+        /// Deprecated: retained for backwards compatibility. Resolution now routes
+        /// through the [`UniversalResolver`], which handles wildcard resolvers and
+        /// CCIP Read.
+        #[sol(rpc)]
+        contract EnsRegistry {
+            /// Returns the resolver for the specified node.
+            function resolver(bytes32 node) view returns (address);
+
+            /// returns the owner of this node
+            function owner(bytes32 node) view returns (address);
+        }
+
+        /// ENS Reverse Registrar contract.
+        ///
+        /// Deprecated: retained for backwards compatibility. Reverse resolution now
+        /// routes through the [`UniversalResolver`].
+        #[sol(rpc)]
+        contract ReverseRegistrar {}
+
         /// ENS Resolver interface (ENSIP-1).
         #[sol(rpc)]
         contract EnsResolver {
@@ -212,6 +245,18 @@ mod contract {
             "ENS name {0:?} requires Universal Resolver resolution (extended or wildcard resolver)"
         )]
         RequiresUniversalResolver(String),
+        /// Failed to get the reverse registrar from the ENS registry.
+        #[deprecated(
+            note = "only produced by the deprecated registry-based `get_reverse_registrar` helper"
+        )]
+        #[error("Failed to get reverse registrar from the ENS registry: {0}")]
+        RevRegistrar(alloy_contract::Error),
+        /// No reverse registrar found for `addr.reverse`.
+        #[deprecated(
+            note = "only produced by the deprecated registry-based `get_reverse_registrar` helper"
+        )]
+        #[error("ENS reverse registrar not found for addr.reverse")]
+        ReverseRegistrarNotFound,
         /// Failed to perform a reverse lookup.
         #[error("Failed to lookup ENS name from an address: {0}")]
         Lookup(alloy_contract::Error),
@@ -232,12 +277,14 @@ mod contract {
 
 #[cfg(feature = "provider")]
 mod provider {
+    #[allow(deprecated)]
     use crate::{
         coin_type, namehash, reverse_address, try_dns_encode, EnsError, EnsMulticoinResolver,
-        EnsResolver, EnsResolver::EnsResolverInstance, UniversalResolver,
-        UNIVERSAL_RESOLVER_ADDRESS,
+        EnsRegistry, EnsResolver, EnsResolver::EnsResolverInstance,
+        ReverseRegistrar::ReverseRegistrarInstance, UniversalResolver, ENS_ADDRESS,
+        ENS_REVERSE_REGISTRAR_DOMAIN, UNIVERSAL_RESOLVER_ADDRESS,
     };
-    use alloy_primitives::{Address, Bytes, U256};
+    use alloy_primitives::{Address, Bytes, B256, U256};
     use alloy_provider::{Network, Provider};
     use alloy_sol_types::{SolCall, SolValue};
 
@@ -254,7 +301,33 @@ mod provider {
         /// direct `addr`/`text`/`name` calls on the resolver are not equivalent to
         /// Universal Resolver resolution — use [`Self::resolve_name`],
         /// [`Self::lookup_txt`], or the other helpers instead.
-        async fn get_resolver(&self, name: &str) -> Result<EnsResolverInstance<&P, N>, EnsError>;
+        async fn get_resolver_for_name(
+            &self,
+            name: &str,
+        ) -> Result<EnsResolverInstance<&P, N>, EnsError>;
+
+        /// Returns the resolver for the specified node.
+        ///
+        /// The `&str` is only used for error messages. Looks up the resolver via the
+        /// ENS registry, matching the historical Alloy API.
+        ///
+        /// Prefer [`Self::get_resolver_for_name`] or the Universal Resolver helpers
+        /// (`resolve_name`, `lookup_txt`, …). Registry-based resolver discovery does
+        /// not handle ENSIP-10 extended or wildcard resolvers correctly.
+        #[deprecated(
+            note = "registry-based resolver discovery; use `get_resolver_for_name` or Universal Resolver helpers"
+        )]
+        async fn get_resolver(
+            &self,
+            node: B256,
+            error_name: &str,
+        ) -> Result<EnsResolverInstance<&P, N>, EnsError>;
+
+        /// Returns the reverse registrar for the specified node.
+        #[deprecated(
+            note = "reverse resolution now routes through the Universal Resolver; use `lookup_address` instead"
+        )]
+        async fn get_reverse_registrar(&self) -> Result<ReverseRegistrarInstance<&P, N>, EnsError>;
 
         /// Performs a forward lookup of an ENS name to an Ethereum address.
         ///
@@ -285,12 +358,16 @@ mod provider {
 
     #[cfg_attr(target_family = "wasm", async_trait::async_trait(?Send))]
     #[cfg_attr(not(target_family = "wasm"), async_trait::async_trait)]
+    #[allow(deprecated)]
     impl<N, P> ProviderEnsExt<N, P> for P
     where
         P: Provider<N>,
         N: Network,
     {
-        async fn get_resolver(&self, name: &str) -> Result<EnsResolverInstance<&P, N>, EnsError> {
+        async fn get_resolver_for_name(
+            &self,
+            name: &str,
+        ) -> Result<EnsResolverInstance<&P, N>, EnsError> {
             let dns = try_dns_encode(name)?;
 
             let ur = UniversalResolver::new(UNIVERSAL_RESOLVER_ADDRESS, self);
@@ -308,6 +385,32 @@ mod provider {
             }
 
             Ok(EnsResolverInstance::new(info.resolver, self))
+        }
+
+        async fn get_resolver(
+            &self,
+            node: B256,
+            error_name: &str,
+        ) -> Result<EnsResolverInstance<&P, N>, EnsError> {
+            let registry = EnsRegistry::new(ENS_ADDRESS, self);
+            let address = registry.resolver(node).call().await.map_err(EnsError::Resolver)?;
+            if address == Address::ZERO {
+                return Err(EnsError::ResolverNotFound(error_name.to_string()));
+            }
+            Ok(EnsResolverInstance::new(address, self))
+        }
+
+        async fn get_reverse_registrar(&self) -> Result<ReverseRegistrarInstance<&P, N>, EnsError> {
+            let registry = EnsRegistry::new(ENS_ADDRESS, self);
+            let address = registry
+                .owner(namehash(ENS_REVERSE_REGISTRAR_DOMAIN))
+                .call()
+                .await
+                .map_err(EnsError::RevRegistrar)?;
+            if address == Address::ZERO {
+                return Err(EnsError::ReverseRegistrarNotFound);
+            }
+            Ok(ReverseRegistrarInstance::new(address, self))
         }
 
         async fn resolve_name(&self, name: &str) -> Result<Address, EnsError> {
@@ -430,35 +533,57 @@ mod tests {
 
 #[cfg(all(test, feature = "provider"))]
 mod provider_tests {
+    #![allow(deprecated)]
+
     use super::*;
     use alloy_primitives::address;
     use alloy_provider::ProviderBuilder;
 
     #[tokio::test]
-    async fn test_pub_resolver_fetching_mainnet() {
-        let provider = ProviderBuilder::new()
-            .connect_http("https://ethereum.reth.rs/rpc".parse().unwrap());
+    async fn test_reverse_registrar_fetching_mainnet() {
+        let provider =
+            ProviderBuilder::new().connect_http("https://ethereum.reth.rs/rpc".parse().unwrap());
 
-        let res = provider.get_resolver("vitalik.eth").await;
+        let res = provider.get_reverse_registrar().await;
+        assert_eq!(*res.unwrap().address(), address!("0xa58E81fe9b61B5c3fE2AFD33CF304c454AbFc7Cb"));
+    }
+
+    #[tokio::test]
+    async fn test_pub_resolver_fetching_mainnet() {
+        let provider =
+            ProviderBuilder::new().connect_http("https://ethereum.reth.rs/rpc".parse().unwrap());
+
+        let name = "vitalik.eth";
+        let node = namehash(name);
+        let res = provider.get_resolver(node, name).await;
+        assert_eq!(*res.unwrap().address(), address!("0x231b0Ee14048e9dCcD1d247744d114a4EB5E8E63"));
+    }
+
+    #[tokio::test]
+    async fn test_get_resolver_for_name_mainnet() {
+        let provider =
+            ProviderBuilder::new().connect_http("https://ethereum.reth.rs/rpc".parse().unwrap());
+
+        let res = provider.get_resolver_for_name("vitalik.eth").await;
         assert_eq!(*res.unwrap().address(), address!("0x231b0Ee14048e9dCcD1d247744d114a4EB5E8E63"));
     }
 
     #[tokio::test]
     async fn test_pub_resolver_text() {
-        let provider = ProviderBuilder::new()
-            .connect_http("https://ethereum.reth.rs/rpc".parse().unwrap());
+        let provider =
+            ProviderBuilder::new().connect_http("https://ethereum.reth.rs/rpc".parse().unwrap());
 
         let name = "vitalik.eth";
         let node = namehash(name);
-        let res = provider.get_resolver(name).await.unwrap();
+        let res = provider.get_resolver(node, name).await.unwrap();
         let text = res.text(node, "avatar".to_string()).call().await.unwrap();
         assert_eq!(text, "https://euc.li/vitalik.eth")
     }
 
     #[tokio::test]
     async fn test_pub_resolver_fetching_text() {
-        let provider = ProviderBuilder::new()
-            .connect_http("https://ethereum.reth.rs/rpc".parse().unwrap());
+        let provider =
+            ProviderBuilder::new().connect_http("https://ethereum.reth.rs/rpc".parse().unwrap());
 
         let res = provider.lookup_txt("vitalik.eth", "avatar").await.unwrap();
         assert_eq!(res, "https://euc.li/vitalik.eth")
@@ -466,26 +591,26 @@ mod provider_tests {
 
     #[tokio::test]
     async fn test_universal_resolver_integration() {
-        let provider = ProviderBuilder::new()
-            .connect_http("https://ethereum.reth.rs/rpc".parse().unwrap());
+        let provider =
+            ProviderBuilder::new().connect_http("https://ethereum.reth.rs/rpc".parse().unwrap());
 
         let res = provider.resolve_name("ur.integration-tests.eth").await.unwrap();
         assert_eq!(res, address!("0x2222222222222222222222222222222222222222"));
     }
 
     #[tokio::test]
-    async fn test_get_resolver_rejects_extended_resolver() {
-        let provider = ProviderBuilder::new()
-            .connect_http("https://ethereum.reth.rs/rpc".parse().unwrap());
+    async fn test_get_resolver_for_name_rejects_extended_resolver() {
+        let provider =
+            ProviderBuilder::new().connect_http("https://ethereum.reth.rs/rpc".parse().unwrap());
 
-        let err = provider.get_resolver("ur.integration-tests.eth").await.unwrap_err();
+        let err = provider.get_resolver_for_name("ur.integration-tests.eth").await.unwrap_err();
         assert!(matches!(err, EnsError::RequiresUniversalResolver(_)));
     }
 
     #[tokio::test]
     async fn test_multicoin_resolver_integration() {
-        let provider = ProviderBuilder::new()
-            .connect_http("https://ethereum.reth.rs/rpc".parse().unwrap());
+        let provider =
+            ProviderBuilder::new().connect_http("https://ethereum.reth.rs/rpc".parse().unwrap());
 
         let res = provider
             .resolve_name_for_coin_type(
@@ -502,8 +627,8 @@ mod provider_tests {
 
     #[tokio::test]
     async fn test_reverse_resolver_integration() {
-        let provider = ProviderBuilder::new()
-            .connect_http("https://ethereum.reth.rs/rpc".parse().unwrap());
+        let provider =
+            ProviderBuilder::new().connect_http("https://ethereum.reth.rs/rpc".parse().unwrap());
 
         let res = provider
             .lookup_address(&address!("0xeE9eeaAB0Bb7D9B969D701f6f8212609EDeA252E"))

--- a/crates/ens/src/lib.rs
+++ b/crates/ens/src/lib.rs
@@ -46,11 +46,18 @@ pub mod coin_type {
     ///
     /// Chain ID `1` (Ethereum mainnet) returns [`ETH`] (`60`) per SLIP-0044.
     /// All other chains use `0x80000000 | chain_id`.
-    pub fn evm_chain(chain_id: u32) -> u64 {
+    ///
+    /// Returns `None` for chain IDs of `0x80000000` and above: ENSIP-11 reserves
+    /// a 31-bit chain ID space, and larger IDs would collide with the coin types
+    /// of smaller ones (e.g. `0` and `0x80000000`).
+    pub const fn evm_chain(chain_id: u64) -> Option<u64> {
         if chain_id == 1 {
-            return ETH;
+            return Some(ETH);
         }
-        0x8000_0000u64 | u64::from(chain_id)
+        if chain_id >= 0x8000_0000 {
+            return None;
+        }
+        Some(0x8000_0000 | chain_id)
     }
 }
 
@@ -519,15 +526,18 @@ mod tests {
 
     #[test]
     fn test_coin_type_evm_chain() {
-        assert_eq!(coin_type::evm_chain(1), coin_type::ETH); // mainnet special case
-        assert_eq!(coin_type::evm_chain(8453), 0x8000_2105); // Base
-        assert_eq!(coin_type::evm_chain(10), 0x8000_000A); // Optimism
-        assert_eq!(coin_type::evm_chain(42161), 0x8000_A4B1); // Arbitrum One
+        assert_eq!(coin_type::evm_chain(1), Some(coin_type::ETH)); // mainnet special case
+        assert_eq!(coin_type::evm_chain(8453), Some(0x8000_2105)); // Base
+        assert_eq!(coin_type::evm_chain(10), Some(0x8000_000A)); // Optimism
+        assert_eq!(coin_type::evm_chain(42161), Some(0x8000_A4B1)); // Arbitrum One
     }
 
     #[test]
-    fn test_coin_type_evm_chain_does_not_reject_high_bit() {
-        assert_eq!(coin_type::evm_chain(0x8000_0000), 0x8000_0000);
+    fn test_coin_type_evm_chain_rejects_out_of_range_ids() {
+        // ENSIP-11 coin types are `0x80000000 | chainId` over a 31-bit chain ID
+        // space; IDs with the high bit set would collide with smaller IDs.
+        assert_eq!(coin_type::evm_chain(0x8000_0000), None);
+        assert_eq!(coin_type::evm_chain(u64::MAX), None);
     }
 }
 
@@ -615,7 +625,7 @@ mod provider_tests {
         let res = provider
             .resolve_name_for_coin_type(
                 "coins.integration-tests.eth",
-                coin_type::evm_chain(8453),
+                coin_type::evm_chain(8453).unwrap(),
             )
             .await
             .unwrap();

--- a/crates/ens/src/lib.rs
+++ b/crates/ens/src/lib.rs
@@ -14,58 +14,52 @@ pub use utils::{dns_encode, namehash, reverse_address, try_dns_encode, DnsEncode
 use alloy_primitives::{address, Address};
 use std::str::FromStr;
 
-/// ENS Universal Resolver address (`0xeEeEEEeE14D718C2B47D9923Deab1335E144EeEe`).
+/// ENS registry address (`0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e`)
+pub const ENS_ADDRESS: Address = address!("0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e");
+
+/// ENS Universal Resolver address on Ethereum Mainnet
+/// (`0xeEeEEEeE14D718C2B47D9923Deab1335E144EeEe`)
 ///
-/// The primary entry-point for ENS name resolution. Supports wildcard resolvers
-/// and CCIP Read (ERC-3668).
+/// The Universal Resolver is the canonical entry point for all ENS resolution. It routes to
+/// wildcard (ENSIP-10) resolvers and signals CCIP Read (ERC-3668) with an `OffchainLookup` revert.
 pub const UNIVERSAL_RESOLVER_ADDRESS: Address =
     address!("0xeEeEEEeE14D718C2B47D9923Deab1335E144EeEe");
 
-/// ENS registry address (`0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e`).
-#[deprecated(
-    note = "resolution now routes through the Universal Resolver; use `UNIVERSAL_RESOLVER_ADDRESS` and the Universal Resolver helpers"
-)]
-pub const ENS_ADDRESS: Address = address!("0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e");
-
-/// ENS registry domain for reverse records: `addr.reverse`.
-#[deprecated(
-    note = "reverse resolution now routes through the Universal Resolver; use `reverse_address` or `lookup_address`"
-)]
+/// ENS const for registrar domain
 pub const ENS_REVERSE_REGISTRAR_DOMAIN: &str = "addr.reverse";
-
-/// Helpers for ENS multichain coin types.
-///
-/// Non-EVM chains use their static SLIP-0044 coin type according to ENSIP-9.
-/// EVM-compatible chains follow ENSIP-11: `coinType = 0x80000000 | chainId`.
-/// Use [`evm_chain`][coin_type::evm_chain] to derive an EVM coin type.
-pub mod coin_type {
-    /// Ethereum mainnet (SLIP-0044, coin type 60).
-    pub const ETH: u64 = 60;
-
-    /// Converts an EVM chain ID to its ENSIP-11 coin type.
-    ///
-    /// Chain ID `1` (Ethereum mainnet) returns [`ETH`] (`60`) per SLIP-0044.
-    /// All other chains use `0x80000000 | chain_id`.
-    ///
-    /// Returns `None` for chain IDs of `0x80000000` and above: ENSIP-11 reserves
-    /// a 31-bit chain ID space, and larger IDs would collide with the coin types
-    /// of smaller ones (e.g. `0` and `0x80000000`).
-    pub const fn evm_chain(chain_id: u64) -> Option<u64> {
-        if chain_id == 1 {
-            return Some(ETH);
-        }
-        if chain_id >= 0x8000_0000 {
-            return None;
-        }
-        Some(0x8000_0000 | chain_id)
-    }
-}
 
 #[cfg(feature = "contract")]
 pub use contract::*;
 
 #[cfg(feature = "provider")]
 pub use provider::*;
+
+/// Helpers for ENS multichain coin types.
+///
+/// Non-EVM chains use their static SLIP-0044 coin type according to
+/// [ENSIP-9](https://docs.ens.domains/ensip/9). EVM chains follow
+/// [ENSIP-11](https://docs.ens.domains/ensip/11): `coinType = 0x80000000 | chainId`.
+pub mod coin_type {
+    /// Ethereum mainnet (SLIP-0044 coin type 60).
+    pub const ETH: u64 = 60;
+
+    /// Converts an EVM chain ID to its ENSIP-11 coin type.
+    ///
+    /// Chain ID `1` (Ethereum mainnet) maps to [`ETH`]; all other chains use
+    /// `0x80000000 | chain_id`.
+    ///
+    /// Returns `None` for chain IDs of `0x80000000` and above: ENSIP-11 reserves a 31-bit chain ID
+    /// space, and larger IDs would collide with the coin types of smaller ones.
+    pub const fn evm_chain(chain_id: u64) -> Option<u64> {
+        if chain_id == 1 {
+            Some(ETH)
+        } else if chain_id < 0x8000_0000 {
+            Some(0x8000_0000 | chain_id)
+        } else {
+            None
+        }
+    }
+}
 
 /// An ENS name or Ethereum address.
 ///
@@ -131,14 +125,14 @@ impl FromStr for NameOrAddress {
 
 #[cfg(feature = "contract")]
 mod contract {
+    use alloy_primitives::Address;
     use alloy_sol_types::sol;
 
     sol! {
         /// ENS Registry contract.
         ///
-        /// Deprecated: retained for backwards compatibility. Resolution now routes
-        /// through the [`UniversalResolver`], which handles wildcard resolvers and
-        /// CCIP Read.
+        /// The resolution helpers in this crate route through the [`UniversalResolver`] instead of
+        /// querying the registry directly, since the registry is unaware of wildcard resolvers.
         #[sol(rpc)]
         contract EnsRegistry {
             /// Returns the resolver for the specified node.
@@ -148,10 +142,7 @@ mod contract {
             function owner(bytes32 node) view returns (address);
         }
 
-        /// ENS Reverse Registrar contract.
-        ///
-        /// Deprecated: retained for backwards compatibility. Reverse resolution now
-        /// routes through the [`UniversalResolver`].
+        /// ENS Reverse Registrar contract
         #[sol(rpc)]
         contract ReverseRegistrar {}
 
@@ -170,32 +161,23 @@ mod contract {
 
         /// ENS Multicoin Resolver interface (ENSIP-11).
         ///
-        /// Provides multichain address resolution. Use with the Universal Resolver and
-        /// coin types from ENSIP-9 or [`coin_type::evm_chain`][crate::coin_type::evm_chain].
+        /// Use with the Universal Resolver and coin types from ENSIP-9 or
+        /// [`coin_type::evm_chain`](crate::coin_type::evm_chain).
         #[sol(rpc)]
         contract EnsMulticoinResolver {
-            /// Returns the address for `node` on the chain identified by `coin_type`.
+            /// Returns the address for `node` on the chain identified by `coinType`.
             ///
-            /// The returned bytes are the raw address encoding for that coin type
-            /// (e.g., 20 raw bytes for EVM chains, script bytes for Bitcoin).
-            function addr(bytes32 node, uint256 coin_type) view returns (bytes memory);
+            /// The returned bytes are the raw address encoding for that coin type, e.g. 20 raw
+            /// bytes for EVM chains or script bytes for Bitcoin.
+            function addr(bytes32 node, uint256 coinType) view returns (bytes memory);
         }
 
-        /// ENS Universal Resolver (ENSIP-23).
+        /// ENS Universal Resolver ([ENSIP-23](https://docs.ens.domains/ensip/23)).
         ///
-        /// The single entry-point for all ENS resolution. Handles routing to wildcard
-        /// resolvers and CCIP Read (ERC-3668).
-        ///
-        /// Spec: <https://docs.ens.domains/ensip/23>
-        ///
-        /// `resolve` keeps unnamed returns so downstream `resolveReturn._0` / `_1`
-        /// still compile. Reverse uses the deployed ENSIP-23 ABI
-        /// `reverse(bytes,uint256)`; the historical 1-arg `reverse(bytes reverseName)`
-        /// binding did not match the chain and is not preserved.
-        ///
-        /// Note: CCIP Read requires client-side handling of the `OffchainLookup` revert
-        /// (ERC-3668). Alloy does not currently implement this; calls to names that require
-        /// CCIP Read will surface as [`EnsError::Resolve`].
+        /// The single entry point for ENS resolution. It routes to wildcard (ENSIP-10) resolvers
+        /// and signals CCIP Read (ERC-3668) with an `OffchainLookup` revert, which this binding
+        /// does not follow. The provider helpers in this crate surface such names as a
+        /// resolution error.
         #[sol(rpc)]
         contract UniversalResolver {
             error ResolverNotFound(bytes name);
@@ -215,14 +197,13 @@ mod contract {
             /// Like `findResolver`, but reverts with `ResolverNotFound` if no resolver exists.
             function requireResolver(bytes memory name) public view returns (ResolverInfo memory info);
 
-            /// Returns the resolver for `name` (DNS wire-format) without performing resolution.
+            /// Returns the resolver for `name` (DNS wire format) without performing resolution.
             ///
-            /// Returns `(resolver, node, offset)` where `resolver` is the contract address,
-            /// `node` is the namehash, and `offset` is the byte offset into `name` at which
-            /// the resolver was found (for wildcard/parent resolution).
+            /// Returns `(resolver, node, offset)`, where `offset` is the byte offset into `name`
+            /// at which the resolver was found (non-zero for parent/wildcard resolution).
             function findResolver(bytes memory name) public view returns (address, bytes32, uint256);
 
-            /// Resolves `name` (DNS wire-format) using the encoded `data` call.
+            /// Resolves `name` (DNS wire format) using the encoded resolver call `data`.
             ///
             /// Returns the ABI-encoded result of the resolver call and the resolver address.
             /// Reverts with `OffchainLookup` when CCIP Read (ERC-3668) is required.
@@ -231,10 +212,8 @@ mod contract {
             /// Like `resolve`, but uses `gateways` for CCIP Read instead of the default.
             function resolveWithGateways(bytes calldata name, bytes calldata data, string[] memory gateways) public view returns (bytes memory, address);
 
-            /// Reverse-resolves an address to its primary ENS name.
-            ///
-            /// `lookupAddress` is the raw byte encoding of the address.
-            /// `coinType` specifies the chain (use [`coin_type::ETH`] for Ethereum).
+            /// Reverse-resolves the raw address bytes `lookupAddress` on the chain identified by
+            /// `coinType` (see [`coin_type`](crate::coin_type)) to its primary ENS name.
             function reverse(bytes calldata lookupAddress, uint256 coinType) external view returns (string memory name, address resolver, address reverseResolver);
 
             /// Like `reverse`, but uses `gateways` for CCIP Read instead of the default.
@@ -242,25 +221,21 @@ mod contract {
         }
     }
 
-    /// Returns the resolver address when it is safe to call `addr`/`text`/`name` directly.
-    ///
-    /// Extended (ENSIP-10) and parent/wildcard resolvers must be queried through the
-    /// Universal Resolver instead.
-    pub(crate) fn direct_resolver_address(
-        info: &UniversalResolver::ResolverInfo,
-        name: &str,
-    ) -> Result<alloy_primitives::Address, EnsError> {
-        if info.extended || !info.offset.is_zero() {
-            Err(EnsError::RequiresUniversalResolver(name.to_string()))
-        } else {
-            Ok(info.resolver)
+    impl UniversalResolver::ResolverInfo {
+        /// Returns the resolver address if `addr`/`text`/`name` may be called on it directly.
+        ///
+        /// Extended (ENSIP-10) and parent/wildcard resolvers must be queried through the Universal
+        /// Resolver instead, so this returns [`EnsError::RequiresUniversalResolver`] for them.
+        pub(crate) fn direct_resolver(&self, name: &str) -> Result<Address, EnsError> {
+            if self.extended || !self.offset.is_zero() {
+                Err(EnsError::RequiresUniversalResolver(name.to_string()))
+            } else {
+                Ok(self.resolver)
+            }
         }
     }
 
     /// Error type for ENS resolution.
-    ///
-    /// New variants (`RequiresUniversalResolver`, `DnsEncode`, `InvalidResponse`) are
-    /// an intentional semver break relative to Alloy 1.x `EnsError`.
     #[derive(Debug, thiserror::Error)]
     #[non_exhaustive]
     pub enum EnsError {
@@ -270,29 +245,21 @@ mod contract {
         /// No resolver found for the given name.
         #[error("ENS resolver not found for name {0:?}")]
         ResolverNotFound(String),
-        /// Direct resolver calls are unsafe for this name; use Universal Resolver helpers.
+        /// The name resolves through an ENSIP-10 extended resolver or a parent/wildcard resolver,
+        /// so calling `addr`/`text`/`name` on the resolver directly can return incorrect data.
         ///
-        /// Returned when the name resolves through an ENSIP-10 extended resolver or a
-        /// parent/wildcard resolver. Calling `addr`/`text`/`name` on the raw resolver
-        /// instance can return incorrect data — use `resolve_name`, `lookup_txt`, or
-        /// related helpers instead.
+        /// Use `resolve_name`, `lookup_txt`, or the other Universal Resolver helpers instead.
         #[error(
             "ENS name {0:?} requires Universal Resolver resolution (extended or wildcard resolver)"
         )]
         RequiresUniversalResolver(String),
         /// Failed to get the reverse registrar from the ENS registry.
-        #[deprecated(
-            note = "only produced by the deprecated registry-based `get_reverse_registrar` helper"
-        )]
         #[error("Failed to get reverse registrar from the ENS registry: {0}")]
         RevRegistrar(alloy_contract::Error),
         /// No reverse registrar found for `addr.reverse`.
-        #[deprecated(
-            note = "only produced by the deprecated registry-based `get_reverse_registrar` helper"
-        )]
         #[error("ENS reverse registrar not found for addr.reverse")]
         ReverseRegistrarNotFound,
-        /// Failed to perform a reverse lookup.
+        /// Failed to lookup ENS name from an address.
         #[error("Failed to lookup ENS name from an address: {0}")]
         Lookup(alloy_contract::Error),
         /// Failed to resolve ENS name to an address.
@@ -312,7 +279,6 @@ mod contract {
 
 #[cfg(feature = "provider")]
 mod provider {
-    #[allow(deprecated)]
     use crate::{
         coin_type, namehash, reverse_address, try_dns_encode, EnsError, EnsMulticoinResolver,
         EnsRegistry, EnsResolver, EnsResolver::EnsResolverInstance,
@@ -324,34 +290,34 @@ mod provider {
     use alloy_sol_types::{SolCall, SolValue};
 
     /// Extension trait for ENS contract calls.
+    ///
+    /// All ENS name strings must already be normalized according to ENSIP-15. These helpers do not
+    /// perform complete normalization or validation before hashing or DNS-encoding them;
+    /// [`namehash`] and [`try_dns_encode`] only remove `U+FE0F`.
+    ///
+    /// Resolution routes through the [Universal Resolver](UNIVERSAL_RESOLVER_ADDRESS), which
+    /// handles wildcard resolvers. EIP-3668 CCIP Read redirects are not followed by these helpers
+    /// and surface as a resolution error.
     #[cfg_attr(target_family = "wasm", async_trait::async_trait(?Send))]
     #[cfg_attr(not(target_family = "wasm"), async_trait::async_trait)]
-    pub trait ProviderEnsExt<N: alloy_provider::Network, P: Provider<N>> {
+    pub trait ProviderEnsExt<N: Network, P: Provider<N>> {
         /// Returns the resolver contract instance for the given ENS name.
         ///
-        /// Determines the resolver address via the Universal Resolver.
-        ///
-        /// Returns [`EnsError::RequiresUniversalResolver`] when the name uses an
-        /// ENSIP-10 extended resolver or a parent/wildcard resolver. In those cases
-        /// direct `addr`/`text`/`name` calls on the resolver are not equivalent to
-        /// Universal Resolver resolution — use [`Self::resolve_name`],
-        /// [`Self::lookup_txt`], or the other helpers instead.
+        /// The resolver is discovered through the Universal Resolver. Returns
+        /// [`EnsError::RequiresUniversalResolver`] when the name uses an ENSIP-10 extended
+        /// resolver or a parent/wildcard resolver: direct `addr`/`text`/`name` calls on such
+        /// resolvers are not equivalent to Universal Resolver resolution, so use
+        /// [`Self::resolve_name`], [`Self::lookup_txt`], or the other helpers instead.
         async fn get_resolver_for_name(
             &self,
             name: &str,
         ) -> Result<EnsResolverInstance<&P, N>, EnsError>;
 
-        /// Returns the resolver for the specified node.
+        /// Returns the resolver for the specified node. The `&str` is only used for error messages.
         ///
-        /// The `&str` is only used for error messages. Looks up the resolver via the
-        /// ENS registry, matching the historical Alloy API.
-        ///
-        /// Prefer [`Self::get_resolver_for_name`] or the Universal Resolver helpers
-        /// (`resolve_name`, `lookup_txt`, …). Registry-based resolver discovery does
-        /// not handle ENSIP-10 extended or wildcard resolvers correctly.
-        #[deprecated(
-            note = "registry-based resolver discovery; use `get_resolver_for_name` or Universal Resolver helpers"
-        )]
+        /// This looks up the resolver in the ENS registry, which does not account for ENSIP-10
+        /// extended or wildcard resolvers.
+        #[deprecated(note = "use `get_resolver_for_name` or the Universal Resolver helpers")]
         async fn get_resolver(
             &self,
             node: B256,
@@ -360,24 +326,18 @@ mod provider {
 
         /// Returns the reverse registrar for the specified node.
         #[deprecated(
-            note = "reverse resolution now routes through the Universal Resolver; use `lookup_address` instead"
+            note = "reverse resolution routes through the Universal Resolver; use `lookup_address`"
         )]
         async fn get_reverse_registrar(&self) -> Result<ReverseRegistrarInstance<&P, N>, EnsError>;
 
         /// Performs a forward lookup of an ENS name to an Ethereum address.
-        ///
-        /// Routes through the [Universal Resolver], which handles wildcard resolvers
-        /// and CCIP Read (ERC-3668).
-        ///
-        /// [Universal Resolver]: https://docs.ens.domains/web/ensv2-readiness
         async fn resolve_name(&self, name: &str) -> Result<Address, EnsError>;
 
         /// Resolves an ENS name to a multichain address for the given coin type (ENSIP-11).
         ///
-        /// Returns the raw address bytes as stored in the resolver. The encoding varies
-        /// by coin type: 20 raw address bytes for EVM chains, script bytes for
-        /// Bitcoin, etc. Use [`coin_type::evm_chain`][crate::coin_type::evm_chain] for
-        /// EVM chains; for non-EVM chains, pass the static SLIP-0044 coin type.
+        /// Returns the raw address bytes as stored in the resolver, whose encoding depends on the
+        /// coin type: 20 raw bytes for EVM chains, script bytes for Bitcoin, etc. Use
+        /// [`coin_type::evm_chain`] for EVM chains and the static SLIP-0044 coin type otherwise.
         async fn resolve_name_for_coin_type(
             &self,
             name: &str,
@@ -385,6 +345,9 @@ mod provider {
         ) -> Result<Bytes, EnsError>;
 
         /// Performs a reverse lookup of an address to its primary ENS name.
+        ///
+        /// The Universal Resolver verifies that the primary name resolves back to `address`, and
+        /// returns an empty string if no primary name is set.
         async fn lookup_address(&self, address: &Address) -> Result<String, EnsError>;
 
         /// Looks up a text record for an ENS name.
@@ -393,7 +356,6 @@ mod provider {
 
     #[cfg_attr(target_family = "wasm", async_trait::async_trait(?Send))]
     #[cfg_attr(not(target_family = "wasm"), async_trait::async_trait)]
-    #[allow(deprecated)]
     impl<N, P> ProviderEnsExt<N, P> for P
     where
         P: Provider<N>,
@@ -404,16 +366,12 @@ mod provider {
             name: &str,
         ) -> Result<EnsResolverInstance<&P, N>, EnsError> {
             let dns = try_dns_encode(name)?;
-
-            let ur = UniversalResolver::new(UNIVERSAL_RESOLVER_ADDRESS, self);
-            let info = ur
+            let info = UniversalResolver::new(UNIVERSAL_RESOLVER_ADDRESS, self)
                 .requireResolver(dns.into())
                 .call()
                 .await
                 .map_err(|error| map_ur_error(error, name, EnsError::Resolver))?;
-
-            let resolver = crate::direct_resolver_address(&info, name)?;
-            Ok(EnsResolverInstance::new(resolver, self))
+            Ok(EnsResolverInstance::new(info.direct_resolver(name)?, self))
         }
 
         async fn get_resolver(
@@ -443,18 +401,9 @@ mod provider {
         }
 
         async fn resolve_name(&self, name: &str) -> Result<Address, EnsError> {
-            let node = namehash(name);
-            let dns = try_dns_encode(name)?;
-            let calldata = EnsResolver::addrCall { node }.abi_encode();
-
-            let ur = UniversalResolver::new(UNIVERSAL_RESOLVER_ADDRESS, self);
-            let ret = ur
-                .resolve(dns.into(), calldata.into())
-                .call()
-                .await
-                .map_err(|error| map_ur_error(error, name, EnsError::Resolve))?;
-
-            Address::abi_decode(ret._0.as_ref()).map_err(|_| EnsError::InvalidResponse)
+            let data = EnsResolver::addrCall { node: namehash(name) }.abi_encode();
+            let ret = resolve(self, name, data, EnsError::Resolve).await?;
+            Address::abi_decode(&ret).map_err(|_| EnsError::InvalidResponse)
         }
 
         async fn resolve_name_for_coin_type(
@@ -462,50 +411,49 @@ mod provider {
             name: &str,
             coin_type: u64,
         ) -> Result<Bytes, EnsError> {
-            let node = namehash(name);
-            let dns = try_dns_encode(name)?;
-            let calldata = EnsMulticoinResolver::addrCall {
-                node,
-                coin_type: U256::from(coin_type),
+            let data = EnsMulticoinResolver::addrCall {
+                node: namehash(name),
+                coinType: U256::from(coin_type),
             }
             .abi_encode();
-
-            let ur = UniversalResolver::new(UNIVERSAL_RESOLVER_ADDRESS, self);
-            let ret = ur
-                .resolve(dns.into(), calldata.into())
-                .call()
-                .await
-                .map_err(|error| map_ur_error(error, name, EnsError::Resolve))?;
-
-            Bytes::abi_decode(ret._0.as_ref()).map_err(|_| EnsError::InvalidResponse)
+            let ret = resolve(self, name, data, EnsError::Resolve).await?;
+            Bytes::abi_decode(&ret).map_err(|_| EnsError::InvalidResponse)
         }
 
         async fn lookup_address(&self, address: &Address) -> Result<String, EnsError> {
-            let reverse_name = reverse_address(address);
-            let ur = UniversalResolver::new(UNIVERSAL_RESOLVER_ADDRESS, self);
-            let ret = ur
+            let ret = UniversalResolver::new(UNIVERSAL_RESOLVER_ADDRESS, self)
                 .reverse(Bytes::copy_from_slice(address.as_slice()), U256::from(coin_type::ETH))
                 .call()
                 .await
-                .map_err(|error| map_ur_error(error, &reverse_name, EnsError::Lookup))?;
-
+                .map_err(|error| {
+                    map_ur_error(error, &reverse_address(address), EnsError::Lookup)
+                })?;
             Ok(ret.name)
         }
 
         async fn lookup_txt(&self, name: &str, key: &str) -> Result<String, EnsError> {
-            let node = namehash(name);
-            let dns = try_dns_encode(name)?;
-            let calldata = EnsResolver::textCall { node, key: key.to_string() }.abi_encode();
-
-            let ur = UniversalResolver::new(UNIVERSAL_RESOLVER_ADDRESS, self);
-            let ret = ur
-                .resolve(dns.into(), calldata.into())
-                .call()
-                .await
-                .map_err(|error| map_ur_error(error, name, EnsError::ResolveTxtRecord))?;
-
-            String::abi_decode(ret._0.as_ref()).map_err(|_| EnsError::InvalidResponse)
+            let data =
+                EnsResolver::textCall { node: namehash(name), key: key.to_string() }.abi_encode();
+            let ret = resolve(self, name, data, EnsError::ResolveTxtRecord).await?;
+            String::abi_decode(&ret).map_err(|_| EnsError::InvalidResponse)
         }
+    }
+
+    /// Resolves the encoded resolver call `data` for `name` through the Universal Resolver and
+    /// returns the resolver's return data.
+    async fn resolve<N: Network, P: Provider<N>>(
+        provider: &P,
+        name: &str,
+        data: Vec<u8>,
+        map_err: impl FnOnce(alloy_contract::Error) -> EnsError,
+    ) -> Result<Bytes, EnsError> {
+        let dns = try_dns_encode(name)?;
+        let ret = UniversalResolver::new(UNIVERSAL_RESOLVER_ADDRESS, provider)
+            .resolve(dns.into(), data.into())
+            .call()
+            .await
+            .map_err(|error| map_ur_error(error, name, map_err))?;
+        Ok(ret._0)
     }
 
     /// Maps Universal Resolver contract errors, preserving [`EnsError::ResolverNotFound`].
@@ -525,7 +473,6 @@ mod provider {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::str::FromStr;
 
     #[test]
     fn test_invalid_address() {
@@ -540,24 +487,21 @@ mod tests {
     }
 
     #[test]
-    fn test_name_or_address_dns_detection() {
-        assert!(matches!(NameOrAddress::from_str("foo.eth"), Ok(NameOrAddress::Name(_))));
-        assert!(matches!(NameOrAddress::from_str("ensfairy.xyz"), Ok(NameOrAddress::Name(_))));
-        assert!(matches!(NameOrAddress::from_str("sub.foo.eth"), Ok(NameOrAddress::Name(_))));
+    fn test_name_or_address_from_str_name() {
+        for name in ["foo.eth", "ensfairy.xyz", "sub.foo.eth"] {
+            assert_eq!(NameOrAddress::from_str(name).unwrap(), NameOrAddress::Name(name.into()));
+        }
     }
 
     #[test]
     fn test_coin_type_evm_chain() {
-        assert_eq!(coin_type::evm_chain(1), Some(coin_type::ETH)); // mainnet special case
+        assert_eq!(coin_type::evm_chain(1), Some(coin_type::ETH));
         assert_eq!(coin_type::evm_chain(8453), Some(0x8000_2105)); // Base
         assert_eq!(coin_type::evm_chain(10), Some(0x8000_000A)); // Optimism
         assert_eq!(coin_type::evm_chain(42161), Some(0x8000_A4B1)); // Arbitrum One
-    }
-
-    #[test]
-    fn test_coin_type_evm_chain_rejects_out_of_range_ids() {
-        // ENSIP-11 coin types are `0x80000000 | chainId` over a 31-bit chain ID
-        // space; IDs with the high bit set would collide with smaller IDs.
+                                                                    // Chain IDs with the high bit
+                                                                    // set would collide with
+                                                                    // smaller IDs.
         assert_eq!(coin_type::evm_chain(0x8000_0000), None);
         assert_eq!(coin_type::evm_chain(u64::MAX), None);
     }
@@ -566,54 +510,26 @@ mod tests {
 #[cfg(all(test, feature = "contract"))]
 mod resolver_info_tests {
     use super::*;
-    use alloy_primitives::{address, Address, Bytes, B256, U256};
+    use alloy_primitives::{address, Bytes, B256, U256};
 
-    fn info(extended: bool, offset: u64, resolver: Address) -> UniversalResolver::ResolverInfo {
-        UniversalResolver::ResolverInfo {
+    #[test]
+    fn direct_resolver_rejects_extended_and_wildcard_resolvers() {
+        let resolver = address!("0x231b0Ee14048e9dCcD1d247744d114a4EB5E8E63");
+        let info = |extended: bool, offset: u64| UniversalResolver::ResolverInfo {
             name: Bytes::new(),
             offset: U256::from(offset),
             node: B256::ZERO,
             resolver,
             extended,
-        }
-    }
-
-    #[test]
-    fn preserves_legacy_universal_resolver_binding_shape() {
-        let _ = UniversalResolver::resolveReturn { _0: Default::default(), _1: Address::ZERO };
-        let _ = UniversalResolver::reverseCall {
-            lookupAddress: Default::default(),
-            coinType: Default::default(),
         };
-    }
 
-    #[test]
-    fn direct_resolver_accepts_unextended_zero_offset() {
-        let resolver = address!("0x231b0Ee14048e9dCcD1d247744d114a4EB5E8E63");
-        assert_eq!(
-            direct_resolver_address(&info(false, 0, resolver), "vitalik.eth").unwrap(),
-            resolver
-        );
-    }
-
-    #[test]
-    fn direct_resolver_rejects_extended() {
-        let err = direct_resolver_address(
-            &info(true, 0, address!("0x1111111111111111111111111111111111111111")),
-            "ur.integration-tests.eth",
-        )
-        .unwrap_err();
-        assert!(matches!(err, EnsError::RequiresUniversalResolver(_)));
-    }
-
-    #[test]
-    fn direct_resolver_rejects_wildcard_offset() {
-        let err = direct_resolver_address(
-            &info(false, 4, address!("0x1111111111111111111111111111111111111111")),
-            "sub.wildcard.eth",
-        )
-        .unwrap_err();
-        assert!(matches!(err, EnsError::RequiresUniversalResolver(_)));
+        assert_eq!(info(false, 0).direct_resolver("vitalik.eth").unwrap(), resolver);
+        for (extended, offset) in [(true, 0), (false, 4), (true, 4)] {
+            let err = info(extended, offset).direct_resolver("sub.wildcard.eth").unwrap_err();
+            assert!(
+                matches!(err, EnsError::RequiresUniversalResolver(name) if name == "sub.wildcard.eth")
+            );
+        }
     }
 }
 
@@ -623,42 +539,43 @@ mod provider_tests {
 
     use super::*;
     use alloy_primitives::address;
-    use alloy_provider::ProviderBuilder;
+    use alloy_provider::{Provider, ProviderBuilder};
+
+    fn provider() -> impl Provider {
+        ProviderBuilder::new().connect_http("https://ethereum.reth.rs/rpc".parse().unwrap())
+    }
 
     #[tokio::test]
     async fn test_reverse_registrar_fetching_mainnet() {
-        let provider =
-            ProviderBuilder::new().connect_http("https://ethereum.reth.rs/rpc".parse().unwrap());
-
+        let provider = provider();
         let res = provider.get_reverse_registrar().await;
         assert_eq!(*res.unwrap().address(), address!("0xa58E81fe9b61B5c3fE2AFD33CF304c454AbFc7Cb"));
     }
 
     #[tokio::test]
     async fn test_pub_resolver_fetching_mainnet() {
-        let provider =
-            ProviderBuilder::new().connect_http("https://ethereum.reth.rs/rpc".parse().unwrap());
-
+        let provider = provider();
         let name = "vitalik.eth";
-        let node = namehash(name);
-        let res = provider.get_resolver(node, name).await;
+        let res = provider.get_resolver(namehash(name), name).await;
         assert_eq!(*res.unwrap().address(), address!("0x231b0Ee14048e9dCcD1d247744d114a4EB5E8E63"));
     }
 
     #[tokio::test]
     async fn test_get_resolver_for_name_mainnet() {
-        let provider =
-            ProviderBuilder::new().connect_http("https://ethereum.reth.rs/rpc".parse().unwrap());
-
+        let provider = provider();
         let res = provider.get_resolver_for_name("vitalik.eth").await;
         assert_eq!(*res.unwrap().address(), address!("0x231b0Ee14048e9dCcD1d247744d114a4EB5E8E63"));
     }
 
     #[tokio::test]
-    async fn test_pub_resolver_text() {
-        let provider =
-            ProviderBuilder::new().connect_http("https://ethereum.reth.rs/rpc".parse().unwrap());
+    async fn test_get_resolver_for_name_rejects_extended_resolver() {
+        let err = provider().get_resolver_for_name("ur.integration-tests.eth").await.unwrap_err();
+        assert!(matches!(err, EnsError::RequiresUniversalResolver(_)));
+    }
 
+    #[tokio::test]
+    async fn test_pub_resolver_text() {
+        let provider = provider();
         let name = "vitalik.eth";
         let node = namehash(name);
         let res = provider.get_resolver(node, name).await.unwrap();
@@ -667,59 +584,44 @@ mod provider_tests {
     }
 
     #[tokio::test]
-    async fn test_pub_resolver_fetching_text() {
-        let provider =
-            ProviderBuilder::new().connect_http("https://ethereum.reth.rs/rpc".parse().unwrap());
-
-        let res = provider.lookup_txt("vitalik.eth", "avatar").await.unwrap();
-        assert_eq!(res, "https://euc.li/vitalik.eth")
+    async fn test_resolve_name_via_universal_resolver() {
+        let addr = provider().resolve_name("ur.integration-tests.eth").await.unwrap();
+        assert_eq!(addr, address!("0x2222222222222222222222222222222222222222"));
     }
 
     #[tokio::test]
-    async fn test_universal_resolver_integration() {
-        let provider =
-            ProviderBuilder::new().connect_http("https://ethereum.reth.rs/rpc".parse().unwrap());
-
-        let res = provider.resolve_name("ur.integration-tests.eth").await.unwrap();
-        assert_eq!(res, address!("0x2222222222222222222222222222222222222222"));
-    }
-
-    #[tokio::test]
-    async fn test_get_resolver_for_name_rejects_extended_resolver() {
-        let provider =
-            ProviderBuilder::new().connect_http("https://ethereum.reth.rs/rpc".parse().unwrap());
-
-        let err = provider.get_resolver_for_name("ur.integration-tests.eth").await.unwrap_err();
-        assert!(matches!(err, EnsError::RequiresUniversalResolver(_)));
-    }
-
-    #[tokio::test]
-    async fn test_multicoin_resolver_integration() {
-        let provider =
-            ProviderBuilder::new().connect_http("https://ethereum.reth.rs/rpc".parse().unwrap());
-
-        let res = provider
+    async fn test_resolve_name_for_coin_type_via_universal_resolver() {
+        let res = provider()
             .resolve_name_for_coin_type(
                 "coins.integration-tests.eth",
                 coin_type::evm_chain(8453).unwrap(),
             )
             .await
             .unwrap();
+        assert_eq!(res.as_ref(), address!("0xa66E90D515F576f49Af2dF40952476D56F72A420").as_slice());
+    }
+
+    #[tokio::test]
+    async fn test_lookup_address_via_universal_resolver() {
+        let name = provider()
+            .lookup_address(&address!("0xeE9eeaAB0Bb7D9B969D701f6f8212609EDeA252E"))
+            .await
+            .unwrap();
+        assert_eq!(name, "devrel.enslabs.eth");
+    }
+
+    #[tokio::test]
+    async fn test_lookup_txt_via_universal_resolver() {
+        let avatar = provider().lookup_txt("integration-tests.eth", "avatar").await.unwrap();
         assert_eq!(
-            res.as_ref(),
-            address!("0xa66E90D515F576f49Af2dF40952476D56F72A420").as_slice()
+            avatar,
+            "https://raw.githubusercontent.com/ensdomains/resolution-tests/refs/heads/main/assets/avatar.svg"
         );
     }
 
     #[tokio::test]
-    async fn test_reverse_resolver_integration() {
-        let provider =
-            ProviderBuilder::new().connect_http("https://ethereum.reth.rs/rpc".parse().unwrap());
-
-        let res = provider
-            .lookup_address(&address!("0xeE9eeaAB0Bb7D9B969D701f6f8212609EDeA252E"))
-            .await
-            .unwrap();
-        assert_eq!(res, "devrel.enslabs.eth");
+    async fn test_pub_resolver_fetching_txt() {
+        let res = provider().lookup_txt("vitalik.eth", "avatar").await.unwrap();
+        assert_eq!(res, "https://euc.li/vitalik.eth")
     }
 }

--- a/crates/ens/src/lib.rs
+++ b/crates/ens/src/lib.rs
@@ -9,7 +9,7 @@
 //! ENS Name resolving utilities.
 
 mod utils;
-pub use utils::{dns_encode, namehash, reverse_address, DnsEncodeError};
+pub use utils::{dns_encode, namehash, reverse_address, try_dns_encode, DnsEncodeError};
 
 use alloy_primitives::{address, Address};
 use std::str::FromStr;
@@ -233,7 +233,7 @@ mod contract {
 #[cfg(feature = "provider")]
 mod provider {
     use crate::{
-        coin_type, dns_encode, namehash, reverse_address, EnsError, EnsMulticoinResolver,
+        coin_type, namehash, reverse_address, try_dns_encode, EnsError, EnsMulticoinResolver,
         EnsResolver, EnsResolver::EnsResolverInstance, UniversalResolver,
         UNIVERSAL_RESOLVER_ADDRESS,
     };
@@ -291,7 +291,7 @@ mod provider {
         N: Network,
     {
         async fn get_resolver(&self, name: &str) -> Result<EnsResolverInstance<&P, N>, EnsError> {
-            let dns = dns_encode(name)?;
+            let dns = try_dns_encode(name)?;
 
             let ur = UniversalResolver::new(UNIVERSAL_RESOLVER_ADDRESS, self);
             let info = ur
@@ -312,7 +312,7 @@ mod provider {
 
         async fn resolve_name(&self, name: &str) -> Result<Address, EnsError> {
             let node = namehash(name);
-            let dns = dns_encode(name)?;
+            let dns = try_dns_encode(name)?;
             let calldata = EnsResolver::addrCall { node }.abi_encode();
 
             let ur = UniversalResolver::new(UNIVERSAL_RESOLVER_ADDRESS, self);
@@ -331,7 +331,7 @@ mod provider {
             coin_type: u64,
         ) -> Result<Bytes, EnsError> {
             let node = namehash(name);
-            let dns = dns_encode(name)?;
+            let dns = try_dns_encode(name)?;
             let calldata = EnsMulticoinResolver::addrCall {
                 node,
                 coin_type: U256::from(coin_type),
@@ -362,7 +362,7 @@ mod provider {
 
         async fn lookup_txt(&self, name: &str, key: &str) -> Result<String, EnsError> {
             let node = namehash(name);
-            let dns = dns_encode(name)?;
+            let dns = try_dns_encode(name)?;
             let calldata = EnsResolver::textCall { node, key: key.to_string() }.abi_encode();
 
             let ur = UniversalResolver::new(UNIVERSAL_RESOLVER_ADDRESS, self);

--- a/crates/ens/src/lib.rs
+++ b/crates/ens/src/lib.rs
@@ -346,8 +346,13 @@ mod provider {
 
         /// Performs a reverse lookup of an address to its primary ENS name.
         ///
-        /// The Universal Resolver verifies that the primary name resolves back to `address`, and
-        /// returns an empty string if no primary name is set.
+        /// The Universal Resolver verifies that the raw primary name resolves back to `address`,
+        /// and returns an empty string if no primary name is set. Neither the Universal Resolver
+        /// nor this helper performs ENSIP-15 normalization of the returned name.
+        ///
+        /// Before using a non-empty result as an authenticated identity, normalize it according to
+        /// ENSIP-15 and reject it if normalization fails or changes the name. Normalizing and using
+        /// a changed name is insufficient: the address check applied to the original name.
         async fn lookup_address(&self, address: &Address) -> Result<String, EnsError>;
 
         /// Looks up a text record for an ENS name.

--- a/crates/ens/src/utils.rs
+++ b/crates/ens/src/utils.rs
@@ -1,0 +1,158 @@
+use alloy_primitives::{Address, Keccak256, B256};
+use std::borrow::Cow;
+
+/// Error returned by [`dns_encode`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DnsEncodeError {
+    /// A label in the name is empty (e.g., consecutive dots or leading/trailing dot).
+    EmptyLabel,
+    /// A label exceeds the 63-byte maximum DNS length.
+    LabelTooLong,
+}
+
+impl std::fmt::Display for DnsEncodeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::EmptyLabel => f.write_str("ENS name contains an empty label"),
+            Self::LabelTooLong => f.write_str("ENS name label exceeds 63 bytes"),
+        }
+    }
+}
+
+impl std::error::Error for DnsEncodeError {}
+
+/// DNS wire-format encodes an ENS name for use with the Universal Resolver's `resolve()`.
+///
+/// Each label is prefixed with its byte length and the sequence is terminated with `\x00`.
+/// For example, `"foo.eth"` encodes to `[3, 'f', 'o', 'o', 3, 'e', 't', 'h', 0]`.
+///
+/// Returns an error if any label is empty or exceeds 63 bytes.
+pub fn dns_encode(name: &str) -> Result<Vec<u8>, DnsEncodeError> {
+    if name.is_empty() {
+        return Ok(vec![0]);
+    }
+
+    // Strip variation selector as in namehash.
+    const VARIATION_SELECTOR: char = '\u{fe0f}';
+    let name = if name.contains(VARIATION_SELECTOR) {
+        Cow::Owned(name.replace(VARIATION_SELECTOR, ""))
+    } else {
+        Cow::Borrowed(name)
+    };
+
+    let mut out = Vec::with_capacity(name.len() + 2);
+    for label in name.split('.') {
+        let bytes = label.as_bytes();
+        if bytes.is_empty() {
+            return Err(DnsEncodeError::EmptyLabel);
+        }
+        if bytes.len() > 63 {
+            return Err(DnsEncodeError::LabelTooLong);
+        }
+        out.push(bytes.len() as u8);
+        out.extend_from_slice(bytes);
+    }
+    out.push(0);
+    Ok(out)
+}
+
+/// Returns the ENS namehash as specified in [EIP-137](https://eips.ethereum.org/EIPS/eip-137).
+pub fn namehash(name: &str) -> B256 {
+    if name.is_empty() {
+        return B256::ZERO;
+    }
+
+    // Remove the variation selector `U+FE0F` if present.
+    const VARIATION_SELECTOR: char = '\u{fe0f}';
+    let name = if name.contains(VARIATION_SELECTOR) {
+        Cow::Owned(name.replace(VARIATION_SELECTOR, ""))
+    } else {
+        Cow::Borrowed(name)
+    };
+
+    // Generate the node starting from the right.
+    // This buffer is `[node @ [u8; 32], label_hash @ [u8; 32]]`.
+    let mut buffer = [0u8; 64];
+    for label in name.rsplit('.') {
+        // node = keccak256([node, keccak256(label)])
+
+        // Hash the label.
+        let mut label_hasher = Keccak256::new();
+        label_hasher.update(label.as_bytes());
+        label_hasher.finalize_into(&mut buffer[32..]);
+
+        // Hash both the node and the label hash, writing into the node.
+        let mut buffer_hasher = Keccak256::new();
+        buffer_hasher.update(buffer.as_slice());
+        buffer_hasher.finalize_into(&mut buffer[..32]);
+    }
+    buffer[..32].try_into().unwrap()
+}
+
+/// Returns the reverse-registrar name of an address.
+pub fn reverse_address(addr: &Address) -> String {
+    format!("{addr:x}.addr.reverse")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::hex;
+
+    fn assert_hex(hash: B256, val: &str) {
+        assert_eq!(hash.0[..], hex::decode(val).unwrap()[..]);
+    }
+
+    #[test]
+    fn test_namehash() {
+        for (name, expected) in &[
+            ("", "0x0000000000000000000000000000000000000000000000000000000000000000"),
+            ("eth", "0x93cdeb708b7545dc668eb9280176169d1c33cfd8ed6f04690a0bcc88a93fc4ae"),
+            ("foo.eth", "0xde9b09fd7c5f901e23a3f19fecc54828e9c848539801e86591bd9801b019f84f"),
+            ("alice.eth", "0x787192fc5378cc32aa956ddfdedbf26b24e8d78e40109add0eea2c1a012c3dec"),
+            ("ret↩️rn.eth", "0x3de5f4c02db61b221e7de7f1c40e29b6e2f07eb48d65bf7e304715cd9ed33b24"),
+        ] {
+            assert_hex(namehash(name), expected);
+        }
+    }
+
+    #[test]
+    fn test_reverse_address() {
+        for (addr, expected) in [
+            (
+                "0x314159265dd8dbb310642f98f50c066173c1259b",
+                "314159265dd8dbb310642f98f50c066173c1259b.addr.reverse",
+            ),
+            (
+                "0x28679A1a632125fbBf7A68d850E50623194A709E",
+                "28679a1a632125fbbf7a68d850e50623194a709e.addr.reverse",
+            ),
+        ] {
+            assert_eq!(reverse_address(&addr.parse().unwrap()), expected, "{addr}");
+        }
+    }
+
+    #[test]
+    fn test_dns_encode() {
+        assert_eq!(dns_encode("").unwrap(), vec![0]);
+        assert_eq!(
+            dns_encode("foo.eth").unwrap(),
+            vec![3, b'f', b'o', b'o', 3, b'e', b't', b'h', 0]
+        );
+        assert_eq!(
+            dns_encode("alice.eth").unwrap(),
+            vec![5, b'a', b'l', b'i', b'c', b'e', 3, b'e', b't', b'h', 0]
+        );
+        // Known vector: "integration-tests.eth"
+        assert_eq!(
+            dns_encode("integration-tests.eth").unwrap(),
+            hex::decode("11696e746567726174696f6e2d74657374730365746800").unwrap()
+        );
+        // Empty label errors
+        assert_eq!(dns_encode(".eth").unwrap_err(), DnsEncodeError::EmptyLabel);
+        assert_eq!(dns_encode("foo..eth").unwrap_err(), DnsEncodeError::EmptyLabel);
+        // Label too long
+        let long_label = "a".repeat(64) + ".eth";
+        assert_eq!(dns_encode(&long_label).unwrap_err(), DnsEncodeError::LabelTooLong);
+    }
+}

--- a/crates/ens/src/utils.rs
+++ b/crates/ens/src/utils.rs
@@ -1,7 +1,7 @@
 use alloy_primitives::{Address, Keccak256, B256};
 use std::borrow::Cow;
 
-/// Error returned by [`dns_encode`].
+/// Error returned by [`try_dns_encode`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum DnsEncodeError {
     /// A label in the name is empty (e.g., consecutive dots or leading/trailing dot).
@@ -21,13 +21,27 @@ impl std::fmt::Display for DnsEncodeError {
 
 impl std::error::Error for DnsEncodeError {}
 
-/// DNS wire-format encodes an ENS name for use with the Universal Resolver's `resolve()`.
+/// DNS wire-format encodes a name.
 ///
 /// Each label is prefixed with its byte length and the sequence is terminated with `\x00`.
 /// For example, `"foo.eth"` encodes to `[3, 'f', 'o', 'o', 3, 'e', 't', 'h', 0]`.
 ///
+/// This preserves the original infallible API. Use [`try_dns_encode`] when encoding
+/// untrusted input for the Universal Resolver.
+pub fn dns_encode(name: &str) -> Vec<u8> {
+    let mut out = Vec::with_capacity(name.len() + 2);
+    for label in name.split('.') {
+        out.push(label.len() as u8);
+        out.extend_from_slice(label.as_bytes());
+    }
+    out.push(0);
+    out
+}
+
+/// DNS wire-format encodes an ENS name for use with the Universal Resolver's `resolve()`.
+///
 /// Returns an error if any label is empty or exceeds 63 bytes.
-pub fn dns_encode(name: &str) -> Result<Vec<u8>, DnsEncodeError> {
+pub fn try_dns_encode(name: &str) -> Result<Vec<u8>, DnsEncodeError> {
     if name.is_empty() {
         return Ok(vec![0]);
     }
@@ -134,25 +148,32 @@ mod tests {
 
     #[test]
     fn test_dns_encode() {
-        assert_eq!(dns_encode("").unwrap(), vec![0]);
+        assert_eq!(dns_encode(""), vec![0, 0]);
         assert_eq!(
-            dns_encode("foo.eth").unwrap(),
+            dns_encode("foo.eth"),
             vec![3, b'f', b'o', b'o', 3, b'e', b't', b'h', 0]
         );
         assert_eq!(
-            dns_encode("alice.eth").unwrap(),
+            dns_encode("alice.eth"),
             vec![5, b'a', b'l', b'i', b'c', b'e', 3, b'e', b't', b'h', 0]
         );
         // Known vector: "integration-tests.eth"
         assert_eq!(
-            dns_encode("integration-tests.eth").unwrap(),
+            dns_encode("integration-tests.eth"),
             hex::decode("11696e746567726174696f6e2d74657374730365746800").unwrap()
         );
+        assert_eq!(dns_encode(".eth"), vec![0, 3, b'e', b't', b'h', 0]);
+    }
+
+    #[test]
+    fn test_try_dns_encode() {
+        assert_eq!(try_dns_encode(""), Ok(vec![0]));
+        assert_eq!(try_dns_encode("foo.eth"), Ok(dns_encode("foo.eth")));
         // Empty label errors
-        assert_eq!(dns_encode(".eth").unwrap_err(), DnsEncodeError::EmptyLabel);
-        assert_eq!(dns_encode("foo..eth").unwrap_err(), DnsEncodeError::EmptyLabel);
+        assert_eq!(try_dns_encode(".eth").unwrap_err(), DnsEncodeError::EmptyLabel);
+        assert_eq!(try_dns_encode("foo..eth").unwrap_err(), DnsEncodeError::EmptyLabel);
         // Label too long
         let long_label = "a".repeat(64) + ".eth";
-        assert_eq!(dns_encode(&long_label).unwrap_err(), DnsEncodeError::LabelTooLong);
+        assert_eq!(try_dns_encode(&long_label).unwrap_err(), DnsEncodeError::LabelTooLong);
     }
 }

--- a/crates/ens/src/utils.rs
+++ b/crates/ens/src/utils.rs
@@ -1,7 +1,7 @@
 use alloy_primitives::{Address, Keccak256, B256};
 use std::borrow::Cow;
 
-/// Error returned by [`try_dns_encode`].
+/// Error returned by [`dns_encode`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum DnsEncodeError {
     /// A label in the name is empty (e.g., consecutive dots or leading/trailing dot).
@@ -21,27 +21,13 @@ impl std::fmt::Display for DnsEncodeError {
 
 impl std::error::Error for DnsEncodeError {}
 
-/// DNS wire-format encodes a name.
+/// DNS wire-format encodes an ENS name for use with the Universal Resolver's `resolve()`.
 ///
 /// Each label is prefixed with its byte length and the sequence is terminated with `\x00`.
 /// For example, `"foo.eth"` encodes to `[3, 'f', 'o', 'o', 3, 'e', 't', 'h', 0]`.
 ///
-/// This preserves the original infallible API. Use [`try_dns_encode`] when encoding
-/// untrusted input for the Universal Resolver.
-pub fn dns_encode(name: &str) -> Vec<u8> {
-    let mut out = Vec::with_capacity(name.len() + 2);
-    for label in name.split('.') {
-        out.push(label.len() as u8);
-        out.extend_from_slice(label.as_bytes());
-    }
-    out.push(0);
-    out
-}
-
-/// DNS wire-format encodes an ENS name for use with the Universal Resolver's `resolve()`.
-///
 /// Returns an error if any label is empty or exceeds 63 bytes.
-pub fn try_dns_encode(name: &str) -> Result<Vec<u8>, DnsEncodeError> {
+pub fn dns_encode(name: &str) -> Result<Vec<u8>, DnsEncodeError> {
     if name.is_empty() {
         return Ok(vec![0]);
     }
@@ -148,32 +134,22 @@ mod tests {
 
     #[test]
     fn test_dns_encode() {
-        assert_eq!(dns_encode(""), vec![0, 0]);
-        assert_eq!(
-            dns_encode("foo.eth"),
-            vec![3, b'f', b'o', b'o', 3, b'e', b't', b'h', 0]
-        );
+        assert_eq!(dns_encode(""), Ok(vec![0]));
+        assert_eq!(dns_encode("foo.eth"), Ok(vec![3, b'f', b'o', b'o', 3, b'e', b't', b'h', 0]));
         assert_eq!(
             dns_encode("alice.eth"),
-            vec![5, b'a', b'l', b'i', b'c', b'e', 3, b'e', b't', b'h', 0]
+            Ok(vec![5, b'a', b'l', b'i', b'c', b'e', 3, b'e', b't', b'h', 0])
         );
         // Known vector: "integration-tests.eth"
         assert_eq!(
             dns_encode("integration-tests.eth"),
-            hex::decode("11696e746567726174696f6e2d74657374730365746800").unwrap()
+            Ok(hex::decode("11696e746567726174696f6e2d74657374730365746800").unwrap())
         );
-        assert_eq!(dns_encode(".eth"), vec![0, 3, b'e', b't', b'h', 0]);
-    }
-
-    #[test]
-    fn test_try_dns_encode() {
-        assert_eq!(try_dns_encode(""), Ok(vec![0]));
-        assert_eq!(try_dns_encode("foo.eth"), Ok(dns_encode("foo.eth")));
         // Empty label errors
-        assert_eq!(try_dns_encode(".eth").unwrap_err(), DnsEncodeError::EmptyLabel);
-        assert_eq!(try_dns_encode("foo..eth").unwrap_err(), DnsEncodeError::EmptyLabel);
+        assert_eq!(dns_encode(".eth").unwrap_err(), DnsEncodeError::EmptyLabel);
+        assert_eq!(dns_encode("foo..eth").unwrap_err(), DnsEncodeError::EmptyLabel);
         // Label too long
         let long_label = "a".repeat(64) + ".eth";
-        assert_eq!(try_dns_encode(&long_label).unwrap_err(), DnsEncodeError::LabelTooLong);
+        assert_eq!(dns_encode(&long_label).unwrap_err(), DnsEncodeError::LabelTooLong);
     }
 }

--- a/crates/ens/src/utils.rs
+++ b/crates/ens/src/utils.rs
@@ -6,7 +6,7 @@ use std::borrow::Cow;
 pub enum DnsEncodeError {
     /// A label in the name is empty (e.g., consecutive dots or leading/trailing dot).
     EmptyLabel,
-    /// A label exceeds the 63-byte maximum DNS length.
+    /// A label exceeds the 255-byte maximum used by ENS DNS wire encoding.
     LabelTooLong,
 }
 
@@ -14,7 +14,7 @@ impl std::fmt::Display for DnsEncodeError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::EmptyLabel => f.write_str("ENS name contains an empty label"),
-            Self::LabelTooLong => f.write_str("ENS name label exceeds 63 bytes"),
+            Self::LabelTooLong => f.write_str("ENS name label exceeds 255 bytes"),
         }
     }
 }
@@ -26,7 +26,9 @@ impl std::error::Error for DnsEncodeError {}
 /// Each label is prefixed with its byte length and the sequence is terminated with `\x00`.
 /// For example, `"foo.eth"` encodes to `[3, 'f', 'o', 'o', 3, 'e', 't', 'h', 0]`.
 ///
-/// Returns an error if any label is empty or exceeds 63 bytes.
+/// Returns an error if any label is empty or exceeds 255 bytes. This matches ENS
+/// [`NameCoder`](https://github.com/ensdomains/ens-contracts/blob/staging/contracts/utils/NameCoder.sol),
+/// which uses a full length byte (not the RFC 1035 63-octet DNS message limit).
 pub fn dns_encode(name: &str) -> Result<Vec<u8>, DnsEncodeError> {
     if name.is_empty() {
         return Ok(vec![0]);
@@ -46,7 +48,7 @@ pub fn dns_encode(name: &str) -> Result<Vec<u8>, DnsEncodeError> {
         if bytes.is_empty() {
             return Err(DnsEncodeError::EmptyLabel);
         }
-        if bytes.len() > 63 {
+        if bytes.len() > 255 {
             return Err(DnsEncodeError::LabelTooLong);
         }
         out.push(bytes.len() as u8);
@@ -148,8 +150,10 @@ mod tests {
         // Empty label errors
         assert_eq!(dns_encode(".eth").unwrap_err(), DnsEncodeError::EmptyLabel);
         assert_eq!(dns_encode("foo..eth").unwrap_err(), DnsEncodeError::EmptyLabel);
-        // Label too long
-        let long_label = "a".repeat(64) + ".eth";
-        assert_eq!(dns_encode(&long_label).unwrap_err(), DnsEncodeError::LabelTooLong);
+        // Labels up to 255 bytes are valid for ENS DNS wire encoding / NameCoder.
+        let max_label = "a".repeat(255) + ".eth";
+        assert!(dns_encode(&max_label).is_ok());
+        let too_long = "a".repeat(256) + ".eth";
+        assert_eq!(dns_encode(&too_long).unwrap_err(), DnsEncodeError::LabelTooLong);
     }
 }

--- a/crates/ens/src/utils.rs
+++ b/crates/ens/src/utils.rs
@@ -30,6 +30,13 @@ impl std::error::Error for DnsEncodeError {}
 /// This preserves the original infallible API and does not validate the name. Use
 /// [`try_dns_encode`] when encoding untrusted input for the Universal Resolver.
 ///
+/// # Warning
+///
+/// An oversized label's length prefix is silently truncated (`label.len() as u8`),
+/// producing corrupted DNS wire data. Labels longer than 255 bytes therefore do
+/// not round-trip. Prefer [`try_dns_encode`], which returns
+/// [`DnsEncodeError::LabelTooLong`] instead.
+///
 /// # Examples
 ///
 /// ```

--- a/crates/ens/src/utils.rs
+++ b/crates/ens/src/utils.rs
@@ -1,12 +1,13 @@
+use crate::ENS_REVERSE_REGISTRAR_DOMAIN;
 use alloy_primitives::{Address, Keccak256, B256};
 use std::borrow::Cow;
 
 /// Error returned by [`try_dns_encode`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum DnsEncodeError {
-    /// A label in the name is empty (e.g., consecutive dots or leading/trailing dot).
+    /// A label in the name is empty, e.g. because of consecutive, leading, or trailing dots.
     EmptyLabel,
-    /// A label exceeds the 255-byte maximum used by ENS DNS wire encoding.
+    /// A label exceeds the 255-byte maximum of the ENS DNS wire encoding.
     LabelTooLong,
 }
 
@@ -21,21 +22,47 @@ impl std::fmt::Display for DnsEncodeError {
 
 impl std::error::Error for DnsEncodeError {}
 
+/// Returns the ENS namehash as specified in [EIP-137](https://eips.ethereum.org/EIPS/eip-137).
+///
+/// `name` must already be ENSIP-15 normalized. Apart from removing the `U+FE0F` variation selector,
+/// this function hashes labels verbatim and does not normalize or validate them.
+pub fn namehash(name: &str) -> B256 {
+    if name.is_empty() {
+        return B256::ZERO;
+    }
+
+    let name = strip_variation_selector(name);
+
+    // Generate the node starting from the right.
+    // This buffer is `[node @ [u8; 32], label_hash @ [u8; 32]]`.
+    let mut buffer = [0u8; 64];
+    for label in name.rsplit('.') {
+        // node = keccak256([node, keccak256(label)])
+
+        // Hash the label.
+        let mut label_hasher = Keccak256::new();
+        label_hasher.update(label.as_bytes());
+        label_hasher.finalize_into(&mut buffer[32..]);
+
+        // Hash both the node and the label hash, writing into the node.
+        let mut buffer_hasher = Keccak256::new();
+        buffer_hasher.update(buffer.as_slice());
+        buffer_hasher.finalize_into(&mut buffer[..32]);
+    }
+    buffer[..32].try_into().unwrap()
+}
+
 /// Encodes a domain name into DNS wire format as specified in
 /// [RFC 1035](https://datatracker.ietf.org/doc/html/rfc1035).
 ///
 /// Each label is prefixed with its length byte, and the name is terminated with a
 /// zero-length label (null byte).
 ///
-/// This preserves the original infallible API and does not validate the name. Use
-/// [`try_dns_encode`] when encoding untrusted input for the Universal Resolver.
-///
-/// # Warning
-///
-/// An oversized label's length prefix is silently truncated (`label.len() as u8`),
-/// producing corrupted DNS wire data. Labels longer than 255 bytes therefore do
-/// not round-trip. Prefer [`try_dns_encode`], which returns
-/// [`DnsEncodeError::LabelTooLong`] instead.
+/// This is an unchecked encoder: `name` must already be ENSIP-15 normalized and non-empty, must
+/// not contain empty labels (including leading, trailing, or repeated dots), and each UTF-8 label
+/// length must fit in a `u8`. Invalid input is encoded without an error, and an oversized label's
+/// length prefix is silently truncated, producing corrupted wire data. Use [`try_dns_encode`] to
+/// validate the name instead.
 ///
 /// # Examples
 ///
@@ -57,79 +84,51 @@ pub fn dns_encode(name: &str) -> Vec<u8> {
     result
 }
 
-/// DNS wire-format encodes an ENS name for use with the Universal Resolver's `resolve()`.
+/// Encodes an ENS name into DNS wire format for the Universal Resolver, validating its labels.
 ///
-/// Each label is prefixed with its byte length and the sequence is terminated with `\x00`.
-/// For example, `"foo.eth"` encodes to `[3, 'f', 'o', 'o', 3, 'e', 't', 'h', 0]`.
+/// Like [`dns_encode`], each label is prefixed with its byte length and the name is terminated
+/// with a null byte, but the `U+FE0F` variation selector is removed first so that the encoded name
+/// hashes to [`namehash`] on chain. Returns an error if any label is empty or exceeds 255 bytes,
+/// matching the ENS [`NameCoder`] limits.
 ///
-/// Returns an error if any label is empty or exceeds 255 bytes. This matches ENS
-/// [`NameCoder`](https://github.com/ensdomains/ens-contracts/blob/staging/contracts/utils/NameCoder.sol),
-/// which uses a full length byte (not the RFC 1035 63-octet DNS message limit).
+/// The empty name encodes to the root (`[0]`).
+///
+/// [`NameCoder`]: https://github.com/ensdomains/ens-contracts/blob/staging/contracts/utils/NameCoder.sol
 pub fn try_dns_encode(name: &str) -> Result<Vec<u8>, DnsEncodeError> {
     if name.is_empty() {
         return Ok(vec![0]);
     }
 
-    // Strip variation selector as in namehash.
-    const VARIATION_SELECTOR: char = '\u{fe0f}';
-    let name = if name.contains(VARIATION_SELECTOR) {
-        Cow::Owned(name.replace(VARIATION_SELECTOR, ""))
-    } else {
-        Cow::Borrowed(name)
-    };
-
+    let name = strip_variation_selector(name);
     let mut out = Vec::with_capacity(name.len() + 2);
     for label in name.split('.') {
-        let bytes = label.as_bytes();
-        if bytes.is_empty() {
+        let label = label.as_bytes();
+        if label.is_empty() {
             return Err(DnsEncodeError::EmptyLabel);
         }
-        if bytes.len() > 255 {
+        let Ok(len) = u8::try_from(label.len()) else {
             return Err(DnsEncodeError::LabelTooLong);
-        }
-        out.push(bytes.len() as u8);
-        out.extend_from_slice(bytes);
+        };
+        out.push(len);
+        out.extend_from_slice(label);
     }
     out.push(0);
     Ok(out)
 }
 
-/// Returns the ENS namehash as specified in [EIP-137](https://eips.ethereum.org/EIPS/eip-137).
-pub fn namehash(name: &str) -> B256 {
-    if name.is_empty() {
-        return B256::ZERO;
-    }
+/// Returns the reverse-registrar name of an address.
+pub fn reverse_address(addr: &Address) -> String {
+    format!("{addr:x}.{ENS_REVERSE_REGISTRAR_DOMAIN}")
+}
 
-    // Remove the variation selector `U+FE0F` if present.
+/// Removes the `U+FE0F` variation selector, which ENS ignores when hashing names.
+fn strip_variation_selector(name: &str) -> Cow<'_, str> {
     const VARIATION_SELECTOR: char = '\u{fe0f}';
-    let name = if name.contains(VARIATION_SELECTOR) {
+    if name.contains(VARIATION_SELECTOR) {
         Cow::Owned(name.replace(VARIATION_SELECTOR, ""))
     } else {
         Cow::Borrowed(name)
-    };
-
-    // Generate the node starting from the right.
-    // This buffer is `[node @ [u8; 32], label_hash @ [u8; 32]]`.
-    let mut buffer = [0u8; 64];
-    for label in name.rsplit('.') {
-        // node = keccak256([node, keccak256(label)])
-
-        // Hash the label.
-        let mut label_hasher = Keccak256::new();
-        label_hasher.update(label.as_bytes());
-        label_hasher.finalize_into(&mut buffer[32..]);
-
-        // Hash both the node and the label hash, writing into the node.
-        let mut buffer_hasher = Keccak256::new();
-        buffer_hasher.update(buffer.as_slice());
-        buffer_hasher.finalize_into(&mut buffer[..32]);
     }
-    buffer[..32].try_into().unwrap()
-}
-
-/// Returns the reverse-registrar name of an address.
-pub fn reverse_address(addr: &Address) -> String {
-    format!("{addr:x}.addr.reverse")
 }
 
 #[cfg(test)]
@@ -171,34 +170,22 @@ mod tests {
     }
 
     #[test]
-    fn test_dns_encode() {
-        assert_eq!(dns_encode("eth"), vec![3, b'e', b't', b'h', 0]);
-        assert_eq!(dns_encode("foo.eth"), vec![3, b'f', b'o', b'o', 3, b'e', b't', b'h', 0]);
-    }
-
-    #[test]
     fn test_try_dns_encode() {
         assert_eq!(try_dns_encode(""), Ok(vec![0]));
-        assert_eq!(
-            try_dns_encode("foo.eth"),
-            Ok(vec![3, b'f', b'o', b'o', 3, b'e', b't', b'h', 0])
-        );
-        assert_eq!(
-            try_dns_encode("alice.eth"),
-            Ok(vec![5, b'a', b'l', b'i', b'c', b'e', 3, b'e', b't', b'h', 0])
-        );
-        // Known vector: "integration-tests.eth"
+        assert_eq!(try_dns_encode("foo.eth"), Ok(dns_encode("foo.eth")));
         assert_eq!(
             try_dns_encode("integration-tests.eth"),
             Ok(hex::decode("11696e746567726174696f6e2d74657374730365746800").unwrap())
         );
-        // Empty label errors
-        assert_eq!(try_dns_encode(".eth").unwrap_err(), DnsEncodeError::EmptyLabel);
-        assert_eq!(try_dns_encode("foo..eth").unwrap_err(), DnsEncodeError::EmptyLabel);
-        // Labels up to 255 bytes are valid for ENS DNS wire encoding / NameCoder.
+        assert_eq!(try_dns_encode("ret↩️rn.eth"), Ok(dns_encode("ret↩rn.eth")));
+
+        assert_eq!(try_dns_encode(".eth"), Err(DnsEncodeError::EmptyLabel));
+        assert_eq!(try_dns_encode("foo..eth"), Err(DnsEncodeError::EmptyLabel));
+        assert_eq!(try_dns_encode("foo.eth."), Err(DnsEncodeError::EmptyLabel));
+
         let max_label = "a".repeat(255) + ".eth";
         assert!(try_dns_encode(&max_label).is_ok());
         let too_long = "a".repeat(256) + ".eth";
-        assert_eq!(try_dns_encode(&too_long).unwrap_err(), DnsEncodeError::LabelTooLong);
+        assert_eq!(try_dns_encode(&too_long), Err(DnsEncodeError::LabelTooLong));
     }
 }

--- a/crates/ens/src/utils.rs
+++ b/crates/ens/src/utils.rs
@@ -1,7 +1,7 @@
 use alloy_primitives::{Address, Keccak256, B256};
 use std::borrow::Cow;
 
-/// Error returned by [`dns_encode`].
+/// Error returned by [`try_dns_encode`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum DnsEncodeError {
     /// A label in the name is empty (e.g., consecutive dots or leading/trailing dot).
@@ -21,6 +21,35 @@ impl std::fmt::Display for DnsEncodeError {
 
 impl std::error::Error for DnsEncodeError {}
 
+/// Encodes a domain name into DNS wire format as specified in
+/// [RFC 1035](https://datatracker.ietf.org/doc/html/rfc1035).
+///
+/// Each label is prefixed with its length byte, and the name is terminated with a
+/// zero-length label (null byte).
+///
+/// This preserves the original infallible API and does not validate the name. Use
+/// [`try_dns_encode`] when encoding untrusted input for the Universal Resolver.
+///
+/// # Examples
+///
+/// ```
+/// use alloy_ens::dns_encode;
+/// assert_eq!(dns_encode("eth"), vec![3, b'e', b't', b'h', 0]);
+/// assert_eq!(
+///     dns_encode("vitalik.eth"),
+///     vec![7, b'v', b'i', b't', b'a', b'l', b'i', b'k', 3, b'e', b't', b'h', 0]
+/// );
+/// ```
+pub fn dns_encode(name: &str) -> Vec<u8> {
+    let mut result = Vec::with_capacity(name.len() + 2);
+    for label in name.split('.') {
+        result.push(label.len() as u8);
+        result.extend_from_slice(label.as_bytes());
+    }
+    result.push(0);
+    result
+}
+
 /// DNS wire-format encodes an ENS name for use with the Universal Resolver's `resolve()`.
 ///
 /// Each label is prefixed with its byte length and the sequence is terminated with `\x00`.
@@ -29,7 +58,7 @@ impl std::error::Error for DnsEncodeError {}
 /// Returns an error if any label is empty or exceeds 255 bytes. This matches ENS
 /// [`NameCoder`](https://github.com/ensdomains/ens-contracts/blob/staging/contracts/utils/NameCoder.sol),
 /// which uses a full length byte (not the RFC 1035 63-octet DNS message limit).
-pub fn dns_encode(name: &str) -> Result<Vec<u8>, DnsEncodeError> {
+pub fn try_dns_encode(name: &str) -> Result<Vec<u8>, DnsEncodeError> {
     if name.is_empty() {
         return Ok(vec![0]);
     }
@@ -136,24 +165,33 @@ mod tests {
 
     #[test]
     fn test_dns_encode() {
-        assert_eq!(dns_encode(""), Ok(vec![0]));
-        assert_eq!(dns_encode("foo.eth"), Ok(vec![3, b'f', b'o', b'o', 3, b'e', b't', b'h', 0]));
+        assert_eq!(dns_encode("eth"), vec![3, b'e', b't', b'h', 0]);
+        assert_eq!(dns_encode("foo.eth"), vec![3, b'f', b'o', b'o', 3, b'e', b't', b'h', 0]);
+    }
+
+    #[test]
+    fn test_try_dns_encode() {
+        assert_eq!(try_dns_encode(""), Ok(vec![0]));
         assert_eq!(
-            dns_encode("alice.eth"),
+            try_dns_encode("foo.eth"),
+            Ok(vec![3, b'f', b'o', b'o', 3, b'e', b't', b'h', 0])
+        );
+        assert_eq!(
+            try_dns_encode("alice.eth"),
             Ok(vec![5, b'a', b'l', b'i', b'c', b'e', 3, b'e', b't', b'h', 0])
         );
         // Known vector: "integration-tests.eth"
         assert_eq!(
-            dns_encode("integration-tests.eth"),
+            try_dns_encode("integration-tests.eth"),
             Ok(hex::decode("11696e746567726174696f6e2d74657374730365746800").unwrap())
         );
         // Empty label errors
-        assert_eq!(dns_encode(".eth").unwrap_err(), DnsEncodeError::EmptyLabel);
-        assert_eq!(dns_encode("foo..eth").unwrap_err(), DnsEncodeError::EmptyLabel);
+        assert_eq!(try_dns_encode(".eth").unwrap_err(), DnsEncodeError::EmptyLabel);
+        assert_eq!(try_dns_encode("foo..eth").unwrap_err(), DnsEncodeError::EmptyLabel);
         // Labels up to 255 bytes are valid for ENS DNS wire encoding / NameCoder.
         let max_label = "a".repeat(255) + ".eth";
-        assert!(dns_encode(&max_label).is_ok());
+        assert!(try_dns_encode(&max_label).is_ok());
         let too_long = "a".repeat(256) + ".eth";
-        assert_eq!(dns_encode(&too_long).unwrap_err(), DnsEncodeError::LabelTooLong);
+        assert_eq!(try_dns_encode(&too_long).unwrap_err(), DnsEncodeError::LabelTooLong);
     }
 }


### PR DESCRIPTION
Part 1 of the ENS CCIP Read stack; the CCIP Read client and the ENS wiring follow in separate PRs stacked on this one.

ENS resolution in `alloy-ens` went through the registry and called a resolver's `addr`/`name`/`text` directly, which does not work for wildcard (ENSIP-10) names and can return wrong data for extended resolvers. The helpers now route forward, reverse, multicoin and text lookups through the ENSIP-23 Universal Resolver, which finds the correct resolver on chain. `get_resolver_for_name` discovers a resolver through the Universal Resolver and refuses to hand out one that must be queried through it (extended or parent resolvers), returning the new `EnsError::RequiresUniversalResolver` instead.

The bindings are updated to the deployed ENSIP-23 ABI, including `reverse(bytes,uint256)` and the `ResolverNotFound` family of errors, which map to `EnsError::ResolverNotFound`. `try_dns_encode` is the validated DNS wire-format encoder used for Universal Resolver calls, while the infallible `dns_encode` is unchanged. `coin_type::evm_chain` derives ENSIP-11 coin types and `resolve_name_for_coin_type` resolves multichain addresses.

Reverse lookup verifies the raw primary name on chain. Callers must still reject a non-empty result if ENSIP-15 normalization fails or changes it before using it as an authenticated identity; this requirement is explicit in the helper documentation.

The registry-based `get_resolver` and `get_reverse_registrar` helpers stay available but are deprecated. `EnsError` gains the `RequiresUniversalResolver`, `DnsEncode` and `InvalidResponse` variants and is now `#[non_exhaustive]`.

CCIP Read (ERC-3668) reverts are not followed yet; the next two PRs add the client and wire the ENS helpers through it.

Supersedes #4110 by @yashgo0018, whose commits are preserved here. That PR's branch lives in an organization-owned fork, which maintainers cannot push to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

