### PR TITLE
feat(rpc-types-debug): add execution witness encoding

### DIFF
--- a/crates/rpc-types-debug/Cargo.toml
+++ b/crates/rpc-types-debug/Cargo.toml
@@ -23,8 +23,8 @@ rustdoc-args = [
 workspace = true
 
 [dependencies]
-alloy-primitives = { workspace = true, features = ["serde", "rlp"] }
-alloy-rlp.workspace = true
+alloy-primitives = { workspace = true, features = ["serde"] }
+alloy-rlp = { workspace = true, optional = true }
 
 serde.workspace = true
 serde_with = { workspace = true, features = ["alloc", "base64"] }
@@ -38,3 +38,6 @@ derive_more = { workspace = true, features = [
 
 [dev-dependencies]
 serde_json.workspace = true
+
+[features]
+rlp = ["dep:alloy-rlp", "alloy-primitives/rlp"]

--- a/crates/rpc-types-debug/Cargo.toml
+++ b/crates/rpc-types-debug/Cargo.toml
@@ -23,8 +23,8 @@ rustdoc-args = [
 workspace = true
 
 [dependencies]
-alloy-primitives = { workspace = true, features = ["serde"] }
-alloy-rlp = { workspace = true, optional = true }
+alloy-primitives = { workspace = true, features = ["serde", "rlp"] }
+alloy-rlp.workspace = true
 
 serde.workspace = true
 serde_with = { workspace = true, features = ["alloc", "base64"] }
@@ -38,6 +38,3 @@ derive_more = { workspace = true, features = [
 
 [dev-dependencies]
 serde_json.workspace = true
-
-[features]
-rlp = ["dep:alloy-rlp", "alloy-primitives/rlp"]

--- a/crates/rpc-types-debug/Cargo.toml
+++ b/crates/rpc-types-debug/Cargo.toml
@@ -23,7 +23,7 @@ rustdoc-args = [
 workspace = true
 
 [dependencies]
-alloy-primitives = { workspace = true, features = ["serde"] }
+alloy-primitives = { workspace = true, features = ["serde", "rlp"] }
 alloy-rlp.workspace = true
 
 serde.workspace = true

--- a/crates/rpc-types-debug/src/execution_witness.rs
+++ b/crates/rpc-types-debug/src/execution_witness.rs
@@ -1,5 +1,6 @@
 use alloc::vec::Vec;
 use alloy_primitives::Bytes;
+use alloy_rlp::{Encodable, Header};
 use serde::{Deserialize, Serialize};
 
 /// Represents the execution witness of a block. Contains lists of required preimages and
@@ -73,23 +74,19 @@ impl ExecutionWitness {
     /// The headers must contain valid RLP-encoded block headers; they are not validated here.
     ///
     /// See <https://github.com/ethereum/go-ethereum/blob/7538039f06792da46a91165e7eda98917edcfde2/core/stateless/encoding.go>.
-    #[cfg(feature = "rlp")]
     pub fn encode_witness(&self) -> Bytes {
         let mut fields = Vec::new();
-        alloy_rlp::Header {
-            list: true,
-            payload_length: self.headers.iter().map(|header| header.len()).sum(),
-        }
-        .encode(&mut fields);
+        Header { list: true, payload_length: self.headers.iter().map(|header| header.len()).sum() }
+            .encode(&mut fields);
         for header in &self.headers {
             fields.extend_from_slice(header);
         }
-        alloy_rlp::Encodable::encode(&self.codes, &mut fields);
-        alloy_rlp::Encodable::encode(&self.state, &mut fields);
-        alloy_rlp::Header { list: true, payload_length: 0 }.encode(&mut fields);
+        self.codes.encode(&mut fields);
+        self.state.encode(&mut fields);
+        Header { list: true, payload_length: 0 }.encode(&mut fields);
 
         let mut encoded = Vec::new();
-        alloy_rlp::Header { list: true, payload_length: fields.len() }.encode(&mut encoded);
+        Header { list: true, payload_length: fields.len() }.encode(&mut encoded);
         encoded.extend_from_slice(&fields);
         encoded.into()
     }
@@ -101,16 +98,12 @@ impl ExecutionWitness {
     }
 
     /// Sets the `headers` field by RLP-encoding each item.
-    #[cfg(feature = "rlp")]
-    pub fn with_headers<H: alloy_rlp::Encodable>(
-        mut self,
-        headers: impl IntoIterator<Item = H>,
-    ) -> Self {
+    pub fn with_headers<H: Encodable>(mut self, headers: impl IntoIterator<Item = H>) -> Self {
         self.headers = headers
             .into_iter()
             .map(|header| {
                 let mut buf = Vec::new();
-                alloy_rlp::Encodable::encode(&header, &mut buf);
+                header.encode(&mut buf);
                 buf.into()
             })
             .collect();
@@ -118,7 +111,7 @@ impl ExecutionWitness {
     }
 }
 
-#[cfg(all(test, feature = "rlp"))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use alloc::vec;

--- a/crates/rpc-types-debug/src/execution_witness.rs
+++ b/crates/rpc-types-debug/src/execution_witness.rs
@@ -1,6 +1,5 @@
 use alloc::vec::Vec;
 use alloy_primitives::Bytes;
-use alloy_rlp::{Encodable, Header};
 use serde::{Deserialize, Serialize};
 
 /// Represents the execution witness of a block. Contains lists of required preimages and
@@ -74,19 +73,23 @@ impl ExecutionWitness {
     /// The headers must contain valid RLP-encoded block headers; they are not validated here.
     ///
     /// See <https://github.com/ethereum/go-ethereum/blob/7538039f06792da46a91165e7eda98917edcfde2/core/stateless/encoding.go>.
+    #[cfg(feature = "rlp")]
     pub fn encode_witness(&self) -> Bytes {
         let mut fields = Vec::new();
-        Header { list: true, payload_length: self.headers.iter().map(|header| header.len()).sum() }
-            .encode(&mut fields);
+        alloy_rlp::Header {
+            list: true,
+            payload_length: self.headers.iter().map(|header| header.len()).sum(),
+        }
+        .encode(&mut fields);
         for header in &self.headers {
             fields.extend_from_slice(header);
         }
-        self.codes.encode(&mut fields);
-        self.state.encode(&mut fields);
-        Header { list: true, payload_length: 0 }.encode(&mut fields);
+        alloy_rlp::Encodable::encode(&self.codes, &mut fields);
+        alloy_rlp::Encodable::encode(&self.state, &mut fields);
+        alloy_rlp::Header { list: true, payload_length: 0 }.encode(&mut fields);
 
         let mut encoded = Vec::new();
-        Header { list: true, payload_length: fields.len() }.encode(&mut encoded);
+        alloy_rlp::Header { list: true, payload_length: fields.len() }.encode(&mut encoded);
         encoded.extend_from_slice(&fields);
         encoded.into()
     }
@@ -98,12 +101,16 @@ impl ExecutionWitness {
     }
 
     /// Sets the `headers` field by RLP-encoding each item.
-    pub fn with_headers<H: Encodable>(mut self, headers: impl IntoIterator<Item = H>) -> Self {
+    #[cfg(feature = "rlp")]
+    pub fn with_headers<H: alloy_rlp::Encodable>(
+        mut self,
+        headers: impl IntoIterator<Item = H>,
+    ) -> Self {
         self.headers = headers
             .into_iter()
             .map(|header| {
                 let mut buf = Vec::new();
-                header.encode(&mut buf);
+                alloy_rlp::Encodable::encode(&header, &mut buf);
                 buf.into()
             })
             .collect();
@@ -111,7 +118,7 @@ impl ExecutionWitness {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "rlp"))]
 mod tests {
     use super::*;
     use alloc::vec;

--- a/crates/rpc-types-debug/src/execution_witness.rs
+++ b/crates/rpc-types-debug/src/execution_witness.rs
@@ -75,19 +75,27 @@ impl ExecutionWitness {
     ///
     /// See <https://github.com/ethereum/go-ethereum/blob/7538039f06792da46a91165e7eda98917edcfde2/core/stateless/encoding.go>.
     pub fn encode_witness(&self) -> Bytes {
-        let mut fields = Vec::new();
-        Header { list: true, payload_length: self.headers.iter().map(|header| header.len()).sum() }
-            .encode(&mut fields);
+        let headers = Header {
+            list: true,
+            payload_length: self.headers.iter().map(|header| header.len()).sum(),
+        };
+        let keys = Header { list: true, payload_length: 0 };
+        let witness = Header {
+            list: true,
+            payload_length: headers.length_with_payload()
+                + self.codes.length()
+                + self.state.length()
+                + keys.length(),
+        };
+        let mut encoded = Vec::with_capacity(witness.length_with_payload());
+        witness.encode(&mut encoded);
+        headers.encode(&mut encoded);
         for header in &self.headers {
-            fields.extend_from_slice(header);
+            encoded.extend_from_slice(header);
         }
-        self.codes.encode(&mut fields);
-        self.state.encode(&mut fields);
-        Header { list: true, payload_length: 0 }.encode(&mut fields);
-
-        let mut encoded = Vec::new();
-        Header { list: true, payload_length: fields.len() }.encode(&mut encoded);
-        encoded.extend_from_slice(&fields);
+        self.codes.encode(&mut encoded);
+        self.state.encode(&mut encoded);
+        keys.encode(&mut encoded);
         encoded.into()
     }
 
@@ -129,6 +137,14 @@ mod tests {
             witness.encode_witness().as_ref(),
             &hex!("d2c4c101c102c584636f6465c5846e6f6465c0")
         );
+    }
+
+    #[test]
+    fn encode_witness_long_rlp_payload() {
+        let witness =
+            ExecutionWitness { codes: vec![Bytes::from(vec![0x7f; 56])], ..Default::default() };
+        let expected = [&hex!("f83fc0f83ab838")[..], &[0x7f; 56], &hex!("c0c0")].concat();
+        assert_eq!(witness.encode_witness().as_ref(), expected);
     }
 
     #[test]

--- a/crates/rpc-types-debug/src/execution_witness.rs
+++ b/crates/rpc-types-debug/src/execution_witness.rs
@@ -1,6 +1,6 @@
 use alloc::vec::Vec;
 use alloy_primitives::Bytes;
-use alloy_rlp::Encodable;
+use alloy_rlp::{Encodable, Header};
 use serde::{Deserialize, Serialize};
 
 /// Represents the execution witness of a block. Contains lists of required preimages and
@@ -65,6 +65,32 @@ pub struct ExecutionWitness {
 }
 
 impl ExecutionWitness {
+    /// RLP-encodes the witness in Geth's external witness format: `[headers, codes, state, keys]`.
+    ///
+    /// Headers are embedded as already RLP-encoded lists, while codes and state nodes are encoded
+    /// as byte strings. The debug API's unhashed account and storage keys are omitted by encoding
+    /// an empty keys list. The order of headers, codes, and state nodes is preserved.
+    ///
+    /// The headers must contain valid RLP-encoded block headers; they are not validated here.
+    ///
+    /// See <https://github.com/ethereum/go-ethereum/blob/7538039f06792da46a91165e7eda98917edcfde2/core/stateless/encoding.go>.
+    pub fn encode_witness(&self) -> Bytes {
+        let mut fields = Vec::new();
+        Header { list: true, payload_length: self.headers.iter().map(|header| header.len()).sum() }
+            .encode(&mut fields);
+        for header in &self.headers {
+            fields.extend_from_slice(header);
+        }
+        self.codes.encode(&mut fields);
+        self.state.encode(&mut fields);
+        Header { list: true, payload_length: 0 }.encode(&mut fields);
+
+        let mut encoded = Vec::new();
+        Header { list: true, payload_length: fields.len() }.encode(&mut encoded);
+        encoded.extend_from_slice(&fields);
+        encoded.into()
+    }
+
     /// Sets the `headers` field from already RLP-encoded headers.
     pub fn with_rlp_headers(mut self, headers: Vec<Bytes>) -> Self {
         self.headers = headers;
@@ -82,5 +108,31 @@ impl ExecutionWitness {
             })
             .collect();
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec;
+    use alloy_primitives::hex;
+
+    #[test]
+    fn encode_witness_nested_headers_and_empty_keys() {
+        let witness = ExecutionWitness {
+            headers: vec![Bytes::from_static(&hex!("c101")), Bytes::from_static(&hex!("c102"))],
+            codes: vec![Bytes::from_static(b"code")],
+            state: vec![Bytes::from_static(b"node")],
+            keys: vec![Bytes::from_static(b"debug-only")],
+        };
+        assert_eq!(
+            witness.encode_witness().as_ref(),
+            &hex!("d2c4c101c102c584636f6465c5846e6f6465c0")
+        );
+    }
+
+    #[test]
+    fn encode_empty_witness() {
+        assert_eq!(ExecutionWitness::default().encode_witness().as_ref(), &hex!("c4c0c0c0c0"));
     }
 }


### PR DESCRIPTION
Adds `ExecutionWitness::encode_witness(&self) -> Bytes` so callers can encode Engine API witnesses directly, replacing the helper in https://github.com/paradigmxyz/reth/pull/27083.

Preserves the helper's Geth-compatible RLP layout: `[headers, codes, state, keys]`, with headers embedded as RLP lists, codes and state nodes encoded as byte strings, and an empty keys list regardless of debug keys. Input ordering is preserved and the witness is borrowed. Enables the primitives `rlp` feature for standalone crate builds.
