### PR TITLE
fix: preserve changelog history during releases

### DIFF
--- a/scripts/changelog.sh
+++ b/scripts/changelog.sh
@@ -17,7 +17,7 @@ if [[ "$crate" = */tests/* || "$crate" = *test-utils* ]]; then
     exit 0
 fi
 
-command=(git cliff --workdir "$root" --config "$root/cliff.toml" "${@}")
+command=(git cliff --repository "$root" --config "$root/cliff.toml" "${@}")
 run_unless_dry_run "${command[@]}" --output "$root/CHANGELOG.md"
 if [ -n "$crate" ] && [ "$root" != "$crate" ]; then
     run_unless_dry_run "${command[@]}" --include-path "$crate_glob" --output "$crate/CHANGELOG.md"


### PR DESCRIPTION
Passing the workspace root through `--workdir` can leave git-cliff 2.13.1 with no commits, so the release hook writes an empty changelog. Use `--repository` to select the repository without implicit path filtering.
