### PR TITLE
fix(trace): decode regularGasUsed and explain gas

### DIFF
--- a/crates/consensus/src/block/header.rs
+++ b/crates/consensus/src/block/header.rs
@@ -55,10 +55,17 @@ pub struct Header {
     /// zero; formally Hi.
     #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
     pub number: BlockNumber,
-    /// A scalar value equal to the current limit of gas expenditure per block; formally Hl.
+    /// Block gas limit; under [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037), bounds each of
+    /// the accumulated regular (execution) and state gas dimensions, not their sum.
+    /// Without EIP-8037 this is the ordinary single-dimensional block gas limit. Excludes blob
+    /// gas.
     #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
     pub gas_limit: u64,
-    /// A scalar value equal to the total gas used in transactions in this block; formally Hg.
+    /// Gas used for block capacity and base-fee accounting.
+    /// Under [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037), the maximum of the accumulated
+    /// regular (execution) and state gas dimensions, not their sum or cumulative receipt gas.
+    /// EIP-7778 keeps ordinary refunds in block usage; state gas is still net of state refills.
+    /// Without these EIPs, the network's ordinary block gas rules apply. Excludes blob gas.
     #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
     pub gas_used: u64,
     /// A scalar value equal to the reasonable output of Unix’s time() at this block’s inception;
@@ -647,10 +654,16 @@ pub trait BlockHeader {
     /// Retrieves the block number
     fn number(&self) -> BlockNumber;
 
-    /// Retrieves the gas limit of the block
+    /// Block gas limit; under [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037), bounds each of
+    /// the accumulated regular (execution) and state gas dimensions, not their sum.
+    /// Without EIP-8037 this is the ordinary single-dimensional block gas limit. Excludes blob gas.
     fn gas_limit(&self) -> u64;
 
-    /// Retrieves the gas used by the block
+    /// Gas used for block capacity and base-fee accounting.
+    /// Under [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037), the maximum of the accumulated
+    /// regular (execution) and state gas dimensions, not their sum or cumulative receipt gas.
+    /// EIP-7778 keeps ordinary refunds in block usage; state gas is still net of state refills.
+    /// Without these EIPs, the network's ordinary block gas rules apply. Excludes blob gas.
     fn gas_used(&self) -> u64;
 
     /// Retrieves the timestamp of the block

--- a/crates/consensus/src/block/header.rs
+++ b/crates/consensus/src/block/header.rs
@@ -55,17 +55,16 @@ pub struct Header {
     /// zero; formally Hi.
     #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
     pub number: BlockNumber,
-    /// Block gas limit; under [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037), bounds each of
-    /// the accumulated regular (execution) and state gas dimensions, not their sum.
-    /// Without EIP-8037 this is the ordinary single-dimensional block gas limit. Excludes blob
-    /// gas.
+    /// A scalar value equal to the current limit of gas expenditure per block; formally Hl.
+    /// Under [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037) it bounds each of the block's two
+    /// gas dimensions (execution and state) separately, not their sum.
     #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
     pub gas_limit: u64,
-    /// Gas used for block capacity and base-fee accounting.
-    /// Under [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037), the maximum of the accumulated
-    /// regular (execution) and state gas dimensions, not their sum or cumulative receipt gas.
-    /// EIP-7778 keeps ordinary refunds in block usage; state gas is still net of state refills.
-    /// Without these EIPs, the network's ordinary block gas rules apply. Excludes blob gas.
+    /// A scalar value equal to the total gas used in transactions in this block; formally Hg.
+    /// Under [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037) this is the larger of the block's
+    /// execution-gas and state-gas totals, counted before refunds ([EIP-7778](https://eips.ethereum.org/EIPS/eip-7778)),
+    /// so it need not equal the last receipt's `cumulativeGasUsed`. State totals remain net of
+    /// state refills.
     #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
     pub gas_used: u64,
     /// A scalar value equal to the reasonable output of Unix’s time() at this block’s inception;
@@ -654,16 +653,16 @@ pub trait BlockHeader {
     /// Retrieves the block number
     fn number(&self) -> BlockNumber;
 
-    /// Block gas limit; under [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037), bounds each of
-    /// the accumulated regular (execution) and state gas dimensions, not their sum.
-    /// Without EIP-8037 this is the ordinary single-dimensional block gas limit. Excludes blob gas.
+    /// A scalar value equal to the current limit of gas expenditure per block; formally Hl.
+    /// Under [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037) it bounds each of the block's two
+    /// gas dimensions (execution and state) separately, not their sum.
     fn gas_limit(&self) -> u64;
 
-    /// Gas used for block capacity and base-fee accounting.
-    /// Under [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037), the maximum of the accumulated
-    /// regular (execution) and state gas dimensions, not their sum or cumulative receipt gas.
-    /// EIP-7778 keeps ordinary refunds in block usage; state gas is still net of state refills.
-    /// Without these EIPs, the network's ordinary block gas rules apply. Excludes blob gas.
+    /// A scalar value equal to the total gas used in transactions in this block; formally Hg.
+    /// Under [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037) this is the larger of the block's
+    /// execution-gas and state-gas totals, counted before refunds ([EIP-7778](https://eips.ethereum.org/EIPS/eip-7778)),
+    /// so it need not equal the last receipt's `cumulativeGasUsed`. State totals remain net of
+    /// state refills.
     fn gas_used(&self) -> u64;
 
     /// Retrieves the timestamp of the block

--- a/crates/consensus/src/receipt/mod.rs
+++ b/crates/consensus/src/receipt/mod.rs
@@ -89,7 +89,12 @@ pub trait TxReceipt: Clone + fmt::Debug + PartialEq + Eq + Send + Sync {
         ReceiptWithBloom { logs_bloom, receipt: self }
     }
 
-    /// Returns the cumulative gas used in the block after this transaction was executed.
+    /// Cumulative charged receipt gas through this transaction, including this transaction's gas.
+    /// Includes intrinsic costs and, where [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037) is
+    /// active, both regular (execution) and net state gas, after ordinary refunds and the calldata
+    /// floor. Excludes blob gas. This is not just this transaction's gas or the EIP-8037 block
+    /// header's `gasUsed`, which uses the maximum of the block's two dimensions instead of
+    /// their sum.
     fn cumulative_gas_used(&self) -> u64;
 
     /// Returns the logs emitted by this transaction.

--- a/crates/consensus/src/receipt/mod.rs
+++ b/crates/consensus/src/receipt/mod.rs
@@ -89,12 +89,11 @@ pub trait TxReceipt: Clone + fmt::Debug + PartialEq + Eq + Send + Sync {
         ReceiptWithBloom { logs_bloom, receipt: self }
     }
 
-    /// Cumulative charged receipt gas through this transaction, including this transaction's gas.
-    /// Includes intrinsic costs and, where [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037) is
-    /// active, both regular (execution) and net state gas, after ordinary refunds and the calldata
-    /// floor. Excludes blob gas. This is not just this transaction's gas or the EIP-8037 block
-    /// header's `gasUsed`, which uses the maximum of the block's two dimensions instead of
-    /// their sum.
+    /// Returns the cumulative gas used in the block up to and including this transaction.
+    ///
+    /// This is charged gas, after refunds and the calldata floor. Under
+    /// [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037) it includes both execution and state gas, so
+    /// the last receipt's value need not equal the block header's `gasUsed`.
     fn cumulative_gas_used(&self) -> u64;
 
     /// Returns the logs emitted by this transaction.

--- a/crates/consensus/src/receipt/receipt2.rs
+++ b/crates/consensus/src/receipt/receipt2.rs
@@ -61,7 +61,7 @@ pub struct EthereumReceipt<T = TxType, L = Log> {
     #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity", rename = "status"))]
     pub success: bool,
     /// Cumulative gas used in the block up to and including this transaction.
-    /// See [`TxReceipt::cumulative_gas_used`](crate::TxReceipt::cumulative_gas_used).
+    /// See [`TxReceipt::cumulative_gas_used`].
     #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
     pub cumulative_gas_used: u64,
     /// Log send from contracts.

--- a/crates/consensus/src/receipt/receipt2.rs
+++ b/crates/consensus/src/receipt/receipt2.rs
@@ -60,7 +60,12 @@ pub struct EthereumReceipt<T = TxType, L = Log> {
     /// This is the `statusCode`
     #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity", rename = "status"))]
     pub success: bool,
-    /// Gas used
+    /// Cumulative charged receipt gas through this transaction, including this transaction's gas.
+    /// Includes intrinsic costs and, where [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037) is
+    /// active, both regular (execution) and net state gas, after ordinary refunds and the calldata
+    /// floor. Excludes blob gas. This is not just this transaction's gas or the EIP-8037 block
+    /// header's `gasUsed`, which uses the maximum of the block's two dimensions instead of
+    /// their sum.
     #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
     pub cumulative_gas_used: u64,
     /// Log send from contracts.

--- a/crates/consensus/src/receipt/receipt2.rs
+++ b/crates/consensus/src/receipt/receipt2.rs
@@ -60,12 +60,8 @@ pub struct EthereumReceipt<T = TxType, L = Log> {
     /// This is the `statusCode`
     #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity", rename = "status"))]
     pub success: bool,
-    /// Cumulative charged receipt gas through this transaction, including this transaction's gas.
-    /// Includes intrinsic costs and, where [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037) is
-    /// active, both regular (execution) and net state gas, after ordinary refunds and the calldata
-    /// floor. Excludes blob gas. This is not just this transaction's gas or the EIP-8037 block
-    /// header's `gasUsed`, which uses the maximum of the block's two dimensions instead of
-    /// their sum.
+    /// Cumulative gas used in the block up to and including this transaction.
+    /// See [`TxReceipt::cumulative_gas_used`](crate::TxReceipt::cumulative_gas_used).
     #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
     pub cumulative_gas_used: u64,
     /// Log send from contracts.

--- a/crates/consensus/src/receipt/receipts.rs
+++ b/crates/consensus/src/receipt/receipts.rs
@@ -25,7 +25,7 @@ pub struct Receipt<T = Log> {
     #[cfg_attr(feature = "serde", serde(flatten))]
     pub status: Eip658Value,
     /// Cumulative gas used in the block up to and including this transaction.
-    /// See [`TxReceipt::cumulative_gas_used`](crate::TxReceipt::cumulative_gas_used).
+    /// See [`TxReceipt::cumulative_gas_used`].
     #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
     pub cumulative_gas_used: u64,
     /// Log send from contracts.

--- a/crates/consensus/src/receipt/receipts.rs
+++ b/crates/consensus/src/receipt/receipts.rs
@@ -24,7 +24,12 @@ pub struct Receipt<T = Log> {
     /// This is the `statusCode`
     #[cfg_attr(feature = "serde", serde(flatten))]
     pub status: Eip658Value,
-    /// Gas used
+    /// Cumulative charged receipt gas through this transaction, including this transaction's gas.
+    /// Includes intrinsic costs and, where [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037) is
+    /// active, both regular (execution) and net state gas, after ordinary refunds and the calldata
+    /// floor. Excludes blob gas. This is not just this transaction's gas or the EIP-8037 block
+    /// header's `gasUsed`, which uses the maximum of the block's two dimensions instead of
+    /// their sum.
     #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
     pub cumulative_gas_used: u64,
     /// Log send from contracts.

--- a/crates/consensus/src/receipt/receipts.rs
+++ b/crates/consensus/src/receipt/receipts.rs
@@ -24,12 +24,8 @@ pub struct Receipt<T = Log> {
     /// This is the `statusCode`
     #[cfg_attr(feature = "serde", serde(flatten))]
     pub status: Eip658Value,
-    /// Cumulative charged receipt gas through this transaction, including this transaction's gas.
-    /// Includes intrinsic costs and, where [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037) is
-    /// active, both regular (execution) and net state gas, after ordinary refunds and the calldata
-    /// floor. Excludes blob gas. This is not just this transaction's gas or the EIP-8037 block
-    /// header's `gasUsed`, which uses the maximum of the block's two dimensions instead of
-    /// their sum.
+    /// Cumulative gas used in the block up to and including this transaction.
+    /// See [`TxReceipt::cumulative_gas_used`](crate::TxReceipt::cumulative_gas_used).
     #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
     pub cumulative_gas_used: u64,
     /// Log send from contracts.

--- a/crates/consensus/src/transaction/mod.rs
+++ b/crates/consensus/src/transaction/mod.rs
@@ -91,7 +91,11 @@ pub trait Transaction: Typed2718 + fmt::Debug + any::Any + Send + Sync + 'static
     /// Get `nonce`.
     fn nonce(&self) -> u64;
 
-    /// Get `gas_limit`.
+    /// Combined transaction gas limit, including intrinsic costs.
+    /// Under [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037), this funds regular (execution) and
+    /// state gas through the reservoir model; the regular gas cap still applies independently.
+    /// Without EIP-8037, state creation uses the ordinary gas schedule. Excludes blob gas.
+    /// Gas charged after refunds or state refills need not be a sufficient limit for execution.
     fn gas_limit(&self) -> u64;
 
     /// Get `gas_price`.

--- a/crates/consensus/src/transaction/mod.rs
+++ b/crates/consensus/src/transaction/mod.rs
@@ -91,11 +91,10 @@ pub trait Transaction: Typed2718 + fmt::Debug + any::Any + Send + Sync + 'static
     /// Get `nonce`.
     fn nonce(&self) -> u64;
 
-    /// Combined transaction gas limit, including intrinsic costs.
-    /// Under [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037), this funds regular (execution) and
-    /// state gas through the reservoir model; the regular gas cap still applies independently.
-    /// Without EIP-8037, state creation uses the ordinary gas schedule. Excludes blob gas.
-    /// Gas charged after refunds or state refills need not be a sufficient limit for execution.
+    /// Get `gas_limit`.
+    ///
+    /// Under [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037) this single limit funds both execution
+    /// and state gas via the reservoir model.
     fn gas_limit(&self) -> u64;
 
     /// Get `gas_price`.

--- a/crates/network-primitives/src/traits.rs
+++ b/crates/network-primitives/src/traits.rs
@@ -56,13 +56,17 @@ pub trait ReceiptResponse {
     /// Index within the block.
     fn transaction_index(&self) -> Option<u64>;
 
-    /// Gas used by this transaction alone.
+    /// Total gas charged for this transaction alone, after refunds and the applicable calldata
+    /// floor. Includes intrinsic costs and both regular (execution) and net state gas where
+    /// [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037) is active. Without it, state creation costs
+    /// use the ordinary gas schedule. Excludes blob gas. This is not a gas-limit estimate.
     fn gas_used(&self) -> u64;
 
     /// Effective gas price.
     fn effective_gas_price(&self) -> u128;
 
-    /// Returns the execution-gas cost in wei: `gas_used * effective_gas_price`.
+    /// Returns the transaction gas fee in wei: `gas_used * effective_gas_price`.
+    /// Includes regular (execution) and state gas where EIP-8037 is active.
     ///
     /// This excludes blob-gas charges, transferred value, and network-specific fee components;
     /// it is not the sender's total balance change. The ordinary `u128` multiplication can
@@ -83,7 +87,10 @@ pub trait ReceiptResponse {
     /// Address of the receiver, or `None` for contract creation.
     fn to(&self) -> Option<Address>;
 
-    /// Returns the gas used in the block up to and including this transaction.
+    /// Returns cumulative receipt gas through this transaction, including this transaction's gas.
+    /// Under EIP-8037 this sums charged regular and state gas. It is not the block header's
+    /// `gasUsed`, which uses the larger of the block's two gas dimensions, with its own
+    /// refund/floor rules.
     fn cumulative_gas_used(&self) -> u64;
 
     /// Returns the post-transaction state root carried by pre-[EIP-658] receipts.

--- a/crates/network-primitives/src/traits.rs
+++ b/crates/network-primitives/src/traits.rs
@@ -56,10 +56,8 @@ pub trait ReceiptResponse {
     /// Index within the block.
     fn transaction_index(&self) -> Option<u64>;
 
-    /// Total gas charged for this transaction alone, after refunds and the applicable calldata
-    /// floor. Includes intrinsic costs and both regular (execution) and net state gas where
-    /// [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037) is active. Without it, state creation costs
-    /// use the ordinary gas schedule. Excludes blob gas. This is not a gas-limit estimate.
+    /// Gas used by this transaction alone, as charged (after refunds and the calldata floor).
+    /// Under [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037) this includes both execution and state gas.
     fn gas_used(&self) -> u64;
 
     /// Effective gas price.
@@ -87,10 +85,9 @@ pub trait ReceiptResponse {
     /// Address of the receiver, or `None` for contract creation.
     fn to(&self) -> Option<Address>;
 
-    /// Returns cumulative receipt gas through this transaction, including this transaction's gas.
-    /// Under EIP-8037 this sums charged regular and state gas. It is not the block header's
-    /// `gasUsed`, which uses the larger of the block's two gas dimensions, with its own
-    /// refund/floor rules.
+    /// Returns the gas used in the block up to and including this transaction.
+    /// Under [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037) this is the sum of charged execution and
+    /// state gas, so it need not match the block header's `gasUsed`.
     fn cumulative_gas_used(&self) -> u64;
 
     /// Returns the post-transaction state root carried by pre-[EIP-658] receipts.

--- a/crates/provider/src/provider/trait.rs
+++ b/crates/provider/src/provider/trait.rs
@@ -258,6 +258,12 @@ pub trait Provider<N: Network = Ethereum>: Send + Sync {
     /// # Note
     ///
     /// Not all client implementations support state overrides for `eth_estimateGas`.
+    ///
+    /// On networks with [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037), the node must estimate
+    /// one transaction limit covering intrinsic costs, regular (execution) gas, and state gas,
+    /// including temporary charges before state refills. Alloy forwards this request; it does not
+    /// add state gas locally. Use a node implementing the target fork's rules. A receipt's charged
+    /// gas or a trace's net consumption is not a substitute for this estimate.
     fn estimate_gas(&self, tx: N::TransactionRequest) -> EthCall<N, U64, u64> {
         EthCall::gas_estimate(self.weak_client(), tx)
             .block(BlockNumberOrTag::Pending.into())

--- a/crates/rpc-types-eth/src/transaction/receipt.rs
+++ b/crates/rpc-types-eth/src/transaction/receipt.rs
@@ -30,7 +30,15 @@ pub struct TransactionReceipt<T = ReceiptEnvelope<Log>> {
     /// Number of the block this transaction was included within.
     #[cfg_attr(feature = "serde", serde(default, with = "alloy_serde::quantity::opt"))]
     pub block_number: Option<u64>,
-    /// Gas used by this transaction alone.
+    /// Total gas charged for this transaction alone, after refunds and the applicable calldata
+    /// floor.
+    ///
+    /// Includes intrinsic gas and, on networks with [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037),
+    /// both regular (execution) gas and net state gas. Do not add trace `stateGasUsed` again.
+    /// Before EIP-8037, state creation costs are included under the ordinary gas schedule.
+    /// Excludes blob gas and network-specific fee components. This is not a sufficient gas limit:
+    /// execution can require gas that is later refunded or returned. Use `eth_estimateGas` to
+    /// estimate.
     #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
     pub gas_used: u64,
     /// The price paid post-execution by the transaction, in wei per gas (base fee plus priority

--- a/crates/rpc-types-eth/src/transaction/request.rs
+++ b/crates/rpc-types-eth/src/transaction/request.rs
@@ -74,7 +74,14 @@ pub struct TransactionRequest {
         )
     )]
     pub max_fee_per_blob_gas: Option<u128>,
-    /// The gas limit for the transaction.
+    /// The combined gas limit for the transaction, including intrinsic costs.
+    ///
+    /// On networks with [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037), this funds both regular
+    /// (execution) gas and state gas. The protocol splits it into regular gas and a state
+    /// reservoir; callers still supply one limit. The regular gas cap applies independently.
+    /// Without EIP-8037, state creation uses the ordinary gas schedule with no separate reservoir.
+    /// Use `eth_estimateGas` with the target network's rules. Receipt gas or net trace consumption
+    /// may be too low because gas can be required before a later refund or state refill.
     #[cfg_attr(
         feature = "serde",
         serde(
@@ -212,7 +219,9 @@ impl TransactionRequest {
         self
     }
 
-    /// Sets the gas limit for the transaction.
+    /// Sets the combined transaction gas limit, including intrinsic, regular, and EIP-8037 state
+    /// gas. See [`Self::gas`] for the reservoir model and why charged gas is not a sufficient
+    /// estimate.
     pub const fn gas_limit(mut self, gas_limit: u64) -> Self {
         self.gas = Some(gas_limit);
         self
@@ -1465,7 +1474,15 @@ pub(super) mod serde_bincode_compat {
         pub max_priority_fee_per_gas: Option<u128>,
         /// The max fee per blob gas for EIP-4844 blob transactions.
         pub max_fee_per_blob_gas: Option<u128>,
-        /// The gas limit for the transaction.
+        /// The combined gas limit for the transaction, including intrinsic costs.
+        ///
+        /// On networks with [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037), this funds both regular
+        /// (execution) gas and state gas. The protocol splits it into regular gas and a state
+        /// reservoir; callers still supply one limit. The regular gas cap applies
+        /// independently. Without EIP-8037, state creation uses the ordinary gas schedule
+        /// with no separate reservoir. Use `eth_estimateGas` with the target network's
+        /// rules. Receipt gas or net trace consumption may be too low because gas can be
+        /// required before a later refund or state refill.
         pub gas: Option<u64>,
         /// The value transferred in the transaction, in wei.
         pub value: Option<U256>,

--- a/crates/rpc-types-eth/src/transaction/request.rs
+++ b/crates/rpc-types-eth/src/transaction/request.rs
@@ -74,14 +74,12 @@ pub struct TransactionRequest {
         )
     )]
     pub max_fee_per_blob_gas: Option<u128>,
-    /// The combined gas limit for the transaction, including intrinsic costs.
+    /// The gas limit for the transaction, including intrinsic costs.
     ///
-    /// On networks with [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037), this funds both regular
-    /// (execution) gas and state gas. The protocol splits it into regular gas and a state
-    /// reservoir; callers still supply one limit. The regular gas cap applies independently.
-    /// Without EIP-8037, state creation uses the ordinary gas schedule with no separate reservoir.
-    /// Use `eth_estimateGas` with the target network's rules. Receipt gas or net trace consumption
-    /// may be too low because gas can be required before a later refund or state refill.
+    /// Under [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037) this single limit funds both execution
+    /// and state gas; the protocol splits it into regular gas and a state reservoir. A receipt's
+    /// `gasUsed` or a trace's net consumption can be too low as a limit, because gas may be needed
+    /// before a later refund or state refill. Use `eth_estimateGas` against the target network.
     #[cfg_attr(
         feature = "serde",
         serde(
@@ -219,9 +217,7 @@ impl TransactionRequest {
         self
     }
 
-    /// Sets the combined transaction gas limit, including intrinsic, regular, and EIP-8037 state
-    /// gas. See [`Self::gas`] for the reservoir model and why charged gas is not a sufficient
-    /// estimate.
+    /// Sets the gas limit for the transaction. See [`Self::gas`].
     pub const fn gas_limit(mut self, gas_limit: u64) -> Self {
         self.gas = Some(gas_limit);
         self
@@ -1474,15 +1470,7 @@ pub(super) mod serde_bincode_compat {
         pub max_priority_fee_per_gas: Option<u128>,
         /// The max fee per blob gas for EIP-4844 blob transactions.
         pub max_fee_per_blob_gas: Option<u128>,
-        /// The combined gas limit for the transaction, including intrinsic costs.
-        ///
-        /// On networks with [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037), this funds both regular
-        /// (execution) gas and state gas. The protocol splits it into regular gas and a state
-        /// reservoir; callers still supply one limit. The regular gas cap applies
-        /// independently. Without EIP-8037, state creation uses the ordinary gas schedule
-        /// with no separate reservoir. Use `eth_estimateGas` with the target network's
-        /// rules. Receipt gas or net trace consumption may be too low because gas can be
-        /// required before a later refund or state refill.
+        /// The gas limit for the transaction.
         pub gas: Option<u64>,
         /// The value transferred in the transaction, in wei.
         pub value: Option<U256>,

--- a/crates/rpc-types-trace/src/geth/call.rs
+++ b/crates/rpc-types-trace/src/geth/call.rs
@@ -33,7 +33,12 @@ pub struct CallFrame {
     ///
     /// A transaction summary on the top-level frame when supported; not a per-child breakdown.
     /// `None` means not reported (for example, a nested frame, older fork, or unsupported node).
-    #[serde(default, rename = "executionGasUsed", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        rename = "executionGasUsed",
+        alias = "regularGasUsed",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub execution_gas_used: Option<U256>,
     /// Net EIP-8037 state gas for the whole transaction, excluding regular execution gas.
     ///
@@ -52,11 +57,10 @@ pub struct CallFrame {
     /// reported. This transaction summary is reported on the top-level frame when supported.
     #[serde(default, rename = "gasRefund", skip_serializing_if = "Option::is_none")]
     pub gas_refund: Option<U256>,
-    /// Optional node-reported EIP-8037 state gas refill amount.
-    /// Distinct from the ordinary capped refund in `gas_refund`; refills undo state creation
-    /// charges during execution. The top-level `state_gas_used` is already net, so do not
-    /// subtract this again. This is a client extension: availability and frame scope depend on
-    /// the node. `None` is not zero. See [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037).
+    /// Total EIP-8037 state gas refilled within the transaction, which the proposal calls
+    /// "source-based state-gas refunds". Already netted out of `state_gas_used`; do not subtract
+    /// it again. Optional in the proposal and only meaningful on the top-level frame; `None`
+    /// means not reported. See [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037).
     #[serde(default, rename = "stateGasRefund", skip_serializing_if = "Option::is_none")]
     pub state_gas_refund: Option<U256>,
     /// The address of the contract that was called.

--- a/crates/rpc-types-trace/src/geth/call.rs
+++ b/crates/rpc-types-trace/src/geth/call.rs
@@ -11,26 +11,52 @@ use serde::{Deserialize, Serialize};
 pub struct CallFrame {
     /// The address of that initiated the call.
     pub from: Address,
-    /// How much gas was left before the call.
+    /// Gas allowance before the call. For nested frames, regular gas excluding the EIP-8037
+    /// reservoir. The reservoir is passed separately in full, outside the regular-gas 63/64
+    /// rule. The top-level frame describes the transaction; do not interpret this as a
+    /// per-frame combined budget.
     #[serde(default)]
     pub gas: U256,
-    /// How much gas was used by the call.
+    /// Gas used by this call, including nested execution; do not sum parents and their children.
+    /// On the top-level transaction frame this is receipt gas, including both EIP-8037 dimensions,
+    /// after refunds and the calldata floor. Do not add `state_gas_used` to that total.
+    /// Nested-frame gas semantics vary by client and are not a transaction fee or gas-limit
+    /// estimate. See the [tracing schema proposal](https://github.com/ethereum/execution-apis/pull/852).
     #[serde(default, rename = "gasUsed")]
     pub gas_used: U256,
-    /// Gross execution-dimension gas used by the transaction.
+    /// Regular (execution) gas contribution to block accounting, excluding EIP-8037 state gas.
     ///
-    /// This is present on the top-level frame for Amsterdam and later blocks.
-    /// See [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037) and the
-    /// [execution-apis call tracer proposal](https://github.com/ethereum/execution-apis/pull/852).
+    /// Includes intrinsic gas and the execution-dimension calldata floor; before ordinary refunds
+    /// under EIP-7778. This is not receipt gas. See the
+    /// [gas accounting guide](crate::geth::state_gas) and
+    /// [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037).
+    ///
+    /// A transaction summary on the top-level frame when supported; not a per-child breakdown.
+    /// `None` means not reported (for example, a nested frame, older fork, or unsupported node).
     #[serde(default, rename = "executionGasUsed", skip_serializing_if = "Option::is_none")]
     pub execution_gas_used: Option<U256>,
-    /// Gross state-dimension gas used by the transaction.
+    /// Net EIP-8037 state gas for the whole transaction, excluding regular execution gas.
+    ///
+    /// Includes state creation charges after state refills and rollback, not peak state gas
+    /// demand. Do not subtract `gas_refund` or `state_gas_refund` from this already-net
+    /// transaction value. Zero when reported for an inactive EIP-8037 fork; `None` means the
+    /// node did not report it. See [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037).
+    /// This transaction summary is reported on the top-level frame when supported.
     #[serde(default, rename = "stateGasUsed", skip_serializing_if = "Option::is_none")]
     pub state_gas_used: Option<U256>,
-    /// EIP-3529 gas refund applied at the transaction boundary.
+    /// Ordinary transaction refund reported after transaction-boundary refund processing.
+    ///
+    /// Subject to the [EIP-3529](https://eips.ethereum.org/EIPS/eip-3529) cap; not a raw frame counter.
+    /// Excludes EIP-8037 state refills and unused gas. The calldata floor can limit the fee
+    /// saving; use the transaction's receipt gas for the final charge. `None` means not
+    /// reported. This transaction summary is reported on the top-level frame when supported.
     #[serde(default, rename = "gasRefund", skip_serializing_if = "Option::is_none")]
     pub gas_refund: Option<U256>,
-    /// State gas refunded within the transaction.
+    /// Optional node-reported EIP-8037 state gas refill amount.
+    /// Distinct from the ordinary capped refund in `gas_refund`; refills undo state creation
+    /// charges during execution. The top-level `state_gas_used` is already net, so do not
+    /// subtract this again. This is a client extension: availability and frame scope depend on
+    /// the node. `None` is not zero. See [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037).
     #[serde(default, rename = "stateGasRefund", skip_serializing_if = "Option::is_none")]
     pub state_gas_refund: Option<U256>,
     /// The address of the contract that was called.

--- a/crates/rpc-types-trace/src/geth/mod.rs
+++ b/crates/rpc-types-trace/src/geth/mod.rs
@@ -74,14 +74,18 @@ pub struct ChainBlockTraceResult {
 pub struct DefaultFrame {
     /// Whether the transaction failed
     pub failed: bool,
-    /// How much gas was used.
+    /// Total transaction gas charged, matching receipt `gasUsed`.
+    /// Includes regular and EIP-8037 state gas, intrinsic costs, refunds, and the calldata floor.
+    /// Excludes blob gas. Do not add `state_gas_used` again or use this as a gas-limit estimate.
     pub gas: u64,
-    /// Gross execution-dimension gas used by the transaction.
+    /// Regular (execution) gas contribution to block accounting, excluding EIP-8037 state gas.
     ///
-    /// These fields are optional because pre-Amsterdam responses omit them. The
-    /// optional representation preserves decoding of both old and new responses;
-    /// adding them is JSON-RPC backward-compatible, but adding public Rust fields
-    /// can require downstream struct literals to use `..Default::default()`.
+    /// Includes intrinsic gas and the execution-dimension calldata floor; before ordinary refunds
+    /// under EIP-7778. This is not receipt gas. See the
+    /// [gas accounting guide](crate::geth::state_gas) and
+    /// [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037).
+    ///
+    /// Optional because older forks and nodes can omit this field; `None` does not mean zero.
     #[serde(
         default,
         with = "alloy_serde::quantity::opt",
@@ -89,7 +93,12 @@ pub struct DefaultFrame {
         skip_serializing_if = "Option::is_none"
     )]
     pub execution_gas_used: Option<u64>,
-    /// Gross state-dimension gas used by the transaction.
+    /// Net EIP-8037 state gas for the whole transaction, excluding regular execution gas.
+    ///
+    /// Includes state creation charges after state refills and rollback, not peak state gas
+    /// demand. Do not subtract `gas_refund` from this already-net transaction value.
+    /// Zero when reported for an inactive EIP-8037 fork; `None` means the node did not report it.
+    /// See [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037).
     #[serde(
         default,
         with = "alloy_serde::quantity::opt",
@@ -97,7 +106,12 @@ pub struct DefaultFrame {
         skip_serializing_if = "Option::is_none"
     )]
     pub state_gas_used: Option<u64>,
-    /// EIP-3529 gas refund applied at the transaction boundary.
+    /// Ordinary transaction refund reported after transaction-boundary refund processing.
+    ///
+    /// Subject to the [EIP-3529](https://eips.ethereum.org/EIPS/eip-3529) cap; not a raw frame counter.
+    /// Excludes EIP-8037 state refills and unused gas. The calldata floor can limit the fee
+    /// saving; use the transaction's receipt gas for the final charge. `None` means not
+    /// reported.
     #[serde(
         default,
         with = "alloy_serde::quantity::opt",
@@ -120,16 +134,28 @@ pub struct StructLog {
     pub pc: u64,
     /// opcode to be executed
     pub op: Cow<'static, str>,
-    /// remaining gas
+    /// Regular gas remaining before this opcode, excluding the EIP-8037 state gas reservoir.
+    /// This is the `GAS`/`gasleft()` dimension. State charges can spill into it and refills can
+    /// raise it. See [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037).
     pub gas: u64,
-    /// cost for executing op
+    /// Gas charged to the regular gas counter for this opcode.
+    /// Under EIP-8037 this can include state gas spilling out of an empty reservoir; it excludes
+    /// state gas paid from the reservoir. It is not necessarily a pure execution-gas charge.
+    /// Do not blindly add `state_gas_cost`, which can overlap with spillover.
     #[serde(rename = "gasCost")]
     pub gas_cost: u64,
-    /// Net state-dimension gas change caused by this opcode. This can be negative
-    /// for source-based state-gas refunds under EIP-8037.
+    /// Net EIP-8037 state gas charged by this opcode, regardless of which gas pool paid it.
+    /// Positive means a charge; negative means a state refill, not an EIP-3529 refund.
+    /// `None` means not reported. Summing steps cannot reconstruct transaction state gas:
+    /// account creation, code deposit, authorization processing, and rollback can occur outside
+    /// steps. See [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037).
     #[serde(default, rename = "stateGasCost", skip_serializing_if = "Option::is_none")]
     pub state_gas_cost: Option<i64>,
-    /// State-gas reservoir remaining before this opcode.
+    /// EIP-8037 state gas reservoir remaining before this opcode, excluded from `gas`.
+    /// State charges spend it first, then spill into regular gas. Regular execution cannot spend
+    /// it. It is passed to child frames in full, outside the 63/64 rule; it is not a per-call
+    /// gas limit. `Some(0)` means an empty reservoir, not that state gas is disabled. `None`
+    /// means not reported. See [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037).
     #[serde(default, rename = "stateGasReservoir", skip_serializing_if = "Option::is_none")]
     pub state_gas_reservoir: Option<u64>,
     /// Current call depth
@@ -157,7 +183,8 @@ pub struct StructLog {
         serialize_with = "serialize_string_storage_map_opt"
     )]
     pub storage: Option<BTreeMap<B256, B256>>,
-    /// Refund counter
+    /// Ordinary transaction refund counter at this step, before the transaction-wide cap/floor.
+    /// Excludes EIP-8037 state refills. This is not the applied refund or available execution gas.
     #[serde(default, rename = "refund", skip_serializing_if = "Option::is_none")]
     pub refund_counter: Option<u64>,
 }
@@ -639,7 +666,9 @@ impl GethDebugTracingOptions {
         Self::new_tracer(GethDebugBuiltInTracerType::PreStateTracer).with_prestate_config(config)
     }
 
-    /// Creates new options for the EIP-8037 state-gas tracer.
+    /// Requests the EIP-8037 transaction gas breakdown as [`StateGasTrace`].
+    /// Requires node support for `stateGasTracer`; selecting it does not activate EIP-8037.
+    /// See the [gas accounting guide](crate::geth::state_gas) for fields and network support.
     pub fn state_gas_tracer() -> Self {
         Self::new_tracer(GethDebugBuiltInTracerType::StateGasTracer)
     }

--- a/crates/rpc-types-trace/src/geth/mod.rs
+++ b/crates/rpc-types-trace/src/geth/mod.rs
@@ -90,6 +90,7 @@ pub struct DefaultFrame {
         default,
         with = "alloy_serde::quantity::opt",
         rename = "executionGasUsed",
+        alias = "regularGasUsed",
         skip_serializing_if = "Option::is_none"
     )]
     pub execution_gas_used: Option<u64>,

--- a/crates/rpc-types-trace/src/geth/state_gas.rs
+++ b/crates/rpc-types-trace/src/geth/state_gas.rs
@@ -42,11 +42,10 @@
 //! if it does not implement the tracer. `None` means not reported, not zero.
 //!
 //! The tracing wire format is still described by an
-//! [execution-apis proposal](https://github.com/ethereum/execution-apis/pull/852); support and
-//! historical responses depend on the node. Alloy uses the wire name `executionGasUsed`; older
-//! proposal/node revisions may use `regularGasUsed`, which these fields do not alias. Match the
-//! node's response schema to the Alloy version. These types decode responses; they do not enable
-//! EIPs.
+//! [execution-apis proposal](https://github.com/ethereum/execution-apis/pull/852), which names the
+//! execution dimension `regularGasUsed`. Alloy serializes `executionGasUsed` and accepts both names
+//! when decoding. Support and historical responses depend on the node; these types decode
+//! responses, they do not enable EIPs.
 
 use serde::{Deserialize, Serialize};
 
@@ -72,7 +71,7 @@ pub struct StateGasTrace {
     /// Without EIP-8037, state creation remains part of the ordinary gas schedule. A floor can
     /// make this value larger than the execution work actually consumed; use `gas_used` for
     /// receipt gas.
-    #[serde(with = "alloy_serde::quantity")]
+    #[serde(with = "alloy_serde::quantity", alias = "regularGasUsed")]
     pub execution_gas_used: u64,
     /// Net [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037) state gas for the whole transaction.
     ///
@@ -97,7 +96,7 @@ pub struct StateGasTrace {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::geth::{GethDebugTracingOptions, GethTrace, StructLog};
+    use crate::geth::{CallFrame, DefaultFrame, GethDebugTracingOptions, GethTrace, StructLog};
 
     #[test]
     fn test_state_gas_trace_serde() {
@@ -142,6 +141,53 @@ mod tests {
 
         let options = GethDebugTracingOptions::state_gas_tracer();
         assert_eq!(options.tracer.unwrap().as_str(), "stateGasTracer");
+    }
+
+    #[test]
+    fn execution_gas_field_names() {
+        for name in ["executionGasUsed", "regularGasUsed"] {
+            let summary = serde_json::json!({
+                "gasUsed": "0x5208",
+                name: "0x5208",
+                "stateGasUsed": "0x0",
+                "gasRefund": "0x0"
+            });
+            let trace: StateGasTrace = serde_json::from_value(summary.clone()).unwrap();
+            assert_eq!(trace.execution_gas_used, 21_000);
+            let wrapped: GethTrace = serde_json::from_value(summary).unwrap();
+            assert_eq!(wrapped.try_into_state_gas_trace().unwrap().execution_gas_used, 21_000);
+            let encoded = serde_json::to_value(trace).unwrap();
+            assert_eq!(encoded["executionGasUsed"], "0x5208");
+            assert!(encoded.get("regularGasUsed").is_none());
+
+            let call: CallFrame = serde_json::from_value(serde_json::json!({
+                "type": "CALL",
+                "from": "0x0000000000000000000000000000000000000000",
+                "input": "0x",
+                name: "0x5208"
+            }))
+            .unwrap();
+            assert_eq!(call.execution_gas_used, Some(alloy_primitives::U256::from(21_000)));
+            let encoded = serde_json::to_value(call).unwrap();
+            assert_eq!(encoded["executionGasUsed"], "0x5208");
+            assert!(encoded.get("regularGasUsed").is_none());
+
+            // The opcode tracer proposal uses JSON integers; accept quantities as well.
+            for value in [serde_json::json!(21_000), serde_json::json!("0x5208")] {
+                let frame: DefaultFrame = serde_json::from_value(serde_json::json!({
+                    "failed": false,
+                    "gas": 21_000,
+                    "returnValue": "0x",
+                    "structLogs": [],
+                    name: value
+                }))
+                .unwrap();
+                assert_eq!(frame.execution_gas_used, Some(21_000));
+                let encoded = serde_json::to_value(frame).unwrap();
+                assert_eq!(encoded["executionGasUsed"], "0x5208");
+                assert!(encoded.get("regularGasUsed").is_none());
+            }
+        }
     }
 
     #[test]

--- a/crates/rpc-types-trace/src/geth/state_gas.rs
+++ b/crates/rpc-types-trace/src/geth/state_gas.rs
@@ -1,24 +1,95 @@
-//! EIP-8037 state-gas tracer types.
+//! Transaction gas accounting for [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037).
+//!
+//! **Execution gas**, also called **regular gas**, pays for computation, memory, access costs,
+//! and intrinsic transaction costs. **State gas** pays for state creation, such as a new storage
+//! slot, account, or deployed code. Reading or updating existing state still costs execution gas.
+//!
+//! A transaction supplies one gas limit covering both dimensions. EIP-8037 splits the available
+//! gas into regular gas and a state gas reservoir. Execution charges use regular gas only; state
+//! charges use the reservoir first and spill into regular gas when it is empty. `GAS`/`gasleft()`
+//! exposes only regular gas. Child calls receive the reservoir in full, independently of the
+//! 63/64 rule for regular gas, so a call's gas allowance is not a combined state/execution budget.
+//!
+//! State **refills** undo state creation charges during execution and are already deducted from
+//! reported transaction state gas. They differ from the ordinary transaction **refund counter**,
+//! whose application is capped by [EIP-3529](https://eips.ethereum.org/EIPS/eip-3529).
+//!
+//! # Choosing a value
+//!
+//! - Use [`StateGasTrace::gas_used`] or the transaction receipt's `gasUsed` for charged gas. It
+//!   includes both dimensions, after refunds and the calldata floor; do not add state gas again.
+//! - Use [`StateGasTrace::execution_gas_used`] and [`StateGasTrace::state_gas_used`] for the
+//!   transaction's separate block-accounting contributions. With EIP-7778, execution gas is before
+//!   ordinary refunds; state gas is still net of state refills.
+//! - Use [`StateGasTrace::gas_refund`] for the reported transaction refund, not a nested frame's
+//!   uncapped refund counter. It is separate from state refills and unused gas returned to the
+//!   sender.
+//! - Use `eth_estimateGas` on a node implementing the target network's rules to choose a gas limit.
+//!   Neither charged gas nor the sum of the two reported dimensions guarantees enough gas:
+//!   temporary state charges, forwarding rules, and the regular gas cap also matter.
+//!
+//! Without a binding calldata floor, `execution_gas_used + state_gas_used - gas_refund` equals
+//! receipt gas under the EIP-8037/EIP-7778 accounting model. With a binding floor, use `gas_used`
+//! directly: the execution contribution has its own floor and cannot always reconstruct the
+//! receipt. Neither figure includes EIP-4844 blob gas, which has separate accounting and fees.
+//!
+//! # Network and RPC support
+//!
+//! EIP-8037 applies only when activated by the target network's hardfork rules (Amsterdam in
+//! Ethereum EVM implementations). An EVM-compatible network or an Alloy type does not imply
+//! activation. Before activation, state creation uses the ordinary gas schedule and the separate
+//! state dimension is zero. A node may omit optional breakdown fields or reject `stateGasTracer`
+//! if it does not implement the tracer. `None` means not reported, not zero.
+//!
+//! The tracing wire format is still described by an
+//! [execution-apis proposal](https://github.com/ethereum/execution-apis/pull/852); support and
+//! historical responses depend on the node. Alloy uses the wire name `executionGasUsed`; older
+//! proposal/node revisions may use `regularGasUsed`, which these fields do not alias. Match the
+//! node's response schema to the Alloy version. These types decode responses; they do not enable
+//! EIPs.
 
 use serde::{Deserialize, Serialize};
 
 /// The per-transaction two-dimensional gas summary returned by `stateGasTracer`.
 ///
-/// The shape is specified by the
+/// Based on the
 /// [execution-apis state-gas tracer proposal](https://github.com/ethereum/execution-apis/pull/852).
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct StateGasTrace {
-    /// Receipt gas used, after refunds and any calldata floor.
+    /// Total gas charged for this transaction, including execution and state gas.
+    ///
+    /// Matches receipt `gasUsed`: includes intrinsic costs, subtracts applicable transaction
+    /// refunds, and applies the [EIP-7623](https://eips.ethereum.org/EIPS/eip-7623) calldata floor.
+    /// State refills are already accounted for. Excludes blob gas. Do not add `state_gas_used`
+    /// again. This is gas charged, not the minimum gas limit required to execute.
     #[serde(with = "alloy_serde::quantity")]
     pub gas_used: u64,
-    /// Gross execution-dimension gas used by the transaction.
+    /// Regular (execution) gas contribution to block accounting, excluding EIP-8037 state gas.
+    ///
+    /// Includes intrinsic gas and the execution-dimension calldata floor. With
+    /// [EIP-7778](https://eips.ethereum.org/EIPS/eip-7778), this is before ordinary transaction refunds.
+    /// Without EIP-8037, state creation remains part of the ordinary gas schedule. A floor can
+    /// make this value larger than the execution work actually consumed; use `gas_used` for
+    /// receipt gas.
     #[serde(with = "alloy_serde::quantity")]
     pub execution_gas_used: u64,
-    /// Gross state-dimension gas used by the transaction.
+    /// Net [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037) state gas for the whole transaction.
+    ///
+    /// Covers state creation and excludes regular execution gas. State refills and rollback have
+    /// already been deducted; this is not the peak or the sum of all positive state charges.
+    /// It remains net even under EIP-7778. Do not subtract `gas_refund` from this field.
+    /// Zero when EIP-8037 is inactive. Unlike a nested frame's signed state delta, this is
+    /// unsigned.
     #[serde(with = "alloy_serde::quantity")]
     pub state_gas_used: u64,
-    /// EIP-3529 gas refund applied at the transaction boundary.
+    /// Ordinary transaction gas refund reported after transaction-boundary refund processing.
+    ///
+    /// Subject to the [EIP-3529](https://eips.ethereum.org/EIPS/eip-3529) cap, rather than the raw
+    /// refund counter. The calldata floor can limit the fee saving; use `gas_used` for charged
+    /// gas. Excludes EIP-8037 state refills (already netted into `state_gas_used`) and unused
+    /// gas. Refunds do not fund execution and must not be subtracted when choosing a gas
+    /// limit.
     #[serde(with = "alloy_serde::quantity")]
     pub gas_refund: u64,
 }


### PR DESCRIPTION
Accept both `regularGasUsed` (the execution-apis proposal) and `executionGasUsed` when decoding state-gas, call, and opcode traces. Keep serialization as `executionGasUsed` for compatibility. This prevents proposal-shaped responses from failing to decode or silently losing the optional execution-gas breakdown.

Clarify EIP-8037 gas accounting across transaction traces, opcode logs, call frames, receipts, block headers, transaction limits, and estimation APIs. Explain regular/execution gas versus net state gas, reservoir spillover, state refills versus ordinary refunds, transaction-versus-block totals, calldata-floor caveats, and inactive-network/optional-field behavior. Link each relevant surface to the EIP and add a tracing guide directing users to receipt gas for charges and node estimation for required limits.

The matching Foundry guide is in foundry-rs/book#2076, with cheatcode documentation in foundry-rs/foundry#16772 and foundry-rs/forge-std#910.

AI assistance: Codex authored the documentation, decoding aliases, regression test, and PR text.
