### PR TITLE
fix(provider): recover missed transactions in heartbeat

### DIFF
--- a/crates/provider/src/blocks.rs
+++ b/crates/provider/src/blocks.rs
@@ -49,12 +49,18 @@ impl Paused {
     /// Returns `true` if the method actually waited for the paused state to become unpaused,
     /// or `false` if it was already unpaused when called.
     async fn wait(&self) -> bool {
-        if !self.is_paused() {
-            return false;
+        let mut waited = false;
+        loop {
+            // Create the notification before checking the flag so notify_waiters cannot
+            // fall between the check and registration. Recheck after waking: receipt
+            // recovery may already have paused the heartbeat again.
+            let notified = self.notify.notified();
+            if !self.is_paused() {
+                return waited;
+            }
+            notified.await;
+            waited = true;
         }
-        self.notify.notified().await;
-        debug_assert!(!self.is_paused());
-        true
     }
 }
 
@@ -309,5 +315,25 @@ mod tests {
         for (i, block) in blocks.iter().enumerate() {
             assert_eq!(block.header.number, first + i as u64);
         }
+    }
+}
+
+#[cfg(test)]
+mod pause_tests {
+    use super::*;
+    use futures::FutureExt;
+
+    #[tokio::test]
+    async fn pause_again_before_stream_resumes() {
+        let paused = Paused::default();
+        paused.set_paused(true);
+        let mut wait = Box::pin(paused.wait());
+        assert!((&mut wait).now_or_never().is_none());
+        paused.set_paused(false);
+        paused.set_paused(true);
+        assert!((&mut wait).now_or_never().is_none());
+        paused.set_paused(false);
+        assert!(wait.await);
+        assert!(!paused.wait().await);
     }
 }

--- a/crates/provider/src/heart.rs
+++ b/crates/provider/src/heart.rs
@@ -3,13 +3,17 @@
 use crate::{blocks::Paused, Provider, RootProvider};
 use alloy_consensus::BlockHeader;
 use alloy_json_rpc::RpcError;
-use alloy_network::{BlockResponse, Network};
+use alloy_network::{BlockResponse, Network, ReceiptResponse};
 use alloy_primitives::{
     map::{B256HashMap, B256HashSet},
-    TxHash, B256,
+    TxHash, U64,
 };
+use alloy_rpc_client::WeakClient;
 use alloy_transport::{utils::Spawnable, TransportError};
