### PR TITLE
fix(provider): preserve user-set EIP-1559 fee fields in GasFiller

### DIFF
--- a/crates/provider/src/fillers/gas.rs
+++ b/crates/provider/src/fillers/gas.rs
@@ -181,13 +181,23 @@ impl<N: Network> TxFiller<N> for GasFiller {
         if let Some(builder) = tx.as_mut_builder() {
             match fillable {
                 GasFillable::Legacy { gas_limit, gas_price } => {
-                    builder.set_gas_limit(gas_limit);
-                    builder.set_gas_price(gas_price);
+                    if builder.gas_limit().is_none() {
+                        builder.set_gas_limit(gas_limit);
+                    }
+                    if builder.gas_price().is_none() {
+                        builder.set_gas_price(gas_price);
+                    }
                 }
                 GasFillable::Eip1559 { gas_limit, estimate } => {
-                    builder.set_gas_limit(gas_limit);
-                    builder.set_max_fee_per_gas(estimate.max_fee_per_gas);
-                    builder.set_max_priority_fee_per_gas(estimate.max_priority_fee_per_gas);
+                    if builder.gas_limit().is_none() {
+                        builder.set_gas_limit(gas_limit);
+                    }
+                    if builder.max_fee_per_gas().is_none() {
+                        builder.set_max_fee_per_gas(estimate.max_fee_per_gas);
+                    }
+                    if builder.max_priority_fee_per_gas().is_none() {
+                        builder.set_max_priority_fee_per_gas(estimate.max_priority_fee_per_gas);
+                    }
                 }
             }
         };
@@ -454,5 +464,51 @@ mod tests {
             <BlobGasFiller as TxFiller<Ethereum>>::status(&BlobGasFiller::default(), &tx),
             FillerControlFlow::Ready
         );
+    }
+
+    #[tokio::test]
+    async fn preserves_user_set_max_fee_per_gas() {
+        let provider = ProviderBuilder::new().connect_anvil_with_wallet();
+
+        let user_max_fee = 100_000_000_000u128;
+        let tx = TransactionRequest {
+            value: Some(U256::from(100)),
+            to: Some(address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045").into()),
+            chain_id: Some(31337),
+            max_fee_per_gas: Some(user_max_fee),
+            // max_priority_fee_per_gas is intentionally not set
+            ..Default::default()
+        };
+
+        let tx = provider.send_transaction(tx).await.unwrap();
+        let receipt = tx.get_receipt().await.unwrap();
+
+        let tx = provider.get_transaction_by_hash(receipt.transaction_hash).await.unwrap().unwrap();
+
+        // User-set max_fee_per_gas should be preserved
+        assert_eq!(tx.max_fee_per_gas().unwrap(), user_max_fee);
+    }
+
+    #[tokio::test]
+    async fn preserves_user_set_max_priority_fee_per_gas() {
+        let provider = ProviderBuilder::new().connect_anvil_with_wallet();
+
+        let user_priority_fee = 2_000_000_000u128;
+        let tx = TransactionRequest {
+            value: Some(U256::from(100)),
+            to: Some(address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045").into()),
+            chain_id: Some(31337),
+            // max_fee_per_gas is intentionally not set
+            max_priority_fee_per_gas: Some(user_priority_fee),
+            ..Default::default()
+        };
+
+        let tx = provider.send_transaction(tx).await.unwrap();
+        let receipt = tx.get_receipt().await.unwrap();
+
+        let tx = provider.get_transaction_by_hash(receipt.transaction_hash).await.unwrap().unwrap();
+
+        // User-set max_priority_fee_per_gas should be preserved
+        assert_eq!(tx.max_priority_fee_per_gas().unwrap(), user_priority_fee);
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/alloy/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Fixes the bug where `GasFiller` overwrites user-explicitly-set EIP-1559 fee fields instead of only filling unset fields as documented.

The current implementation in `GasFiller::fill()` unconditionally sets `max_fee_per_gas` and `max_priority_fee_per_gas`, even when the user has already set one of them. This violates the documented contract that fillers should only populate "unset" fields.

**Root cause:**
- `prepare_1559()` only preserves fees when **both** fields are set
- `fill()` unconditionally overwrites all fields with estimated values
- This breaks the common pattern of setting one fee field and letting the filler estimate the other



## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Modified `GasFiller::fill()` to only set fields that are currently `None`:

```rust
// EIP-1559 branch
if builder.gas_limit().is_none() {
    builder.set_gas_limit(gas_limit);
}
if builder.max_fee_per_gas().is_none() {
    builder.set_max_fee_per_gas(estimate.max_fee_per_gas);
}
if builder.max_priority_fee_per_gas().is_none() {
    builder.set_max_priority_fee_per_gas(estimate.max_priority_fee_per_gas);
}
```

Applied the same "fill-only-if-none" logic to the legacy branch for consistency.




## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
