### PR TITLE
Reject 0x00 type byte in `EthereumReceipt` decoding

### DIFF
--- a/crates/consensus/src/receipt/receipt2.rs
+++ b/crates/consensus/src/receipt/receipt2.rs
@@ -157,6 +157,9 @@ impl<T: TxTy> Eip2718EncodableReceipt for EthereumReceipt<T> {
 
 impl<T: TxTy> Eip2718DecodableReceipt for EthereumReceipt<T> {
     fn typed_decode_with_bloom(ty: u8, buf: &mut &[u8]) -> Eip2718Result<ReceiptWithBloom<Self>> {
+        if ty == 0 {
+            return Err(Eip2718Error::UnexpectedType(0));
+        }
         Ok(Self::rlp_decode_inner(buf, T::try_from(ty)?)?)
     }
 
@@ -201,6 +204,9 @@ impl<T: TxTy> RlpDecodableReceipt for EthereumReceipt<T> {
         let remaining = buf.len();
 
         let tx_type = T::decode(buf)?;
+        if tx_type.is_legacy() {
+            return Err(Eip2718Error::UnexpectedType(0).into());
+        }
         let this = Self::rlp_decode_inner(buf, tx_type)?;
 
         if buf.len() + header.payload_length != remaining {


### PR DESCRIPTION
A legacy receipt has no type byte. but here T::try_from(ty)? will decode to TxType::Legacy here. similar to #4167.

Due to this, encoding the decoded struct does not match the original input.
for example, the assert will fail here.
```rust
use alloy_consensus::{Eip2718EncodableReceipt, EthereumReceipt, ReceiptWithBloom, TxType};
use alloy_eips::{Decodable2718, Encodable2718};
use alloy_primitives::Bloom;

fn main() {
    let receipt = EthereumReceipt::<TxType> {
        tx_type: TxType::Legacy,
        success: true,
        cumulative_gas_used: 21000,
        logs: vec![],
    };
    let mut input = vec![0x00];
    receipt.eip2718_encode_with_bloom(&Bloom::ZERO, &mut input);

    match ReceiptWithBloom::<EthereumReceipt<TxType>>::decode_2718(&mut &input[..]) {
        Err(e) => println!("rejected: {e}"),
        Ok(decoded) => {
            let mut reencoded = vec![];
            decoded.encode_2718(&mut reencoded);
            assert_eq!(reencoded, input);
        }
    }
}
```
