### PR TITLE
fix(provider): recover watch() when heartbeat skips blocks

### DIFF
--- a/crates/provider/src/heart.rs
+++ b/crates/provider/src/heart.rs
@@ -208,7 +208,38 @@ impl<N: Network> PendingTransactionBuilder<N> {
     /// - [`get_receipt`](Self::get_receipt) for fetching the receipt after the transaction has been
     ///   confirmed.
     pub async fn watch(self) -> Result<TxHash, PendingTransactionError> {
-        self.register().await?.await
+        let hash = self.config.tx_hash;
+        let required_confirmations = self.config.required_confirmations;
+        let mut pending_tx = self.provider.watch_pending_transaction(self.config).await?;
+
+        // Fallback polling for single confirmation to prevent hangs when the heartbeat
+        // misses or skips the block the tx was mined in (e.g. HTTP poller intervals).
+        let mut interval = if required_confirmations > 1 {
+            None
+        } else {
+            Some(interval(self.provider.client().poll_interval()))
+        };
+
+        loop {
+            let tick_fut = if let Some(interval) = interval.as_mut() {
+                interval.tick().map(|_| ()).left_future()
+            } else {
+                pending::<()>().right_future()
+            };
+
+            select! {
+                _ = tick_fut => {},
+                res = &mut pending_tx => {
+                    return res;
+                }
+            }
+
+            // If the transaction has already been mined in a block skipped by the heartbeat,
+            // return its hash.
+            if let Ok(Some(_)) = self.provider.get_transaction_receipt(hash).await {
+                return Ok(hash);
+            }
+        }
     }
 
     /// Waits for the transaction to confirm with the given number of confirmations, and


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/alloy/blob/main/CONTRIBUTING.md
-->

## Motivation

When using an HTTP provider, `PendingTransactionBuilder::watch()` can hang indefinitely if the block poll interval or RPC latency causes the heartbeat to skip past the block the transaction was mined in (or when RPC nodes return stale block numbers).

As documented in #4181 and #3881:
- The heartbeat only checks transactions in blocks delivered by its stream (`crates/provider/src/heart.rs#L625-L660`).
- If a block height gap occurs (e.g. block N then N+2), transactions mined in block N+1 remain in the unconfirmed map forever because the default timeout is `None`.
- `get_receipt()` already documents and mitigates this exact race condition by periodically polling `eth_getTransactionReceipt` on interval. However, `watch()` previously only awaited `self.register().await?.await`, lacking this recovery mechanism.

Fixes #4181
Fixes #3881

## Solution

Mirrors the fallback recovery pattern already used in `get_receipt()`:
- For 1 confirmation (`required_confirmations <= 1`), set up a periodic ticker based on `self.provider.client().poll_interval()`.
- In each tick, check `self.provider.get_transaction_receipt(hash)`. If a receipt is present, the transaction has already been mined in a block skipped by the stream, so return `Ok(hash)` immediately rather than hanging indefinitely.

## PR Checklist

- [x] Added Tests / verified against existing provider test suite
- [x] Documentation integrity preserved
- [x] `cargo clippy -p alloy-provider -- -D warnings` passes cleanly
- [x] `cargo fmt --check -p alloy-provider` passes cleanly
