### PR TITLE
fix(consensus): reject 0x00-tagged legacy transactions and receipts

### DIFF
--- a/crates/consensus-any/src/receipt/envelope.rs
+++ b/crates/consensus-any/src/receipt/envelope.rs
@@ -1,7 +1,7 @@
 use alloc::vec::Vec;
 use alloy_consensus::{Eip658Value, Receipt, ReceiptWithBloom, TxReceipt};
 use alloy_eips::{
-    eip2718::{Decodable2718, Eip2718Result, Encodable2718},
+    eip2718::{Decodable2718, Eip2718Error, Eip2718Result, Encodable2718},
     Typed2718,
 };
 use alloy_primitives::{bytes::BufMut, Bloom, Log};
@@ -10,8 +10,8 @@ use core::fmt;
 
 /// Receipt envelope, as defined in [EIP-2718].
 ///
-/// Represents legacy and typed EIP-2718 receipts. Type ID 0 is encoded as untagged legacy; this
-/// type does not preserve a literal `0x00` prefix.
+/// Represents untagged legacy receipts and typed EIP-2718 variants. Binary decoding rejects a
+/// literal `0x00` type prefix; type ID 0 uses the untagged legacy encoding.
 ///
 /// Transaction receipt payloads are specified in their respective EIPs.
 ///
