### PR TITLE
Add block_opt method for optional block setting

### DIFF
--- a/crates/provider/src/provider/eth_call/mod.rs
+++ b/crates/provider/src/provider/eth_call/mod.rs
@@ -335,6 +335,12 @@ where
         self
     }
 
+    /// Set the block to use for this call, if any.
+    pub const fn block_opt(mut self, block: Option<BlockId>) -> Self {
+        self.params.block = block;
+        self
+    }
+
     /// Set the block id to "pending".
     pub const fn pending(self) -> Self {
         self.block(BlockId::pending())


### PR DESCRIPTION
Add a method to set an optional block for the call parameters.

## Motivation

ReqwestTransport{url=https://evm.gatenode.cc/}:request{method_names=eth_estimateGas}: alloy_transport_http::reqwest_transport: response body body={"jsonrpc":"2.0","id":8,"error":{"code":-32602,"message":"too many arguments, want at most 1"}}

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
