### PR TITLE
fix(pubsub)!: cancel pending requests during reconnection [AI-authored]

### DIFF
--- a/crates/provider/src/builder.rs
+++ b/crates/provider/src/builder.rs
@@ -487,7 +487,7 @@ impl<L, F, N> ProviderBuilder<L, F, N> {
     /// Finish the layer stack by providing a connection string with custom configuration.
     ///
     /// This method allows for fine-grained control over connection settings
-    /// such as authentication, retry behavior, and transport-specific options.
+    /// such as authentication and transport-specific options.
     /// The transport type is extracted from the connection string and configured
     /// using the provided [`ConnectionConfig`].
     ///
@@ -497,12 +497,8 @@ impl<L, F, N> ProviderBuilder<L, F, N> {
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// use alloy_provider::{ConnectionConfig, ProviderBuilder};
     /// use alloy_transport::Authorization;
-    /// use std::time::Duration;
     ///
-    /// let config = ConnectionConfig::new()
-    ///     .with_auth(Authorization::bearer("my-token"))
-    ///     .with_max_retries(3)
-    ///     .with_retry_interval(Duration::from_secs(2));
+    /// let config = ConnectionConfig::new().with_auth(Authorization::bearer("my-token"));
     ///
     /// let provider =
     ///     ProviderBuilder::new().connect_with_config("ws://localhost:8545", config).await?;

--- a/crates/pubsub/Cargo.toml
+++ b/crates/pubsub/Cargo.toml
@@ -31,12 +31,18 @@ auto_impl.workspace = true
 bimap.workspace = true
 futures.workspace = true
 parking_lot.workspace = true
+rand.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-tokio = { workspace = true, features = ["macros", "sync"] }
+tokio = { workspace = true, features = ["macros", "sync", "time"] }
 tokio-stream = { workspace = true, features = ["sync"] }
 tower.workspace = true
 tracing.workspace = true
 
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
 wasmtimer.workspace = true
+# rand uses browser entropy on wasm32-unknown-unknown.
+getrandom = { version = "0.2", features = ["js"] }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["rt", "test-util"] }

--- a/crates/pubsub/README.md
+++ b/crates/pubsub/README.md
@@ -84,15 +84,28 @@ server ID changes across reconnections.
 
 ### Reconnection, replay, and cancellation
 
-After a retryable established-backend failure, the service attempts reconnection under its
-configured retry policy; non-retryable failures terminate it immediately. Following a successful
-reconnect, it re-sends every
-request still awaiting a response and re-creates active subscriptions. If the
-server processed a request but its response was lost, that request may execute
-more than once. Do not rely on at-most-once execution for non-idempotent methods.
+After a connection failure, the service preserves completed responses and returns
+unresolved ordinary requests to the caller with a transport error. It does not
+replay ordinary requests. The caller owns read retries and must decide which
+methods are safe to retry. The service restores active subscriptions and pending
+subscription requests that are still live.
 
-Dropping a request future stops waiting locally, but does not cancel a request
-already accepted by the service. Likewise, dropping a [`RawSubscription`] or
+Dropping a request future cancels its pending service entry. Use
+[`with_request_deadline`] to attach a monotonic deadline to a future's requests;
+the service processes cancellation and expiration during both reconnect attempts
+and backoff. Expired reads do not stop active subscriptions. Cancellation cannot
+undo work already received by the remote server. [`PartialBatchError`] retains
+completed per-ID responses when other batch items fail.
+
+Transient reconnect failures use [`RecoveryBackoff`]: the delay ceiling starts
+at 100 ms, doubles to a 500 ms cap, and each delay samples between half and all
+of its ceiling. Reconnects continue until recovery, a permanent failure, or closure
+of all frontends. The former retry-count and retry-interval builder settings
+have been removed. Native WebSocket handshake statuses 408, 429, 500, 502, 503,
+and 504 retain their HTTP type and permit reconnection; authentication failures
+terminate it.
+
+Likewise, dropping a [`RawSubscription`] or
 [`Subscription`] only drops that receiver; it does not send
 `eth_unsubscribe`. Call [`PubSubFrontend::unsubscribe`] with the local ID when
 the server-side subscription is no longer needed. `unsubscribe` only queues

--- a/crates/pubsub/src/frontend.rs
+++ b/crates/pubsub/src/frontend.rs
@@ -1,8 +1,8 @@
-use crate::{ix::PubSubInstruction, managers::InFlight, RawSubscription};
+use crate::{ix::PubSubInstruction, managers::InFlight, PartialBatchError, RawSubscription};
 use alloy_json_rpc::{RequestPacket, Response, ResponsePacket, SerializedRequest};
 use alloy_primitives::B256;
 use alloy_transport::{TransportError, TransportErrorKind, TransportFut, TransportResult};
-use futures::{future::try_join_all, FutureExt, TryFutureExt};
+use futures::{future::join_all, FutureExt, TryFutureExt};
 use std::{
     future::Future,
     sync::{
@@ -76,9 +76,23 @@ impl PubSubFrontend {
         async move {
             debug!("sending request to backend");
             let (in_flight, rx) = InFlight::new(req, channel_size);
+            let deadline = in_flight.deadline;
+            let guard = CancelOnDrop {
+                tx: tx.clone(),
+                id: in_flight.request.id().clone(),
+                identity: in_flight.identity.clone(),
+            };
             tx.send(PubSubInstruction::Request(in_flight))
                 .map_err(|_| TransportErrorKind::backend_gone())?;
-            let resp = rx.await.map_err(|_| TransportErrorKind::backend_gone())?;
+            let resp = if let Some(deadline) = deadline {
+                crate::time::timeout_at(deadline, rx).await.map_err(|_| {
+                    TransportErrorKind::custom(std::io::Error::from(std::io::ErrorKind::TimedOut))
+                })?
+            } else {
+                rx.await
+            }
+            .map_err(|_| TransportErrorKind::backend_gone())?;
+            drop(guard);
             if tracing::enabled!(tracing::Level::TRACE) {
                 trace!(?resp, "retrieved response");
             } else {
@@ -95,9 +109,28 @@ impl PubSubFrontend {
     pub fn send_packet(&self, req: RequestPacket) -> TransportFut<'static> {
         match req {
             RequestPacket::Single(req) => self.send(req).map_ok(ResponsePacket::Single).boxed(),
-            RequestPacket::Batch(reqs) => try_join_all(reqs.into_iter().map(|req| self.send(req)))
-                .map_ok(ResponsePacket::Batch)
-                .boxed(),
+            RequestPacket::Batch(reqs) => {
+                let requests = reqs.into_iter().map(|req| {
+                    let id = req.id().clone();
+                    let response = self.send(req);
+                    async move { (id, response.await) }
+                });
+                let response = join_all(requests);
+                async move {
+                    let results = response.await;
+                    if results.iter().any(|(_, result)| result.is_err()) {
+                        Err(TransportErrorKind::custom(PartialBatchError(results)))
+                    } else {
+                        Ok(ResponsePacket::Batch(
+                            results
+                                .into_iter()
+                                .map(|(_, result)| result.expect("checked above"))
+                                .collect(),
+                        ))
+                    }
+                }
+                .boxed()
+            }
         }
     }
 
@@ -134,5 +167,18 @@ impl tower::Service<RequestPacket> for PubSubFrontend {
     #[inline]
     fn call(&mut self, req: RequestPacket) -> Self::Future {
         self.send_packet(req)
+    }
+}
+
+/// Drop cancellation uses the attempt identity as well as the RPC ID, so a
+/// delayed cancellation can never remove a newer retry with that same ID.
+struct CancelOnDrop {
+    tx: mpsc::UnboundedSender<PubSubInstruction>,
+    id: alloy_json_rpc::Id,
+    identity: Arc<()>,
+}
+impl Drop for CancelOnDrop {
+    fn drop(&mut self) {
+        let _ = self.tx.send(PubSubInstruction::Cancel(self.id.clone(), self.identity.clone()));
     }
 }

--- a/crates/pubsub/src/handle.rs
+++ b/crates/pubsub/src/handle.rs
@@ -1,7 +1,6 @@
 use alloy_json_rpc::PubSubItem;
 use alloy_transport::{TransportError, TransportErrorKind};
 use serde_json::value::RawValue;
-use std::time::Duration;
 use tokio::sync::{
     mpsc,
     oneshot::{self, error::TryRecvError},
@@ -33,15 +32,6 @@ pub struct ConnectionHandle {
 
     /// Notify the backend of intentional shutdown.
     pub(crate) shutdown: oneshot::Sender<()>,
-
-    /// Max number of retries before failing and exiting the connection.
-    /// Default is 10.
-    pub(crate) max_retries: u32,
-    /// The base interval between retries.
-    ///
-    /// Reconnect retries use capped exponential backoff from this base interval.
-    /// Default is 3 seconds.
-    pub(crate) retry_interval: Duration,
 }
 
 impl ConnectionHandle {
@@ -52,14 +42,7 @@ impl ConnectionHandle {
         let (error_tx, error_rx) = oneshot::channel();
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
 
-        let handle = Self {
-            to_socket,
-            from_socket,
-            error: error_rx,
-            shutdown: shutdown_tx,
-            max_retries: 10,
-            retry_interval: Duration::from_secs(3),
-        };
+        let handle = Self { to_socket, from_socket, error: error_rx, shutdown: shutdown_tx };
         let interface = ConnectionInterface {
             from_frontend,
             to_frontend,
@@ -67,21 +50,6 @@ impl ConnectionHandle {
             shutdown: shutdown_rx,
         };
         (handle, interface)
-    }
-
-    /// Set the max number of retries before failing and exiting the connection.
-    /// Default is 10.
-    pub const fn with_max_retries(mut self, max_retries: u32) -> Self {
-        self.max_retries = max_retries;
-        self
-    }
-
-    /// Set the base interval between retries.
-    ///
-    /// Reconnect retries use capped exponential backoff from this base interval.
-    pub const fn with_retry_interval(mut self, retry_interval: Duration) -> Self {
-        self.retry_interval = retry_interval;
-        self
     }
 
     /// Shutdown the backend.
@@ -130,8 +98,8 @@ impl ConnectionInterface {
     /// Close the interface, signaling a generic backend-gone error to the
     /// frontend.
     ///
-    /// The pubsub service will attempt to reconnect using the configured
-    /// retry policy. Use [`Self::close_with_transport_error`] to opt out of
+    /// The pubsub service will attempt to reconnect using capped exponential
+    /// backoff. Use [`Self::close_with_transport_error`] to opt out of
     /// the reconnect loop on deterministic, non-retryable failures.
     pub fn close_with_error(self) {
         let _ = self.error.send(TransportErrorKind::backend_gone());

--- a/crates/pubsub/src/ix.rs
+++ b/crates/pubsub/src/ix.rs
@@ -1,12 +1,15 @@
 use crate::{managers::InFlight, RawSubscription};
+use alloy_json_rpc::Id;
 use alloy_primitives::B256;
-use std::fmt;
+use std::{fmt, sync::Arc};
 use tokio::sync::oneshot;
 
 /// Instructions for the pubsub service.
 pub enum PubSubInstruction {
     /// Send a request.
     Request(InFlight),
+    /// Cancel this exact request attempt.
+    Cancel(Id, Arc<()>),
     /// Get the subscription ID for a local ID.
     GetSub(B256, oneshot::Sender<Option<RawSubscription>>),
     /// Unsubscribe from a subscription.
@@ -17,6 +20,7 @@ impl fmt::Debug for PubSubInstruction {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Request(arg0) => f.debug_tuple("Request").field(arg0).finish(),
+            Self::Cancel(id, _) => f.debug_tuple("Cancel").field(id).finish(),
             Self::GetSub(arg0, _) => f.debug_tuple("GetSub").field(arg0).finish(),
             Self::Unsubscribe(arg0) => f.debug_tuple("Unsubscribe").field(arg0).finish(),
         }

--- a/crates/pubsub/src/lib.rs
+++ b/crates/pubsub/src/lib.rs
@@ -36,7 +36,7 @@ pub use sub::{
 use getrandom as _; // Enable rand's browser entropy source.
 
 mod recovery;
-pub use recovery::{with_request_deadline, PartialBatchError, RecoveryBackoff};
+pub use recovery::{with_request_timings, PartialBatchError, RecoveryBackoff, RequestTimings};
 
 // Preserve the transport's native and browser clock implementations.
 mod time {

--- a/crates/pubsub/src/lib.rs
+++ b/crates/pubsub/src/lib.rs
@@ -31,3 +31,20 @@ pub use sub::{
     RawSubscription, SubAnyStream, SubResultStream, Subscription, SubscriptionItem,
     SubscriptionStream,
 };
+
+#[cfg(all(target_family = "wasm", target_os = "unknown"))]
+use getrandom as _; // Enable rand's browser entropy source.
+
+mod recovery;
+pub use recovery::{with_request_deadline, PartialBatchError, RecoveryBackoff};
+
+// Preserve the transport's native and browser clock implementations.
+mod time {
+    #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+    pub(crate) use tokio::time::{sleep_until, timeout_at, Instant};
+    #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+    pub(crate) use wasmtimer::{
+        std::Instant,
+        tokio::{sleep_until, timeout_at},
+    };
+}

--- a/crates/pubsub/src/managers/in_flight.rs
+++ b/crates/pubsub/src/managers/in_flight.rs
@@ -1,6 +1,7 @@
+use crate::{recovery::REQUEST_DEADLINE, time::Instant};
 use alloy_json_rpc::{Response, ResponsePayload, SerializedRequest, SubId};
 use alloy_transport::{TransportError, TransportResult};
-use std::fmt;
+use std::{fmt, sync::Arc};
 use tokio::sync::oneshot;
 
 /// An in-flight JSON-RPC request.
@@ -8,6 +9,10 @@ use tokio::sync::oneshot;
 /// This struct contains the request that was sent, as well as a channel to
 /// receive the response on.
 pub struct InFlight {
+    /// Monotonic deadline supplied by the provider.
+    pub deadline: Option<Instant>,
+    pub(crate) identity: Arc<()>,
+    pub(crate) subscription_replay: bool,
     /// The request
     pub request: SerializedRequest,
 
@@ -36,7 +41,22 @@ impl InFlight {
     ) -> (Self, oneshot::Receiver<TransportResult<Response>>) {
         let (tx, rx) = oneshot::channel();
 
-        (Self { request, channel_size, tx }, rx)
+        (
+            Self {
+                request,
+                channel_size,
+                tx,
+                deadline: REQUEST_DEADLINE.try_with(|deadline| *deadline).ok(),
+                identity: Arc::new(()),
+                subscription_replay: false,
+            },
+            rx,
+        )
+    }
+
+    pub(crate) fn is_live(&self) -> bool {
+        (self.subscription_replay || !self.tx.is_closed())
+            && self.deadline.is_none_or(|deadline| Instant::now() < deadline)
     }
 
     /// Check if the request is a subscription.
@@ -55,6 +75,9 @@ impl InFlight {
     /// request. If the request is a subscription and the response is not an
     /// error, the subscription ID and the in-flight request are returned.
     pub fn fulfill(self, resp: Response) -> Option<(SubId, Self)> {
+        if !self.is_live() {
+            return None;
+        }
         if self.is_subscription() {
             if let ResponsePayload::Success(val) = resp.payload {
                 let sub_id: serde_json::Result<SubId> = serde_json::from_str(val.get());

--- a/crates/pubsub/src/managers/in_flight.rs
+++ b/crates/pubsub/src/managers/in_flight.rs
@@ -1,4 +1,7 @@
-use crate::{recovery::REQUEST_DEADLINE, time::Instant};
+use crate::{
+    recovery::{RequestTimings, REQUEST_TIMINGS},
+    time::Instant,
+};
 use alloy_json_rpc::{Response, ResponsePayload, SerializedRequest, SubId};
 use alloy_transport::{TransportError, TransportResult};
 use std::{fmt, sync::Arc};
@@ -11,6 +14,7 @@ use tokio::sync::oneshot;
 pub struct InFlight {
     /// Monotonic deadline supplied by the provider.
     pub deadline: Option<Instant>,
+    timings: Option<RequestTimings>,
     pub(crate) identity: Arc<()>,
     pub(crate) subscription_replay: bool,
     /// The request
@@ -40,13 +44,16 @@ impl InFlight {
         channel_size: usize,
     ) -> (Self, oneshot::Receiver<TransportResult<Response>>) {
         let (tx, rx) = oneshot::channel();
+        let timings = REQUEST_TIMINGS.try_with(Clone::clone).ok();
+        let deadline = timings.as_ref().and_then(|timings| timings.deadline(request.id()));
 
         (
             Self {
                 request,
                 channel_size,
                 tx,
-                deadline: REQUEST_DEADLINE.try_with(|deadline| *deadline).ok(),
+                deadline,
+                timings,
                 identity: Arc::new(()),
                 subscription_replay: false,
             },
@@ -75,8 +82,14 @@ impl InFlight {
     /// request. If the request is a subscription and the response is not an
     /// error, the subscription ID and the in-flight request are returned.
     pub fn fulfill(self, resp: Response) -> Option<(SubId, Self)> {
-        if !self.is_live() {
+        let received_at = Instant::now();
+        if (self.tx.is_closed() && !self.subscription_replay)
+            || self.deadline.is_some_and(|deadline| received_at >= deadline)
+        {
             return None;
+        }
+        if let Some(timings) = &self.timings {
+            timings.record_response(self.request.id(), received_at);
         }
         if self.is_subscription() {
             if let ResponsePayload::Success(val) = resp.payload {

--- a/crates/pubsub/src/managers/req.rs
+++ b/crates/pubsub/src/managers/req.rs
@@ -1,6 +1,8 @@
-use crate::managers::InFlight;
+use crate::{managers::InFlight, time::Instant};
 use alloy_json_rpc::{Id, Response, SubId};
 use alloy_primitives::map::HashMap;
+use alloy_transport::TransportErrorKind;
+use std::{io, sync::Arc};
 
 /// Manages in-flight requests.
 #[derive(Debug, Default)]
@@ -22,6 +24,47 @@ impl RequestManager {
     /// Insert a new in-flight request.
     pub(crate) fn insert(&mut self, in_flight: InFlight) {
         self.reqs.insert(in_flight.request.id().clone(), in_flight);
+    }
+
+    pub(crate) fn cancel(&mut self, id: &Id, identity: &Arc<()>) {
+        if self.reqs.get(id).is_some_and(|request| Arc::ptr_eq(&request.identity, identity)) {
+            self.reqs.remove(id);
+        }
+    }
+
+    pub(crate) fn next_deadline(&self) -> Option<Instant> {
+        self.reqs.values().filter_map(|request| request.deadline).min()
+    }
+
+    pub(crate) fn expire(&mut self) {
+        for (_, request) in self.reqs.extract_if(|_, request| !request.is_live()) {
+            // Closing the channel alone would report BackendGone even though
+            // the connection manager still serves active subscriptions.
+            let _ = request
+                .tx
+                .send(Err(TransportErrorKind::custom(io::Error::from(io::ErrorKind::TimedOut))));
+        }
+    }
+
+    pub(crate) fn fail_all(&mut self, detail: &str) {
+        for (_, request) in std::mem::take(&mut self.reqs) {
+            let _ = request.tx.send(Err(TransportErrorKind::non_retryable_str(detail)));
+        }
+    }
+
+    pub(crate) fn disconnect(&mut self) {
+        // Completed responses have already left this map. The provider alone
+        // retries reads; this manager only restores subscriptions.
+        let pending = std::mem::take(&mut self.reqs);
+        for (id, request) in pending {
+            if request.is_subscription() && request.is_live() && !request.subscription_replay {
+                self.reqs.insert(id, request);
+            } else {
+                let _ = request.tx.send(Err(TransportErrorKind::custom(io::Error::from(
+                    io::ErrorKind::ConnectionReset,
+                ))));
+            }
+        }
     }
 
     /// Handle a response by sending the payload to the waiter.

--- a/crates/pubsub/src/recovery.rs
+++ b/crates/pubsub/src/recovery.rs
@@ -3,16 +3,78 @@ use crate::time::Instant;
 use alloy_json_rpc::{Id, Response};
 use alloy_transport::TransportResult;
 use rand::Rng;
-use std::{fmt, future::Future, time::Duration};
+use std::{
+    collections::HashMap,
+    fmt,
+    future::Future,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
 
 tokio::task_local! {
-    pub(crate) static REQUEST_DEADLINE: Instant;
+    pub(crate) static REQUEST_TIMINGS: RequestTimings;
 }
 
-/// Attach the provider's monotonic deadline to requests sent by this future.
-/// This metadata stays local and never changes the JSON-RPC wire request.
-pub async fn with_request_deadline<T>(deadline: Instant, future: impl Future<Output = T>) -> T {
-    REQUEST_DEADLINE.scope(deadline, future).await
+#[derive(Debug)]
+struct RequestTiming {
+    deadline: Instant,
+    received_at: Option<Instant>,
+}
+
+/// Local timing evidence for one physical attempt, indexed by JSON-RPC ID.
+///
+/// Pubsub responses arrive independently. Their arrival times must survive
+/// packet aggregation so a completed item does not expire while a sibling waits.
+/// Create fresh metadata for each attempt; retries must not reuse arrival times.
+#[derive(Debug, Clone)]
+pub struct RequestTimings(Arc<Mutex<HashMap<Id, RequestTiming>>>);
+
+impl RequestTimings {
+    /// Set each item's deadline, including the physical attempt timeout.
+    pub fn new(deadlines: impl IntoIterator<Item = (Id, Instant)>) -> Self {
+        Self(Arc::new(Mutex::new(
+            deadlines
+                .into_iter()
+                .map(|(id, deadline)| (id, RequestTiming { deadline, received_at: None }))
+                .collect(),
+        )))
+    }
+
+    /// Return the deadline supplied for this ID.
+    pub fn deadline(&self, id: &Id) -> Option<Instant> {
+        self.0
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .get(id)
+            .map(|timing| timing.deadline)
+    }
+
+    /// Return when the connection manager accepted this item's response.
+    /// Missing entries do not establish that a response arrived before expiry.
+    pub fn received_at(&self, id: &Id) -> Option<Instant> {
+        self.0
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .get(id)
+            .and_then(|timing| timing.received_at)
+    }
+
+    pub(crate) fn record_response(&self, id: &Id, received_at: Instant) {
+        if let Some(timing) =
+            self.0.lock().unwrap_or_else(std::sync::PoisonError::into_inner).get_mut(id)
+        {
+            timing.received_at = Some(received_at);
+        }
+    }
+}
+
+/// Attach per-item deadlines and arrival metadata to requests sent by this future.
+/// The metadata stays local and never changes the JSON-RPC wire request.
+pub async fn with_request_timings<T>(
+    timings: RequestTimings,
+    future: impl Future<Output = T>,
+) -> T {
+    REQUEST_TIMINGS.scope(timings, future).await
 }
 
 /// Capped exponential backoff shared by read recovery and connection recovery.
@@ -56,7 +118,80 @@ impl std::error::Error for PartialBatchError {}
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::managers::InFlight;
+    use alloy_json_rpc::Request;
     use rand::{rngs::StdRng, SeedableRng};
+
+    #[tokio::test(start_paused = true)]
+    async fn batch_items_keep_distinct_deadlines_and_original_receipt_times() {
+        let started = Instant::now();
+        let early = Id::Number(11);
+        let late = Id::Number(22);
+        let timings = RequestTimings::new([
+            (early.clone(), started + Duration::from_millis(5)),
+            (late.clone(), started + Duration::from_millis(20)),
+        ]);
+        with_request_timings(timings.clone(), async {
+            let (first, first_rx) = InFlight::new(
+                Request::new("eth_call", early.clone(), ("0x11", "0x123")).serialize().unwrap(),
+                16,
+            );
+            let (second, second_rx) = InFlight::new(
+                Request::new("eth_call", late.clone(), ("0x22", "0x456")).serialize().unwrap(),
+                16,
+            );
+            assert_eq!(first.deadline, Some(started + Duration::from_millis(5)));
+            assert_eq!(second.deadline, Some(started + Duration::from_millis(20)));
+            let response = |id| Response {
+                id,
+                payload: alloy_json_rpc::ResponsePayload::Success(
+                    serde_json::value::to_raw_value("0x42").unwrap(),
+                ),
+            };
+            first.fulfill(response(early.clone()));
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            second.fulfill(response(late.clone()));
+            assert_eq!(first_rx.await.unwrap().unwrap().id, early);
+            assert_eq!(second_rx.await.unwrap().unwrap().id, late);
+        })
+        .await;
+        assert_eq!(timings.received_at(&early), Some(started));
+        assert_eq!(timings.received_at(&late), Some(started + Duration::from_millis(10)));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn expired_and_cancelled_reads_do_not_record_successful_receipts() {
+        let started = Instant::now();
+        let timings = RequestTimings::new([
+            (Id::Number(1), started + Duration::from_millis(5)),
+            (Id::Number(2), started + Duration::from_millis(20)),
+        ]);
+        with_request_timings(timings.clone(), async {
+            let (expired, expired_rx) = InFlight::new(
+                Request::new("eth_blockNumber", Id::Number(1), ()).serialize().unwrap(),
+                16,
+            );
+            let (cancelled, cancelled_rx) = InFlight::new(
+                Request::new("eth_blockNumber", Id::Number(2), ()).serialize().unwrap(),
+                16,
+            );
+            drop(cancelled_rx);
+            tokio::time::sleep(Duration::from_millis(5)).await;
+            for request in [expired, cancelled] {
+                let id = request.request.id().clone();
+                request.fulfill(Response {
+                    id,
+                    payload: alloy_json_rpc::ResponsePayload::Success(
+                        serde_json::value::to_raw_value("0x42").unwrap(),
+                    ),
+                });
+            }
+            assert!(expired_rx.await.is_err());
+        })
+        .await;
+        assert_eq!(timings.received_at(&Id::Number(1)), None);
+        assert_eq!(timings.received_at(&Id::Number(2)), None);
+    }
 
     #[test]
     fn capped_exponential_backoff_obeys_both_jitter_bounds() {

--- a/crates/pubsub/src/recovery.rs
+++ b/crates/pubsub/src/recovery.rs
@@ -1,0 +1,100 @@
+//! Request lifecycle metadata and the shared recovery backoff.
+use crate::time::Instant;
+use alloy_json_rpc::{Id, Response};
+use alloy_transport::TransportResult;
+use rand::Rng;
+use std::{fmt, future::Future, time::Duration};
+
+tokio::task_local! {
+    pub(crate) static REQUEST_DEADLINE: Instant;
+}
+
+/// Attach the provider's monotonic deadline to requests sent by this future.
+/// This metadata stays local and never changes the JSON-RPC wire request.
+pub async fn with_request_deadline<T>(deadline: Instant, future: impl Future<Output = T>) -> T {
+    REQUEST_DEADLINE.scope(deadline, future).await
+}
+
+/// Capped exponential backoff shared by read recovery and connection recovery.
+#[derive(Debug, Clone)]
+pub struct RecoveryBackoff {
+    ceiling_ms: u64,
+}
+
+impl Default for RecoveryBackoff {
+    fn default() -> Self {
+        Self { ceiling_ms: 100 }
+    }
+}
+
+impl RecoveryBackoff {
+    /// Sample between half and all of the current ceiling, then double the
+    /// next ceiling up to 500 ms.
+    pub fn next_delay(&mut self) -> Duration {
+        self.sample_delay(&mut rand::thread_rng())
+    }
+
+    fn sample_delay(&mut self, rng: &mut impl Rng) -> Duration {
+        let delay = rng.gen_range(self.ceiling_ms / 2..=self.ceiling_ms);
+        self.ceiling_ms = (self.ceiling_ms * 2).min(500);
+        Duration::from_millis(delay)
+    }
+}
+
+/// A batch can contain completed responses alongside lost connections.
+/// Retaining each ID lets the provider retry only unresolved reads.
+#[derive(Debug)]
+pub struct PartialBatchError(pub Vec<(Id, TransportResult<Response>)>);
+
+impl fmt::Display for PartialBatchError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "RPC batch contains {} item results", self.0.len())
+    }
+}
+impl std::error::Error for PartialBatchError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::{rngs::StdRng, SeedableRng};
+
+    #[test]
+    fn capped_exponential_backoff_obeys_both_jitter_bounds() {
+        let mut rng = StdRng::seed_from_u64(113);
+        for _ in 0..1000 {
+            let mut backoff = RecoveryBackoff::default();
+            for ceiling in [100, 200, 400, 500, 500, 500] {
+                let delay = backoff.sample_delay(&mut rng);
+                assert!((Duration::from_millis(ceiling / 2)..=Duration::from_millis(ceiling))
+                    .contains(&delay));
+            }
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn seeded_callers_follow_different_bounded_schedules() {
+        async fn caller(seed: u64) -> Vec<Duration> {
+            let start = Instant::now();
+            let mut backoff = RecoveryBackoff::default();
+            let mut rng = StdRng::seed_from_u64(seed);
+            let mut times = Vec::new();
+            for _ in 0..6 {
+                let delay = backoff.sample_delay(&mut rng);
+                tokio::time::sleep(delay).await;
+                times.push(start.elapsed());
+            }
+            times
+        }
+        let (first, second) = tokio::join!(caller(113), caller(114));
+        assert_ne!(first, second);
+        for times in [first, second] {
+            let mut previous = Duration::ZERO;
+            for (at, ceiling) in times.into_iter().zip([100, 200, 400, 500, 500, 500]) {
+                let delay = at - previous;
+                assert!((Duration::from_millis(ceiling / 2)..=Duration::from_millis(ceiling + 1))
+                    .contains(&delay));
+                previous = at;
+            }
+        }
+    }
+}

--- a/crates/pubsub/src/service.rs
+++ b/crates/pubsub/src/service.rs
@@ -591,3 +591,95 @@ mod tests {
         );
     }
 }
+
+#[cfg(test)]
+mod recovery_regressions {
+    use super::*;
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
+    use tokio::time::timeout;
+
+    #[derive(Debug)]
+    struct NextConnection(std::sync::Mutex<Option<ConnectionHandle>>);
+    impl PubSubConnect for NextConnection {
+        fn is_local(&self) -> bool {
+            true
+        }
+        async fn connect(&self) -> TransportResult<ConnectionHandle> {
+            self.0.lock().unwrap().take().ok_or_else(TransportErrorKind::backend_gone)
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    struct Refused(Arc<AtomicUsize>);
+
+    impl PubSubConnect for Refused {
+        fn is_local(&self) -> bool {
+            true
+        }
+        async fn connect(&self) -> TransportResult<ConnectionHandle> {
+            self.0.fetch_add(1, Ordering::SeqCst);
+            Err(TransportErrorKind::custom(std::io::Error::from(
+                std::io::ErrorKind::ConnectionRefused,
+            )))
+        }
+    }
+
+    #[tokio::test]
+    async fn dropping_frontend_stops_reconnect_work() {
+        let (handle, interface) = ConnectionHandle::new();
+        let calls = Arc::new(AtomicUsize::new(0));
+        let (tx, reqs) = mpsc::unbounded_channel();
+        let service = PubSubService {
+            handle,
+            connector: Refused(calls.clone()),
+            reqs,
+            subs: SubscriptionManager::default(),
+            in_flights: RequestManager::default(),
+        };
+        service.spawn();
+        interface.close_with_error();
+        timeout(Duration::from_secs(1), async {
+            while calls.load(Ordering::SeqCst) == 0 {
+                sleep(Duration::from_millis(1)).await;
+            }
+        })
+        .await
+        .unwrap();
+        drop(tx);
+        sleep(Duration::from_millis(50)).await;
+        let stopped = calls.load(Ordering::SeqCst);
+        sleep(Duration::from_secs(4)).await;
+        assert_eq!(calls.load(Ordering::SeqCst), stopped, "closed provider kept reconnecting");
+    }
+
+    #[tokio::test]
+    async fn cancelled_request_does_not_replay_after_reconnect() {
+        let (handle, interface) = ConnectionHandle::new();
+        let (new_handle, mut new_interface) = ConnectionHandle::new();
+        let connector = NextConnection(std::sync::Mutex::new(Some(new_handle)));
+        let (tx, reqs) = mpsc::unbounded_channel();
+        let mut service = PubSubService {
+            handle,
+            connector,
+            reqs,
+            subs: SubscriptionManager::default(),
+            in_flights: RequestManager::default(),
+        };
+        let request =
+            Request::new("eth_call", Id::Number(91), ("exact", "0x123")).serialize().unwrap();
+        let (pending, rx) = InFlight::new(request, 16);
+        service.in_flights.insert(pending);
+        drop(rx);
+        drop(interface);
+        service.reconnect().await.unwrap();
+        assert!(
+            timeout(Duration::from_millis(100), new_interface.recv_from_frontend()).await.is_err(),
+            "cancelled request was replayed"
+        );
+        assert_eq!(service.in_flights.len(), 0);
+        drop(tx);
+    }
+}

--- a/crates/pubsub/src/service.rs
+++ b/crates/pubsub/src/service.rs
@@ -2,7 +2,8 @@ use crate::{
     handle::ConnectionHandle,
     ix::PubSubInstruction,
     managers::{InFlight, RequestManager, SubscriptionManager},
-    PubSubConnect, PubSubFrontend, RawSubscription,
+    time::{sleep_until, Instant},
+    PubSubConnect, PubSubFrontend, RawSubscription, RecoveryBackoff,
 };
 use alloy_json_rpc::{Id, PubSubItem, Request, Response, ResponsePayload, RpcError, SubId};
 use alloy_primitives::B256;
@@ -10,17 +11,27 @@ use alloy_transport::{
     utils::{to_json_raw_value, Spawnable},
     TransportErrorKind, TransportResult,
 };
+#[cfg(not(target_family = "wasm"))]
+use futures::future::BoxFuture;
+#[cfg(target_family = "wasm")]
+use futures::future::LocalBoxFuture as BoxFuture;
 use serde_json::value::RawValue;
-use std::time::Duration;
+use std::{future::pending, sync::Arc};
 use tokio::sync::{mpsc, oneshot};
 
-#[cfg(all(target_family = "wasm", target_os = "unknown"))]
-use wasmtimer::tokio::sleep;
+#[cfg(test)]
+use tokio::time::{sleep, Duration};
 
-#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
-use tokio::time::sleep;
+enum ConnectionState {
+    Connected,
+    Waiting(Instant),
+    Connecting(BoxFuture<'static, TransportResult<ConnectionHandle>>),
+}
 
-const MAX_RECONNECT_RETRY_INTERVAL: Duration = Duration::from_secs(30);
+enum ReconnectEvent {
+    Start,
+    Complete(TransportResult<ConnectionHandle>),
+}
 
 /// The service contains the backend handle, a subscription manager, and the
 /// configuration details required to reconnect.
@@ -30,7 +41,7 @@ pub(crate) struct PubSubService<T> {
     pub(crate) handle: ConnectionHandle,
 
     /// The configuration details required to reconnect.
-    pub(crate) connector: T,
+    pub(crate) connector: Arc<T>,
 
     /// The inbound requests.
     pub(crate) reqs: mpsc::UnboundedReceiver<PubSubInstruction>,
@@ -50,7 +61,7 @@ impl<T: PubSubConnect> PubSubService<T> {
         let (tx, reqs) = mpsc::unbounded_channel();
         let this = Self {
             handle,
-            connector,
+            connector: Arc::new(connector),
             reqs,
             subs: SubscriptionManager::default(),
             in_flights: Default::default(),
@@ -59,19 +70,9 @@ impl<T: PubSubConnect> PubSubService<T> {
         Ok(PubSubFrontend::new(tx))
     }
 
-    /// Reconnect by dropping the backend and creating a new one.
-    async fn get_new_backend(&mut self) -> TransportResult<ConnectionHandle> {
-        let mut handle = self.connector.try_reconnect().await?;
-        std::mem::swap(&mut self.handle, &mut handle);
-        Ok(handle)
-    }
-
-    /// Reconnect the backend, re-issue pending requests, and re-start active
-    /// subscriptions.
-    async fn reconnect(&mut self) -> TransportResult<()> {
-        debug!("Reconnecting pubsub service backend");
-
-        let mut old_handle = self.get_new_backend().await?;
+    /// Install a new backend and restore live subscriptions.
+    fn install_backend(&mut self, mut old_handle: ConnectionHandle) -> TransportResult<()> {
+        std::mem::swap(&mut self.handle, &mut old_handle);
 
         debug!("Draining old backend to_handle");
 
@@ -82,7 +83,9 @@ impl<T: PubSubConnect> PubSubService<T> {
 
         old_handle.shutdown();
 
-        // Re-issue pending requests.
+        self.in_flights.expire();
+
+        // Re-issue pending subscription requests.
         debug!(count = self.in_flights.len(), "Reissuing pending requests");
         for (_, in_flight) in self.in_flights.iter() {
             let msg = in_flight.request.serialized().to_owned();
@@ -98,7 +101,8 @@ impl<T: PubSubConnect> PubSubService<T> {
         // Dispatch all subscription requests.
         for (_, sub) in self.subs.iter() {
             let req = sub.request().to_owned();
-            let (in_flight, _) = InFlight::new(req.clone(), sub.tx.receiver_count());
+            let (mut in_flight, _) = InFlight::new(req.clone(), sub.tx.receiver_count());
+            in_flight.subscription_replay = true;
             self.in_flights.insert(in_flight);
 
             let msg = req.into_serialized();
@@ -115,12 +119,12 @@ impl<T: PubSubConnect> PubSubService<T> {
 
     /// Service a request.
     fn service_request(&mut self, in_flight: InFlight) -> TransportResult<()> {
-        let brv = in_flight.request();
-
-        self.dispatch_request(brv.serialized().to_owned())?;
+        if !in_flight.is_live() {
+            return Ok(());
+        }
+        let brv = in_flight.request().serialized().to_owned();
         self.in_flights.insert(in_flight);
-
-        Ok(())
+        self.dispatch_request(brv)
     }
 
     /// Service a GetSub instruction.
@@ -149,6 +153,10 @@ impl<T: PubSubConnect> PubSubService<T> {
         trace!(?ix, "servicing instruction");
         match ix {
             PubSubInstruction::Request(in_flight) => self.service_request(in_flight),
+            PubSubInstruction::Cancel(id, identity) => {
+                self.in_flights.cancel(&id, &identity);
+                Ok(())
+            }
             PubSubInstruction::GetSub(alias, tx) => {
                 self.service_get_sub(alias, tx);
                 Ok(())
@@ -193,130 +201,157 @@ impl<T: PubSubConnect> PubSubService<T> {
         Ok(())
     }
 
-    /// Attempt to reconnect with retries.
-    ///
-    /// Aborts immediately when a reconnect attempt returns a
-    /// [`TransportErrorKind::NonRetryable`] error so deterministic backend
-    /// failures (auth/protocol violations, malformed handshake, etc.) do not
-    /// burn the full retry budget.
-    async fn reconnect_with_retries(&mut self) -> TransportResult<()> {
-        let mut retry_count = 0;
-        let max_retries = self.handle.max_retries;
-        let interval = self.handle.retry_interval;
-        loop {
-            match self.reconnect().await {
-                Ok(()) => break Ok(()),
-                Err(e) => {
-                    if matches!(&e, RpcError::Transport(k) if k.is_non_retryable()) {
-                        error!("Reconnect aborted (non-retryable), shutting down: {e}");
-                        break Err(e);
-                    }
-                    retry_count += 1;
-                    if retry_count >= max_retries {
-                        error!("Reconnect failed after {max_retries} attempts, shutting down: {e}");
-                        break Err(e);
-                    }
-                    let retry_interval = reconnect_retry_interval(interval, retry_count);
-                    warn!(
-                        "Reconnection attempt {retry_count}/{max_retries} failed: {e}. \
-                         Retrying in {retry_interval:?}...",
-                    );
-                    sleep(retry_interval).await;
+    fn disconnect(&mut self) -> TransportResult<()> {
+        // Process every completed item before failing unresolved reads.
+        while let Ok(item) = self.handle.from_socket.try_recv() {
+            self.handle_item(item)?;
+        }
+        self.in_flights.disconnect();
+        Ok(())
+    }
+
+    fn disconnected_instruction(&mut self, ix: PubSubInstruction) {
+        match ix {
+            PubSubInstruction::Request(request) if request.is_subscription() => {
+                if request.is_live() {
+                    self.in_flights.insert(request);
                 }
+            }
+            PubSubInstruction::Request(request) => {
+                let _ = request.tx.send(Err(TransportErrorKind::custom(std::io::Error::from(
+                    std::io::ErrorKind::NotConnected,
+                ))));
+            }
+            PubSubInstruction::Cancel(id, identity) => self.in_flights.cancel(&id, &identity),
+            PubSubInstruction::GetSub(id, tx) => self.service_get_sub(id, tx),
+            PubSubInstruction::Unsubscribe(id) => {
+                self.subs.remove_sub(id);
             }
         }
     }
 
-    /// Spawn the service.
+    fn fail_requests(&mut self, error: &alloy_transport::TransportError) {
+        let detail = error.to_string();
+        self.in_flights.fail_all(&detail);
+        self.reqs.close();
+        while let Ok(instruction) = self.reqs.try_recv() {
+            if let PubSubInstruction::Request(request) = instruction {
+                let _ = request.tx.send(Err(TransportErrorKind::non_retryable_str(&detail)));
+            }
+        }
+    }
+
+    /// Process cancellation, expiry, and provider closure even during a slow
+    /// reconnect or its backoff. Only the provider retries read requests.
     pub(crate) fn spawn(mut self) {
-        let fut = async move {
-            let result: TransportResult<()> = loop {
-                // We bias the loop so that we always handle new messages before
-                // reconnecting, and always reconnect before dispatching new
-                // requests.
+        async move {
+            let mut state = ConnectionState::Connected;
+            let mut backoff = RecoveryBackoff::default();
+            loop {
+                self.in_flights.expire();
+                let deadline = self.in_flights.next_deadline();
+                let connected = matches!(state, ConnectionState::Connected);
                 tokio::select! {
                     biased;
-
-                    item_opt = self.handle.from_socket.recv() => {
-                        if let Some(item) = item_opt {
-                            if let Err(e) = self.handle_item(item) {
-                                break Err(e)
+                    request = self.reqs.recv() => {
+                        let Some(request) = request else { break; };
+                        if connected {
+                            if let Err(error) = self.service_ix(request) {
+                                if !error.as_transport_err().is_some_and(TransportErrorKind::is_backend_gone) { break; }
+                                if self.disconnect().is_err() { break; }
+                                state = ConnectionState::Waiting(Instant::now() + backoff.next_delay());
                             }
                         } else {
-                            // The backend dropped its `to_frontend` sender.
-                            // It may have also signaled a typed error via the
-                            // `error` oneshot; drain it before reconnecting
-                            // so a non-retryable error short-circuits the loop.
-                            if let Ok(err) = self.handle.error.try_recv() {
-                                if matches!(&err, RpcError::Transport(k) if k.is_non_retryable()) {
-                                    error!(%err, "Pubsub service backend reported a non-retryable error, shutting down.");
-                                    break Err(err)
-                                }
-                                error!(%err, "Pubsub service backend error.");
-                            }
-                            if let Err(e) = self.reconnect_with_retries().await {
-                                break Err(e)
-                            }
+                            self.disconnected_instruction(request);
                         }
                     }
-
-                    res = &mut self.handle.error => {
-                        // The backend signaled a terminal error. The carried
-                        // `TransportError` indicates whether it is recoverable.
-                        // If the sender was dropped without a value, fall back
-                        // to a generic backend-gone error.
-                        let err = res.unwrap_or_else(|_| TransportErrorKind::backend_gone());
-                        if matches!(&err, RpcError::Transport(k) if k.is_non_retryable()) {
-                            error!(%err, "Pubsub service backend reported a non-retryable error, shutting down.");
-                            break Err(err)
-                        }
-                        error!(%err, "Pubsub service backend error.");
-                        if let Err(e) = self.reconnect_with_retries().await {
-                            break Err(e)
+                    () = async {
+                        if let Some(deadline) = deadline { sleep_until(deadline).await; }
+                        else { pending::<()>().await; }
+                    } => { self.in_flights.expire(); }
+                    item = self.handle.from_socket.recv(), if connected => {
+                        if let Some(item) = item {
+                            if self.handle_item(item).is_err() { break; }
+                            backoff = RecoveryBackoff::default();
+                        } else {
+                            if let Ok(error @ RpcError::Transport(TransportErrorKind::NonRetryable(_))) = self.handle.error.try_recv() {
+                                self.fail_requests(&error);
+                                break;
+                            }
+                            if self.disconnect().is_err() { break; }
+                            state = ConnectionState::Waiting(Instant::now() + backoff.next_delay());
                         }
                     }
-
-                    req_opt = self.reqs.recv() => {
-                        if let Some(req) = req_opt {
-                            if let Err(err) = self.service_ix(req) {
-                                if err
-                                    .as_transport_err()
-                                    .is_some_and(TransportErrorKind::is_backend_gone)
-                                {
-                                    if let Err(e) = self.reconnect_with_retries().await {
-                                        break Err(e)
-                                    }
+                    error = &mut self.handle.error, if connected => {
+                        if let Ok(error @ RpcError::Transport(TransportErrorKind::NonRetryable(_))) = error {
+                            self.fail_requests(&error);
+                            break;
+                        }
+                        if self.disconnect().is_err() { break; }
+                        state = ConnectionState::Waiting(Instant::now() + backoff.next_delay());
+                    }
+                    event = async {
+                        match &mut state {
+                            ConnectionState::Connected => pending().await,
+                            ConnectionState::Waiting(at) => { sleep_until(*at).await; ReconnectEvent::Start }
+                            ConnectionState::Connecting(attempt) => ReconnectEvent::Complete(attempt.await),
+                        }
+                    }, if !connected => {
+                        match event {
+                            ReconnectEvent::Start => {
+                                let connector = self.connector.clone();
+                                state = ConnectionState::Connecting(Box::pin(async move { connector.try_reconnect().await }));
+                            }
+                            ReconnectEvent::Complete(Ok(handle)) => {
+                                if self.install_backend(handle).is_err() {
+                                    if self.disconnect().is_err() { break; }
+                                    state = ConnectionState::Waiting(Instant::now() + backoff.next_delay());
                                 } else {
-                                    break Err(err)
+                                    // A socket handshake alone does not prove recovery.
+                                    // Reset backoff only after receiving a response or notification.
+                                    state = ConnectionState::Connected;
                                 }
                             }
-                        } else {
-                            info!("Pubsub service request channel closed. Shutting down.");
-                           break Ok(())
+                            ReconnectEvent::Complete(Err(error)) => {
+                                if !transient_connect_error(&error) { self.fail_requests(&error); break; }
+                                state = ConnectionState::Waiting(Instant::now() + backoff.next_delay());
+                            }
                         }
                     }
                 }
-            };
-
-            if let Err(err) = result {
-                error!(%err, "pubsub service reconnection error");
             }
-        };
-        fut.spawn_task();
+            self.handle.shutdown();
+        }.spawn_task();
     }
 }
 
-/// Returns the capped exponential backoff interval for a reconnect retry.
-///
-/// The configured retry interval is used as the base delay. Retry counts are 1-based, so the first
-/// failed attempt waits for the base interval, the second waits for twice the base interval, and so
-/// on. The delay is capped at [`MAX_RECONNECT_RETRY_INTERVAL`], unless the configured base interval
-/// is already higher, in which case the configured base interval is preserved.
-fn reconnect_retry_interval(base_interval: Duration, retry_count: u32) -> Duration {
-    let backoff_multiplier = 1u32.checked_shl(retry_count.saturating_sub(1)).unwrap_or(u32::MAX);
-    let max_interval = base_interval.max(MAX_RECONNECT_RETRY_INTERVAL);
-
-    base_interval.saturating_mul(backoff_multiplier).min(max_interval)
+fn transient_connect_error(error: &alloy_transport::TransportError) -> bool {
+    if let RpcError::Transport(TransportErrorKind::HttpError(error)) = error {
+        return matches!(error.status, 408 | 429 | 500 | 502 | 503 | 504);
+    }
+    if let RpcError::Transport(TransportErrorKind::BackendGone) = error {
+        return true;
+    }
+    if let RpcError::Transport(TransportErrorKind::Custom(error)) = error {
+        let mut source: Option<&(dyn std::error::Error + 'static)> = Some(error.as_ref());
+        while let Some(error) = source {
+            if let Some(error) = error.downcast_ref::<std::io::Error>() {
+                return matches!(
+                    error.kind(),
+                    std::io::ErrorKind::NotFound
+                        | std::io::ErrorKind::ConnectionRefused
+                        | std::io::ErrorKind::ConnectionReset
+                        | std::io::ErrorKind::ConnectionAborted
+                        | std::io::ErrorKind::BrokenPipe
+                        | std::io::ErrorKind::NotConnected
+                        | std::io::ErrorKind::TimedOut
+                        | std::io::ErrorKind::UnexpectedEof
+                );
+            }
+            source = error.source();
+        }
+    }
+    false
 }
 
 #[cfg(test)]
@@ -409,32 +444,6 @@ mod tests {
         }
     }
 
-    #[test]
-    fn reconnect_retry_interval_uses_capped_exponential_backoff() {
-        let base = Duration::from_secs(1);
-
-        assert_eq!(reconnect_retry_interval(base, 1), Duration::from_secs(1));
-        assert_eq!(reconnect_retry_interval(base, 2), Duration::from_secs(2));
-        assert_eq!(reconnect_retry_interval(base, 3), Duration::from_secs(4));
-        assert_eq!(reconnect_retry_interval(base, 6), Duration::from_secs(30));
-    }
-
-    #[test]
-    fn reconnect_retry_interval_uses_configured_base_interval() {
-        let base = Duration::from_millis(1);
-
-        assert_eq!(reconnect_retry_interval(base, 1), Duration::from_millis(1));
-        assert_eq!(reconnect_retry_interval(base, 2), Duration::from_millis(2));
-    }
-
-    #[test]
-    fn reconnect_retry_interval_does_not_shorten_base_above_cap() {
-        let base = Duration::from_secs(60);
-
-        assert_eq!(reconnect_retry_interval(base, 1), Duration::from_secs(60));
-        assert_eq!(reconnect_retry_interval(base, 2), Duration::from_secs(60));
-    }
-
     #[tokio::test]
     async fn reconnects_after_request_dispatch_hits_backend_gone() {
         let (dead_handle, dead_interface) = ConnectionHandle::new();
@@ -447,7 +456,7 @@ mod tests {
         let (tx, reqs) = mpsc::unbounded_channel();
         let service = PubSubService {
             handle: dead_handle,
-            connector,
+            connector: Arc::new(connector),
             reqs,
             subs: SubscriptionManager::default(),
             in_flights: RequestManager::default(),
@@ -461,9 +470,11 @@ mod tests {
         timeout(Duration::from_secs(1), rx)
             .await
             .expect("failed request should resolve promptly")
-            .expect_err("raced request should be dropped when the backend is gone");
+            .expect("manager must return the connection failure")
+            .expect_err("raced request should fail when the backend is gone");
 
-        let second = Request::new("eth_chainId", Id::Number(2), ()).serialize().unwrap();
+        let second =
+            Request::new("eth_subscribe", Id::Number(2), ("newHeads",)).serialize().unwrap();
         let expected = second.serialized().get().to_owned();
         let (in_flight, _rx) = InFlight::new(second, 16);
         tx.send(PubSubInstruction::Request(in_flight)).unwrap();
@@ -488,7 +499,7 @@ mod tests {
         let (tx, reqs) = mpsc::unbounded_channel();
         let service = PubSubService {
             handle: dead_handle,
-            connector,
+            connector: Arc::new(connector),
             reqs,
             subs: SubscriptionManager::default(),
             in_flights: RequestManager::default(),
@@ -502,9 +513,11 @@ mod tests {
         timeout(Duration::from_secs(1), rx)
             .await
             .expect("non-retryable reconnect should resolve promptly")
+            .expect("manager must return the connection failure")
             .expect_err("request should fail when backend is gone and reconnect aborts");
+        tx.closed().await;
 
-        // Exactly one attempt, not `max_retries`.
+        // A permanent failure must stop after one attempt.
         assert_eq!(counter.load(Ordering::SeqCst), 1);
     }
 
@@ -525,7 +538,7 @@ mod tests {
         let (_tx, reqs) = mpsc::unbounded_channel();
         let service = PubSubService {
             handle: live_handle,
-            connector,
+            connector: Arc::new(connector),
             reqs,
             subs: SubscriptionManager::default(),
             in_flights: RequestManager::default(),
@@ -560,7 +573,7 @@ mod tests {
         let (tx, reqs) = mpsc::unbounded_channel();
         let service = PubSubService {
             handle: live_handle,
-            connector,
+            connector: Arc::new(connector),
             reqs,
             subs: SubscriptionManager::default(),
             in_flights: RequestManager::default(),
@@ -572,7 +585,7 @@ mod tests {
 
         // After reconnect, a freshly dispatched request must reach the new
         // backend.
-        let req = Request::new("eth_chainId", Id::Number(1), ()).serialize().unwrap();
+        let req = Request::new("eth_subscribe", Id::Number(1), ("newHeads",)).serialize().unwrap();
         let expected = req.serialized().get().to_owned();
         let (in_flight, _rx) = InFlight::new(req, 16);
         tx.send(PubSubInstruction::Request(in_flight)).unwrap();
@@ -634,7 +647,7 @@ mod recovery_regressions {
         let (tx, reqs) = mpsc::unbounded_channel();
         let service = PubSubService {
             handle,
-            connector: Refused(calls.clone()),
+            connector: Arc::new(Refused(calls.clone())),
             reqs,
             subs: SubscriptionManager::default(),
             in_flights: RequestManager::default(),
@@ -663,7 +676,7 @@ mod recovery_regressions {
         let (tx, reqs) = mpsc::unbounded_channel();
         let mut service = PubSubService {
             handle,
-            connector,
+            connector: Arc::new(connector),
             reqs,
             subs: SubscriptionManager::default(),
             in_flights: RequestManager::default(),
@@ -674,12 +687,61 @@ mod recovery_regressions {
         service.in_flights.insert(pending);
         drop(rx);
         drop(interface);
-        service.reconnect().await.unwrap();
+        let new_handle = service.connector.try_reconnect().await.unwrap();
+        service.install_backend(new_handle).unwrap();
         assert!(
             timeout(Duration::from_millis(100), new_interface.recv_from_frontend()).await.is_err(),
             "cancelled request was replayed"
         );
         assert_eq!(service.in_flights.len(), 0);
         drop(tx);
+    }
+}
+
+#[cfg(test)]
+mod unstable_connection_tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[derive(Debug)]
+    struct ClosesImmediately(Arc<AtomicUsize>);
+    impl PubSubConnect for ClosesImmediately {
+        fn is_local(&self) -> bool {
+            true
+        }
+        async fn connect(&self) -> TransportResult<ConnectionHandle> {
+            self.0.fetch_add(1, Ordering::SeqCst);
+            let (handle, interface) = ConnectionHandle::new();
+            interface.close_with_error();
+            Ok(handle)
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn socket_handshakes_without_responses_do_not_reset_backoff() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let (handle, interface) = ConnectionHandle::new();
+        let (tx, reqs) = mpsc::unbounded_channel();
+        PubSubService {
+            handle,
+            connector: Arc::new(ClosesImmediately(calls.clone())),
+            reqs,
+            subs: SubscriptionManager::default(),
+            in_flights: RequestManager::default(),
+        }
+        .spawn();
+        interface.close_with_error();
+        // Step time so each reconnect receives a polling turn.
+        for _ in 0..600 {
+            sleep(Duration::from_millis(10)).await;
+        }
+        let attempts = calls.load(Ordering::SeqCst);
+        assert!(
+            (12..=27).contains(&attempts),
+            "reconnect attempts did not use bounded backoff: {attempts}"
+        );
+        drop(tx);
+        sleep(Duration::from_secs(1)).await;
+        assert_eq!(calls.load(Ordering::SeqCst), attempts);
     }
 }

--- a/crates/rpc-client/src/builder.rs
+++ b/crates/rpc-client/src/builder.rs
@@ -144,7 +144,7 @@ impl<L> ClientBuilder<L> {
     /// [`RpcClient`].
     ///
     /// This method allows for fine-grained control over connection settings
-    /// such as authentication, retry behavior, and transport-specific options.
+    /// such as authentication and transport-specific options.
     ///
     /// # Examples
     ///
@@ -152,12 +152,8 @@ impl<L> ClientBuilder<L> {
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// use alloy_rpc_client::{ClientBuilder, ConnectionConfig};
     /// use alloy_transport::Authorization;
-    /// use std::time::Duration;
     ///
-    /// let config = ConnectionConfig::new()
-    ///     .with_auth(Authorization::bearer("my-token"))
-    ///     .with_max_retries(3)
-    ///     .with_retry_interval(Duration::from_secs(2));
+    /// let config = ConnectionConfig::new().with_auth(Authorization::bearer("my-token"));
     ///
     /// let client =
     ///     ClientBuilder::default().connect_with_config("ws://localhost:8545", config).await?;

--- a/crates/rpc-client/src/builtin.rs
+++ b/crates/rpc-client/src/builtin.rs
@@ -1,6 +1,6 @@
 use alloy_json_rpc::RpcError;
 use alloy_transport::{BoxTransport, TransportConnect, TransportError, TransportErrorKind};
-use std::{str::FromStr, time::Duration};
+use std::str::FromStr;
 
 #[cfg(any(feature = "ws-base", feature = "ipc"))]
 use alloy_pubsub::PubSubConnect;
@@ -67,7 +67,7 @@ impl BuiltInConnectionString {
     /// Parse a connection string and connect with custom configuration.
     ///
     /// This method allows for fine-grained control over connection settings
-    /// such as authentication, retry behavior, and transport-specific options.
+    /// such as authentication and transport-specific options.
     ///
     /// # Examples
     ///
@@ -76,13 +76,9 @@ impl BuiltInConnectionString {
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// use alloy_rpc_client::{BuiltInConnectionString, ConnectionConfig};
     /// use alloy_transport::Authorization;
-    /// use std::time::Duration;
     ///
     /// // Configure connection with custom settings
-    /// let config = ConnectionConfig::new()
-    ///     .with_auth(Authorization::bearer("my-token"))
-    ///     .with_max_retries(3)
-    ///     .with_retry_interval(Duration::from_secs(2));
+    /// let config = ConnectionConfig::new().with_auth(Authorization::bearer("my-token"));
     ///
     /// // Connect to WebSocket endpoint with configuration
     /// let transport = BuiltInConnectionString::connect_with("ws://localhost:8545", config).await?;
@@ -169,14 +165,6 @@ impl BuiltInConnectionString {
                 #[cfg(not(target_family = "wasm"))]
                 if let Some(ws_config) = config.ws_config {
                     ws_connect = ws_connect.with_config(ws_config);
-                }
-
-                // Apply retry configuration
-                if let Some(max_retries) = config.max_retries {
-                    ws_connect = ws_connect.with_max_retries(max_retries);
-                }
-                if let Some(retry_interval) = config.retry_interval {
-                    ws_connect = ws_connect.with_retry_interval(retry_interval);
                 }
 
                 ws_connect.into_service().await.map(alloy_transport::Transport::boxed)
@@ -285,18 +273,12 @@ impl FromStr for BuiltInConnectionString {
 /// Configuration for connecting to built-in transports.
 ///
 /// Provides a flexible way to configure various aspects of the connection,
-/// including authentication, retry behavior, and transport-specific settings.
+/// including authentication and transport-specific settings.
 #[derive(Clone, Debug, Default)]
 #[non_exhaustive]
 pub struct ConnectionConfig {
     /// Authorization header for authenticated connections.
     pub auth: Option<alloy_transport::Authorization>,
-    /// Maximum number of connection retries.
-    pub max_retries: Option<u32>,
-    /// Base interval between connection retries.
-    ///
-    /// WebSocket reconnect retries use capped exponential backoff from this base interval.
-    pub retry_interval: Option<Duration>,
     /// WebSocket-specific configuration.
     #[cfg(all(feature = "ws-base", not(target_family = "wasm")))]
     pub ws_config: Option<alloy_transport_ws::WebSocketConfig>,
@@ -307,8 +289,6 @@ impl ConnectionConfig {
     pub const fn new() -> Self {
         Self {
             auth: None,
-            max_retries: None,
-            retry_interval: None,
             #[cfg(all(feature = "ws-base", not(target_family = "wasm")))]
             ws_config: None,
         }
@@ -317,20 +297,6 @@ impl ConnectionConfig {
     /// Set the authorization header.
     pub fn with_auth(mut self, auth: alloy_transport::Authorization) -> Self {
         self.auth = Some(auth);
-        self
-    }
-
-    /// Set the maximum number of retries.
-    pub const fn with_max_retries(mut self, max_retries: u32) -> Self {
-        self.max_retries = Some(max_retries);
-        self
-    }
-
-    /// Set the base retry interval.
-    ///
-    /// WebSocket reconnect retries use capped exponential backoff from this base interval.
-    pub const fn with_retry_interval(mut self, retry_interval: Duration) -> Self {
-        self.retry_interval = Some(retry_interval);
         self
     }
 
@@ -474,7 +440,6 @@ mod test {
         // Verify connect() uses default config (maintaining backward compatibility)
         let default_config = ConnectionConfig::default();
         assert!(default_config.auth.is_none());
-        assert!(default_config.max_retries.is_none());
 
         // connect() -> connect_boxed() -> connect_boxed_with(default) ensures compatibility
     }

--- a/crates/transport-ws/Cargo.toml
+++ b/crates/transport-ws/Cargo.toml
@@ -49,3 +49,6 @@ aws-lc-rs = ["rustls-tls", "rustls?/aws-lc-rs"]
 ring = ["rustls-tls", "rustls?/ring"]
 native-tls = ["tokio-tungstenite/native-tls"]
 rustls-tls = ["dep:rustls", "tokio-tungstenite/rustls-tls-webpki-roots"]
+
+[dev-dependencies]
+alloy-json-rpc.workspace = true

--- a/crates/transport-ws/src/native.rs
+++ b/crates/transport-ws/src/native.rs
@@ -330,3 +330,41 @@ mod tests {
         assert!(ws.auth().is_none());
     }
 }
+
+#[cfg(test)]
+mod handshake_error_tests {
+    use super::*;
+    use tokio::net::TcpListener;
+
+    #[tokio::test]
+    async fn handshake_failure_retains_http_status_and_body() {
+        for status in [408, 429, 500, 502, 503, 504, 401, 403] {
+            let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let address = listener.local_addr().unwrap();
+            let server = tokio::spawn(async move {
+                let (socket, _) = listener.accept().await.unwrap();
+                let result = tokio_tungstenite::accept_hdr_async(
+                    socket,
+                    move |_: &tungstenite::handshake::server::Request,
+                          _: tungstenite::handshake::server::Response| {
+                        Err(http::Response::builder()
+                            .status(status)
+                            .body(Some("handshake rejected".into()))
+                            .unwrap())
+                    },
+                )
+                .await;
+                assert!(result.is_err());
+            });
+            let error = WsConnect::new(format!("ws://{address}")).connect().await.unwrap_err();
+            match error.as_transport_err() {
+                Some(TransportErrorKind::HttpError(error)) => {
+                    assert_eq!(error.status, status);
+                    assert_eq!(error.body, "handshake rejected");
+                }
+                other => panic!("handshake status {status} lost its HTTP type: {other:?}"),
+            }
+            server.await.unwrap();
+        }
+    }
+}

--- a/crates/transport-ws/src/native.rs
+++ b/crates/transport-ws/src/native.rs
@@ -1,6 +1,8 @@
 use crate::{WsBackend, DEFAULT_KEEPALIVE};
 use alloy_pubsub::PubSubConnect;
-use alloy_transport::{utils::Spawnable, Authorization, TransportErrorKind, TransportResult};
+use alloy_transport::{
+    utils::Spawnable, Authorization, TransportError, TransportErrorKind, TransportResult,
+};
 use futures::{SinkExt, StreamExt};
 use serde_json::value::RawValue;
 use std::time::Duration;
@@ -23,14 +25,6 @@ pub struct WsConnect {
     auth: Option<Authorization>,
     /// The websocket config.
     config: Option<WebSocketConfig>,
-    /// Max number of retries before failing and exiting the connection.
-    /// Default is 10.
-    max_retries: u32,
-    /// The base interval between retries.
-    ///
-    /// Reconnect retries use capped exponential backoff from this base interval.
-    /// Default is 3 seconds.
-    retry_interval: Duration,
     /// The interval between keepalive pings.
     /// Default is 10 seconds.
     keepalive_interval: Duration,
@@ -45,14 +39,7 @@ impl WsConnect {
         let url = url.into();
         let auth =
             url::Url::parse(&url).ok().and_then(|parsed| Authorization::extract_from_url(&parsed));
-        Self {
-            url,
-            auth,
-            config: None,
-            max_retries: 10,
-            retry_interval: Duration::from_secs(3),
-            keepalive_interval: Duration::from_secs(DEFAULT_KEEPALIVE),
-        }
+        Self { url, auth, config: None, keepalive_interval: Duration::from_secs(DEFAULT_KEEPALIVE) }
     }
 
     /// Sets the authorization header.
@@ -88,22 +75,6 @@ impl WsConnect {
     /// Get the websocket config.
     pub const fn config(&self) -> Option<&WebSocketConfig> {
         self.config.as_ref()
-    }
-
-    /// Sets the max number of retries before failing and exiting the connection.
-    /// Default is 10.
-    pub const fn with_max_retries(mut self, max_retries: u32) -> Self {
-        self.max_retries = max_retries;
-        self
-    }
-
-    /// Sets the base interval between retries.
-    ///
-    /// Reconnect retries use capped exponential backoff from this base interval.
-    /// Default is 3 seconds.
-    pub const fn with_retry_interval(mut self, retry_interval: Duration) -> Self {
-        self.retry_interval = retry_interval;
-        self
     }
 
     /// Sets the keepalive ping interval.
@@ -146,14 +117,31 @@ impl PubSubConnect for WsConnect {
         let req = request.map_err(TransportErrorKind::custom)?;
         let (socket, _) = tokio_tungstenite::connect_async_with_config(req, self.config, false)
             .await
-            .map_err(TransportErrorKind::custom)?;
+            .map_err(handshake_error)?;
 
         let (handle, interface) = alloy_pubsub::ConnectionHandle::new();
         let backend = WsBackend { socket, interface, keepalive_interval: self.keepalive_interval };
 
         backend.spawn();
 
-        Ok(handle.with_max_retries(self.max_retries).with_retry_interval(self.retry_interval))
+        Ok(handle)
+    }
+}
+
+// Keep handshake HTTP evidence visible to the pubsub reconnect policy.
+fn handshake_error(error: tungstenite::Error) -> TransportError {
+    match error {
+        tungstenite::Error::Http(response) => TransportErrorKind::http_error(
+            response.status().as_u16(),
+            String::from_utf8_lossy(response.body().as_deref().unwrap_or_default()).into_owned(),
+        ),
+        tungstenite::Error::ConnectionClosed | tungstenite::Error::AlreadyClosed => {
+            TransportErrorKind::custom(std::io::Error::from(std::io::ErrorKind::ConnectionReset))
+        }
+        tungstenite::Error::Protocol(tungstenite::error::ProtocolError::HandshakeIncomplete) => {
+            TransportErrorKind::custom(std::io::Error::from(std::io::ErrorKind::UnexpectedEof))
+        }
+        error => TransportErrorKind::custom(error),
     }
 }
 
@@ -334,7 +322,67 @@ mod tests {
 #[cfg(test)]
 mod handshake_error_tests {
     use super::*;
-    use tokio::net::TcpListener;
+    use alloy_json_rpc::{Id, Request};
+    use serde_json::{json, Value};
+    use tokio::{net::TcpListener, sync::oneshot, time::timeout};
+
+    #[tokio::test]
+    async fn subscription_recovers_after_temporary_handshake_rejection() {
+        timeout(Duration::from_secs(3), async {
+            let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let address = listener.local_addr().unwrap();
+            let (ready_tx, ready_rx) = oneshot::channel();
+            let (done_tx, done_rx) = oneshot::channel();
+            let server = tokio::spawn(async move {
+                let (socket, _) = listener.accept().await.unwrap();
+                let mut socket = tokio_tungstenite::accept_async(socket).await.unwrap();
+                let request: Value = serde_json::from_str(
+                    socket.next().await.unwrap().unwrap().to_text().unwrap(),
+                ).unwrap();
+                assert_eq!(request, json!({"jsonrpc":"2.0", "id":91,
+                    "method":"eth_subscribe", "params":["newHeads"]}));
+                socket.send(Message::Text(json!({"jsonrpc":"2.0", "id":91,
+                    "result":"original-subscription"}).to_string().into())).await.unwrap();
+                ready_rx.await.unwrap();
+                drop(socket);
+
+                let (socket, _) = listener.accept().await.unwrap();
+                let rejected = tokio_tungstenite::accept_hdr_async(socket,
+                    |_: &tungstenite::handshake::server::Request,
+                     _: tungstenite::handshake::server::Response| {
+                        Err(http::Response::builder().status(503)
+                            .body(Some("temporarily unavailable".into())).unwrap())
+                    }).await;
+                assert!(rejected.is_err());
+
+                let (socket, _) = listener.accept().await.unwrap();
+                let mut socket = tokio_tungstenite::accept_async(socket).await.unwrap();
+                let replay: Value = serde_json::from_str(
+                    socket.next().await.unwrap().unwrap().to_text().unwrap(),
+                ).unwrap();
+                assert_eq!(replay, request, "replay must preserve ID and subscription parameters");
+                socket.send(Message::Text(json!({"jsonrpc":"2.0", "id":91,
+                    "result":"replacement-subscription"}).to_string().into())).await.unwrap();
+                socket.send(Message::Text(json!({"jsonrpc":"2.0", "method":"eth_subscription",
+                    "params":{"subscription":"replacement-subscription", "result":{"number":"0x123"}}})
+                    .to_string().into())).await.unwrap();
+                done_rx.await.unwrap();
+            });
+            let frontend = WsConnect::new(format!("ws://{address}")).into_service().await.unwrap();
+            let request = Request::new("eth_subscribe", Id::Number(91), ("newHeads",))
+                .serialize().unwrap();
+            let response = frontend.send(request).await.unwrap();
+            let local_id = response.try_success_as().unwrap().unwrap();
+            let mut subscription = frontend.get_subscription(local_id).await.unwrap();
+            ready_tx.send(()).unwrap();
+            let notification: Value = serde_json::from_str(subscription.recv().await.unwrap().get()).unwrap();
+            assert_eq!(notification, json!({"number":"0x123"}));
+            assert_eq!(*subscription.local_id(), local_id);
+            done_tx.send(()).unwrap();
+            drop(frontend);
+            server.await.unwrap();
+        }).await.expect("subscription must survive the HTTP 503 reconnect");
+    }
 
     #[tokio::test]
     async fn handshake_failure_retains_http_status_and_body() {

--- a/crates/transport-ws/src/wasm.rs
+++ b/crates/transport-ws/src/wasm.rs
@@ -14,14 +14,6 @@ use ws_stream_wasm::{WsErr, WsMessage, WsMeta, WsStream};
 pub struct WsConnect {
     /// The URL to connect to.
     url: String,
-    /// Max number of retries before failing and exiting the connection.
-    /// Default is 10.
-    max_retries: u32,
-    /// The base interval between retries.
-    ///
-    /// Reconnect retries use capped exponential backoff from this base interval.
-    /// Default is 3 seconds.
-    retry_interval: Duration,
     /// The interval between keepalive pings.
     /// Default is 10 seconds.
     keepalive_interval: Duration,
@@ -30,28 +22,7 @@ pub struct WsConnect {
 impl WsConnect {
     /// Creates a new websocket connection configuration.
     pub fn new<S: Into<String>>(url: S) -> Self {
-        Self {
-            url: url.into(),
-            max_retries: 10,
-            retry_interval: Duration::from_secs(3),
-            keepalive_interval: Duration::from_secs(DEFAULT_KEEPALIVE),
-        }
-    }
-
-    /// Sets the max number of retries before failing and exiting the connection.
-    /// Default is 10.
-    pub const fn with_max_retries(mut self, max_retries: u32) -> Self {
-        self.max_retries = max_retries;
-        self
-    }
-
-    /// Sets the base interval between retries.
-    ///
-    /// Reconnect retries use capped exponential backoff from this base interval.
-    /// Default is 3 seconds.
-    pub const fn with_retry_interval(mut self, retry_interval: Duration) -> Self {
-        self.retry_interval = retry_interval;
-        self
+        Self { url: url.into(), keepalive_interval: Duration::from_secs(DEFAULT_KEEPALIVE) }
     }
 
     /// Sets the keepalive ping interval.
@@ -86,7 +57,7 @@ impl PubSubConnect for WsConnect {
 
         backend.spawn();
 
-        Ok(handle.with_max_retries(self.max_retries).with_retry_interval(self.retry_interval))
+        Ok(handle)
     }
 }
 


### PR DESCRIPTION
**AI-authored PR:** OpenAI Codex wrote this patch, its tests, and this description at the request of the SatoshiAndKin repository owner. This is not a claim of completed human review.

## Motivation

A dropped pubsub request can remain pending and replay after reconnection. A retry layer above the transport can then send the same read independently. Reconnect waits also prevent timely cancellation and shutdown, and an interrupted batch can discard successful item responses.

Native WebSocket reconnection has a related failure: HTTP 429/502/503 handshake errors are boxed as tungstenite errors, so a typed reconnect classifier cannot identify the temporary HTTP status.

## Solution

- Attach optional per-item monotonic deadlines and response receipt times through `RequestTimings` without changing JSON-RPC wire contents. Process cancellation, expiry, and frontend closure while reconnecting or waiting. A reply received on time remains valid while the transport waits for a slower batch sibling; each item keeps its own deadline.
- Keep request-attempt identity separate from RPC ID, so delayed cancellation cannot remove a newer retry with the same ID.
- Preserve completed batch responses by ID in `PartialBatchError`. Return unresolved ordinary requests to the caller; restore live subscriptions in the manager.
- Share capped exponential jitter through `RecoveryBackoff`: ceilings 100/200/400/500 ms, sampled from half to all of each ceiling. Retry transient connection failures until recovery, permanent failure, or frontend closure. A socket handshake alone does not reset backoff.
- Retain native WebSocket handshake HTTP status/body and retry temporary 408/429/500/502/503/504 responses. An actual local WebSocket test verifies subscription recovery through HTTP 503 with unchanged subscription request ID and parameters.

### Breaking changes

Ordinary pending RPC requests no longer replay automatically after disconnect; callers own retry safety. Remove `with_max_retries` and `with_retry_interval` from `ConnectionHandle`, `WsConnect`, and `ConnectionConfig`, plus the corresponding public configuration fields. `InFlight` gains lifecycle state and `PubSubInstruction` gains cancellation. This draft proposes these changes explicitly; it is not a patch-release compatibility claim. Subscription consumer methods remain in place.

### Validation

- Three isolated regressions failed on the starting upstream code and were committed before implementation.
- Fresh `cargo nextest run --locked -p alloy-pubsub -p alloy-transport-ws -p alloy-transport-ipc`: 34 passed. This includes distinct item deadlines, exact receipt times, and cancelled/expired receipt rejection with paused Tokio time.
- The downstream Unix-socket regression first reproduced loss of an on-time successful item at a sibling's expiry. It passes with this change.
- Fresh `cargo clippy --locked -p alloy-pubsub -p alloy-transport-ws -p alloy-transport-ipc --all-targets -- -D warnings`: passed.
- Earlier validation of the parent revision: `cargo clippy -p alloy-rpc-client -p alloy-provider --all-targets --features alloy-provider/ws,alloy-provider/ipc,alloy-provider/anvil-node -- -D warnings`: passed.
- Fresh `cargo check --locked -p alloy-pubsub -p alloy-transport-ws --target wasm32-unknown-unknown`: passed. Existing WebSocket unused-url/keepalive warnings remain. Browser runtime behavior was not tested.
- `cargo fmt --all --check` and `git diff --check`: passed.

The full Alloy workspace integration suite has not been run. The downstream recovery integration is tracked in https://github.com/SatoshiAndKin/flashprofits-monorepo/pull/113.

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [x] Breaking changes