-use futures::{future::pending, stream::StreamExt, FutureExt, Stream};
+use futures::{
+    stream::{FusedStream, StreamExt},
+    FutureExt, Stream,
+};
 use std::{
     collections::{BTreeMap, VecDeque},
     fmt,
@@ -25,14 +29,19 @@ use tokio::{
 #[cfg(all(target_family = "wasm", target_os = "unknown"))]
 use wasmtimer::{
     std::Instant,
-    tokio::{interval, sleep_until},
+    tokio::{sleep_until, timeout},
 };
 
 #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
 use {
     std::time::Instant,
-    tokio::time::{interval, sleep_until},
+    tokio::time::{sleep_until, timeout},
 };
+
+#[cfg(not(target_family = "wasm"))]
+use futures::stream::BoxStream;
+#[cfg(target_family = "wasm")]
+use futures::stream::LocalBoxStream as BoxStream;
 
 /// Errors which may occur when watching a pending transaction.
 #[derive(Debug, thiserror::Error)]
@@ -224,48 +233,8 @@ impl<N: Network> PendingTransactionBuilder<N> {
     /// - [`watch`](Self::watch) for watching the transaction without fetching the receipt.
     pub async fn get_receipt(self) -> Result<N::ReceiptResponse, PendingTransactionError> {
         let hash = self.config.tx_hash;
-        let required_confirmations = self.config.required_confirmations;
-        let mut pending_tx = self.provider.watch_pending_transaction(self.config).await?;
-
-        // FIXME: this is a hotfix to prevent a race condition where the heartbeat would miss the
-        // block the tx was mined in. Only apply this for single confirmation to respect the
-        // confirmation setting.
-        let mut interval = if required_confirmations > 1 {
-            None
-        } else {
-            Some(interval(self.provider.client().poll_interval()))
-        };
-
-        loop {
-            let mut confirmed = false;
-
-            // If more than 1 block confirmations is specified then we can rely on the regular
-            // watch_pending_transaction and dont need this workaround for the above mentioned race
-            // condition
-            let tick_fut = if let Some(interval) = interval.as_mut() {
-                interval.tick().map(|_| ()).left_future()
-            } else {
-                pending::<()>().right_future()
-            };
-
-            select! {
-                _ = tick_fut => {},
-                res = &mut pending_tx => {
-                    let _ = res?;
-                    confirmed = true;
-                }
-            }
-
-            // try to fetch the receipt
-            let receipt = self.provider.get_transaction_receipt(hash).await?;
-            if let Some(receipt) = receipt {
-                return Ok(receipt);
-            }
-
-            if confirmed {
-                return Err(RpcError::NullResp.into());
-            }
-        }
+        self.provider.watch_pending_transaction(self.config).await?.await?;
+        self.provider.get_transaction_receipt(hash).await?.ok_or_else(|| RpcError::NullResp.into())
     }
 }
 
@@ -379,6 +348,8 @@ struct TxWatcher {
     /// Invariant: any confirmed transaction in `Heart` has this value set.
     received_at_block: Option<u64>,
     tx: oneshot::Sender<Result<(), WatchTxError>>,
+    /// Each registration has its own deadline, including duplicate transaction hashes.
+    deadline: Option<Instant>,
 }
 
 impl TxWatcher {
@@ -455,12 +426,22 @@ impl HeartbeatHandle {
     ) -> Result<PendingTransaction, PendingTransactionConfig> {
         let (tx, rx) = oneshot::channel();
         let tx_hash = config.tx_hash;
-        match self.tx.send(TxWatcher { config, received_at_block, tx }).await {
+        let deadline = config.timeout.map(|timeout| Instant::now() + timeout);
+        match self.tx.send(TxWatcher { config, received_at_block, tx, deadline }).await {
             Ok(()) => Ok(PendingTransaction { tx_hash, rx }),
             Err(e) => Err(e.0.config),
         }
     }
 }
+
+/// A receipt observed independently of the block stream.
+struct ReceiptCheck {
+    hash: TxHash,
+    block: Option<u64>,
+    height: Option<u64>,
+}
+
+type ReceiptChecks = futures::stream::Fuse<BoxStream<'static, ReceiptCheck>>;
 
 /// A heartbeat task that receives blocks and watches for transactions.
 pub(crate) struct Heartbeat<N, S> {
@@ -471,13 +452,16 @@ pub(crate) struct Heartbeat<N, S> {
     past_blocks: VecDeque<(u64, B256HashSet)>,
 
     /// Transactions to watch for.
-    unconfirmed: B256HashMap<TxWatcher>,
+    unconfirmed: B256HashMap<Vec<TxWatcher>>,
 
     /// Ordered map of transactions waiting for confirmations.
     waiting_confs: BTreeMap<u64, Vec<TxWatcher>>,
 
-    /// Ordered map of transactions to reap at a certain time.
-    reap_at: BTreeMap<Instant, B256>,
+    /// Earliest deadline across both watcher maps. Recomputed after reaping.
+    next_timeout: Option<Instant>,
+
+    /// Weak ownership avoids a cycle through the root provider and its heartbeat handle.
+    client: WeakClient,
 
     /// Whether the heartbeat is currently paused.
     paused: Arc<Paused>,
@@ -487,13 +471,14 @@ pub(crate) struct Heartbeat<N, S> {
 
 impl<N: Network, S: Stream<Item = N::BlockResponse> + Unpin + 'static> Heartbeat<N, S> {
     /// Create a new heartbeat task.
-    pub(crate) fn new(stream: S, is_paused: Arc<Paused>) -> Self {
+    pub(crate) fn new(stream: S, is_paused: Arc<Paused>, client: WeakClient) -> Self {
         Self {
             stream: stream.fuse(),
             past_blocks: Default::default(),
             unconfirmed: Default::default(),
             waiting_confs: Default::default(),
-            reap_at: Default::default(),
+            client,
+            next_timeout: None,
             paused: is_paused,
             _network: Default::default(),
         }
@@ -501,7 +486,11 @@ impl<N: Network, S: Stream<Item = N::BlockResponse> + Unpin + 'static> Heartbeat
 
     /// Check if any transactions have enough confirmations to notify.
     fn check_confirmations(&mut self, current_height: u64) {
-        let to_keep = self.waiting_confs.split_off(&(current_height + 1));
+        let to_keep = if current_height == u64::MAX {
+            BTreeMap::new()
+        } else {
+            self.waiting_confs.split_off(&(current_height + 1))
+        };
         let to_notify = std::mem::replace(&mut self.waiting_confs, to_keep);
         for watcher in to_notify.into_values().flatten() {
             watcher.notify(Ok(()));
@@ -511,24 +500,26 @@ impl<N: Network, S: Stream<Item = N::BlockResponse> + Unpin + 'static> Heartbeat
     /// Get the next time to reap a transaction. If no reaps, this is a very
     /// long time from now (i.e. will not be woken).
     fn next_reap(&self) -> Instant {
-        self.reap_at
-            .first_key_value()
-            .map(|(k, _)| *k)
-            .unwrap_or_else(|| Instant::now() + Duration::from_secs(60_000))
+        self.next_timeout.unwrap_or_else(|| Instant::now() + Duration::from_secs(60_000))
     }
 
-    /// Reap any timeout
+    /// Reap timeouts even after inclusion, and stop watching cancelled futures.
     fn reap_timeouts(&mut self) {
         let now = Instant::now();
-        let to_keep = self.reap_at.split_off(&now);
-        let to_reap = std::mem::replace(&mut self.reap_at, to_keep);
-
-        for tx_hash in to_reap.values() {
-            if let Some(watcher) = self.unconfirmed.remove(tx_hash) {
-                debug!(tx=%tx_hash, "reaped");
+        self.next_timeout = None;
+        for watchers in self.unconfirmed.values_mut().chain(self.waiting_confs.values_mut()) {
+            for watcher in watchers.extract_if(.., |watcher| {
+                watcher.tx.is_closed() || watcher.deadline.is_some_and(|deadline| deadline <= now)
+            }) {
                 watcher.notify(Err(WatchTxError::Timeout));
             }
+            for deadline in watchers.iter().filter_map(|watcher| watcher.deadline) {
+                self.next_timeout =
+                    Some(self.next_timeout.map_or(deadline, |next| next.min(deadline)));
+            }
         }
+        self.unconfirmed.retain(|_, watchers| !watchers.is_empty());
+        self.waiting_confs.retain(|_, watchers| !watchers.is_empty());
     }
 
     /// Reap transactions overridden by a chain gap (true reorg or resync after a pause).
@@ -542,13 +533,16 @@ impl<N: Network, S: Stream<Item = N::BlockResponse> + Unpin + 'static> Heartbeat
                     if received_at_block >= new_height {
                         let hash = watcher.config.tx_hash;
                         debug!(tx=%hash, %received_at_block, %new_height, "return to unconfirmed after chain gap");
-                        self.unconfirmed.insert(hash, watcher);
+                        let mut watcher = watcher;
+                        watcher.received_at_block = None;
+                        self.unconfirmed.entry(hash).or_default().push(watcher);
                         return None;
                     }
                 }
                 Some(watcher)
             }).collect();
         }
+        self.waiting_confs.retain(|_, watchers| !watchers.is_empty());
     }
 
     /// Check if we have any pending transactions.
@@ -566,8 +560,11 @@ impl<N: Network, S: Stream<Item = N::BlockResponse> + Unpin + 'static> Heartbeat
     }
 
     /// Handle a watch instruction by adding it to the watch list, and
-    /// potentially adding it to our `reap_at` list.
+    /// preserving its individual timeout.
     fn handle_watch_ix(&mut self, to_watch: TxWatcher) {
+        if let Some(deadline) = to_watch.deadline {
+            self.next_timeout = Some(self.next_timeout.map_or(deadline, |next| next.min(deadline)));
+        }
         // Start watching for the transaction.
         debug!(tx=%to_watch.config.tx_hash, "watching");
         trace!(?to_watch.config, ?to_watch.received_at_block);
@@ -575,7 +572,7 @@ impl<N: Network, S: Stream<Item = N::BlockResponse> + Unpin + 'static> Heartbeat
             // Transaction is already confirmed, we just need to wait for the required
             // confirmations.
             let confirmations = to_watch.config.required_confirmations;
-            let confirmed_at = received_at_block + confirmations - 1;
+            let confirmed_at = received_at_block.saturating_add(confirmations.saturating_sub(1));
             let current_height =
                 self.past_blocks.back().map(|(h, _)| *h).unwrap_or(received_at_block);
 
@@ -587,15 +584,12 @@ impl<N: Network, S: Stream<Item = N::BlockResponse> + Unpin + 'static> Heartbeat
             return;
         }
 
-        if let Some(timeout) = to_watch.config.timeout {
-            self.reap_at.insert(Instant::now() + timeout, to_watch.config.tx_hash);
-        }
         // Transaction may be confirmed already, check the lookbehind history first.
         // If so, insert it into the waiting list.
         for (block_height, txs) in self.past_blocks.iter().rev() {
             if txs.contains(&to_watch.config.tx_hash) {
                 let confirmations = to_watch.config.required_confirmations;
-                let confirmed_at = *block_height + confirmations - 1;
+                let confirmed_at = block_height.saturating_add(confirmations.saturating_sub(1));
                 let current_height = self.past_blocks.back().map(|(h, _)| *h).unwrap();
 
                 if confirmed_at <= current_height {
@@ -613,13 +607,81 @@ impl<N: Network, S: Stream<Item = N::BlockResponse> + Unpin + 'static> Heartbeat
             }
         }
 
-        self.unconfirmed.insert(to_watch.config.tx_hash, to_watch);
+        self.unconfirmed.entry(to_watch.config.tx_hash).or_default().push(to_watch);
     }
 
     fn add_to_waiting_list(&mut self, watcher: TxWatcher, block_height: u64) {
         let confirmations = watcher.config.required_confirmations;
         debug!(tx=%watcher.config.tx_hash, %block_height, confirmations, "adding to waiting list");
-        self.waiting_confs.entry(block_height + confirmations - 1).or_default().push(watcher);
+        self.waiting_confs
+            .entry(block_height.saturating_add(confirmations.saturating_sub(1)))
+            .or_default()
+            .push(watcher);
+    }
+
+    /// Recheck each hash once per round, regardless of how many callers watch it.
+    /// Receipt RPCs run concurrently with block processing and timeout handling.
+    fn receipt_checks(&self) -> ReceiptChecks {
+        let mut hashes = B256HashMap::<bool>::default();
+        for watcher in self.unconfirmed.values().chain(self.waiting_confs.values()).flatten() {
+            *hashes.entry(watcher.config.tx_hash).or_default() |=
+                watcher.config.required_confirmations > 1;
+        }
+        let client = self.client.clone();
+        let checks = futures::stream::iter(hashes).map(move |(hash, needs_height)| {
+            let client = client.clone();
+            Box::pin(async_stream::stream! {
+                let Some(client) = client.upgrade() else { return };
+                // Bound each RPC so a stalled endpoint cannot occupy a recovery slot forever.
+                let receipt = match timeout(Duration::from_secs(30), client.request::<_, Option<N::ReceiptResponse>>(
+                    "eth_getTransactionReceipt", (hash,),
+                )).await {
+                    Ok(Ok(Some(receipt))) => receipt,
+                    Ok(Err(err)) => {
+                        debug!(tx=%hash, %err, "failed to recheck receipt; retrying next round");
+                        return;
+                    }
+                    _ => return,
+                };
+                let block = receipt.block_number();
+                // Notify single-confirmation callers before querying the head, even if a
+                // different caller watches the same hash with multiple confirmations.
+                yield ReceiptCheck { hash, block, height: None };
+                if needs_height && block.is_some() {
+                    if let Ok(Ok(height)) = timeout(Duration::from_secs(30), client.request::<_, U64>("eth_blockNumber", ())).await {
+                        yield ReceiptCheck { hash, block, height: Some(height.to()) };
+                    }
+                }
+            })
+        }).flatten_unordered(16);
+        (Box::pin(checks) as BoxStream<'static, _>).fuse()
+    }
+
+    fn handle_receipt(&mut self, ReceiptCheck { hash, block, height }: ReceiptCheck) {
+        let confirmed = |watcher: &mut TxWatcher| {
+            let confirmations = watcher.config.required_confirmations;
+            watcher.config.tx_hash == hash
+                && (confirmations <= 1
+                    || block.zip(height).is_some_and(|(block, height)| {
+                        height >= block.saturating_add(confirmations.saturating_sub(1))
+                    }))
+        };
+        if let Some(watchers) = self.unconfirmed.get_mut(&hash) {
+            for watcher in watchers.extract_if(.., confirmed) {
+                watcher.notify(Ok(()));
+            }
+            if watchers.is_empty() {
+                self.unconfirmed.remove(&hash);
+            }
+        }
+        if let Some(height) = height {
+            for watchers in self.waiting_confs.range_mut(..=height).map(|(_, watchers)| watchers) {
+                for watcher in watchers.extract_if(.., confirmed) {
+                    watcher.notify(Ok(()));
+                }
+            }
+            self.waiting_confs.retain(|_, watchers| !watchers.is_empty());
+        }
     }
 
     /// Handle a new block by checking if any of the transactions we're
@@ -657,6 +719,7 @@ impl<N: Network, S: Stream<Item = N::BlockResponse> + Unpin + 'static> Heartbeat
             .transactions()
             .hashes()
             .filter_map(|tx_hash| self.unconfirmed.remove(&tx_hash))
+            .flatten()
             .collect();
         for mut watcher in to_check {
             // If `confirmations` is not more than 1 we can notify the watcher immediately.
@@ -708,37 +771,56 @@ impl<N: Network, S: Stream<Item = N::BlockResponse> + Unpin + 'static> Heartbeat
     }
 
     async fn into_future(mut self, mut ixns: mpsc::Receiver<TxWatcher>) {
+        // There is at most one bounded recovery round in flight. Dropping it when idle
+        // also cancels outstanding requests. Keep no strong provider/client reference here.
+        let mut checks: Option<ReceiptChecks> = None;
+        let mut next_check = Instant::now();
         'shutdown: loop {
-            {
-                self.update_pause_state();
-
-                let next_reap = self.next_reap();
-                let sleep = std::pin::pin!(sleep_until(next_reap.into()));
-
-                // We bias the select so that we always handle new messages
-                // before checking blocks, and reap timeouts are last.
-                select! {
-                    biased;
-
-                    // Watch for new transactions.
-                    ix_opt = ixns.recv() => match ix_opt {
-                        Some(to_watch) => self.handle_watch_ix(to_watch),
-                        None => break 'shutdown, // ix channel is closed
-                    },
-
-                    // Wake up to handle new blocks.
-                    Some(block) = self.stream.next() => {
-                        self.handle_new_block(block);
-                    },
-
-                    // This arm ensures we always wake up to reap timeouts,
-                    // even if there are no other events.
-                    _ = sleep => {},
-                }
+            if self.next_timeout.is_some_and(|deadline| deadline <= Instant::now()) {
+                self.reap_timeouts();
             }
-
-            // Always reap timeouts
-            self.reap_timeouts();
+            self.update_pause_state();
+            if !self.has_pending_transactions() {
+                checks = None;
+            }
+            let wake_at = if self.has_pending_transactions() {
+                self.next_reap().min(next_check)
+            } else {
+                self.next_reap()
+            };
+            let sleep = std::pin::pin!(sleep_until(wake_at.into()));
+            select! {
+                ix_opt = ixns.recv() => match ix_opt {
+                    Some(to_watch) => self.handle_watch_ix(to_watch),
+                    None => break 'shutdown,
+                },
+                Some(block) = self.stream.next() => {
+                    // Discard in-flight receipt observations on a detected reorg.
+                    if self.past_blocks.back().is_some_and(|(height, _)| block.header().as_ref().number() <= *height) {
+                        checks = Some(self.receipt_checks());
+                    }
+                    self.handle_new_block(block);
+                },
+                Some(receipt) = async {
+                    match checks.as_mut() {
+                        Some(checks) => checks.next().await,
+                        None => futures::future::pending().await,
+                    }
+                } => self.handle_receipt(receipt),
+                _ = sleep => {
+                    if Instant::now() >= next_check {
+                        self.reap_timeouts();
+                        if checks.as_ref().is_none_or(FusedStream::is_terminated) {
+                            checks = Some(self.receipt_checks());
+                        }
+                        let poll_interval = self.client.upgrade().map(|client| client.poll_interval()).unwrap_or(Duration::from_secs(1));
+                        next_check = Instant::now() + poll_interval.max(Duration::from_millis(1));
+                    }
+                },
+            }
         }
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/provider/src/heart/tests.rs
+++ b/crates/provider/src/heart/tests.rs
@@ -1,0 +1,437 @@
+use super::*;
+use alloy_network::Ethereum;
+use alloy_primitives::B256;
+use alloy_rpc_types_eth::Block;
+
+fn watcher(
+    hash: TxHash,
+    confirmations: u64,
+    received: Option<u64>,
+    deadline: Option<Instant>,
+) -> (TxWatcher, PendingTransaction) {
+    let (tx, rx) = oneshot::channel();
+    (
+        TxWatcher {
+            config: PendingTransactionConfig::new(hash).with_required_confirmations(confirmations),
+            received_at_block: received,
+            tx,
+            deadline,
+        },
+        PendingTransaction { tx_hash: hash, rx },
+    )
+}
+
+fn heart() -> Heartbeat<Ethereum, futures::stream::Pending<Block>> {
+    let client = alloy_rpc_client::RpcClient::mocked(alloy_transport::mock::Asserter::new());
+    Heartbeat::new(futures::stream::pending(), Arc::default(), client.get_weak())
+}
+
+fn block(number: u64, hashes: Vec<TxHash>) -> Block {
+    let mut block: Block = Block::default();
+    block.header.number = number;
+    block.transactions = alloy_rpc_types_eth::BlockTransactions::Hashes(hashes);
+    block
+}
+
+#[tokio::test]
+async fn duplicate_watchers_keep_independent_confirmations_and_deadlines() {
+    let mut heart = heart();
+    let hash = B256::repeat_byte(1);
+    let (first, first_rx) = watcher(hash, 1, None, Some(Instant::now()));
+    let (second, mut second_rx) = watcher(hash, 3, None, None);
+    heart.handle_watch_ix(first);
+    heart.handle_watch_ix(second);
+    heart.reap_timeouts();
+    assert!(matches!(
+        first_rx.await,
+        Err(PendingTransactionError::TxWatcher(WatchTxError::Timeout))
+    ));
+    assert!((&mut second_rx).now_or_never().is_none());
+    heart.handle_new_block(block(1, vec![hash]));
+    heart.handle_new_block(block(2, vec![]));
+    assert!((&mut second_rx).now_or_never().is_none());
+    heart.handle_new_block(block(3, vec![]));
+    assert_eq!(second_rx.await.unwrap(), hash);
+    assert!(!heart.has_pending_transactions());
+}
+
+#[tokio::test]
+async fn timeouts_cover_already_mined_and_observed_transactions() {
+    for already_mined in [false, true] {
+        let mut heart = heart();
+        let hash = B256::repeat_byte(2);
+        let (watcher, pending) = watcher(hash, 3, already_mined.then_some(1), Some(Instant::now()));
+        heart.handle_watch_ix(watcher);
+        if !already_mined {
+            heart.handle_new_block(block(1, vec![hash]));
+        }
+        heart.reap_timeouts();
+        assert!(matches!(
+            pending.await,
+            Err(PendingTransactionError::TxWatcher(WatchTxError::Timeout))
+        ));
+        heart.update_pause_state();
+        assert!(heart.paused.is_paused());
+    }
+}
+
+#[tokio::test]
+async fn recovery_respects_confirmations_and_releases_heartbeat() {
+    let mut heart = heart();
+    let hash = B256::repeat_byte(3);
+    let (one, one_rx) = watcher(hash, 1, None, None);
+    let (three, mut three_rx) = watcher(hash, 3, None, None);
+    heart.handle_watch_ix(one);
+    heart.handle_watch_ix(three);
+    // Receipt available while the block stream and block-number RPC are stale.
+    heart.handle_receipt(ReceiptCheck { hash, block: Some(10), height: Some(9) });
+    assert_eq!(one_rx.await.unwrap(), hash);
+    heart.handle_receipt(ReceiptCheck { hash, block: Some(10), height: Some(11) });
+    assert!((&mut three_rx).now_or_never().is_none());
+    heart.handle_receipt(ReceiptCheck { hash, block: Some(10), height: Some(12) });
+    assert_eq!(three_rx.await.unwrap(), hash);
+    heart.update_pause_state();
+    assert!(heart.paused.is_paused());
+}
+
+#[tokio::test]
+async fn reorg_reinclusion_uses_new_height_and_cancellation_cleans_up() {
+    let mut heart = heart();
+    let hash = B256::repeat_byte(4);
+    let (watcher, mut pending) = watcher(hash, 3, None, None);
+    heart.handle_watch_ix(watcher);
+    heart.handle_new_block(block(10, vec![hash]));
+    heart.handle_new_block(block(9, vec![]));
+    assert_eq!(heart.unconfirmed[&hash][0].received_at_block, None);
+    heart.handle_new_block(block(10, vec![]));
+    heart.handle_new_block(block(11, vec![hash]));
+    heart.handle_new_block(block(12, vec![]));
+    assert!((&mut pending).now_or_never().is_none());
+    drop(pending);
+    heart.reap_timeouts();
+    heart.update_pause_state();
+    assert!(heart.paused.is_paused());
+}
+
+#[tokio::test]
+async fn zero_confirmations_at_genesis_do_not_underflow() {
+    for confirmations in [0, 1] {
+        for known_receipt in [false, true] {
+            let mut heart = heart();
+            let hash = B256::repeat_byte(5);
+            heart.handle_new_block(block(0, vec![hash]));
+            let (watcher, pending) = watcher(hash, confirmations, known_receipt.then_some(0), None);
+            heart.handle_watch_ix(watcher);
+            assert_eq!(pending.now_or_never().unwrap().unwrap(), hash);
+        }
+    }
+}
+
+#[cfg(all(feature = "anvil-node", not(target_family = "wasm")))]
+mod anvil {
+    use super::*;
+    use crate::{ext::AnvilApi, ProviderBuilder};
+    use alloy_json_rpc::{RequestPacket, Response, ResponsePacket, ResponsePayload};
+    use alloy_node_bindings::{Anvil, AnvilInstance};
+    use alloy_rpc_client::RpcClient;
+    use alloy_rpc_types_eth::TransactionRequest;
+    use alloy_transport::{TransportErrorKind, TransportResult};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use tokio::sync::Semaphore;
+    use tower::Service;
+
+    struct Control {
+        stale_head: AtomicBool,
+        block_head: AtomicBool,
+        head_gate: Semaphore,
+        receipts: AtomicUsize,
+        fail_receipts: AtomicBool,
+        stall_receipts: AtomicBool,
+    }
+
+    fn provider(anvil: &AnvilInstance) -> (RootProvider, Arc<Control>) {
+        let control = Arc::new(Control {
+            stale_head: AtomicBool::new(false),
+            block_head: AtomicBool::new(false),
+            head_gate: Semaphore::new(0),
+            receipts: AtomicUsize::new(0),
+            fail_receipts: AtomicBool::new(false),
+            stall_receipts: AtomicBool::new(false),
+        });
+        let state = control.clone();
+        let http = alloy_transport_http::Http::new(anvil.endpoint_url());
+        let transport = tower::service_fn(
+            move |request: RequestPacket| -> alloy_transport::TransportFut<'static> {
+                let mut http = http.clone();
+                let state = state.clone();
+                Box::pin(async move {
+                    let RequestPacket::Single(ref single) = request else {
+                        panic!("unexpected batch")
+                    };
+                    let receipt = single.method() == "eth_getTransactionReceipt";
+                    if single.method() == "eth_blockNumber" {
+                        if state.block_head.load(Ordering::SeqCst) {
+                            state.head_gate.acquire().await.unwrap().forget();
+                        }
+                        if state.stale_head.load(Ordering::SeqCst) {
+                            return Ok(ResponsePacket::Single(Response {
+                                id: single.id().clone(),
+                                payload: ResponsePayload::Success(
+                                    serde_json::value::to_raw_value(&U64::ZERO).unwrap(),
+                                ),
+                            }));
+                        }
+                    }
+                    if receipt && state.stall_receipts.load(Ordering::SeqCst) {
+                        return futures::future::pending::<TransportResult<ResponsePacket>>().await;
+                    }
+                    if receipt && state.fail_receipts.load(Ordering::SeqCst) {
+                        state.receipts.fetch_add(1, Ordering::SeqCst);
+                        return Err(TransportErrorKind::custom_str(
+                            "injected transient receipt failure",
+                        ));
+                    }
+                    let response = http.call(request).await;
+                    if receipt {
+                        state.receipts.fetch_add(1, Ordering::SeqCst);
+                    }
+                    response
+                })
+            },
+        );
+        let client = RpcClient::builder().transport(transport, true);
+        client.set_poll_interval(Duration::from_millis(25));
+        (RootProvider::new(client), control)
+    }
+
+    async fn wait_for(mut condition: impl FnMut() -> bool) {
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while !condition() {
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("condition did not become true");
+    }
+
+    async fn send(provider: &RootProvider, anvil: &AnvilInstance) -> TxHash {
+        *provider
+            .send_transaction(
+                TransactionRequest::default()
+                    .from(anvil.addresses()[0])
+                    .to(anvil.addresses()[1])
+                    .gas_limit(21_000)
+                    .gas_price(20_000_000_000),
+            )
+            .await
+            .unwrap()
+            .tx_hash()
+    }
+
+    // Force the first block-number request to complete only after twenty blocks
+    // have been mined. NewBlocks starts at tip-1, deterministically missing the tx.
+    async fn missed_initial_block(api: u8) {
+        let anvil = Anvil::new().spawn();
+        let admin = RootProvider::<Ethereum>::new_http(anvil.endpoint_url());
+        admin.anvil_set_auto_mine(false).await.unwrap();
+        let (provider, control) = provider(&anvil);
+        // Repeat with the same root provider to cover both startup and resuming after idle.
+        for _ in 0..2 {
+            let hash = send(&admin, &anvil).await;
+            control.head_gate.forget_permits(control.head_gate.available_permits());
+            control.block_head.store(true, Ordering::SeqCst);
+            let before = control.receipts.load(Ordering::SeqCst);
+            let builder = PendingTransactionBuilder::new(provider.clone(), hash)
+                .with_required_confirmations(3);
+            let task = tokio::spawn(async move {
+                match api {
+                    0 => builder.register().await.unwrap().await.unwrap(),
+                    1 => builder.watch().await.unwrap(),
+                    _ => builder.get_receipt().await.unwrap().transaction_hash,
+                }
+            });
+            wait_for(|| control.receipts.load(Ordering::SeqCst) > before).await;
+            admin.anvil_mine(Some(20), None).await.unwrap();
+            control.block_head.store(false, Ordering::SeqCst);
+            control.head_gate.add_permits(16);
+            assert_eq!(
+                tokio::time::timeout(Duration::from_secs(5), task).await.unwrap().unwrap(),
+                hash
+            );
+            // Successful receipt recovery must remove the heartbeat watcher, not leave it polling.
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            let calls = control.receipts.load(Ordering::SeqCst);
+            tokio::time::sleep(Duration::from_millis(150)).await;
+            assert_eq!(control.receipts.load(Ordering::SeqCst), calls);
+        }
+    }
+
+    #[tokio::test]
+    async fn register_recovers_missed_initial_block() {
+        missed_initial_block(0).await;
+    }
+    #[tokio::test]
+    async fn watch_recovers_missed_initial_block() {
+        missed_initial_block(1).await;
+    }
+    #[tokio::test]
+    async fn get_receipt_recovers_missed_initial_block() {
+        missed_initial_block(2).await;
+    }
+
+    #[tokio::test]
+    async fn stale_head_recovers_single_but_waits_for_multiple_confirmations() {
+        let anvil = Anvil::new().spawn();
+        let admin = RootProvider::<Ethereum>::new_http(anvil.endpoint_url());
+        admin.anvil_set_auto_mine(false).await.unwrap();
+        let hash = send(&admin, &anvil).await;
+        let (provider, control) = provider(&anvil);
+        control.stale_head.store(true, Ordering::SeqCst);
+        let one = PendingTransactionBuilder::new(provider.clone(), hash).register().await.unwrap();
+        let mut three = PendingTransactionBuilder::new(provider.clone(), hash)
+            .with_required_confirmations(3)
+            .register()
+            .await
+            .unwrap();
+        admin.anvil_mine(Some(1), None).await.unwrap();
+        assert_eq!(tokio::time::timeout(Duration::from_secs(5), one).await.unwrap().unwrap(), hash);
+        assert!(tokio::time::timeout(Duration::from_millis(100), &mut three).await.is_err());
+        control.stale_head.store(false, Ordering::SeqCst);
+        admin.anvil_mine(Some(1), None).await.unwrap();
+        assert!(tokio::time::timeout(Duration::from_millis(100), &mut three).await.is_err());
+        admin.anvil_mine(Some(1), None).await.unwrap();
+        assert_eq!(
+            tokio::time::timeout(Duration::from_secs(5), three).await.unwrap().unwrap(),
+            hash
+        );
+    }
+
+    #[tokio::test]
+    async fn transient_receipt_errors_retry_and_stalled_rpcs_do_not_block_timeouts() {
+        let anvil = Anvil::new().spawn();
+        let admin = RootProvider::<Ethereum>::new_http(anvil.endpoint_url());
+        admin.anvil_set_auto_mine(false).await.unwrap();
+        let hash = send(&admin, &anvil).await;
+        let (provider, control) = provider(&anvil);
+        control.stale_head.store(true, Ordering::SeqCst);
+        let pending =
+            PendingTransactionBuilder::new(provider.clone(), hash).register().await.unwrap();
+        control.fail_receipts.store(true, Ordering::SeqCst);
+        let before = control.receipts.load(Ordering::SeqCst);
+        admin.anvil_mine(Some(1), None).await.unwrap();
+        wait_for(|| control.receipts.load(Ordering::SeqCst) >= before + 2).await;
+        control.fail_receipts.store(false, Ordering::SeqCst);
+        assert_eq!(
+            tokio::time::timeout(Duration::from_secs(5), pending).await.unwrap().unwrap(),
+            hash
+        );
+
+        let pending = PendingTransactionBuilder::new(provider.clone(), hash)
+            .with_required_confirmations(100)
+            .with_timeout(Some(Duration::from_millis(100)))
+            .register()
+            .await
+            .unwrap();
+        control.stall_receipts.store(true, Ordering::SeqCst);
+        assert!(matches!(
+            tokio::time::timeout(Duration::from_secs(2), pending).await.unwrap(),
+            Err(PendingTransactionError::TxWatcher(WatchTxError::Timeout))
+        ));
+    }
+
+    #[tokio::test]
+    async fn stalled_head_does_not_delay_single_confirmation_for_duplicate_hash() {
+        let anvil = Anvil::new().spawn();
+        let admin = RootProvider::<Ethereum>::new_http(anvil.endpoint_url());
+        admin.anvil_set_auto_mine(false).await.unwrap();
+        let hash = send(&admin, &anvil).await;
+        let (provider, control) = provider(&anvil);
+        control.block_head.store(true, Ordering::SeqCst);
+        let one = PendingTransactionBuilder::new(provider.clone(), hash).register().await.unwrap();
+        let three = PendingTransactionBuilder::new(provider.clone(), hash)
+            .with_required_confirmations(3)
+            .with_timeout(Some(Duration::from_millis(250)))
+            .register()
+            .await
+            .unwrap();
+        admin.anvil_mine(Some(1), None).await.unwrap();
+        assert_eq!(tokio::time::timeout(Duration::from_secs(2), one).await.unwrap().unwrap(), hash);
+        assert!(matches!(
+            tokio::time::timeout(Duration::from_secs(2), three).await.unwrap(),
+            Err(PendingTransactionError::TxWatcher(WatchTxError::Timeout))
+        ));
+    }
+
+    #[tokio::test]
+    async fn already_mined_confirmation_wait_times_out() {
+        let anvil = Anvil::new().spawn();
+        let admin = RootProvider::<Ethereum>::new_http(anvil.endpoint_url());
+        admin.anvil_set_auto_mine(false).await.unwrap();
+        let hash = send(&admin, &anvil).await;
+        admin.anvil_mine(Some(1), None).await.unwrap();
+        assert!(admin.get_transaction_receipt(hash).await.unwrap().is_some());
+        let (provider, _) = provider(&anvil);
+        let pending = PendingTransactionBuilder::new(provider.clone(), hash)
+            .with_required_confirmations(3)
+            .with_timeout(Some(Duration::from_millis(100)));
+        assert!(matches!(
+            tokio::time::timeout(Duration::from_secs(2), pending.watch()).await.unwrap(),
+            Err(PendingTransactionError::TxWatcher(WatchTxError::Timeout))
+        ));
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "ws-base")]
+    async fn websocket_receipt_recovery_without_block_notifications() {
+        let anvil = Anvil::new().spawn();
+        let provider = RootProvider::<Ethereum>::connect(&anvil.ws_endpoint()).await.unwrap();
+        provider.client().set_poll_interval(Duration::from_millis(25));
+        provider.anvil_set_auto_mine(false).await.unwrap();
+        let hash = send(&provider, &anvil).await;
+        let paused = Arc::new(Paused::default());
+        // Model a missed subscription notification without depending on socket scheduling.
+        let heart = Heartbeat::<Ethereum, _>::new(
+            futures::stream::pending::<Block>(),
+            paused.clone(),
+            provider.weak_client(),
+        )
+        .spawn();
+        let pending = heart
+            .watch_tx(PendingTransactionConfig::new(hash).with_required_confirmations(3), None)
+            .await
+            .unwrap();
+        provider.anvil_mine(Some(3), None).await.unwrap();
+        assert_eq!(
+            tokio::time::timeout(Duration::from_secs(5), pending).await.unwrap().unwrap(),
+            hash
+        );
+        wait_for(|| paused.is_paused()).await;
+    }
+
+    #[tokio::test]
+    async fn fast_blocks_slower_http_polling() {
+        let provider = ProviderBuilder::new()
+            .connect_anvil_with_wallet_and_config(|anvil| anvil.block_time_f64(0.1))
+            .unwrap();
+        provider.client().set_poll_interval(Duration::from_millis(500));
+        for confirmations in [0, 1, 3] {
+            let pending = provider
+                .send_transaction(
+                    TransactionRequest::default()
+                        .to(alloy_primitives::Address::ZERO)
+                        .value(alloy_primitives::U256::from(1)),
+                )
+                .await
+                .unwrap()
+                .with_required_confirmations(confirmations);
+            let hash = *pending.tx_hash();
+            assert_eq!(
+                tokio::time::timeout(Duration::from_secs(10), pending.watch())
+                    .await
+                    .unwrap()
+                    .unwrap(),
+                hash
+            );
+        }
+    }
+}

--- a/crates/provider/src/provider/root.rs
+++ b/crates/provider/src/provider/root.rs
@@ -103,7 +103,7 @@ impl<N: Network> RootProvider<N> {
             let new_blocks = NewBlocks::<N>::new(self.inner.weak_client());
             let paused = new_blocks.paused.clone();
             let stream = new_blocks.into_stream();
-            Heartbeat::<N, _>::new(Box::pin(stream), paused).spawn()
+            Heartbeat::<N, _>::new(Box::pin(stream), paused, self.inner.weak_client()).spawn()
         })
     }
 }


### PR DESCRIPTION
Pending transaction watches can wait forever when the heartbeat never sees the mined block. `NewBlocks` backfills ordinary height gaps, but starts or resumes near the tip: if a transaction lands in block 1 before the stream resumes at blocks 19–20, the heartbeat leaves it unconfirmed even though its receipt is available. The existing single-confirmation `get_receipt()` workaround could return successfully while leaving that watcher alive.

Move receipt recovery into the heartbeat so `register()`, `watch()`, and `get_receipt()` share it. Recheck each pending hash on the client polling interval with bounded concurrency, independently of block processing and timeout handling. Single-confirmation watchers resolve from the receipt without waiting for the head RPC; multiple-confirmation watchers also require the appropriate chain height. Successful recovery removes the watcher, allowing the heartbeat to pause, and replaces the separate `get_receipt()` workaround.

Keep duplicate registrations and their deadlines independent, enforce timeouts after inclusion as well as before it, and prune cancelled watchers. Clear obsolete inclusion heights on detected reorgs and make the pause notification wait safe when recovery pauses the heartbeat again before the block stream resumes. Public APIs and configuration remain unchanged.

Fixes #4181
Fixes #3881
Fixes #3916
Fixes #3408

Supersedes the following PRs:

- Closes #4191, closes #4013 — receipt fallback for `.watch()` when blocks are missed or the RPC head is stale.
- Closes #4162 — heartbeat-level receipt rechecking.
- Closes #4065, closes #3996 — receipt recovery while waiting for multiple confirmations.
- Closes #3992, closes #3729 — enforcing timeouts after inclusion while waiting for confirmations.
- Closes #3551 — the large-gap workaround for #3408; this PR recovers missed receipts instead of introducing an automatic timeout for large gaps.

#3771 (default timeout policy) and #2689 (mempool-drop detection) remain separate work and are not superseded by this PR.