@@ -146,11 +146,85 @@ impl Encodable2718 for AnyReceiptEnvelope {
 
 impl Decodable2718 for AnyReceiptEnvelope {
     fn typed_decode(ty: u8, buf: &mut &[u8]) -> Eip2718Result<Self> {
+        // Legacy receipts are untagged: `encode_2718` never emits a `0x00` type byte, so a
+        // literal `0x00` prefix must be rejected rather than decoded as legacy, which would not
+        // round-trip. Untagged legacy receipts are handled by `fallback_decode`.
+        if ty == 0 {
+            return Err(Eip2718Error::UnexpectedType(ty));
+        }
         let receipt = Decodable::decode(buf)?;
         Ok(Self { inner: receipt, r#type: ty })
     }
 
     fn fallback_decode(buf: &mut &[u8]) -> Eip2718Result<Self> {
-        Self::typed_decode(0, buf)
+        let receipt = Decodable::decode(buf)?;
+        Ok(Self { inner: receipt, r#type: 0 })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec;
+    use alloy_rlp::Header;
+
+    fn envelope(ty: u8) -> AnyReceiptEnvelope {
+        AnyReceiptEnvelope { inner: Default::default(), r#type: ty }
+    }
+
+    /// Wraps an EIP-2718 payload in the RLP string header used by the network encoding of typed
+    /// receipts.
+    fn network_framed(payload: &[u8]) -> Vec<u8> {
+        let mut out = Vec::new();
+        Header { list: false, payload_length: payload.len() }.encode(&mut out);
+        out.extend_from_slice(payload);
+        out
+    }
+
+    #[test]
+    fn legacy_receipt_roundtrips_untagged() {
+        let envelope = envelope(0);
+        let encoded = envelope.encoded_2718();
+        assert!(encoded[0] >= 0xc0, "sanity: legacy receipts are encoded as a bare RLP list");
+        // The network encoding of a legacy receipt is the bare list as well, without a header.
+        let mut network = Vec::new();
+        envelope.network_encode(&mut network);
+        assert_eq!(network, encoded);
+
+        assert_eq!(AnyReceiptEnvelope::decode_2718_exact(&encoded).unwrap(), envelope);
+        assert_eq!(AnyReceiptEnvelope::network_decode(&mut encoded.as_slice()).unwrap(), envelope);
+    }
+
+    #[test]
+    fn typed_receipt_roundtrips() {
+        // A non-Ethereum type id, since this envelope is the catch-all for unknown networks.
+        let envelope = envelope(0x7e);
+        let encoded = envelope.encoded_2718();
+        assert_eq!(encoded[0], 0x7e, "sanity: typed receipts are prefixed with their type byte");
+        let mut network = Vec::new();
+        envelope.network_encode(&mut network);
+        assert_eq!(network, network_framed(&encoded));
+
+        assert_eq!(AnyReceiptEnvelope::decode_2718_exact(&encoded).unwrap(), envelope);
+        assert_eq!(AnyReceiptEnvelope::network_decode(&mut network.as_slice()).unwrap(), envelope);
+    }
+
+    #[test]
+    fn tagged_legacy_receipt_is_rejected() {
+        // Per EIP-2718, legacy receipts are untagged and `0x00` is not an assigned type. The
+        // encoder never emits a `0x00` prefix, so accepting one on decode would re-encode the
+        // receipt differently from the bytes that were decoded.
+        let mut tagged = vec![0x00];
+        tagged.extend_from_slice(&envelope(0).encoded_2718());
+        let tagged_network = network_framed(&tagged);
+
+        assert!(matches!(
+            AnyReceiptEnvelope::decode_2718_exact(&tagged),
+            Err(Eip2718Error::UnexpectedType(0))
+        ));
+        assert!(matches!(
+            AnyReceiptEnvelope::network_decode(&mut tagged_network.as_slice()),
+            Err(Eip2718Error::UnexpectedType(0))
+        ));
     }
 }

--- a/crates/consensus/src/receipt/envelope.rs
+++ b/crates/consensus/src/receipt/envelope.rs
@@ -553,4 +553,35 @@ mod test {
         let receipt = Receipt::<Log>::default();
         let _envelope = ReceiptEnvelope::from_typed(TxType::Eip7702, receipt);
     }
+
+    #[test]
+    fn tagged_legacy_receipt_envelope_is_rejected() {
+        use alloc::{vec, vec::Vec};
+        use alloy_eips::eip2718::{Decodable2718, Eip2718Error, Encodable2718};
+        use alloy_rlp::{Decodable, Header};
+
+        let envelope = ReceiptEnvelope::<Log>::Legacy(Default::default());
+        let encoded = envelope.encoded_2718();
+        assert!(encoded[0] >= 0xc0, "sanity: legacy receipts are encoded as a bare RLP list");
+        assert_eq!(ReceiptEnvelope::decode_2718_exact(&encoded).unwrap(), envelope);
+        assert_eq!(ReceiptEnvelope::network_decode(&mut encoded.as_slice()).unwrap(), envelope);
+        assert_eq!(ReceiptEnvelope::decode(&mut encoded.as_slice()).unwrap(), envelope);
+
+        // A literal `0x00` type byte is rejected in both the raw EIP-2718 and the network framing.
+        let mut tagged = vec![0x00];
+        tagged.extend_from_slice(&encoded);
+        let mut tagged_network = Vec::new();
+        Header { list: false, payload_length: tagged.len() }.encode(&mut tagged_network);
+        tagged_network.extend_from_slice(&tagged);
+
+        assert!(matches!(
+            ReceiptEnvelope::decode_2718_exact(&tagged),
+            Err(Eip2718Error::UnexpectedType(0))
+        ));
+        assert!(matches!(
+            ReceiptEnvelope::network_decode(&mut tagged_network.as_slice()),
+            Err(Eip2718Error::UnexpectedType(0))
+        ));
+        assert!(ReceiptEnvelope::decode(&mut tagged_network.as_slice()).is_err());
+    }
 }

--- a/crates/consensus/src/receipt/receipt2.rs
+++ b/crates/consensus/src/receipt/receipt2.rs
@@ -157,6 +157,13 @@ impl<T: TxTy> Eip2718EncodableReceipt for EthereumReceipt<T> {
 
 impl<T: TxTy> Eip2718DecodableReceipt for EthereumReceipt<T> {
     fn typed_decode_with_bloom(ty: u8, buf: &mut &[u8]) -> Eip2718Result<ReceiptWithBloom<Self>> {
+        // Legacy receipts are untagged: `eip2718_encode_with_bloom` never emits a `0x00` type
+        // byte, so a literal `0x00` prefix must be rejected rather than decoded as legacy, which
+        // would not round-trip. Untagged legacy receipts are handled by
+        // `fallback_decode_with_bloom`.
+        if ty == 0 {
+            return Err(Eip2718Error::UnexpectedType(ty));
+        }
         Ok(Self::rlp_decode_inner(buf, T::try_from(ty)?)?)
     }
 
@@ -201,6 +208,11 @@ impl<T: TxTy> RlpDecodableReceipt for EthereumReceipt<T> {
         let remaining = buf.len();
 
         let tx_type = T::decode(buf)?;
+        // A string header only ever wraps a typed receipt. Legacy receipts are encoded as a bare
+        // list, so a zero type flag behind a string header must be rejected.
+        if tx_type.is_legacy() {
+            return Err(Eip2718Error::UnexpectedType(tx_type.ty()).into());
+        }
         let this = Self::rlp_decode_inner(buf, tx_type)?;
 
         if buf.len() + header.payload_length != remaining {
@@ -429,5 +441,109 @@ pub(crate) mod serde_bincode_compat {
                 bincode::serde::decode_from_slice(&encoded, config::legacy()).unwrap();
             assert_eq!(decoded, data);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec;
+    use alloy_eips::eip2718::Decodable2718;
+
+    fn receipt(tx_type: TxType) -> ReceiptWithBloom<EthereumReceipt> {
+        EthereumReceipt { tx_type, success: true, cumulative_gas_used: 21_000, logs: vec![] }
+            .into_with_bloom()
+    }
+
+    /// Wraps an EIP-2718 payload in the RLP string header used by the network encoding of typed
+    /// receipts.
+    fn network_framed(payload: &[u8]) -> Vec<u8> {
+        let mut out = Vec::new();
+        Header { list: false, payload_length: payload.len() }.encode(&mut out);
+        out.extend_from_slice(payload);
+        out
+    }
+
+    #[test]
+    fn legacy_receipt_roundtrips_untagged_on_all_decode_paths() {
+        let receipt = receipt(TxType::Legacy);
+        let encoded = receipt.encoded_2718();
+        assert!(encoded[0] >= 0xc0, "sanity: legacy receipts are encoded as a bare RLP list");
+        // The network encoding of a legacy receipt is the bare list as well, without a header.
+        let mut network = Vec::new();
+        receipt.network_encode(&mut network);
+        assert_eq!(network, encoded);
+
+        assert_eq!(
+            ReceiptWithBloom::<EthereumReceipt>::decode_2718_exact(&encoded).unwrap(),
+            receipt
+        );
+        assert_eq!(
+            ReceiptWithBloom::<EthereumReceipt>::network_decode(&mut encoded.as_slice()).unwrap(),
+            receipt
+        );
+        assert_eq!(
+            ReceiptWithBloom::<EthereumReceipt>::decode(&mut encoded.as_slice()).unwrap(),
+            receipt
+        );
+    }
+
+    #[test]
+    fn typed_receipt_roundtrips_on_all_decode_paths() {
+        let receipt = receipt(TxType::Eip1559);
+        let encoded = receipt.encoded_2718();
+        assert_eq!(encoded[0], 0x02, "sanity: typed receipts are prefixed with their type byte");
+        let mut network = Vec::new();
+        receipt.network_encode(&mut network);
+        assert_eq!(network, network_framed(&encoded));
+
+        assert_eq!(
+            ReceiptWithBloom::<EthereumReceipt>::decode_2718_exact(&encoded).unwrap(),
+            receipt
+        );
+        assert_eq!(
+            ReceiptWithBloom::<EthereumReceipt>::network_decode(&mut network.as_slice()).unwrap(),
+            receipt
+        );
+        assert_eq!(
+            ReceiptWithBloom::<EthereumReceipt>::decode(&mut network.as_slice()).unwrap(),
+            receipt
+        );
+    }
+
+    #[test]
+    fn tagged_legacy_receipt_is_rejected_on_all_decode_paths() {
+        // Per EIP-2718, legacy receipts are untagged and `0x00` is not an assigned type. The
+        // encoder never emits a `0x00` prefix, so accepting one on decode would re-encode the
+        // receipt differently from the bytes that were decoded.
+        let encoded = receipt(TxType::Legacy).encoded_2718();
+        let mut tagged = vec![0x00];
+        tagged.extend_from_slice(&encoded);
+        let tagged_network = network_framed(&tagged);
+
+        assert!(matches!(
+            ReceiptWithBloom::<EthereumReceipt>::decode_2718_exact(&tagged),
+            Err(Eip2718Error::UnexpectedType(0))
+        ));
+        assert!(matches!(
+            ReceiptWithBloom::<EthereumReceipt>::decode_2718(&mut tagged.as_slice()),
+            Err(Eip2718Error::UnexpectedType(0))
+        ));
+        assert!(matches!(
+            ReceiptWithBloom::<EthereumReceipt>::network_decode(&mut tagged_network.as_slice()),
+            Err(Eip2718Error::UnexpectedType(0))
+        ));
+        assert!(
+            ReceiptWithBloom::<EthereumReceipt>::decode(&mut tagged_network.as_slice()).is_err()
+        );
+
+        // `rlp_decode_with_bloom` reads the type flag as an RLP integer, so `0x80` (the RLP
+        // encoding of zero) is the only way to reach the legacy type through a string header.
+        let mut rlp_zero_tagged = vec![0x80];
+        rlp_zero_tagged.extend_from_slice(&encoded);
+        assert!(ReceiptWithBloom::<EthereumReceipt>::decode(
+            &mut network_framed(&rlp_zero_tagged).as_slice()
+        )
+        .is_err());
     }
 }

--- a/crates/consensus/src/signed.rs
+++ b/crates/consensus/src/signed.rs
@@ -543,6 +543,13 @@ where
     T: RlpEcdsaDecodableTx + Typed2718 + Send + Sync,
 {
     fn typed_decode(ty: u8, buf: &mut &[u8]) -> Eip2718Result<Self> {
+        // Legacy transactions are untagged: `encode_2718` never emits a `0x00` type byte, so a
+        // literal `0x00` prefix must be rejected rather than decoded as legacy, which would not
+        // round-trip. Untagged legacy transactions are handled by `fallback_decode`.
+        if ty == 0 {
+            return Err(Eip2718Error::UnexpectedType(ty));
+        }
+
         let decoded = T::rlp_decode_signed(buf)?;
 
         if decoded.ty() != ty {

--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -14,11 +14,8 @@ use alloy_primitives::{Bytes, Signature, B256};
 ///
 /// # Note:
 ///
-/// This enum distinguishes between tagged and untagged legacy transactions, as
-/// the in-protocol merkle tree may commit to EITHER 0-prefixed or raw.
-/// Therefore we must ensure that encoding returns the precise byte-array that
-/// was decoded, preserving the presence or absence of the `TransactionType`
-/// flag.
+/// Represents untagged legacy transactions and typed [EIP-2718] variants. Binary decoding rejects
+/// a literal `0x00` type prefix; legacy transactions use the untagged fallback encoding.
 ///
 /// [EIP-2718]: https://eips.ethereum.org/EIPS/eip-2718
 pub type TxEnvelope = EthereumTxEnvelope<TxEip4844Variant>;
@@ -468,11 +465,8 @@ impl TryFrom<EthereumTxEnvelope<TxEip4844Variant<alloy_eips::eip4844::BlobTransa
 ///
 /// # Note:
 ///
-/// This enum distinguishes between tagged and untagged legacy transactions, as
-/// the in-protocol merkle tree may commit to EITHER 0-prefixed or raw.
-/// Therefore we must ensure that encoding returns the precise byte-array that
-/// was decoded, preserving the presence or absence of the `TransactionType`
-/// flag.
+/// Represents untagged legacy transactions and typed [EIP-2718] variants. Binary decoding rejects
+/// a literal `0x00` type prefix; legacy transactions use the untagged fallback encoding.
 ///
 /// [EIP-2718]: https://eips.ethereum.org/EIPS/eip-2718
 #[derive(Clone, Debug, TransactionEnvelope)]
@@ -1064,6 +1058,7 @@ mod tests {
     };
     use alloc::vec::Vec;
     use alloy_eips::{
+        eip2718::{Decodable2718, Eip2718Error},
         eip2930::{AccessList, AccessListItem},
         eip4844::BlobTransactionSidecar,
         eip7594::BlobTransactionSidecarVariant,
@@ -1542,6 +1537,87 @@ mod tests {
             eip1559_envelope,
             "a genuine type-tagged EIP-1559 transaction must still decode correctly"
         );
+    }
+
+    #[test]
+    fn legacy_tx_roundtrips_untagged_on_all_decode_paths() {
+        let legacy = TxLegacy {
+            chain_id: None,
+            nonce: 2,
+            gas_limit: 1_000_000,
+            gas_price: 10_000_000_000,
+            to: Address::left_padding_from(&[6]).into(),
+            value: U256::from(7_u64),
+            ..Default::default()
+        }
+        .into_signed(Signature::test_signature().with_parity(true));
+        let envelope: TxEnvelope = legacy.clone().into();
+
+        let encoded = envelope.encoded_2718();
+        assert!(encoded[0] >= 0xc0, "sanity: legacy txs are encoded as a bare RLP list");
+        // The network encoding of a legacy tx is the bare list as well, without a string header.
+        let mut network = Vec::new();
+        envelope.network_encode(&mut network);
+        assert_eq!(network, encoded);
+
+        assert_eq!(TxEnvelope::decode_2718_exact(&encoded).unwrap(), envelope);
+        assert_eq!(TxEnvelope::network_decode(&mut encoded.as_slice()).unwrap(), envelope);
+        assert_eq!(TxEnvelope::decode(&mut encoded.as_slice()).unwrap(), envelope);
+        assert_eq!(Signed::<TxLegacy>::decode_2718_exact(&encoded).unwrap(), legacy);
+        assert_eq!(
+            <Signed<TxLegacy> as Decodable2718>::network_decode(&mut encoded.as_slice()).unwrap(),
+            legacy
+        );
+    }
+
+    #[test]
+    fn tagged_legacy_tx_is_rejected_on_all_decode_paths() {
+        // Per EIP-2718, legacy transactions are untagged and `0x00` is not an assigned
+        // `TransactionType`. `encode_2718` never emits a `0x00` prefix, so accepting one on
+        // decode would re-encode the transaction differently from the bytes that were decoded.
+        // geth, erigon, nethermind and besu all reject the type byte at decode.
+        let legacy = TxLegacy {
+            chain_id: None,
+            nonce: 2,
+            gas_limit: 1_000_000,
+            gas_price: 10_000_000_000,
+            to: Address::left_padding_from(&[6]).into(),
+            value: U256::from(7_u64),
+            ..Default::default()
+        }
+        .into_signed(Signature::test_signature().with_parity(true));
+        let envelope: TxEnvelope = legacy.into();
+
+        let mut tagged = vec![0x00];
+        tagged.extend_from_slice(&envelope.encoded_2718());
+        // Network framing of a typed payload: an RLP string header followed by the payload.
+        let mut tagged_network = Vec::new();
+        alloy_rlp::Header { list: false, payload_length: tagged.len() }.encode(&mut tagged_network);
+        tagged_network.extend_from_slice(&tagged);
+
+        assert!(matches!(
+            TxEnvelope::decode_2718_exact(&tagged),
+            Err(Eip2718Error::UnexpectedType(0))
+        ));
+        assert!(matches!(
+            TxEnvelope::decode_2718(&mut tagged.as_slice()),
+            Err(Eip2718Error::UnexpectedType(0))
+        ));
+        assert!(matches!(
+            TxEnvelope::network_decode(&mut tagged_network.as_slice()),
+            Err(Eip2718Error::UnexpectedType(0))
+        ));
+        assert!(TxEnvelope::decode(&mut tagged_network.as_slice()).is_err());
+
+        // The guard lives in `Signed<T>`, so the same holds for the bare signed transaction.
+        assert!(matches!(
+            Signed::<TxLegacy>::decode_2718_exact(&tagged),
+            Err(Eip2718Error::UnexpectedType(0))
+        ));
+        assert!(matches!(
+            <Signed<TxLegacy> as Decodable2718>::network_decode(&mut tagged_network.as_slice()),
+            Err(Eip2718Error::UnexpectedType(0))
+        ));
     }
 
     #[cfg(feature = "serde")]

--- a/crates/consensus/src/transaction/mod.rs
+++ b/crates/consensus/src/transaction/mod.rs
@@ -657,11 +657,12 @@ mod tests {
 /// tries flattened variants and the legacy variant, and only those) keeps `Flattened` variants
 /// eligible for fallback decode alongside the legacy variant.
 #[cfg(test)]
-mod fallback_decode_flatten_tests {
+mod flatten_decode_tests {
     use crate::{
         SignableTransaction, Signed, TransactionEnvelope, TxEip1559, TxEnvelope, TxLegacy,
     };
-    use alloy_eips::eip2718::{Decodable2718, Encodable2718};
+    use alloc::vec;
+    use alloy_eips::eip2718::{Decodable2718, Eip2718Error, Encodable2718};
     use alloy_primitives::{Address, Signature, U256};
 
     #[derive(Debug, Clone, TransactionEnvelope)]
@@ -698,5 +699,31 @@ mod fallback_decode_flatten_tests {
             MyEnvelope::Ethereum(TxEnvelope::Legacy(_)) => {}
             other => panic!("expected Ethereum(Legacy(..)), got {other:?}"),
         }
+    }
+
+    #[test]
+    fn flattened_variant_rejects_tagged_legacy() {
+        let legacy = TxLegacy {
+            chain_id: None,
+            nonce: 2,
+            gas_limit: 1_000_000,
+            gas_price: 10_000_000_000,
+            to: Address::left_padding_from(&[6]).into(),
+            value: U256::from(7_u64),
+            ..Default::default()
+        }
+        .into_signed(Signature::test_signature().with_parity(true));
+
+        let ethereum_envelope: TxEnvelope = legacy.into();
+        let mut tagged = vec![0x00];
+        tagged.extend_from_slice(&ethereum_envelope.encoded_2718());
+
+        // `MyTxType::try_from(0)` resolves to the flattened `Ethereum(TxType::Legacy)` variant, so
+        // the literal `0x00` type byte is dispatched to the inner envelope's `typed_decode`,
+        // which must reject it just like the top-level `TxEnvelope` does.
+        assert!(matches!(
+            MyEnvelope::decode_2718_exact(&tagged),
+            Err(Eip2718Error::UnexpectedType(0))
+        ));
     }
 }

--- a/crates/consensus/src/transaction/typed.rs
+++ b/crates/consensus/src/transaction/typed.rs
@@ -134,14 +134,14 @@ impl<Eip4844: RlpEcdsaDecodableTx> EthereumTypedTransaction<Eip4844> {
 
         let first_byte = buf[0];
 
-        // Eip2718: legacy transactions start with >= 0xc0
+        // Eip2718: legacy transactions are untagged and start with >= 0xc0. A literal `0x00`
+        // type byte is not a valid type flag and is rejected below.
         if first_byte >= 0xc0 {
             return Ok(Self::Legacy(TxLegacy::decode(buf)?));
         }
 
         let tx_type = buf.get_u8();
         match tx_type {
-            0x00 => Ok(Self::Legacy(TxLegacy::decode(buf)?)),
             0x01 => Ok(Self::Eip2930(TxEip2930::decode(buf)?)),
             0x02 => Ok(Self::Eip1559(TxEip1559::decode(buf)?)),
             0x03 => Ok(Self::Eip4844(Eip4844::rlp_decode(buf)?)),
@@ -573,6 +573,32 @@ mod tests {
         if let Err(err) = result {
             assert!(matches!(err, alloy_eips::eip2718::Eip2718Error::UnexpectedType(0x99)));
         }
+    }
+
+    #[test]
+    fn test_decode_unsigned_rejects_tagged_legacy() {
+        let tx = TypedTransaction::Legacy(TxLegacy {
+            chain_id: Some(1),
+            nonce: 0,
+            gas_price: 1,
+            gas_limit: 2,
+            to: Address::ZERO.into(),
+            value: U256::ZERO,
+            input: Bytes::default(),
+        });
+        let mut encoded = Vec::new();
+        tx.encode_for_signing(&mut encoded);
+        assert!(encoded[0] >= 0xc0, "sanity: unsigned legacy txs are encoded as a bare RLP list");
+        assert_eq!(TypedTransaction::decode_unsigned(&mut encoded.as_slice()).unwrap(), tx);
+
+        // Legacy transactions are untagged, so a literal `0x00` type byte must be rejected rather
+        // than decoded as legacy, which would not round-trip through `encode_for_signing`.
+        let mut tagged = vec![0x00];
+        tagged.extend_from_slice(&encoded);
+        assert!(matches!(
+            TypedTransaction::decode_unsigned(&mut tagged.as_slice()),
+            Err(Eip2718Error::UnexpectedType(0x00))
+        ));
     }
 
     #[test]


### PR DESCRIPTION
Per EIP-2718 legacy transactions and receipts are untagged, and `0x00` is not an assigned type. `TxType::try_from(0)` resolves to `Legacy`, so the derived `typed_decode` accepted an envelope with a literal `0x00` type byte and decoded the body as a legacy transaction. `EthereumTxEnvelope::Legacy` cannot record that a tag was present, so `encode_2718` emitted the untagged form and the input did not round-trip. geth, erigon, nethermind and besu all reject the type byte at decode. The same applied to `EthereumReceipt` and `AnyReceiptEnvelope`.

This is the tagged counterpart of #4090, which restricted `Signed<T>::fallback_decode` to legacy transactions. The guard now lives in `Signed<T>::typed_decode`, so every envelope built with `#[derive(TransactionEnvelope)]`, including flattened variants, rejects `0x00` with `Eip2718Error::UnexpectedType(0)` on the `decode_2718`, `network_decode` and `Decodable` paths. `EthereumTypedTransaction::decode_unsigned` drops its `0x00` arm for the same reason, since `encode_for_signing` never emits it.

For receipts, `EthereumReceipt::typed_decode_with_bloom` rejects `ty == 0`, and `rlp_decode_with_bloom` rejects a legacy type behind a string header. That path reads the type flag as an RLP integer, so it was reachable via `0x80`, while a raw `0x00` already failed as a non-canonical integer. `AnyReceiptEnvelope::typed_decode` gets the same guard and `fallback_decode` constructs the legacy variant directly. `ReceiptEnvelope` already rejected the tag and only gains a regression test. The `EthereumTxEnvelope` docs claiming the enum distinguishes tagged and untagged legacy transactions were inaccurate and now use the wording of `ReceiptEnvelope`.

Tests cover the untagged happy path and the `0x00`-tagged unhappy path on every decode entry point (`decode_2718`, `decode_2718_exact`, `network_decode`, `Decodable`) for `TxEnvelope`, `Signed<TxLegacy>`, a flattened custom envelope, `TypedTransaction::decode_unsigned`, `ReceiptWithBloom<EthereumReceipt>`, `ReceiptEnvelope` and `AnyReceiptEnvelope`, plus typed round-trips to guard against over-correction.

Supersedes #4167 and #4188.

Fixes #4165

🤖 Generated with [Claude Code](https://claude.com/claude-code)
